### PR TITLE
Rescue index_queue_depth if unable to connect to the remote source

### DIFF
--- a/app/helpers/argo_helper.rb
+++ b/app/helpers/argo_helper.rb
@@ -26,6 +26,8 @@ module ArgoHelper
     else
       0
     end
+  rescue
+    0
   end
 
   def index_queue_velocity


### PR DESCRIPTION
@atz @jmartin-sul This is the hot-fix I applied to argo-prod. It should be merged and deployed the right way.