### PR TITLE
addendum to Update Readme to reflect setting up Argo in a development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,28 +11,40 @@ http://java.com/en/download/
 
 Install ruby 1.9.3 or later (e.g., via rvm).
 
-### Check Out the Code and Install Ruby Dependencies
+### Check Out the Code
     
 ```bash
 git clone https://github.com/sul-dlss/argo.git
 cd argo
-bundle install
 ```
     
-### Configure the argo and database yml files.  Stanford users should review internal documentation.
+### Configure the database.yml file.  Stanford users should review internal documentation.
 
 ```bash
 cp config/database.yml.example config/database.yml
 ```
 
+### Configure the rest of the local environment.  Stanford users should review internal documentation.
+
 You will also need to acquire the following config files (per environment):
 
- - `config/development.rb`
- - `config/dor_development.rb`
+ - `config/environments/development.rb`
+ - `config/environments/dor_development.rb`
+ - `config/environments/test.rb`
+ - `config/environments/dor_test.rb`
+ - `config/certs/dlss-dev-$USER-dor-dev.crt`  # should match the value specified by cert_file in dor_development.rb
+ - `config/certs/dlss-dev-$USER-dor-dev.key`  # should match the value specified by key_file in dor_development.rb
 
-### Install components and DB:
+### Run bundler to install the Gem dependencies
+
+`bundle install`
+
+`bundle install` may complain if MySQL isn't installed.  You can either comment out the mysql2 inclusion in Gemfile and come back to it later (you can develop using sqlite), or you can install MySQL.
+
+### Install components, setup DB and Solr:
 
 ```bash
+rails generate argo:solr
 rake argo:jetty:clean
 rake argo:jetty:config
 rake db:setup
@@ -40,19 +52,17 @@ rake db:migrate
 rake tmp:create
 ```
 
-### Optional - Increase Jetty heap size and Solr logging
+### Optional - Increase Jetty heap size and Solr logging verbosity
+#### Delving into this is only recemmended if you run into more trouble than usual starting jetty or getting it to run stably (or if you know you have some other reason to make these sorts of changes).
 
-In the created `./jetty` directory add the following the `start.ini` to increase the heap size
+In the created `./jetty` directory add the following to the `start.ini` to increase the heap size, allow the debugger to attach, and to explicitly specify logging properties.
 
-At LN19
+In the section that starts with the heading `If the arguments in this file include JVM arguments` (at LN19 as of this README update):
 ```
 --exec
 
 Djava.awt.headless=true
 -Dcom.sun.management.jmxremote
--Dorg.eclipse.jetty.util.log.IGNORED=true
--Dorg.eclipse.jetty.LEVEL=INFO
--Dorg.eclipse.jetty.util.log.stderr.SOURCE=true
 -Xmx2000m
 -XX:+PrintCommandLineFlags
 -XX:+UseConcMarkSweepGC
@@ -63,6 +73,8 @@ Djava.awt.headless=true
 # Solr logging
 -Djava.util.logging.config.file=etc/logging.properties
 ```
+
+You may then update values in `jetty/etc/logging.properties` to change logging settings (e.g., set `.level = FINEST`).
 
 ## Run the server
 


### PR DESCRIPTION
* re-ordered a step (moved `bundle install` a bit later)
* edited language a bit
* removed some unnecessary stuff from the java heap size part
* fixed some file paths
* a bit of additional info from my notes on setting up argo

@mejackreed 