### PR TITLE
rename the default blacklight document handler from "document" to "/document"

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -18,6 +18,8 @@ class CatalogController < ApplicationController
     BlacklightConfigHelper.add_common_default_solr_params_to_config! config
     config.default_solr_params[:rows] = 10
 
+    config.document_solr_request_handler = '/document'
+
     config.index.title_field = 'dc_title_ssi'
     config.index.display_type_field = 'content_type_ssim'
 

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -102,7 +102,7 @@
   </requestHandler>
 
   <!-- for requests to get a single document; use id=666 instead of q=id:666 -->
-  <requestHandler name="document" class="solr.SearchHandler" >
+  <requestHandler name="/document" class="solr.SearchHandler" >
     <lst name="defaults">
       <str name="echoParams">all</str>
       <str name="fl">*</str>


### PR DESCRIPTION
* rename the handler in solrconfig.xml (requires re-deploying configuration for the solr instance for the change to take effect)
* update CatalogController to override the default blacklight config value for document_solr_request_handler

once this code change is pulled, the solr config for the relevant instance will have to be redeployed, or the instance won't be able to view detail pages for objects, because it'll be using an undefined handler.

@atz, mind reviewing?