### PR TITLE
Update config pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 app/assets/javascripts/jqgrid/
 config/certs
 config/database.yml
-config/environments/*.rb
 config/newrelic.yml
 config/solr.yml
 coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ public/.htaccess
 public/assets
 public/images/.dpg_pool
 tmp/
+
+config/settings.local.yml
+config/settings/*.local.yml
+config/environments/*.local.yml

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'delayed_job'
 gem 'delayed_job_active_record'
 gem 'daemons'
 gem 'equivalent-xml', '>= 0.6.0'   # For ignoring_attr_values() with arguments
+gem 'config'
 
 # Stanford/Hydra related gems
 gem 'about_page'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,9 @@ GEM
       execjs
     coffee-script-source (1.9.1.1)
     columnize (0.9.0)
+    config (1.0.0)
+      activesupport (>= 3.0)
+      deep_merge (~> 1.0.0)
     confstruct (0.2.7)
     coveralls (0.8.2)
       json (~> 1.8)
@@ -180,6 +183,7 @@ GEM
       debugger-ruby_core_source (~> 1.3.5)
     debugger-linecache (1.2.0)
     debugger-ruby_core_source (1.3.8)
+    deep_merge (1.0.1)
     delayed_job (4.1.1)
       activesupport (>= 3.0, < 5.0)
     delayed_job_active_record (4.1.0)
@@ -526,6 +530,7 @@ DEPENDENCIES
   capybara
   coderay
   coffee-rails
+  config
   confstruct (~> 0.2.4)
   coveralls
   daemons

--- a/README.md
+++ b/README.md
@@ -24,16 +24,14 @@ cd argo
 cp config/database.yml.example config/database.yml
 ```
 
-### Configure the rest of the local environment.  Stanford users should review internal documentation.
+### Configure the rest of the local environment.
 
-You will also need to acquire the following config files (per environment):
+Settings configuration is managed using the [config](https://github.com/railsconfig/config) gem. Developers should create (or obtain) `config/settings/development.local.yml` files to set local development variables specifically.
 
- - `config/environments/development.rb`
- - `config/environments/dor_development.rb`
- - `config/environments/test.rb`
- - `config/environments/dor_test.rb`
- - `config/certs/dlss-dev-$USER-dor-dev.crt`  # should match the value specified by cert_file in dor_development.rb
- - `config/certs/dlss-dev-$USER-dor-dev.key`  # should match the value specified by key_file in dor_development.rb
+You will also need to acquire the following certificate files (per environment):
+
+ - `config/certs/dlss-dev-$USER-dor-dev.crt`  # should match the value specified by `Settings.SSL.CERT_FILE`
+ - `config/certs/dlss-dev-$USER-dor-dev.key`  # should match the value specified by `Settings.SSL.CERT_FILE`
 
 ### Run bundler to install the Gem dependencies
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,0 +1,80 @@
+require 'active_support/cache/dalli_store'
+require 'action_dispatch/middleware/session/dalli_store'
+
+Argo::Application.configure do
+  # Settings specified here will take precedence over those in config/application.rb
+
+  config.assets.compress = false
+
+  # In the development environment your application's code is reloaded on
+  # every request.  This slows down response time but is perfect for development
+  # since you don't have to restart the webserver when you make code changes.
+  config.cache_classes = false
+  config.perform_caching = true
+  config.cache_store = :dalli_store, { namespace: Settings.CACHE_STORE_NAME }
+  config.cache_store.logger.level = Logger::DEBUG
+  # Log error messages when you accidentally call methods on nil.
+  config.whiny_nils = true
+
+  # Show full error reports and disable caching
+  config.consider_all_requests_local       = true
+  config.action_controller.perform_caching = false
+
+  # Don't care if the mailer can't send
+  config.action_mailer.raise_delivery_errors = false
+
+  # Print deprecation notices to the Rails logger
+  config.active_support.deprecation = :log
+
+  # Only use best-standards-support built into browsers
+  config.action_dispatch.best_standards_support = :builtin
+
+  # Silences warning
+  config.eager_load = false
+
+  require 'rack-webauth/test'
+  config.middleware.use(
+    Rack::Webauth::Test,
+    user: Settings.WEBAUTH.USER,
+    mail: Settings.WEBAUTH.MAIL,
+    ldapprivgroup: Settings.WEBAUTH.LDAPPRIVGROUP,
+    suaffiliation: Settings.WEBAUTH.SUAFFILIATION,
+    displayname: Settings.WEBAUTH.DISPLAYNAME,
+    ldapauthrule: Settings.WEBAUTH.LDAPAUTHRULE
+  )
+  config.middleware.use(Rack::Webauth)
+
+  Argo.configure do
+    reindex_on_the_fly      Settings.REINDEX_ON_FLY
+    date_format_str         Settings.DATE_FORMAT_STR
+    urls do
+      mdtoolkit             Settings.MDTOOLKIT_URL
+      purl                  Settings.PURL_URL
+      stacks                Settings.STACKS_URL
+      stacks_file           Settings.STACKS_FILE_URL
+      dor_services          Settings.DOR_SERVICES_URL
+      workflow              Settings.WORKFLOW_URL
+      dpg                   Settings.DPG_URL
+      robot_status          Settings.ROBOT_STATUS_URL
+      modsulator            Settings.MODSULATOR_URL
+      normalizer            Settings.NORMALIZER_URL
+      spreadsheet           Settings.SPREADSHEET_URL
+    end
+    bulk_metadata_directory Settings.BULK_METADATA.DIRECTORY # Directory for storing bulk metadata job info
+    bulk_metadata_log       Settings.BULK_METADATA.LOG # Bulk metadata log file
+    bulk_metadata_xml       Settings.BULK_METADATA.XML # Bulk metadata XML output file
+  end
+
+  # the following config statement gets us two important things on each log line:
+  # 1) unique IDs per request, so that it's easier to correlate
+  # logging statements associated with a given request when multiple
+  # simultaneous requests have interleaved log statements.
+  # 2) time stamps on each log statement, because knowing when something
+  # got logged is quite nice.
+  # (declared after Argo.configure since it uses one of those params)
+  config.log_tags = [:uuid, proc {DateTime.now.strftime(Argo::Config.date_format_str)}]
+
+  # at present, we only use squash in -test and -prod.  but it has to
+  # be configured to be disabled if we don't configure it with an api
+  # key (which we don't have for dev).
+end

--- a/config/environments/dor_development.rb
+++ b/config/environments/dor_development.rb
@@ -1,0 +1,56 @@
+cert_dir = File.expand_path(File.join(File.dirname(__FILE__),"../certs"))
+
+Dor.configure do
+  ssl do
+    cert_file File.join(cert_dir, Settings.SSL.CERT_FILE)
+    key_file File.join(cert_dir, Settings.SSL.KEY_FILE)
+    key_pass Settings.SSL.KEY_PASS
+  end
+
+  fedora do
+    url Settings.FEDORA_URL
+  end
+
+  workflow do
+    url Settings.WORKFLOW_URL
+  end
+
+  dor_services do
+    url Settings.DOR_SERVICES_URL
+  end
+
+  solrizer.url Settings.SOLRIZER_URL
+
+  suri do
+    mint_ids     Settings.SURI.MINT_IDS
+    id_namespace Settings.SURI.ID_NAMESPACE
+    url          Settings.SURI.URL
+    user         Settings.SURI.USER
+    pass         Settings.SURI.PASS
+  end
+
+  metadata do
+    exist.url   Settings.METADATA.EXIST_URL
+    catalog.url Settings.METADATA.CATALOG_URL
+  end
+
+  content do
+    content_user     Settings.CONTENT.USER
+    content_base_dir Settings.CONTENT.BASE_DIR
+    content_server   Settings.CONTENT.SERVER_HOST
+  end
+
+  stacks do
+    document_cache_storage_root Settings.STACKS.DOCUMENT_CACHE_STORAGE_ROOT
+    document_cache_host         Settings.STACKS.DOCUMENT_CACHE_HOST
+    document_cache_user         Settings.STACKS.DOCUMENT_CACHE_USER
+    local_workspace_root        Settings.STACKS.LOCAL_WORKSPACE_ROOT
+    storage_root                Settings.STACKS.STORAGE_ROOT
+    host                        Settings.STACKS.HOST
+    user                        Settings.STACKS.USER
+  end
+
+  sdr do
+    url Settings.SDR_URL
+  end
+end

--- a/config/environments/dor_test.rb
+++ b/config/environments/dor_test.rb
@@ -1,0 +1,40 @@
+Dor.configure do
+
+  fedora do
+    url Settings.FEDORA_URL
+  end
+
+  workflow do
+    url Settings.WORKFLOW_URL
+  end
+
+  dor_services do
+    url Settings.DOR_SERVICES_URL
+  end
+
+  solrizer.url Settings.SOLRIZER_URL
+
+  gsearch do
+    url      Settings.GSEARCH_URL
+    rest_url Settings.GSEARCH_REST_URL
+  end
+
+  suri do
+    mint_ids     Settings.SURI.MINT_IDS
+    id_namespace Settings.SURI.ID_NAMESPACE
+    url          Settings.SURI.URL
+    user         Settings.SURI.USER
+    pass         Settings.SURI.PASS
+  end
+
+  metadata do
+    exist.url   Settings.METADATA.EXIST_URL
+    catalog.url Settings.METADATA.CATALOG_URL
+  end
+
+  content do
+    content_user     Settings.CONTENT.USER
+    content_base_dir Settings.CONTENT.BASE_DIR
+    content_server   Settings.CONTENT.SERVER_HOST
+  end
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,0 +1,75 @@
+require 'active_support/cache/dalli_store'
+require 'action_dispatch/middleware/session/dalli_store'
+
+Argo::Application.configure do
+  # Settings specified here will take precedence over those in config/application.rb
+
+  # The test environment is used exclusively to run your application's
+  # test suite.  You never need to work with it otherwise.  Remember that
+  # your test database is "scratch space" for the test suite and is wiped
+  # and recreated between test runs.  Don't rely on the data there!
+  config.cache_classes = true
+
+  config.cache_store = :dalli_store, { namespace: Settings.CACHE_STORE_NAME }
+
+  # Log error messages when you accidentally call methods on nil.
+  config.whiny_nils = true
+
+  #Set how deprecation warnings are handled.
+  config.active_support.deprecation = :log
+
+  # Show full error reports and disable caching
+  config.consider_all_requests_local       = true
+  config.action_controller.perform_caching = false
+
+  # Raise exceptions instead of rendering exception templates
+  config.action_dispatch.show_exceptions = true
+
+  # Disable request forgery protection in test environment
+  config.action_controller.allow_forgery_protection = false
+
+  # Tell Action Mailer not to deliver emails to the real world.
+  # The :test delivery method accumulates sent emails in the
+  # ActionMailer::Base.deliveries array.
+  config.action_mailer.delivery_method = :test
+
+  # Use SQL instead of Active Record's schema dumper when creating the test database.
+  # This is necessary if your schema can't be completely dumped by the schema dumper,
+  # like if you have constraints or database-specific column types
+  # config.active_record.schema_format = :sql
+
+  # Print deprecation notices to the stderr
+  config.active_support.deprecation = :stderr
+
+  config.middleware.use(Rack::Webauth)
+  config.assets.precompile << 'about.css.sass' << 'argo.css' << 'registration.css' << 'report.css' << 'webcrop.css' << '*.js' << '*.coffee'
+
+  Argo.configure do
+    reindex_on_the_fly      Settings.REINDEX_ON_FLY
+    date_format_str         Settings.DATE_FORMAT_STR
+    urls do
+      stacks_file           Settings.STACKS_FILE_URL
+      stacks                Settings.STACKS_URL
+      mdtoolkit             Settings.MDTOOLKIT_URL
+      purl                  Settings.PURL_URL
+      dor_services          Settings.DOR_SERVICES_URL
+      workflow              Settings.WORKFLOW_URL
+      robot_status          Settings.ROBOT_STATUS_URL
+      modsulator            Settings.MODSULATOR_URL
+      normalizer            Settings.NORMALIZER_URL
+      spreadsheet           Settings.SPREADSHEET_URL
+    end
+    bulk_metadata_directory Settings.BULK_METADATA.DIRECTORY # Directory for storing bulk metadata job info
+    bulk_metadata_log       Settings.BULK_METADATA.LOG # Bulk metadata log file
+    bulk_metadata_xml       Settings.BULK_METADATA.XML # Bulk metadata XML output file
+  end
+
+  # the following config statement gets us two important things on each log line:
+  # 1) unique IDs per request, so that it's easier to correlate
+  # logging statements associated with a given request when multiple
+  # simultaneous requests have interleaved log statements.
+  # 2) time stamps on each log statement, because knowing when something
+  # got logged is quite nice.
+  # (declared after Argo.configure since it uses one of those params)
+  config.log_tags = [:uuid, proc {DateTime.now.strftime(Argo::Config.date_format_str)}]
+end

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -1,0 +1,3 @@
+Config.setup do |config|
+  config.const_name = "Settings"
+end

--- a/config/initializers/squash_exceptions.rb
+++ b/config/initializers/squash_exceptions.rb
@@ -1,0 +1,4 @@
+Squash::Ruby.configure api_host: Settings.SQUASH.API_HOST,
+                       api_key: Settings.SQUASH.API_KEY,
+                       environment: Settings.SQUASH_ENVIRONMENT || Rails.env,
+                       disabled: Settings.SQUASH.DISABLE

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,54 @@
+# Example settings for configuration
+
+# Content
+CONTENT:
+  USER: 'user'
+  BASE_DIR: '/foo/bar'
+  SERVER_HOST: 'example-bar'
+  SDR_SERVER_URL: 'https://sdr.example.com'
+  SDR_USER: 'user'
+  SDR_PASSWORD: 'password'
+
+# URLs
+DOR_SERVICES_URL: 'https://user:password@dor-services.example.com'
+FEDORA_URL: 'https://fedora.example.com/fedora'
+MDTOOLKIT_URL: 'https://mdtoolkit.example.com/md'
+PURL_URL: 'https://purl.example.com'
+ROBOT_STATUS_URL: 'https://robot.example.com/robots'
+SOLRIZER_URL: 'https://solr.example.com/solr/collection'
+STACKS_FILE_URL: 'https://stacks.example.com/file'
+STACKS_URL: 'https://stacks.example.com/image' # TODO: Verify use doesn't seeem to be in use
+STATUS_INDEXER_URL: 'https://status.example.com/render/?format=json&other=params'
+WORKFLOW_URL: 'https://workflow.example.com/workflow'
+
+# Metadata
+METADATA:
+  EXIST_URL: 'https://user:password@metadata.example.com/exist/rest'
+  CATALOG_URL: 'https://catalog.example.com/catalog/mods'
+
+# Squash
+SQUASH:
+  API_HOST: 'https://squash-host.example.com'
+  API_KEY: 'squash-api-key'
+  DISABLE: <%= (Rails.env.development? || Rails.env.test?) %>
+
+# Stacks
+STACKS:
+  DOCUMENT_CACHE_STORAGE_ROOT: '/foo/document_cache'
+  DOCUMENT_CACHE_HOST: 'cache.example.com'
+  DOCUMENT_CACHE_USER: 'user'
+  LOCAL_WORKSPACE_ROOT: '/foo/workspace'
+  STORAGE_ROOT: '/bar'
+  HOST: 'stacks.example.com'
+  USER: 'user'
+
+# Stomp
+STOMP_CLIENT_ID: 'fedora_stomper'
+
+# Suri
+SURI:
+  MINT_IDS: true
+  ID_NAMESPACE: 'druid'
+  URL: 'https://suri.example.com'
+  USER: 'user'
+  PASS: 'pass'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,25 +1,24 @@
 # Example settings for configuration
 
+# General
+CACHE_STORE_NAME: 'argo'
+DATE_FORMAT_STR: '%Y-%m-%d %H:%M:%S.%L'
+REINDEX_ON_FLY: false
+
+# Bulk Metadata
+BULK_METADATA:
+  DIRECTORY: '/foo/bulk'
+  LOG: 'log.txt'
+  XML: 'metadata.xml'
+
 # Content
 CONTENT:
   USER: 'user'
-  BASE_DIR: '/foo/bar'
+  BASE_DIR: '/foo/bar/'
   SERVER_HOST: 'example-bar'
   SDR_SERVER_URL: 'https://sdr.example.com'
   SDR_USER: 'user'
   SDR_PASSWORD: 'password'
-
-# URLs
-DOR_SERVICES_URL: 'https://user:password@dor-services.example.com'
-FEDORA_URL: 'https://fedora.example.com/fedora'
-MDTOOLKIT_URL: 'https://mdtoolkit.example.com/md'
-PURL_URL: 'https://purl.example.com'
-ROBOT_STATUS_URL: 'https://robot.example.com/robots'
-SOLRIZER_URL: 'https://solr.example.com/solr/collection'
-STACKS_FILE_URL: 'https://stacks.example.com/file'
-STACKS_URL: 'https://stacks.example.com/image' # TODO: Verify use doesn't seeem to be in use
-STATUS_INDEXER_URL: 'https://status.example.com/render/?format=json&other=params'
-WORKFLOW_URL: 'https://workflow.example.com/workflow'
 
 # Metadata
 METADATA:
@@ -31,6 +30,12 @@ SQUASH:
   API_HOST: 'https://squash-host.example.com'
   API_KEY: 'squash-api-key'
   DISABLE: <%= (Rails.env.development? || Rails.env.test?) %>
+
+# SSL
+SSL:
+  CERT_FILE: 'cert_name.crt'
+  KEY_FILE: 'key_name.key'
+  KEY_PASS: 'password'
 
 # Stacks
 STACKS:
@@ -52,3 +57,31 @@ SURI:
   URL: 'https://suri.example.com'
   USER: 'user'
   PASS: 'pass'
+
+# URLs
+DOR_SERVICES_URL: 'https://user:password@dor-services.example.com'
+DPG_URL: 'https://dpg.example.com'
+FEDORA_URL: 'https://user:password@fedora.example.com:1000/fedora'
+GSEARCH_URL: 'https://server.example.com/solr/gsearch'
+GSEARCH_REST_URL: 'https://server.example.com/gsearch/rest'
+MDTOOLKIT_URL: 'https://mdtoolkit.example.com/md'
+MODSULATOR_URL: 'https://services.example.com/v1/modsulator'
+NORMALIZER_URL: 'https://services.example.com/v1/normalizer'
+PURL_URL: 'https://purl.example.com'
+ROBOT_STATUS_URL: 'https://robot.example.com/robots'
+SDR_URL: https://user:pass@sdr.example.com/sdr'
+SOLRIZER_URL: 'https://solr.example.com/solr/collection'
+SPREADSHEET_URL: 'https://services.example.com/v1/spreadsheet'
+STACKS_FILE_URL: 'https://stacks.example.com/file'
+STACKS_URL: 'https://stacks.example.com/image' # TODO: Verify use doesn't seeem to be in use
+STATUS_INDEXER_URL: 'https://status.example.com/render/?format=json&other=params'
+WORKFLOW_URL: 'https://workflow.example.com/workflow'
+
+# Webauth
+WEBAUTH:
+  USER: 'user'
+  MAIL: 'user@example.com'
+  LDAPPRIVGROUP: 'group:role|anothergroup:otherrole'
+  SUAFFILIATION: 'org:group'
+  DISPLAYNAME: 'Jane Doe'
+  LDAPAUTHRULE: 'auth-rule'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,0 +1,5 @@
+
+# URLs
+FEDORA_URL: 'http://fedoraAdmin:fedoraAdmin@localhost:8983/fedora'
+SOLRIZER_URL: 'http://localhost:8983/solr/test'
+WORKFLOW_URL: 'https://your-test.workflow-server.com/workflow'


### PR DESCRIPTION
This pull request updates the configuration pattern used in Argo by doing the following:

 - Install and use the [config](https://github.com/railsconfig/config) gem
 - Separating a configuration (not a security vulnerability) from settings which may need to be secure
 - Checking in a default view of configured settings

This was done in a way that aims allow backwards compatibility and to not change any current config object accessing. New configs should be documented in `config/settings.yml` with generic value if security is needed.

Developers can add local configurations by creating `config/settings/development.local.yml` that will override only specified keys.

See follow on tickets #47 & #48 for opportunities for enhancement/refactor

Running tests locally without any additional configs (besides checked in ones) yields 5 failures