### PR TITLE
Fixes failing specs by providing specs with objects that are actually…

### DIFF
--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,25 +1,23 @@
 require 'spec_helper'
 
 describe CatalogController, :type => :controller do
+  let(:druid) { 'hv992ry2431' }
+  let(:item) { double('dor_item', {id: druid}) }
 
   before :each do
-#   log_in_as_mock_user(subject)
-    @druid = 'rn653dy9317'  # a fixture Dor::Item record
-    @item = instantiate_fixture(@druid, Dor::Item)
+    log_in_as_mock_user(subject)
     @user = double(User, :login => 'sunetid', :logged_in? => true, :is_admin => false, :is_viewer => false)
-    allow(Dor).to receive(:find).with("druid:#{@druid}").and_return(@item)
-    allow(Dor::Item).to receive(:find).with("druid:#{@druid}").and_return(@item)
   end
 
   describe "show enforces permissions" do
     describe "without APO" do
       before :each do
-        allow(@item).to receive(:admin_policy_object).and_return(nil)
+        allow(item).to receive(:admin_policy_object).and_return(nil)
       end
       describe "no user" do
         it "basic get redirects to login" do
           expect(subject).to receive(:webauth).and_return(nil)
-          get 'show', :id => @druid
+          get 'show', :id => druid
           expect(response.code).to eq("302")  # redirect for auth
         end
       end
@@ -28,23 +26,23 @@ describe CatalogController, :type => :controller do
           allow(subject).to receive(:current_user).and_return(@user)
         end
         it "unauthorized_user" do
-          get 'show', :id => @druid
+          get 'show', :id => druid
           expect(response.code).to eq("403")  # Forbidden
           expect(response.body).to include 'No APO'
         end
         it "is_admin" do
           allow(@user).to receive(:is_admin).and_return(true)
-          get 'show', :id => @druid
+          get 'show', :id => druid
           expect(response.code).to eq("200")
         end
         it "is_viewer" do
           allow(@user).to receive(:is_viewer).and_return(true)
-          get 'show', :id => @druid
+          get 'show', :id => druid
           expect(response.code).to eq("200")
         end
         it "impersonated_user" do
           allow(@user).to receive(:privgroup).and_return("dlss:testgroup1|dlss:testgroup2|dlss:testgroup3")
-          get 'show', :id => @druid
+          get 'show', :id => druid
           expect(response.code).to eq("403")  # Forbidden
           expect(response.body).to include 'No APO'
         end

--- a/spec/controllers/registration_controller_spec.rb
+++ b/spec/controllers/registration_controller_spec.rb
@@ -204,14 +204,14 @@ describe RegistrationController, :type => :controller do
 
   describe 'tracksheet' do
     it 'should generate a tracking sheet with the right default name' do
-      get 'tracksheet', :druid => 'xb482bw3979'
+      get 'tracksheet', :druid => 'ww057vk7675'
       expect(response.headers["Content-Type"]).to eq("pdf; charset=utf-8")
       expect(response.headers["content-disposition"]).to eq("attachment; filename=tracksheet-1.pdf")
     end
     it 'should generate a tracking sheet with the specified name (and sequence number)' do
       test_name = 'test_name'
       test_seq_no = 7
-      get 'tracksheet', :druid => 'xb482bw3979', :name => test_name, :sequence => test_seq_no
+      get 'tracksheet', :druid => 'ww057vk7675', :name => test_name, :sequence => test_seq_no
       expect(response.headers["content-disposition"]).to eq("attachment; filename=#{test_name}-#{test_seq_no}.pdf")
     end
   end


### PR DESCRIPTION
… able to be indexed. Previously these object druids were not indexable by the CI build

`catalog_controller_spec.rb` also cleaned up to get rid of a lot of no-op expectations.