### PR TITLE
various gem updates, including dor-services

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 
 GIT
   remote: https://github.com/sul-dlss/dor-services.git
-  revision: c1174b3cd5d877a366e7658cd5ce9b523d2c0ff5
+  revision: 327b83c2ae83088502c05b5c96dc83f1083fc54a
   branch: develop
   specs:
     dor-services (5.2.0)
@@ -39,7 +39,7 @@ GIT
       retries
       rsolr-ext (~> 1.0.3)
       ruby-cache (~> 0.3.0)
-      ruby-graphviz (~> 1.0.9)
+      ruby-graphviz
       rubydora (~> 1.6.5)
       solrizer (~> 3.0)
       stanford-mods (~> 1.1)
@@ -154,7 +154,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    childprocess (0.5.6)
+    childprocess (0.5.7)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.0)
     coffee-rails (4.1.0)
@@ -279,7 +279,7 @@ GEM
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.2)
-    minitest (5.8.1)
+    minitest (5.8.2)
     moab-versioning (1.4.4)
       confstruct
       json
@@ -301,7 +301,7 @@ GEM
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
     net-ssh (2.6.8)
-    netrc (0.10.3)
+    netrc (0.11.0)
     newrelic_rpm (3.14.0.305)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
@@ -379,7 +379,7 @@ GEM
     rdf-rdfxml (1.0.1)
       rdf (>= 1.0)
       rdf-xsd (>= 1.0)
-    rdf-xsd (1.1.4)
+    rdf-xsd (1.1.5)
       rdf (~> 1.1, >= 1.1.9)
     ref (2.0.0)
     responders (2.1.0)
@@ -414,7 +414,7 @@ GEM
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
     ruby-cache (0.3.0)
-    ruby-graphviz (1.0.9)
+    ruby-graphviz (1.2.2)
     ruby-prof (0.15.8)
     rubydora (1.6.5)
       activemodel
@@ -501,7 +501,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.1)
     unicode (0.4.4.2)
-    unicorn (4.9.0)
+    unicorn (5.0.0)
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
@@ -592,3 +592,6 @@ DEPENDENCIES
   uglifier (>= 1.0.3)
   unicode
   unicorn
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
new dor-services version should fix the errors when loading test fixtures, which should allow unit tests to pass.

a variety of other incidental gem updates.