### PR TITLE
add phantomjs to the Gemfile, so that installation of phantomjs is handled automatically

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ group :test, :development do
   gem 'pry-rails'
   gem 'coveralls', require: false
   gem 'poltergeist'
+  gem 'phantomjs', :require => 'phantomjs/poltergeist'
 #  gem 'equivalent-xml', '>= 0.6.0'   # For ignoring_attr_values() with arguments
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -324,6 +324,7 @@ GEM
       faraday (~> 0.9.0)
       json
     pdf-core (0.4.0)
+    phantomjs (1.9.8.0)
     poltergeist (1.7.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -566,6 +567,7 @@ DEPENDENCIES
   net-sftp
   newrelic_rpm
   nokogiri (~> 1.6)
+  phantomjs
   poltergeist
   prawn (~> 1)
   prawn-table

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,10 +11,11 @@ require 'capybara/rspec'
 require 'capybara/poltergeist'
 require 'equivalent-xml/rspec_matchers'
 require 'coveralls'
+require 'phantomjs'
 Coveralls.wear!('rails')
 
 Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, {timeout: 60})
+  Capybara::Poltergeist::Driver.new(app, {timeout: 60, phantomjs: Phantomjs.path})
 end
 Capybara.javascript_driver = :poltergeist
 


### PR DESCRIPTION
the addition of this gem allows the user to bundle and run rspec as they normally would, without the need to already have phantomjs installed (now that we use phantomjs for testing).  if phantomjs is already available on the system, nothing is downloaded or installed.

Gemfile was modified as per:  https://github.com/colszowka/phantomjs-gem#usage-with-poltergeistcapybara

spec_helper.rb was modified as per:  https://github.com/colszowka/phantomjs-gem#manual-setup

further info on the gem:  https://github.com/colszowka/phantomjs-gem