### PR TITLE
remove the argo:htaccess rake task

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -25,7 +25,7 @@ set :deploy_to, '/home/lyberadmin/argo'
 # set :pty, true
 
 # Default value for :linked_files is []
-set :linked_files, %w{config/database.yml config/solr.yml config/default_htaccess_directives}
+set :linked_files, %w{config/database.yml config/solr.yml}
 
 # Default value for linked_dirs is []
 set :linked_dirs, %w{log config/certs config/environments tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
@@ -49,16 +49,5 @@ namespace :deploy do
   end
 
   after :publishing, :restart
-
-  after :restart, :initialize_htaccess do
-    on roles(:web), in: :groups, limit: 3, wait: 10 do
-      # Here we can do anything such as:
-      within release_path do
-        with rails_env: fetch(:rails_env) do
-          execute :rake, 'argo:htaccess'
-        end
-      end
-    end
-  end
 
 end

--- a/lib/tasks/argo.rake
+++ b/lib/tasks/argo.rake
@@ -279,29 +279,6 @@ namespace :argo do
     puts "#{facet.items.count} Workgroups:\n#{facet.items.collect(&:value).join(%[\n])}"
   end
 
-  desc "Update the .htaccess file from indexed APOs"
-  task :htaccess => :environment do
-    directives = ['AuthType WebAuth',
-                  'Require privgroup dlss:argo-access',
-                  'WebAuthLdapAttribute suAffiliation',
-                  'WebAuthLdapAttribute displayName',
-                  'WebAuthLdapAttribute mail']
-
-    directives += (File.readlines(File.join(Rails.root, 'config/default_htaccess_directives')) || [])
-    facet = get_workgroups_facet()
-    unless facet.nil?
-      facets = facet.items.collect &:value
-      priv_groups = facets.select { |v| v =~ /^workgroup:/ }
-      directives += priv_groups.collect { |v|
-        ["Require privgroup #{v.split(/:/,2).last}", "WebAuthLdapPrivgroup #{v.split(/:/,2).last}"]
-      }.flatten
-      File.open(File.join(Rails.root, 'public/.htaccess'),'w') do |htaccess|
-        htaccess.puts directives.sort.join("\n")
-      end
-      File.unlink('public/auth/.htaccess') if File.exist?('public/auth/.htaccess')
-    end
-  end  # :htaccess
-
   desc "Update completed/archived workflow counts"
   task :update_archive_counts => :environment do |t|
     Dor.find_all('objectType_ssim:workflow').each(&:update_index)


### PR DESCRIPTION
remove the code for the argo:htaccess rake task, as well as its invocation after restart in deploy.rb.

remove the default_htaccess_directives file that the rake task relied on, as well as the reference to that file in the :linked_files list in deploy.rb.

htaccess generation is no longer needed from argo.  we expect the htaccess file to change infrequently, and do not necessarily expect changes to coincide with web code deployments (which was the expectation set by the code being removed).  this will be managed as part of the deployment code by devops (currently using puppet).