### PR TITLE
various fixes to correct things preventing argo from deploying properly to stage

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -28,7 +28,7 @@ set :deploy_to, '/home/lyberadmin/argo'
 set :linked_files, %w{config/database.yml config/solr.yml config/default_htaccess_directives}
 
 # Default value for linked_dirs is []
-set :linked_dirs, %w{log config/certs config/environments tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
+set :linked_dirs, %w{log config/certs config/settings tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }
@@ -49,16 +49,5 @@ namespace :deploy do
   end
 
   after :publishing, :restart
-
-  after :restart, :initialize_htaccess do
-    on roles(:web), in: :groups, limit: 3, wait: 10 do
-      # Here we can do anything such as:
-      within release_path do
-        with rails_env: fetch(:rails_env) do
-          execute :rake, 'argo:htaccess'
-        end
-      end
-    end
-  end
 
 end

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -2,7 +2,7 @@ server 'argo-stage-b.stanford.edu', user: 'lyberadmin', roles: %w{web db app}
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, "staging"
-set :bundle_without, %w{production development}.join(' ')
+set :bundle_without, %w{test development}.join(' ')
 
 set :deploy_to, '/opt/app/lyberadmin/argo'
 

--- a/config/environments/dor_staging.rb
+++ b/config/environments/dor_staging.rb
@@ -1,9 +1,7 @@
-cert_dir = File.expand_path(File.join(File.dirname(__FILE__),"../certs"))
-
 Dor.configure do
   ssl do
-    cert_file File.join(cert_dir, Settings.SSL.CERT_FILE)
-    key_file File.join(cert_dir, Settings.SSL.KEY_FILE)
+    cert_file Settings.SSL.CERT_FILE
+    key_file Settings.SSL.KEY_FILE
     key_pass Settings.SSL.KEY_PASS
   end
 

--- a/lib/tasks/argo.rake
+++ b/lib/tasks/argo.rake
@@ -278,6 +278,13 @@ namespace :argo do
     puts "#{facet.items.count} Workgroups:\n#{facet.items.collect(&:value).join(%[\n])}"
   end
 
+  # the .htaccess file lists the workgroups that we recognize as relevant to argo.
+  # if a user is in a workgroup, and that workgroup is listed in the .htaccess file,
+  # the name of the workgroup will be in a list of workgroups for the user, passed along
+  # with other webauth info in the request headers.  we use the list of workgroups a user is
+  # in (as well as the user's sunetid) to determine what they can see and do in argo.
+  # NOTE: at present (2015-11-06), this rake task is run regularly by a cron job, so that
+  # the .htaccess file keeps up with workgroup names as listed on APOs in use in argo.
   desc "Update the .htaccess file from indexed APOs"
   task :htaccess => :environment do
     directives = ['AuthType WebAuth',
@@ -290,10 +297,15 @@ namespace :argo do
     facet = get_workgroups_facet()
     unless facet.nil?
       facets = facet.items.collect &:value
+
       priv_groups = facets.select { |v| v =~ /^workgroup:/ }
+      priv_groups += (ADMIN_GROUPS + VIEWER_GROUPS + MANAGER_GROUPS) # we know that we always want these built-in groups to be part of .htaccess
+      priv_groups.uniq! # no need to repeat ourselves (mostly there in case the builtin groups are already listed in APOs)
+
       directives += priv_groups.collect { |v|
         ["Require privgroup #{v.split(/:/,2).last}", "WebAuthLdapPrivgroup #{v.split(/:/,2).last}"]
       }.flatten
+
       File.open(File.join(Rails.root, 'public/.htaccess'),'w') do |htaccess|
         htaccess.puts directives.sort.join("\n")
       end


### PR DESCRIPTION
(similar changes will soon be needed for all other instances).

* _deploy.rb_: `config/environments/` in `:linked_dirs` becomes `config/settings/`, since this is now where per-instance config info lives.
* _deploy.rb_: the post-restart trigger for running the `argo:htaccess` rake task has been removed, as web code deployments don't necessarily coincide with the need for .htaccess refreshing, and the task is run regularly by a cron job anyway.
* _dor_staging.rb_: full paths to cert file and key file are now specified, since they no longer necessarily share a parent directory.  NOTE: a similar change will need to be made in dor_development.rb and dor_production.rb.
* _argo.rake_: `argo:htaccess` rake task now always includes the built-in argo workgroups, and de-dupes the workgroup list.
* _argo.rake_: `argo:htaccess` rake task now has some usage explanation.