### PR TITLE
enables a negative selection for the UseLicense in APO registration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 
 GIT
   remote: https://github.com/sul-dlss/dor-services.git
-  revision: 79bac3829225bda644875b73115527472b2fffc5
+  revision: d96fb43e08547bde54084c3e0914b4d792491d06
   branch: develop
   specs:
     dor-services (5.2.0)
@@ -309,7 +309,7 @@ GEM
       mini_portile (~> 0.6.0)
     nokogiri-happymapper (0.5.9)
       nokogiri (~> 1.5)
-    nom-xml (0.5.3)
+    nom-xml (0.5.4)
       activesupport (>= 3.2.18)
       i18n
       nokogiri
@@ -386,8 +386,8 @@ GEM
     rdf-rdfxml (1.0.1)
       rdf (>= 1.0)
       rdf-xsd (>= 1.0)
-    rdf-xsd (1.1.5)
-      rdf (~> 1.1, >= 1.1.9)
+    rdf-xsd (1.1.5.1)
+      rdf (~> 1.1, >= 1.1.9, < 1.99)
     ref (2.0.0)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)

--- a/app/controllers/apo_controller.rb
+++ b/app/controllers/apo_controller.rb
@@ -87,8 +87,9 @@ class ApoController < ApplicationController
     apo.metadata_source      = md_info[:metadata_source]
     apo.agreement            = md_info[:agreement].to_s
     apo.default_workflow     = md_info[:workflow ] unless (!md_info[:workflow] || md_info[:workflow].length < 5)
-    apo.use_license          = md_info[:use_license]
     apo.default_rights       = md_info[:default_object_rights]
+    # Set the Use License given a machine-readable code for a creative commons or open data commons license
+    apo.use_license          = md_info[:use_license].blank? ? :none : md_info[:use_license]
   end
 
   def register_new_apo

--- a/app/helpers/apo_helper.rb
+++ b/app/helpers/apo_helper.rb
@@ -20,7 +20,7 @@ module ApoHelper
 
   def license_options apo_obj
     cur_use_license = apo_obj ? apo_obj.use_license : nil
-    [['Citation Only','']] + 
+    [['-- none --', '']] +
     options_for_use_license_type(Dor::Editable::CREATIVE_COMMONS_USE_LICENSES, cur_use_license) + 
     options_for_use_license_type(Dor::Editable::OPEN_DATA_COMMONS_USE_LICENSES, cur_use_license)
   end


### PR DESCRIPTION
Fixes #69

Note that there's no unit tests for a generic APO creation:

  https://github.com/sul-dlss/argo/blob/develop/spec/controllers/apo_controller_spec.rb#L29