### PR TITLE
add webmock to mock workflow-services & fix ci FTW

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ db/*.sqlite3
 dpg_pool
 gem_graph.png
 jetty/
-log/*.log
+/log
 public/.htaccess
 public/assets
 public/images/.dpg_pool

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 app/assets/javascripts/jqgrid/
 config/certs
 config/newrelic.yml
-config/solr.yml
 coverage/
 db/*.sqlite3
 dpg_pool

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,5 @@ jdk:
 email: false
 before_script:
   - if [[ -r /etc/hosts ]]; then cat /etc/hosts ; fi
-  - bundle exec rails generate argo:solr
 script: bundle exec rake ci
 sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,7 @@ group :test, :development do
   gem 'coveralls', require: false
   gem 'poltergeist'
   gem 'phantomjs', :require => 'phantomjs/poltergeist'
+  gem 'webmock'
 #  gem 'equivalent-xml', '>= 0.6.0'   # For ignoring_attr_values() with arguments
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,6 +175,8 @@ GEM
       simplecov (~> 0.10.0)
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
     daemons (1.2.3)
     dalli (2.7.4)
     debugger (1.6.8)
@@ -433,6 +435,7 @@ GEM
       nokogiri
       rest-client
     rubyzip (1.1.7)
+    safe_yaml (1.0.4)
     sass (3.4.19)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -513,6 +516,9 @@ GEM
       raindrops (~> 0.7)
     uuidtools (2.1.5)
     validatable (1.6.7)
+    webmock (1.17.4)
+      addressable (>= 2.2.7)
+      crack (>= 0.3.2)
     websocket (1.2.2)
     websocket-driver (0.6.2)
       websocket-extensions (>= 0.1.0)
@@ -603,3 +609,7 @@ DEPENDENCIES
   uglifier (>= 1.0.3)
   unicode
   unicorn
+  webmock
+
+BUNDLED WITH
+   1.10.6

--- a/config/initializers/webmock.rb
+++ b/config/initializers/webmock.rb
@@ -1,0 +1,14 @@
+def mock_workflow_requests
+  escaped_url = Settings.WORKFLOW_URL.gsub('/', '\/')
+  stub_request(:get, /#{escaped_url}workflow_archive.*/).
+    to_return(body: '<objects count="1"/>')
+  stub_request(:get, /#{escaped_url}dor.*/).
+    to_return(body: '<workflows/>')
+end
+
+unless Rails.env.production?
+  require 'webmock'
+  include WebMock::API
+  WebMock.allow_net_connect!
+  mock_workflow_requests unless Settings.DISABLE_WEBMOCK
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -88,7 +88,7 @@ SPREADSHEET_URL: 'https://services.example.com/v1/spreadsheet'
 STACKS_FILE_URL: 'https://stacks.example.com/file'
 STACKS_URL: 'https://stacks.example.com/image' # TODO: Verify use doesn't seeem to be in use
 STATUS_INDEXER_URL: 'https://status.example.com/render/?format=json&other=params'
-WORKFLOW_URL: 'https://workflow.example.com/workflow'
+WORKFLOW_URL: 'https://workflow.example.com/workflow/'
 
 # Webauth is null by default.
 # To specify it to fake webauth credentials for dev instances,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,6 +28,9 @@ CONTENT:
   SDR_USER: 'user'
   SDR_PASSWORD: 'password'
 
+# Webmock settings
+DISABLE_WEBMOCK: false
+
 # Metadata
 METADATA:
   EXIST_URL: 'https://user:password@metadata.example.com/exist/rest'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -2,4 +2,3 @@
 # URLs
 FEDORA_URL: 'http://fedoraAdmin:fedoraAdmin@localhost:8983/fedora'
 SOLRIZER_URL: 'http://localhost:8983/solr/test'
-WORKFLOW_URL: 'https://your-test.workflow-server.com/workflow'

--- a/config/solr.yml
+++ b/config/solr.yml
@@ -1,0 +1,16 @@
+# = jetty_path key
+# each environment can have a jetty_path with absolute or relative
+# (to app root) path to a jetty/solr install. This is used
+# by the rake tasks that start up solr automatically for testing
+# and by rake solr:marc:index.  
+#
+# jetty_path is not used by a running Blacklight application
+# at all. In general you do NOT need to deploy solr in Jetty, you can deploy it
+# however you want.  
+# jetty_path is only required for rake tasks that need to know
+# how to start up solr, generally for automated testing. 
+
+development:
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr" %>
+test: &test
+  url: <%= ENV['TEST_SOLR_URL'] || "http://127.0.0.1:8983/solr/test" %>

--- a/lib/tasks/argo.rake
+++ b/lib/tasks/argo.rake
@@ -19,6 +19,7 @@ task :default => [:ci]
 
 task :ci do
   ENV['RAILS_ENV'] = 'test'
+  WebMock.allow_net_connect!
   Rake::Task['argo:install'].invoke
   jetty_params = jettywrapper_load_config()
   error = Jettywrapper.wrap(jetty_params) do

--- a/lib/tasks/argo.rake
+++ b/lib/tasks/argo.rake
@@ -36,11 +36,8 @@ end
 
 namespace :argo do
   desc "Install db, jetty (fedora/solr) and configs fresh"
-  task :install => ['argo:jetty:clean', 'argo:jetty:config', 'db:setup', 'db:migrate', 'tmp:create'] do
-    ['rails generate argo:solr'].each{ |cmd|
-      puts cmd
-      system cmd
-    }
+  task :install => ['argo:jetty:clean', 'argo:jetty:config', 'db:setup', 'db:migrate'] do
+    puts 'Installed Argo'
   end
 
   desc "Bump Argo's version number before release"


### PR DESCRIPTION
This work fixes the failing travis builds by doing the following:

 - Allow fixtures to actually load, by using @drh-stanford's suggestion of [mocking wfs requests](https://github.com/sul-dlss/argo/pull/120#issuecomment-154692603)
    - needed here was the need to mock both `/dor/*` and `/workflow_archive*` paths a bit differently
    - `WebMock` is loaded in the `development` and `test` gem groups, but is disabled in `production` or when you set `Settings.DISABLE_WEBMOCK = true`
 - 3981a436035af1296905b1988ce634060d038693 removes an unnecessary setting that is set, and puts the default one in the correct format with trailing `/`
 - When `argo:repo:load` 

_Note: With these changes, I don't thing `test.local.yml` is needed for running tests._

Possible enhancements:
 - remove argo solr generator, I'm not sure what the impetus of this was, but AFAIK it's now not being used
 - Potentially delete `testcores` or reduce just to one. Fixtures can be loaded into Fedora in `development` environment and then is indexed in `development` solr core. But that same data needs to be dropped, and reloaded to run in specs against in `test` environment. Not sure about the history here either, so left it untouched.

Would like feedback from others about potential impact of mocking WFS, and the Solr cores dev vs test.

~~TODO~~ Completed during development:
 - [x] Still getting one error on `** File 48` where `to_solr` is being called for tm388wy6148, and throwing `undefined method `value' for nil:NilClass` from https://github.com/sul-dlss/dor-services/blob/develop/lib/dor/models/workflow_object.rb#L51
 - [x] need to figure out a better way to configure WebMock before hydrajetty requests gem download
 - [x] down to only 3 failing specs now... progress