### PR TITLE
[WIP] use default Bootstrap button groups, rather than custom Argo one and …

### DIFF
--- a/app/assets/stylesheets/argo/argo.css.sass
+++ b/app/assets/stylesheets/argo/argo.css.sass
@@ -97,9 +97,6 @@ table
     &:after
       color: red
       content: '[X]'
-.show_sidebar
-  ul
-    list-style-type: none
 .blacklight-wf_error_ssim
   color: red
 #doc4
@@ -154,17 +151,6 @@ table
   font: Arial
   border: 1px solid #84bbf3
 
-a.button
-  width: 115px
-  text-align: left
-  display: block
-  margin-bottom: 3px
-.btn
-  font-size: 12px
-  line-height: 14px
-  margin-bottom: 1px
-a.button:hover
-  background: #4479BA !important
 .CodeRay
   pre
     border: none !important

--- a/app/assets/stylesheets/argo/show.scss
+++ b/app/assets/stylesheets/argo/show.scss
@@ -1,0 +1,3 @@
+.argo-show-btn-group {
+  width: 100%;
+}

--- a/app/views/catalog/_show_external_links.html.erb
+++ b/app/views/catalog/_show_external_links.html.erb
@@ -1,6 +1,6 @@
 <div class="show_sidebar">
   <h3 class="start-open">View in new window</h3>
-  <ul>
+  <ul class='nav nav-stacked'>
     <li><%= render_purl_link document %></li>
     <% if document.has? 'catkey_id_ssim' %>
     <li><%= render_searchworks_link document %></li>

--- a/app/views/items/_button_link_list.html.erb
+++ b/app/views/items/_button_link_list.html.erb
@@ -1,4 +1,4 @@
-<ul>
+<div class='btn-group-vertical argo-show-btn-group' role='group' aria-label='Argo action buttons'>
   <%buttons.each do |button|%>
     <%
       button_data = {}
@@ -9,6 +9,6 @@
         button_data[:ajax_modal] = 'trigger'
       end
     %>
-    <li><%= link_to button[:label], button[:url], class: 'btn button btn-primary', data: button_data %></li>
+    <%= link_to button[:label], button[:url], class: 'btn button btn-primary', data: button_data %>
   <%end%>
-</ul>
+</div>


### PR DESCRIPTION
…use nav-stacked for link list

Rather than rolling our own ui elements, just use the vanilla ones from Bootstrap. Also adds some affordances to users interacting with buttons and links

## Before
<img width="329" alt="screen shot 2015-11-08 at 10 07 09 am" src="https://cloud.githubusercontent.com/assets/1656824/11021228/a197cfca-8600-11e5-8705-5d3a4a0db508.png">
## After
<img width="335" alt="screen shot 2015-11-08 at 10 06 37 am" src="https://cloud.githubusercontent.com/assets/1656824/11021230/a8c93dec-8600-11e5-8be9-2fcaa50bd15d.png">
