### PR TITLE
Link list updates, with added specs

### DIFF
--- a/app/helpers/argo_helper.rb
+++ b/app/helpers/argo_helper.rb
@@ -197,23 +197,19 @@ module ArgoHelper
   end
 
   def render_dpg_link document
-    val = document.get('id').split(/:/).last
-    link_to "DPG Object Status", File.join(Argo::Config.urls.dpg, val)
+    link_to "DPG Object Status", File.join(Argo::Config.urls.dpg, document.druid)
   end
 
   def render_purl_link document, link_text = 'PURL', opts = {:target => '_blank'}
-    val = document.get('id').split(/:/).last
-    link_to link_text, File.join(Argo::Config.urls.purl, val), opts
+    link_to link_text, File.join(Argo::Config.urls.purl, document.druid), opts
   end
 
   def render_dor_link document, link_text = 'Fedora UI', opts = {:target => '_blank'}
-    val = document.get('id')
-    link_to link_text, File.join(Dor::Config.fedora.safeurl, "objects/#{val}"), opts
+    link_to link_text, File.join(Dor::Config.fedora.safeurl, "objects/#{document.id}"), opts
   end
 
   def render_foxml_link document, link_text = 'FoXML', opts = {:target => '_blank'}
-    val = document.get('id')
-    link_to link_text, File.join(Dor::Config.fedora.safeurl, "objects/#{val}/objectXML"), opts
+    link_to link_text, File.join(Dor::Config.fedora.safeurl, "objects/#{document.id}/objectXML"), opts
   end
 
   def render_solr_link document
@@ -228,8 +224,7 @@ module ArgoHelper
   end
 
   def render_searchworks_link document, link_text = 'Searchworks', opts = {:target => '_blank'}
-    val = document.get('catkey_id_ssim')
-    link_to link_text, "http://searchworks.stanford.edu/view/#{val}", opts
+    link_to link_text, "http://searchworks.stanford.edu/view/#{document.catkey}", opts
   end
 
   def render_mdtoolkit_link document, link_text = 'MD Toolkit', opts = {:target => '_blank'}
@@ -248,11 +243,11 @@ module ArgoHelper
   end
 
   def render_full_dc_link document, link_text = "View full Dublin Core"
-    link_to link_text, dc_aspect_view_catalog_path(document.get('id')), :title => 'Dublin Core (derived from MODS)', :data => { ajax_modal: 'trigger' }
+    link_to link_text, dc_aspect_view_catalog_path(document.id), :title => 'Dublin Core (derived from MODS)', :data => { ajax_modal: 'trigger' }
   end
 
   def render_mods_view_link document, link_text = "View MODS"
-    link_to link_text, purl_preview_item_url(document.get('id')), :title => 'MODS View', :data => { ajax_modal: 'trigger' }
+    link_to link_text, purl_preview_item_url(document.id), :title => 'MODS View', :data => { ajax_modal: 'trigger' }
   end
 
   def render_full_view_links document

--- a/app/helpers/argo_helper.rb
+++ b/app/helpers/argo_helper.rb
@@ -227,15 +227,6 @@ module ArgoHelper
     link_to link_text, "http://searchworks.stanford.edu/view/#{document.catkey}", opts
   end
 
-  def render_mdtoolkit_link document, link_text = 'MD Toolkit', opts = {:target => '_blank'}
-    val = document.get('mdtoolkit_id_ssim')
-    forms = JSON.parse(RestClient.get('http://lyberapps-prod.stanford.edu/forms.json'))
-    form = document.get('mdform_tag_ssim')
-    collection = forms.keys.find { |k| forms[k].keys.include?(form) }
-    return unless form && collection
-    link_to link_text, File.join(Argo::Config.urls.mdtoolkit, collection, form, 'edit', val), opts
-  end
-
   def render_section_header_link section, document
     section_header_method = blacklight_config[:show][:section_links][section]
     return if section_header_method.nil?

--- a/app/models/concerns/catkey_concern.rb
+++ b/app/models/concerns/catkey_concern.rb
@@ -1,0 +1,12 @@
+module CatkeyConcern
+  extend Blacklight::Solr::Document
+
+  ##
+  # Access a SolrDocument's catkey
+  # @return [String, nil]
+  def catkey
+    fetch(:catkey_id_ssim).first
+  rescue KeyError
+    nil
+  end
+end

--- a/app/models/concerns/druid_concern.rb
+++ b/app/models/concerns/druid_concern.rb
@@ -1,0 +1,10 @@
+module DruidConcern
+  extend Blacklight::Solr::Document
+
+  ##
+  # Access a SolrDocument's druid parsed from the id format of 'druid:abc123'
+  # @return [String]
+  def druid
+    id.split(/:/).last
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -2,6 +2,8 @@
 class SolrDocument
 
   include Blacklight::Solr::Document
+  include CatkeyConcern
+  include DruidConcern
 
   # self.unique_key = 'id'
 

--- a/app/views/catalog/_show_external_links.html.erb
+++ b/app/views/catalog/_show_external_links.html.erb
@@ -1,3 +1,5 @@
+<% document ||= @document %>
+
 <div class="show_sidebar">
   <h3 class="start-open">View in new window</h3>
   <ul class='nav nav-stacked'>

--- a/app/views/catalog/_show_external_links.html.erb
+++ b/app/views/catalog/_show_external_links.html.erb
@@ -2,7 +2,7 @@
   <h3 class="start-open">View in new window</h3>
   <ul class='nav nav-stacked'>
     <li><%= render_purl_link document %></li>
-    <% if document.has? 'catkey_id_ssim' %>
+    <% if document.catkey.present? %>
     <li><%= render_searchworks_link document %></li>
     <% end %>
     <% if document.has? 'mdtoolkit_id_ssim' %>
@@ -13,5 +13,6 @@
     <li><%= render_solr_link document %></li>
     <li><small><%= render_index_info document %></small></li>
   </ul>
+  <hr>
   <%= render(:partial => 'items/button_link_list', :locals => {:buttons => (render_buttons document, @obj)})%>
 </div>

--- a/app/views/catalog/_show_external_links.html.erb
+++ b/app/views/catalog/_show_external_links.html.erb
@@ -5,9 +5,6 @@
     <% if document.catkey.present? %>
     <li><%= render_searchworks_link document %></li>
     <% end %>
-    <% if document.has? 'mdtoolkit_id_ssim' %>
-    <li><%= render_mdtoolkit_link document %></li>
-    <% end %>
     <li><%= render_dor_link document %></li>
     <li><%= render_foxml_link document %></li>
     <li><%= render_solr_link document %></li>

--- a/spec/models/concerns/catkey_concern_spec.rb
+++ b/spec/models/concerns/catkey_concern_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe CatkeyConcern do
+  let(:document) { SolrDocument.new(document_attributes) }
+  describe '#catkey' do
+    describe 'without one present' do
+      let(:document_attributes) { { not_a_catkey: '8675309' } }
+      it 'should return nil' do
+        expect(document.catkey).to be_nil
+      end
+    end
+    describe 'when a catkey is present' do
+      let(:document_attributes) { { catkey_id_ssim: ['8675309'] } }
+      it 'should return catkey value' do
+        expect(document.catkey).to eq '8675309'
+      end
+    end
+  end
+end

--- a/spec/models/concerns/druid_concern_spec.rb
+++ b/spec/models/concerns/druid_concern_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe DruidConcern do
+  let(:document) { SolrDocument.new(document_attributes) }
+  let(:document_attributes) { { id: 'druid:abc123456' } }
+  describe '#druid' do
+    it 'should return the druid' do
+      expect(document.druid).to eq 'abc123456'
+    end
+  end
+end

--- a/spec/views/catalog/_show_external_links.html.erb_spec.rb
+++ b/spec/views/catalog/_show_external_links.html.erb_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe 'catalog/_show_external_links.html.erb' do
+  let(:document) do
+    SolrDocument.new(id: 'druid:abc123', catkey_id_ssim: 'catz')
+  end
+  let(:current_user) { double('current_user', is_admin: false) }
+  before(:each) do
+    config = Blacklight::Configuration.new
+    allow(view).to receive(:blacklight_config).and_return(config)
+    assign(:document, document)
+  end
+  it 'renders link list' do
+    expect(view).to receive(:current_user).and_return(current_user)
+    expect(view).to receive(:render_buttons).and_return({})
+    render
+    expect(rendered).to have_css '.show_sidebar'
+    expect(rendered).to have_css 'ul.nav.nav-stacked'
+    expect(rendered).to have_css 'li', count: 6
+  end
+end

--- a/spec/views/items/_button_link_list.html.erb_spec.rb
+++ b/spec/views/items/_button_link_list.html.erb_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'items/_button_link_list.html.erb' do
+  let(:buttons) {
+    [
+      {
+        label: 'Click me',
+        url: 'http://www.example.com/click'
+      },
+      {
+        label: 'Confirm me',
+        url: 'http://www.example.com/confirm',
+        confirm: true
+      },
+      {
+        label: 'Ajax me',
+        url: 'http://www.example.com/ajax',
+        ajax_modal: true
+      }
+    ]
+  }
+  it 'should contain button group, with specific buttons' do
+    render 'items/button_link_list', buttons: buttons
+    expect(rendered).to have_css '.btn-group-vertical.argo-show-btn-group'
+    expect(rendered).to have_css 'a', count: buttons.length
+    expect(rendered).to have_css 'a[href="http://www.example.com/click"]', text: 'Click me'
+    expect(rendered).to have_css 'a[href="http://www.example.com/confirm"][data-confirm="true"]', text: 'Confirm me'
+    expect(rendered).to have_css 'a[href="http://www.example.com/ajax"][data-ajax-modal="trigger"]', text: 'Ajax me'
+  end
+end


### PR DESCRIPTION
This PR initially intended for #123 adds in view specs for link list and button list on show page.

Then 6dac49e drys up `argo_helper.rb` by creating mixed in `SolrDocument` concerns and use already available methods on `SolrDocument`.

In addition, bc2af9b removes legacy mdtoolkit links from sidebar, closes #124 