### PR TITLE
fixes for installing on laptop

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,7 @@ For vanilla Stanford laptop installations, the cert files and the local settings
 ### Install components, setup DB and Solr:
 
 ```bash
-rails generate argo:solr
-rake argo:jetty:clean
-rake argo:jetty:config
-rake db:setup
-rake db:migrate
-rake tmp:create
+rake argo:install
 ```
 
 ### Optional - Increase Jetty heap size and Solr logging verbosity
@@ -82,6 +77,12 @@ rails server
 
 ```bash
 rake argo:repo:load
+```
+
+## Run the tests
+
+```bash
+rspec
 ```
 
 ## Delete records

--- a/lib/tasks/argo.rake
+++ b/lib/tasks/argo.rake
@@ -19,7 +19,6 @@ task :default => [:ci]
 
 task :ci do
   ENV['RAILS_ENV'] = 'test'
-  WebMock.allow_net_connect!
   Rake::Task['argo:install'].invoke
   jetty_params = jettywrapper_load_config()
   error = Jettywrapper.wrap(jetty_params) do
@@ -67,6 +66,7 @@ namespace :argo do
 
     desc "Get fresh hydra-jetty [target tag, default: #{WRAPPER_VERSION}] -- DELETES/REPLACES SOLR AND FEDORA"
     task :clean, [:target] do |t, args|
+      WebMock.allow_net_connect!
       args.with_defaults(:target=> WRAPPER_VERSION)
       jettywrapper_load_config()
       Jettywrapper.hydra_jetty_version = args[:target]


### PR DESCRIPTION
* _README.md_: update "Install components" section to just use `rake argo:install` now that it works.
* _README.md_: suggest running the tests.
* _argo.rake_: move "WebMock.allow_net_connect!" call from ci task to `argo:jetty:clean` task, since that's what actually always needs it.