### PR TITLE
Full screen

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,7 @@ class ApplicationController < ActionController::Base
     enable_squash_client
   end
 
-  layout 'blacklight'
+  layout 'application'
 
   def initialize(*args)
     super

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
 
   <%= render partial: 'shared/ajax_modal' %>
 
-  <div id="main-container" class="container">
+  <div id="main-container" class="container-fluid">
     <%= render :partial=>'/flash_msg', layout: 'shared/flash_messages' %>
 
     <div class="row">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,31 +16,33 @@
       <meta http-equiv="cleartype" content="on">
     <![endif]-->
 
-    <title><%= @title %></title>
-    <%= yield :head %>
-
+    <title><%= render_page_title %></title>
     <%= opensearch_description_tag application_name, opensearch_catalog_url(:format => 'xml') %>
     <%= favicon_link_tag 'favicon.ico' %>
     <%= stylesheet_link_tag "application", media: "all" %>
+    <%= javascript_include_tag "application" %>
     <%= csrf_meta_tags %>
+    <%= content_for(:head) %>
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
       <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
+
   </head>
   <body data-application-root="<%= ENV['RACK_BASE_URI'] %>" class="<%= render_body_class %>">
-    <%= render :partial => 'shared/header_navbar' %>
+  <%= render :partial => 'shared/header_navbar' %>
 
-    <%= render partial: 'shared/ajax_modal' %>
+  <%= render partial: 'shared/ajax_modal' %>
 
-    <div id="main-container" class="container">
-      <%= render :partial=>'/flash_msg', layout: 'shared/flash_messages' %>
-      
-      <div class="row">
-        <%= yield %>
-      </div>
+  <div id="main-container" class="container">
+    <%= render :partial=>'/flash_msg', layout: 'shared/flash_messages' %>
+
+    <div class="row">
+      <%= yield %>
     </div>
-    <%= render :partial => 'shared/footer' %>
+  </div>
+
+  <%= render :partial => 'shared/footer' %>
   </body>
 </html>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,0 +1,25 @@
+<%# Default Blacklight _header_navbar.html.erb with only .container changed to .container-fluid %>
+
+<div id="header-navbar" class="navbar navbar-inverse navbar-static-top" role="navigation">
+  <div class="container-fluid">
+    <div class="navbar-header">
+    <button type="button" class="navbar-toggle btn collapsed" data-toggle="collapse" data-target="#user-util-collapse">
+      <span class="sr-only">Toggle navigation</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
+    <%= link_to application_name, root_path, class: "navbar-brand" %>
+    </div>
+
+    <div class="collapse navbar-collapse" id="user-util-collapse">
+      <%= render :partial=>'/user_util_links' %>
+    </div>
+  </div>
+</div>
+
+<div id="search-navbar" class="navbar navbar-default navbar-static-top" role="navigation">
+  <div class="container-fluid">
+    <%= render_search_bar  %>
+  </div>
+</div>

--- a/spec/features/full_width_spec.rb
+++ b/spec/features/full_width_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+feature 'Full width' do
+  before :each do
+    @current_user = double(
+      :webauth_user,
+      login: 'sunetid',
+      logged_in?: true,
+      permitted_apos: [],
+      is_admin: true
+    )
+    allow_any_instance_of(ApplicationController).to receive(:current_user).
+      and_return(@current_user)
+  end
+  scenario 'has bootstrap full width classes' do
+    visit root_path
+    expect(page).to have_css '#main-container.container-fluid'
+    expect(page).to have_css '#search-navbar .container-fluid'
+    expect(page).to have_css '#header-navbar .container-fluid'
+  end
+end


### PR DESCRIPTION
`application.html.erb` locally in argo wasn't even being used. 135cb05 syncs up local layout to reflect Blacklight's (with a minor data attribute added).

af136f5 allows argo to take advantage of Bootstraps fullscreen layout

## Before
<img width="1116" alt="screen shot 2015-11-09 at 8 05 32 am" src="https://cloud.githubusercontent.com/assets/1656824/11039003/8ecd6570-86ba-11e5-9d04-f0ac6413e622.png">
<img width="1119" alt="screen shot 2015-11-09 at 8 05 43 am" src="https://cloud.githubusercontent.com/assets/1656824/11039005/91a809ee-86ba-11e5-967f-88d366503a5b.png">
<img width="1116" alt="screen shot 2015-11-09 at 8 05 52 am" src="https://cloud.githubusercontent.com/assets/1656824/11039007/944e6404-86ba-11e5-9513-9912cf2ee269.png">

## After
<img width="1118" alt="screen shot 2015-11-09 at 8 06 24 am" src="https://cloud.githubusercontent.com/assets/1656824/11039013/99d89958-86ba-11e5-93d3-e9f04ad822dd.png">
<img width="1118" alt="screen shot 2015-11-09 at 8 06 16 am" src="https://cloud.githubusercontent.com/assets/1656824/11039014/99e986e6-86ba-11e5-9c30-902c64e5efe9.png">
<img width="1118" alt="screen shot 2015-11-09 at 8 06 08 am" src="https://cloud.githubusercontent.com/assets/1656824/11039015/99f42380-86ba-11e5-81a0-77214eb51b46.png">
