### PR TITLE
only use Solr core `development` for development and testing

### DIFF
--- a/config/solr.yml
+++ b/config/solr.yml
@@ -13,4 +13,4 @@
 development:
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr" %>
 test: &test
-  url: <%= ENV['TEST_SOLR_URL'] || "http://127.0.0.1:8983/solr/test" %>
+  url: <%= ENV['TEST_SOLR_URL'] || "http://127.0.0.1:8983/solr" %>

--- a/lib/tasks/argo.rake
+++ b/lib/tasks/argo.rake
@@ -85,7 +85,7 @@ namespace :argo do
   fedora_fileglob   = "#{Rails.root}/#{fedora_conf_dir}/data/*.xml"
   fedora_files      = File.foreach(File.join(File.expand_path('../../../fedora_conf/data/', __FILE__), 'load_order')).to_a
   live_solrxml_file = "jetty/solr/solr.xml"
-  testcores = {'development' => 'development-core', 'test' => 'test-core'}  # name => path
+  testcores = {'development' => 'development-core' } # name => path
   restcore_url = Blacklight.solr.options[:url] + "/admin/cores?action=STATUS&wt=json"
   realcores = []
 


### PR DESCRIPTION
Closes #128 

This PR aims to reduce confusion on "what task indexed what where". Previously when running:

 - `rake ci` would index features into `test` core
 - `rake argo:repo:load` would index features into `development` core

Just put everything into development core to reduce confusion which should provide for a more cohesive dev experience.