### PR TITLE
ignore locally deployed bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ tmp/
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
+
+vendor/ruby/


### PR DESCRIPTION
ignores the `vendor/` folder for locally deployed bundles (i.e., `bundle --path vendor`)