### PR TITLE
ensure we have new workflows datastream before we index item

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -609,7 +609,12 @@ class ItemsController < ApplicationController
       render :status => 500, :text => "#{params[:wf]} already exists!"
       return
     end
-    @object.initialize_workflow(params[:wf])
+    @object.create_workflow(params[:wf])
+
+    # sync up the workflows datastream with workflow service and force a reindex before redirection
+    reindex Dor::Item.find(params[:id])
+    Dor::SearchService.solr.commit
+
     if params[:bulk]
       render :text => "Added #{params[:wf]}"
     else

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -374,12 +374,12 @@ describe ItemsController, :type => :controller do
       expect(@item).to receive(:workflows).and_return @wf
     end
     it 'should initialize the new workflow' do
-      expect(@item).to receive(:initialize_workflow)
-      expect(@wf).to receive(:[]).and_return(nil)
+      expect(@item).to receive(:create_workflow)
+      expect(@wf).to receive(:[]).with('accessionWF').and_return(nil)
       post 'add_workflow', :id => @pid, :wf => 'accessionWF'
     end
     it 'shouldnt initialize the workflow if one is already active' do
-      expect(@item).not_to receive(:initialize_workflow)
+      expect(@item).not_to receive(:create_workflow)
       mock_wf = double()
       expect(mock_wf).to receive(:active?).and_return(true)
       expect(@wf).to receive(:[]).and_return(mock_wf)


### PR DESCRIPTION
This fixes #72. It requires `dor-services`. It will *not* work until PR https://github.com/sul-dlss/dor-services/pull/112 is merged.