### PR TITLE
more fixes to allow deployment to argo-stage et al

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,21 @@ source "https://rubygems.org"
 
 gem 'addressable', '=2.3.5' #>=2.3.6 breaks things w/ the following error on rails startup:  "can't modify frozen Addressable::URI"
 gem 'barby'
+gem 'bootstrap-sass'
 gem 'coderay'
+gem 'coffee-rails'
+gem 'config'
 gem 'confstruct', "~> 0.2.4"
 gem 'dalli'
-#gem 'equivalent-xml', '~> 0.5.1'
+gem 'daemons'
+gem 'delayed_job'
+gem 'delayed_job_active_record'
+gem 'equivalent-xml', '>= 0.6.0'   # For ignoring_attr_values() with arguments
 gem 'haml'
+gem 'jqgrid-jquery-rails'
+gem 'jquery-rails'
+gem 'jquery-ui-rails'
+gem 'jquery-validation-rails'
 gem 'kaminari'
 gem 'kgio'
 gem 'mysql2', '~> 0.3.2'    # Temporary fix for mysql2/rails incompatibility, see https://github.com/brianmario/mysql2/issues/675
@@ -21,16 +31,14 @@ gem 'rake'
 gem 'rest-client'
 gem 'retries'
 gem 'ruby-graphviz'
+gem 'sass-rails'
 gem 'squash_rails', '=1.3.3', :require => 'squash/rails'  #TODO: upgrading to 1.3.4 results in weird error output at end of deployment, pinning for now
 gem 'squash_ruby',  :require => 'squash/ruby'
+gem 'therubyracer', "~> 0.11"
 gem 'thin' # or mongrel
 gem 'thread', :git => 'https://github.com/meh/ruby-thread.git'
+gem 'uglifier', '>= 1.0.3'
 gem 'unicode'
-gem 'delayed_job'
-gem 'delayed_job_active_record'
-gem 'daemons'
-gem 'equivalent-xml', '>= 0.6.0'   # For ignoring_attr_values() with arguments
-gem 'config'
 
 # Stanford/Hydra related gems
 gem 'about_page'
@@ -69,24 +77,11 @@ group :test, :development do
   gem 'poltergeist'
   gem 'phantomjs', :require => 'phantomjs/poltergeist'
   gem 'webmock'
-#  gem 'equivalent-xml', '>= 0.6.0'   # For ignoring_attr_values() with arguments
 end
 
 group :development do
   gem 'ruby-prof'
   gem 'sqlite3'
-end
-
-group :assets do
-  gem 'coffee-rails'
-  gem 'uglifier', '>= 1.0.3'
-  gem 'jquery-rails'
-  gem 'jquery-ui-rails'
-  gem 'jquery-validation-rails'
-  gem 'jqgrid-jquery-rails'
-  gem 'therubyracer', "~> 0.11"
-  gem 'sass-rails'
-  gem 'bootstrap-sass'
 end
 
 group :deployment do

--- a/app/assets/stylesheets/argo/argo.sass
+++ b/app/assets/stylesheets/argo/argo.sass
@@ -1,4 +1,3 @@
-
 #header-navbar 
   a.navbar-brand
     background: transparent image_url('/assets/argo4.png') no-repeat top left

--- a/config/initializers/webmock.rb
+++ b/config/initializers/webmock.rb
@@ -6,7 +6,7 @@ def mock_workflow_requests
     to_return(body: '<workflows/>')
 end
 
-unless Rails.env.production?
+if Rails.env.development? || Rails.env.test?
   require 'webmock'
   include WebMock::API
   WebMock.allow_net_connect!

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,7 +10,7 @@ APPLICATION:
   CACHE_CLASSES: true
   ASSETS:
     COMPRESS: true
-    PRECOMPILE: ['about.css.sass', 'argo.css', 'registration.css', 'report.css', 'webcrop.css', '*.js', '*.coffee']
+    PRECOMPILE: ['about.css.sass', 'registration.css', 'report.css', 'webcrop.css', '*.js', '*.coffee']
 
 # Bulk Metadata
 BULK_METADATA:

--- a/lib/tasks/argo.rake
+++ b/lib/tasks/argo.rake
@@ -4,7 +4,6 @@ require 'rest_client'
 require 'open-uri'
 require 'fileutils'
 require 'retries'
-require 'rspec/core/rake_task'
 
 desc "Get application version"
 task :app_version do
@@ -28,9 +27,13 @@ task :ci do
   raise "test failures: #{error}" if error
 end
 
-# Larger integration/acceptance style tests (take several minutes to complete)
-RSpec::Core::RakeTask.new(:integration_tests) do |spec|
-  spec.pattern = 'spec/integration/**/*_spec.rb'
+if ['test', 'development'].include? ENV['RAILS_ENV']
+  require 'rspec/core/rake_task'
+
+  # Larger integration/acceptance style tests (take several minutes to complete)
+  RSpec::Core::RakeTask.new(:integration_tests) do |spec|
+    spec.pattern = 'spec/integration/**/*_spec.rb'
+  end
 end
 
 namespace :argo do


### PR DESCRIPTION
these fixes should be relevant to other deployments (argo-dev, argo-prod), but they were first implemented to get stage deployments working.

* _Gemfile_: remove the `:assets` group distinction, since Rails 4 no longer recognizes that group (http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-3-2-to-rails-4-0-gemfile)
* _Gemfile_: take the gems that were listed in `:assets`, and move them out into the general dependencies lists.
* _Gemfile_: since we're here, clean up the lists a little (alphebetize strays, remove commented out dupe entries).
* _config/initializers/webmock.rb_:  limit webmock inititialization to the two environments where it's relevant (instead of just excluding production).
* _settings.yml_: remove `'argo.css'` from the PRECOMPILE list.
* _argo.rake_: only create the `:integration_tests` rake task in test and development, since it relies on including rspec/core/rake_task (the rspec gem is only included in development and test).