### PR TITLE
specify encoding explicitly so that tests run without error on laptops

### DIFF
--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'spec_helper'
 
 feature 'Search results' do


### PR DESCRIPTION
i had to do this (on suggestion from @atz) to get things to run properly on my laptop.  otherwise, i get:

```
DN0a2323f8:argo suntzu$ rspec
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's 'rails' settings.
[Coveralls] Outside the CI environment, not sending data.
/Users/suntzu/.rvm/gems/ruby-1.9.3-p551/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:268:in `load': /Users/suntzu/rails_projects/argo/spec/features/search_results_spec.rb:23: invalid multibyte char (US-ASCII) (SyntaxError)
/Users/suntzu/rails_projects/argo/spec/features/search_results_spec.rb:23: invalid multibyte char (US-ASCII)
/Users/suntzu/rails_projects/argo/spec/features/search_results_spec.rb:23: syntax error, unexpected $end, expecting keyword_end
        expect(page).to have_css 'a', text: 'Next »'
                                                    ^
```

i'm actually not sure if this is the right way to fix this, but it did work for me, and tests run now.  totally open to other ideas (or changing a setting/env var/whatever on my laptop, if that's possible and more appropriate).