### PR TITLE
Don't ignore public/asssets . When debuging and updating styles, you …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ gem_graph.png
 jetty/
 /log
 public/.htaccess
-public/assets
 public/images/.dpg_pool
 tmp/
 


### PR DESCRIPTION
…don't want be referencing precompiled assets in public. This will help us catch styling fixes/bugs sooner.