### PR TITLE
switch to new cert path style

### DIFF
--- a/config/environments/dor_development.rb
+++ b/config/environments/dor_development.rb
@@ -1,9 +1,7 @@
-cert_dir = File.expand_path(File.join(File.dirname(__FILE__), '../certs'))
-
 Dor.configure do
   ssl do
-    cert_file File.join(cert_dir, Settings.SSL.CERT_FILE)
-    key_file File.join(cert_dir, Settings.SSL.KEY_FILE)
+    cert_file Settings.SSL.CERT_FILE
+    key_file Settings.SSL.KEY_FILE
     key_pass Settings.SSL.KEY_PASS
   end
 


### PR DESCRIPTION
path is specified in settings, no assumption about common parent directory for key and cert.

you'll either need to update your settings (e.g. `development.local.yml`) to specify the path to the cert and key files relative to the argo app root, or you'll need to specify the full path for each.  or, you can pull changes to the private `shared_configs` version, once that PR is merged.  `dor_development.rb` and the appropriate settings file will need to be updated concurrently for things to keep working.

the relevant settings are `Settings.SSL.CERT_FILE` and `Settings.SSL.KEY_FILE`.

@atz @darrenleeweber @mejackreed @drh-stanford @tingulfsen 