### PR TITLE
rename workflow configuration variables

### DIFF
--- a/config/environments/dor_development.rb
+++ b/config/environments/dor_development.rb
@@ -15,8 +15,8 @@ Dor.configure do
 
   workflow do
     url Settings.WORKFLOW_URL
-    logfile Settings.DOR_SERVICES_LOGFILE
-    shift_age Settings.DOR_SERVICES_SHIFT_AGE
+    logfile Settings.WORKFLOW.LOGFILE
+    shift_age Settings.WORKFLOW.SHIFT_AGE
   end
 
   dor_services do

--- a/config/environments/dor_production.rb
+++ b/config/environments/dor_production.rb
@@ -17,8 +17,8 @@ Dor.configure do
 
   workflow do
     url Settings.WORKFLOW_URL
-    logfile Settings.DOR_SERVICES_LOGFILE
-    shift_age Settings.DOR_SERVICES_SHIFT_AGE
+    logfile Settings.WORKFLOW.LOGFILE
+    shift_age Settings.WORKFLOW.SHIFT_AGE
   end
 
   dor_services do

--- a/config/environments/dor_staging.rb
+++ b/config/environments/dor_staging.rb
@@ -15,8 +15,8 @@ Dor.configure do
 
   workflow do
     url Settings.WORKFLOW_URL
-    logfile Settings.DOR_SERVICES_LOGFILE
-    shift_age Settings.DOR_SERVICES_SHIFT_AGE
+    logfile Settings.WORKFLOW.LOGFILE
+    shift_age Settings.WORKFLOW.SHIFT_AGE
   end
 
   dor_services do

--- a/config/environments/dor_test.rb
+++ b/config/environments/dor_test.rb
@@ -13,8 +13,8 @@ Dor.configure do
 
   dor_services do
     url Settings.DOR_SERVICES_URL
-    logfile Settings.DOR_SERVICES_LOGFILE
-    shift_age Settings.DOR_SERVICES_SHIFT_AGE
+    logfile Settings.WORKFLOW.LOGFILE
+    shift_age Settings.WORKFLOW.SHIFT_AGE
   end
 
   suri do

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -64,8 +64,6 @@ SURI:
 
 # URLs
 DOR_SERVICES_URL: 'https://user:password@dor-services.example.com'
-DOR_SERVICES_LOGFILE: 'log/workflow_service.log'
-DOR_SERVICES_SHIFT_AGE: 'weekly'
 DPG_URL: 'https://dpg.example.com'
 FEDORA_URL: 'https://user:password@fedora.example.com:1000/fedora'
 GSEARCH_URL: 'https://server.example.com/solr/gsearch'
@@ -94,3 +92,8 @@ WEBAUTH: ~
 #   SUAFFILIATION: 'org:group'
 #   DISPLAYNAME: 'Jane Doe'
 #   LDAPAUTHRULE: 'auth-rule'
+
+# Workflow
+WORKFLOW:
+  LOGFILE: 'log/workflow_service.log'
+  SHIFT_AGE: 'weekly'


### PR DESCRIPTION
This addresses the naming issue in #97.

**NOTE** that merging this PR means that we will need to change the shared_configs branches and our local development configurations.