### PR TITLE
Don't rubocop autogen migrations and schema files. This should help s…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,10 @@
 inherit_from: .rubocop_todo.yml
 
+AllCops:
+  Excludes:
+    - db/migrate/**
+    - db/schema.rb
+
 # Configuration parameters: AllowURI, URISchemes.
 Metrics/LineLength:
   Max: 180


### PR DESCRIPTION
…top git thrashing of db/schema.rb