### PR TITLE
Refactor render_buttons to use non-blocking ajax requests.

### DIFF
--- a/app/assets/javascripts/modules/button_checker.js
+++ b/app/assets/javascripts/modules/button_checker.js
@@ -1,0 +1,26 @@
+/*global Blacklight */
+'use strict';
+
+(function($) {
+  /*
+    jQuery plugin that enables buttons by checking their url
+  */
+
+  $.fn.buttonChecker = function() {
+    return this.each(function() {
+      var $el = $(this);
+      var url = $el.data('check-url');
+      $.getJSON(url)
+        .done(function(data) {
+          if (data) {
+            $el.removeClass('disabled');
+          }
+        });
+    });
+  };
+
+})(jQuery);
+
+Blacklight.onLoad(function() {
+  $('a.disabled[data-check-url]').buttonChecker();
+});

--- a/app/controllers/workflow_service_controller.rb
+++ b/app/controllers/workflow_service_controller.rb
@@ -1,0 +1,80 @@
+class WorkflowServiceController < ApplicationController
+  ##
+  # Is a document closeable?
+  def closeable
+    @status = check_if_can_close_version
+    render json: @status
+  end
+
+  ##
+  # Is a document openable?
+  def openable
+    @status = check_if_can_open_verison
+    render json: @status
+  end
+
+  ##
+  # Has an object been published?
+  def published
+    @status = check_if_published
+    render json: @status
+  end
+
+  ##
+  # Has an object been submitted?
+  def submitted
+    @status = check_if_submitted
+    render json: @status
+  end
+
+  ##
+  # Has an object been accessioned?
+  def accessioned
+    @status = check_if_accessioned
+    render json: @status
+  end
+
+  private
+
+  ##
+  # Ported over logic from app/helpers/dor_object_helper.rb#LN119
+  # @return [Boolean]
+  def check_if_published
+    return true if Dor::WorkflowService.get_lifecycle('dor', params[:pid], 'published')
+    false
+  end
+
+  ##
+  # Ported over logic from app/helpers/dor_object_helper.rb#LN126
+  # @return [Boolean]
+  def check_if_submitted
+    return true if Dor::WorkflowService.get_lifecycle('dor', params[:pid], 'submitted')
+    false
+  end
+
+  ##
+  # Ported over logic from app/helpers/dor_object_helper.rb#LN133
+  # @return [Boolean]
+  def check_if_accessioned
+    return true if Dor::WorkflowService.get_lifecycle('dor', params[:pid], 'accessioned')
+    false
+  end
+
+  ##
+  # Ported over logic from app/helpers/dor_object_helper.rb#LN167
+  # @return [Boolean]
+  def check_if_can_close_version
+    return true if Dor::WorkflowService.get_active_lifecycle('dor', params[:pid], 'opened') && !Dor::WorkflowService.get_active_lifecycle('dor', params[:pid], 'submitted')
+    false
+  end
+
+  ##
+  # Ported over logic from app/helpers/dor_object_helper.rb#LN160
+  # @return [Boolean]
+  def check_if_can_open_verison
+    return false unless check_if_accessioned
+    return false if Dor::WorkflowService.get_active_lifecycle('dor', params[:pid], 'submitted')
+    return false if Dor::WorkflowService.get_active_lifecycle('dor', params[:pid], 'opened')
+    true
+  end
+end

--- a/app/helpers/dor_object_helper.rb
+++ b/app/helpers/dor_object_helper.rb
@@ -113,14 +113,23 @@ module DorObjectHelper
     source
   end
 
+  ##
+  # @deprecated Please use non-blocking requests rather than blocking helpers.
+  # See WorkflowServiceController#published for JSON API to this logic
   def has_been_published?(pid)
     Dor::WorkflowService.get_lifecycle('dor', pid, 'published')
   end
 
+  ##
+  # @deprecated Please use non-blocking requests rather than blocking helpers.
+  # See WorkflowServiceController#submitted for JSON API to this logic
   def has_been_submitted?(pid)
     Dor::WorkflowService.get_lifecycle('dor', pid, 'submitted')
   end
 
+  ##
+  # @deprecated Please use non-blocking requests rather than blocking helpers.
+  # See WorkflowServiceController#accesssioned for JSON API to this logic
   def has_been_accessioned?(pid)
     Dor::WorkflowService.get_lifecycle('dor', pid, 'accessioned')
   end
@@ -157,6 +166,9 @@ module DorObjectHelper
     response_doc.xpath('/currentVersion/text()')
   end
 
+  ##
+  # @deprecated Please use non-blocking requests rather than blocking helpers.
+  # See WorkflowServiceController#openable for JSON API to this logic
   def can_open_version?(pid)
     return false unless Dor::WorkflowService.get_lifecycle('dor', pid, 'accessioned')
     return false if Dor::WorkflowService.get_active_lifecycle('dor', pid, 'submitted')
@@ -164,6 +176,9 @@ module DorObjectHelper
     true
   end
 
+  ##
+  # @deprecated Please use non-blocking requests rather than blocking helpers.
+  # See WorkflowServiceController#closeable for JSON API to this logic
   def can_close_version?(pid)
     Dor::WorkflowService.get_active_lifecycle('dor', pid, 'opened') && !Dor::WorkflowService.get_active_lifecycle('dor', pid, 'submitted')
   end

--- a/app/views/items/_button_link_list.html.erb
+++ b/app/views/items/_button_link_list.html.erb
@@ -8,7 +8,10 @@
       elsif !button[:new_page]
         button_data[:ajax_modal] = 'trigger'
       end
+      if button[:check_url]
+        button_data[:check_url] = button[:check_url]
+      end
     %>
-    <%= link_to button[:label], button[:url], class: 'btn button btn-primary', data: button_data %>
+    <%= link_to button[:label], button[:url], class: "btn button btn-primary #{'disabled' if button[:check_url]}", data: button_data %>
   <%end%>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -184,6 +184,29 @@ Argo::Application.routes.draw do
 
   get 'index_queue/depth', to: 'index_queue#depth'
 
+  namespace :workflow_service do
+    get '/:pid/closeable',
+        action: 'closeable',
+        as: 'closeable',
+        defaults: { format: :json }
+    get '/:pid/openable',
+        action: 'openable',
+        as: 'openable',
+        defaults: { format: :json }
+    get '/:pid/published',
+        action: 'published',
+        as: 'published',
+        defaults: { format: :json }
+    get '/:pid/submitted',
+        action: 'submitted',
+        as: 'submitted',
+        defaults: { format: :json }
+    get '/:pid/accessioned',
+        action: 'accessioned',
+        as: 'accessioned',
+        defaults: { format: :json }
+  end
+
   # The priority is based upon order of creation:
   # first created -> highest priority.
 

--- a/spec/controllers/workflow_service_controller_spec.rb
+++ b/spec/controllers/workflow_service_controller_spec.rb
@@ -1,0 +1,171 @@
+require 'spec_helper'
+
+describe WorkflowServiceController do
+  before do
+    log_in_as_mock_user(subject)
+  end
+  let(:druid) { 'druid:abc:123' }
+  describe 'GET closeable' do
+    context 'when closeable' do
+      it 'returns true' do
+        expect(Dor::WorkflowService)
+          .to receive(:get_active_lifecycle).with('dor', druid, 'opened')
+          .and_return(true)
+        expect(Dor::WorkflowService)
+          .to receive(:get_active_lifecycle).with('dor', druid, 'submitted')
+          .and_return(false)
+        get :closeable, pid: druid, format: :json
+        expect(assigns(:status)).to eq true
+        expect(response.body).to eq 'true'
+      end
+    end
+    context 'when !closeable' do
+      context 'not opened' do
+        it 'returns false' do
+          expect(Dor::WorkflowService)
+            .to receive(:get_active_lifecycle).with('dor', druid, 'opened')
+            .and_return(false)
+          get :closeable, pid: druid, format: :json
+          expect(assigns(:status)).to eq false
+          expect(response.body).to eq 'false'
+        end
+      end
+      context 'when opened && is submitted' do
+        it 'returns false' do
+          expect(Dor::WorkflowService)
+            .to receive(:get_active_lifecycle).with('dor', druid, 'opened')
+            .and_return(true)
+          expect(Dor::WorkflowService)
+            .to receive(:get_active_lifecycle).with('dor', druid, 'submitted')
+            .and_return(true)
+          get :closeable, pid: druid, format: :json
+          expect(assigns(:status)).to eq false
+          expect(response.body).to eq 'false'
+        end
+      end
+    end
+  end
+  describe 'GET openable' do
+    context 'when not accessioned' do
+      it 'returns false' do
+        expect(Dor::WorkflowService)
+          .to receive(:get_lifecycle).with('dor', druid, 'accessioned')
+          .and_return(false)
+        get :openable, pid: druid, format: :json
+        expect(assigns(:status)).to eq false
+        expect(response.body).to eq 'false'
+      end
+    end
+    context 'when accessioned && submitted' do
+      it 'returns false' do
+        expect(Dor::WorkflowService)
+          .to receive(:get_lifecycle).with('dor', druid, 'accessioned')
+          .and_return(true)
+        expect(Dor::WorkflowService)
+          .to receive(:get_active_lifecycle).with('dor', druid, 'submitted')
+          .and_return(true)
+        get :openable, pid: druid, format: :json
+        expect(assigns(:status)).to eq false
+        expect(response.body).to eq 'false'
+      end
+    end
+    context 'when accessioned && !submitted && opened' do
+      it 'returns false' do
+        expect(Dor::WorkflowService)
+          .to receive(:get_lifecycle).with('dor', druid, 'accessioned')
+          .and_return(true)
+        expect(Dor::WorkflowService)
+          .to receive(:get_active_lifecycle).with('dor', druid, 'submitted')
+          .and_return(false)
+        expect(Dor::WorkflowService)
+          .to receive(:get_active_lifecycle).with('dor', druid, 'opened')
+          .and_return(true)
+        get :openable, pid: druid, format: :json
+        expect(assigns(:status)).to eq false
+        expect(response.body).to eq 'false'
+      end
+    end
+    context 'when accessioned && !submitted && !opened' do
+      it 'returns true' do
+        expect(Dor::WorkflowService)
+          .to receive(:get_lifecycle).with('dor', druid, 'accessioned')
+          .and_return(true)
+        expect(Dor::WorkflowService)
+          .to receive(:get_active_lifecycle).with('dor', druid, 'submitted')
+          .and_return(false)
+        expect(Dor::WorkflowService)
+          .to receive(:get_active_lifecycle).with('dor', druid, 'opened')
+          .and_return(false)
+        get :openable, pid: druid, format: :json
+        expect(assigns(:status)).to eq true
+        expect(response.body).to eq 'true'
+      end
+    end
+  end
+  describe 'GET published' do
+    context 'when published' do
+      it 'returns true' do
+        expect(Dor::WorkflowService)
+          .to receive(:get_lifecycle).with('dor', druid, 'published')
+          .and_return(true)
+        get :published, pid: druid, format: :json
+        expect(assigns(:status)).to eq true
+        expect(response.body).to eq 'true'
+      end
+    end
+    context 'when not published' do
+      it 'returns false' do
+        expect(Dor::WorkflowService)
+          .to receive(:get_lifecycle).with('dor', druid, 'published')
+          .and_return(false)
+        get :published, pid: druid, format: :json
+        expect(assigns(:status)).to eq false
+        expect(response.body).to eq 'false'
+      end
+    end
+  end
+  describe 'GET submitted' do
+    context 'when submitted' do
+      it 'returns true' do
+        expect(Dor::WorkflowService)
+          .to receive(:get_lifecycle).with('dor', druid, 'submitted')
+          .and_return(true)
+        get :submitted, pid: druid, format: :json
+        expect(assigns(:status)).to eq true
+        expect(response.body).to eq 'true'
+      end
+    end
+    context 'when not submitted' do
+      it 'returns false' do
+        expect(Dor::WorkflowService)
+          .to receive(:get_lifecycle).with('dor', druid, 'submitted')
+          .and_return(false)
+        get :submitted, pid: druid, format: :json
+        expect(assigns(:status)).to eq false
+        expect(response.body).to eq 'false'
+      end
+    end
+  end
+  describe 'GET accessioned' do
+    context 'when accessioned' do
+      it 'returns true' do
+        expect(Dor::WorkflowService)
+          .to receive(:get_lifecycle).with('dor', druid, 'accessioned')
+          .and_return(true)
+        get :accessioned, pid: druid, format: :json
+        expect(assigns(:status)).to eq true
+        expect(response.body).to eq 'true'
+      end
+    end
+    context 'when not accessioned' do
+      it 'returns false' do
+        expect(Dor::WorkflowService)
+          .to receive(:get_lifecycle).with('dor', druid, 'accessioned')
+          .and_return(false)
+        get :accessioned, pid: druid, format: :json
+        expect(assigns(:status)).to eq false
+        expect(response.body).to eq 'false'
+      end
+    end
+  end
+end

--- a/spec/features/enable_buttons_spec.rb
+++ b/spec/features/enable_buttons_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+feature 'Enable buttons' do
+  before do
+    @current_user = double(
+      :webauth_user,
+      login: 'sunetid',
+      logged_in?: true,
+      permitted_apos: [],
+      is_admin: true,
+      roles: []
+    )
+    @obj = double(
+      'item',
+      admin_policy_object: false,
+      datastreams: {},
+      can_manage_item?: true
+    )
+    allow_any_instance_of(ApplicationController).to receive(:current_user).
+      and_return(@current_user)
+    allow(Dor).to receive(:find).and_return(@obj)
+  end
+  scenario 'buttons are disabled by default that have check_url' do
+    visit catalog_path 'druid:hj185vb7593'
+    expect(page).to have_css 'a.disabled', text: 'Close Version'
+    expect(page).to have_css 'a.disabled', text: 'Open for modification'
+    expect(page).to have_css 'a.disabled', text: 'Republish'
+    expect(page).to have_css 'a.disabled', text: 'Purge'
+  end
+  scenario 'buttons are enabled if their services return true', js: true do
+    allow_any_instance_of(WorkflowServiceController).to receive(:check_if_can_close_version).and_return(true)
+    allow_any_instance_of(WorkflowServiceController).to receive(:check_if_can_open_verison).and_return(true)
+    expect(page).to_not have_css 'a.disabled', text: 'Close Version'
+    expect(page).to_not have_css 'a.disabled', text: 'Open for modification'
+    expect(page).to_not have_css 'a.disabled', text: 'Republish'
+    expect(page).to_not have_css 'a.disabled', text: 'Purge'
+  end
+end

--- a/spec/helpers/argo_helper_spec.rb
+++ b/spec/helpers/argo_helper_spec.rb
@@ -29,7 +29,6 @@ describe ArgoHelper, :type => :helper do
       allow(@usr).to receive(:roles).with('apo_druid').and_return([])
       allow(Dor::WorkflowService).to receive(:get_active_lifecycle).and_return(true)
       allow(Dor::WorkflowService).to receive(:get_lifecycle).and_return(true)
-      allow(helper).to receive(:has_been_published?).and_return(true)
       allow(helper).to receive(:current_user).and_return(@usr)
       allow(@object).to receive(:can_manage_item?).and_return(true)
       allow(@object).to receive(:pid).and_return('druid:123')
@@ -44,47 +43,57 @@ describe ArgoHelper, :type => :helper do
       allow(Dor).to receive(:find).and_return(@object)
     end
     describe 'visibility with new descMetadata' do
+      let(:default_buttons) do
+        [
+          {
+            label: 'Reindex',
+            url: '/dor/reindex/something'
+          },
+          {
+            label: 'Republish',
+            url: '/dor/republish/something',
+            check_url: '/workflow_service/something/published'
+          },
+          {
+            label: 'Change source id',
+            url: '/items/something/source_id_ui'
+          },
+          {
+            label: 'Edit tags',
+            url: '/items/something/tags_ui'
+          },
+          {
+            label: 'Edit collections',
+            url: '/items/something/collection_ui'
+          },
+          {
+            label: 'Set content type',
+            url: '/items/something/content_type'
+          }
+        ]
+      end
       it 'should create a hash with the needed button info for an admin' do
         buttons = helper.render_buttons(@doc)
-        {
-          'Reindex'           => '/dor/reindex/something',
-          'Republish'         => '/dor/republish/something',
-          'Change source id'  => '/items/something/source_id_ui',
-          'Edit tags'         => '/items/something/tags_ui',
-          'Edit collections'  => '/items/something/collection_ui',
-          'Set content type'  => '/items/something/content_type'
-        }.each_pair do |k, v|
-          expect(buttons.include?({:label => k, :url => v})).to be_truthy
+        default_buttons.each do |button|
+          expect(buttons).to include(button)
         end
       end
       it 'should generate a the same button set for a non admin' do
         allow(@usr).to receive(:is_admin).and_return(false)
         allow(@object).to receive(:can_manage_item?).and_return(true)
         buttons = helper.render_buttons(@doc)
-        {
-          'Reindex'           => '/dor/reindex/something',
-          'Republish'         => '/dor/republish/something',
-          'Change source id'  => '/items/something/source_id_ui',
-          'Edit tags'         => '/items/something/tags_ui',
-          'Edit collections'  => '/items/something/collection_ui',
-          'Set content type'  => '/items/something/content_type'
-        }.each_pair do |k, v|
-          expect(buttons.include?({:label => k, :url => v})).to be_truthy
+        default_buttons.each do |button|
+          expect(buttons).to include(button)
         end
       end
       it 'should include the embargo update button if the user is an admin and the object is embargoed' do
         @doc['embargo_status_ssim'] = ['2012-10-19T00:00:00Z']
         buttons = helper.render_buttons(@doc)
-        {
-          'Reindex'           => '/dor/reindex/something',
-          'Republish'         => '/dor/republish/something',
-          'Change source id'  => '/items/something/source_id_ui',
-          'Edit tags'         => '/items/something/tags_ui',
-          'Edit collections'  => '/items/something/collection_ui',
-          'Set content type'  => '/items/something/content_type',
-          'Update embargo'    => '/items/something/embargo_form'
-        }.each_pair do |k, v|
-          expect(buttons.include?({:label => k, :url => v})).to be_truthy
+        default_buttons.push({
+          label: 'Update embargo',
+          url: '/items/something/embargo_form'
+        }).each do |button|
+          expect(buttons).to include(button)
         end
       end
     end

--- a/spec/views/items/_button_link_list.html.erb_spec.rb
+++ b/spec/views/items/_button_link_list.html.erb_spec.rb
@@ -16,6 +16,11 @@ describe 'items/_button_link_list.html.erb' do
         label: 'Ajax me',
         url: 'http://www.example.com/ajax',
         ajax_modal: true
+      },
+      {
+        label: 'Check me',
+        url: 'http://www.example.com/check',
+        check_url: workflow_service_closeable_path('abc:123')
       }
     ]
   end
@@ -26,5 +31,6 @@ describe 'items/_button_link_list.html.erb' do
     expect(rendered).to have_css 'a[href="http://www.example.com/click"]', text: 'Click me'
     expect(rendered).to have_css 'a[href="http://www.example.com/confirm"][data-confirm="true"]', text: 'Confirm me'
     expect(rendered).to have_css 'a[href="http://www.example.com/ajax"][data-ajax-modal="trigger"]', text: 'Ajax me'
+    expect(rendered).to have_css 'a[href="http://www.example.com/check"][data-check-url="/workflow_service/abc:123/closeable"]', text: 'Check me'
   end
 end


### PR DESCRIPTION
Buttons will be shown to user, but disabled unless api responses come back as true

Addresses part of #187 

Reduces the number of blocking requests by 6 - 9 requests per show page load, depending on the page and the logic path executed.