### PR TITLE
dor-services will handle blank parameters for APO definitions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/sul-dlss/dor-services.git
-  revision: d96fb43e08547bde54084c3e0914b4d792491d06
+  revision: 4c077e0fbea5fad04a8cf0ceb2f9da60b4173d6a
   branch: develop
   specs:
     dor-services (5.2.0)
@@ -22,9 +22,11 @@ GIT
       json (~> 1.8.1)
       lyber-utils (~> 0.1.2)
       moab-versioning (~> 1.4.4)
+      modsulator (~> 0.0.7)
       net-sftp (~> 2.1.2)
       net-ssh (~> 2.6.5)
       nokogiri (~> 1.6.0)
+      nokogiri-pretty (~> 0.1.0)
       om (~> 3.0)
       osullivan (~> 0.0.3)
       progressbar (~> 0.21.0)
@@ -285,6 +287,11 @@ GEM
     mods_display (0.3.5)
       i18n
       stanford-mods
+    modsulator (0.0.7)
+      activesupport (>= 3.0)
+      equivalent-xml (>= 0.6.0)
+      nokogiri
+      roo (>= 1.1)
     multi_json (1.11.2)
     multipart-post (2.0.0)
     mysql2 (0.3.20)
@@ -299,6 +306,8 @@ GEM
       mini_portile (~> 0.6.0)
     nokogiri-happymapper (0.5.9)
       nokogiri (~> 1.5)
+    nokogiri-pretty (0.1.0)
+      nokogiri
     nom-xml (0.5.4)
       activesupport (>= 3.2.18)
       i18n
@@ -386,6 +395,9 @@ GEM
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     retries (0.0.5)
+    roo (2.2.0)
+      nokogiri (~> 1)
+      rubyzip (~> 1.1, < 2.0.0)
     rsolr (1.0.13)
       builder (>= 2.1.2)
     rsolr-client-cert (0.5.2)
@@ -466,7 +478,7 @@ GEM
       net-scp (>= 1.1.2)
       net-ssh
       term-ansicolor
-    stanford-mods (1.2.1)
+    stanford-mods (1.3.0)
       mods (~> 2.0.2)
     stomp (1.3.4)
     sul_styles (0.3.0)
@@ -588,3 +600,6 @@ DEPENDENCIES
   unicode
   unicorn
   webmock
+
+BUNDLED WITH
+   1.10.6

--- a/app/controllers/apo_controller.rb
+++ b/app/controllers/apo_controller.rb
@@ -80,23 +80,23 @@ class ApoController < ApplicationController
   end
 
   def set_apo_metadata(apo, md_info)
-    apo.copyright_statement  = md_info[:copyright] if md_info[:copyright] && md_info[:copyright].length > 0
-    apo.use_statement        = md_info[:use      ] if md_info[:use      ] && md_info[:use      ].length > 0
     apo.mods_title           = md_info[:title    ]
     apo.desc_metadata_format = md_info[:desc_md  ]
     apo.metadata_source      = md_info[:metadata_source]
-    apo.agreement            = md_info[:agreement].to_s
-    apo.default_workflow     = md_info[:workflow ] unless !md_info[:workflow] || md_info[:workflow].length < 5
+    apo.agreement            = md_info[:agreement]
+    apo.default_workflow     = md_info[:workflow ]
     apo.default_rights       = md_info[:default_object_rights]
     # Set the Use License given a machine-readable code for a creative commons or open data commons license
-    apo.use_license          = md_info[:use_license].blank? ? :none : md_info[:use_license]
+    apo.use_license          = md_info[:use_license]
+    apo.copyright_statement  = md_info[:copyright]
+    apo.use_statement        = md_info[:use      ]
   end
 
   def register_new_apo
     reg_params = {:workflow_priority => '70'}
     reg_params[:label] = params[:title]
     reg_params[:object_type ] = 'adminPolicy'
-    reg_params[:admin_policy] = 'druid:hv992ry2431' # TODO: Uber-APO druid must be pulled from config, not hardcoded
+    reg_params[:admin_policy] = SolrDocument::UBER_APO_ID
     reg_params[:workflow_id ] = 'accessionWF'
     response = Dor::RegistrationService.create_from_request(reg_params)
     apo_pid = response[:pid]

--- a/spec/fixtures/apo_defaultObjectRights_clean.xml
+++ b/spec/fixtures/apo_defaultObjectRights_clean.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<rightsMetadata>
+  <copyright>
+    <human type="copyright">My copyright statement</human>
+  </copyright>
+  <access type="discover">
+    <machine>
+      <world/>
+    </machine>
+  </access>
+  <access type="read">
+    <machine>
+      <world/>
+    </machine>
+  </access>
+  <use>
+    <human type="useAndReproduction">My use and reproduction statement</human>
+    <machine type="creativeCommons" uri="https://creativecommons.org/licenses/by-nc/3.0/">by-nc</machine>
+    <human type="creativeCommons">Attribution Non-Commercial 3.0 Unported</human>
+  </use>
+</rightsMetadata>


### PR DESCRIPTION
This PR removes the data cleanup for registering the APO. This logic/tests are moved into dor-services pending https://github.com/sul-dlss/dor-services/pull/117. If that PR is approved, then I'll update the Gemfile.lock here in this PR