### PR TITLE
Update mods_display gem to latest, which addresses Ruby 2.2 warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,7 +284,7 @@ GEM
       iso-639
       nokogiri
       nom-xml (~> 0.5.2)
-    mods_display (0.3.3)
+    mods_display (0.3.4)
       i18n
       stanford-mods
     multi_json (1.11.2)
@@ -297,7 +297,7 @@ GEM
     net-ssh (2.6.8)
     netrc (0.11.0)
     newrelic_rpm (3.14.0.305)
-    nokogiri (1.6.6.2)
+    nokogiri (1.6.6.3)
       mini_portile (~> 0.6.0)
     nokogiri-happymapper (0.5.9)
       nokogiri (~> 1.5)


### PR DESCRIPTION
While we are at it, update Nokogiri to 1.6.3.3 to address upstream security issues
