### PR TITLE
refactor access to authoritative APO and Collection(s) druids and titles

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -45,8 +45,8 @@ class CatalogController < ApplicationController
     config.add_show_field 'identifier_tesim',            :label => 'IDs'
     config.add_show_field 'originInfo_date_created_tesim', :label => 'Created'
     config.add_show_field 'obj_label_ssim',              :label => 'Label'
-    config.add_show_field 'is_governed_by_ssim',         :label => 'Admin Policy'
-    config.add_show_field 'is_member_of_collection_ssim', :label => 'Collection'
+    config.add_show_field SolrDocument::FIELD_APO_ID,    :label => 'Admin Policy'
+    config.add_show_field SolrDocument::FIELD_COLLECTION_ID, :label => 'Collection'
     config.add_show_field 'status_ssi',                  :label => 'Status'
     config.add_show_field 'objectType_ssim',             :label => 'Object Type'
     config.add_show_field 'id',                          :label => 'DRUID'
@@ -54,7 +54,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'source_id_ssim',              :label => 'Source'
     config.add_show_field 'tag_ssim',                    :label => 'Tags'
     config.add_show_field 'wf_error_ssim',               :label => 'Error'
-    config.add_show_field 'collection_title_ssim',       :label => 'Collection Title'
+    config.add_show_field SolrDocument::FIELD_COLLECTION_TITLE, :label => 'Collection Title'
     config.add_show_field 'metadata_source_ssi',         :label => 'MD Source'
     config.add_show_field 'preserved_size_dbtsi',        :label => 'Preservation Size'
 
@@ -97,8 +97,8 @@ class CatalogController < ApplicationController
       :no_has_model                => { :label => 'No Object Model',            :fq => '-has_model_ssim:*' },
       :no_objectType               => { :label => 'No Object Type',             :fq => '-objectType_ssim:*' },
       :no_object_title             => { :label => 'No Object Title',            :fq => '-dc_title_ssi:*' },
-      :no_is_governed_by           => { :label => 'No APO',                     :fq => '-is_governed_by_ssim:*' },
-      :no_collection_title         => { :label => 'No Collection Title',        :fq => '-collection_title_ssim:*' },
+      :no_is_governed_by           => { :label => 'No APO',                     :fq => "-#{SolrDocument::FIELD_APO_ID}:*" },
+      :no_collection_title         => { :label => 'No Collection Title',        :fq => "-#{SolrDocument::FIELD_COLLECTION_TITLE}:*" },
       :no_copyright                => { :label => 'No Copyright',               :fq => '-copyright_ssim:*' },
       :no_license                  => { :label => 'No License',                 :fq => '-use_license_machine_ssi:*' },
       :no_public_dc_creator        => { :label => 'No MODS Creator',            :fq => '-public_dc_creator_tesim:*' },
@@ -145,11 +145,11 @@ class CatalogController < ApplicationController
     config.field_groups = {
       :identification => [
         %w(id objectType_ssim content_type_ssim status_ssi wf_error_ssim),
-        %w(is_governed_by_ssim is_member_of_collection_ssim project_tag_ssim source_id_ssim preserved_size_dbtsi)
+        [SolrDocument::FIELD_APO_ID, SolrDocument::FIELD_COLLECTION_ID].map(&:to_s) + %w(project_tag_ssim source_id_ssim preserved_size_dbtsi)
       ],
       :full_identification => [
         %w(id objectType_ssim content_type_ssim metadata_source_ssim),
-        %w(is_governed_by_ssim is_member_of_collection_ssim project_tag_ssim source_id_ssim)
+        [SolrDocument::FIELD_APO_ID, SolrDocument::FIELD_COLLECTION_ID].map(&:to_s) + %w(project_tag_ssim source_id_ssim)
       ]
     }
 

--- a/app/helpers/argo_helper.rb
+++ b/app/helpers/argo_helper.rb
@@ -123,16 +123,15 @@ module ArgoHelper
   # Ideally this method should not make calls to external services to determine
   # what buttons should be rendered. These external requests are blocking and
   # will not allow the page to load until all requests are finished.
+  # @param [SolrDocument] doc
   # @return [Array]
   def render_buttons(doc, object = nil)
     pid = doc['id']
     object ||= Dor.find(pid)
-    apo_pid = ''
     # wf_stuff.include? 'accessionWF:completed:publish'
-    begin
-      apo_pid = doc['is_governed_by_ssim'].first.gsub('info:fedora/', '')
-    rescue
-    end
+
+    apo_pid = doc.apo_pid
+
     buttons = []
     if pid
       buttons << {

--- a/app/helpers/robot_helper.rb
+++ b/app/helpers/robot_helper.rb
@@ -2,7 +2,7 @@ module RobotHelper
   def render_recent_work(docs)
     res = ''
     docs.each do |doc|
-      res += render(:partial => 'item', :locals => {:title => doc['dc_title_ssi'].first, :druid => doc['id'], :apo_title => doc['apo_title_ssim']})
+      res += render(:partial => 'item', :locals => {:title => doc.title, :druid => doc['id'], :apo_title => doc.apo_title})
     end
     res.html_safe
   end

--- a/app/models/argo/access_controls_enforcement.rb
+++ b/app/models/argo/access_controls_enforcement.rb
@@ -26,7 +26,7 @@ module Argo
         pids = new_pids
         pids = pids.join(' OR ')
       end
-      solr_parameters[:fq] << 'is_governed_by_ssim:(' + pids + ')'
+      solr_parameters[:fq] << "#{SolrDocument::FIELD_APO_ID}:(#{pids})"
       logger.debug("Solr parameters: #{ solr_parameters.inspect }")
       solr_parameters
     end

--- a/app/models/concerns/apo_concern.rb
+++ b/app/models/concerns/apo_concern.rb
@@ -1,0 +1,35 @@
+module ApoConcern
+  extend Blacklight::Solr::Document
+
+  FIELD_APO_ID = :is_governed_by_ssim
+  FIELD_APO_TITLE = :apo_title_ssim
+
+  UBER_APO_ID = 'druid:hv992ry2431' # TODO: Uber-APO is hardcoded
+
+  ##
+  # Access a SolrDocument's APO druid
+  # @return [String, nil]
+  def apo_id
+    fetch(FIELD_APO_ID).first
+  rescue KeyError
+    id == UBER_APO_ID ? id : nil
+  end
+
+  ##
+  # Access a SolrDocument's APO druid without the `info:fedora/` prefix
+  # @return [String, nil]
+  def apo_pid
+    apo_id.gsub('info:fedora/', '')
+  rescue NoMethodError
+    nil
+  end
+
+  ##
+  # Access a SolrDocument's APO title
+  # @return [String, nil]
+  def apo_title
+    fetch(FIELD_APO_TITLE).first
+  rescue KeyError
+    id == UBER_APO_ID ? title : nil
+  end
+end

--- a/app/models/concerns/catkey_concern.rb
+++ b/app/models/concerns/catkey_concern.rb
@@ -1,12 +1,23 @@
 module CatkeyConcern
   extend Blacklight::Solr::Document
 
+  FIELD_CATKEY_ID = :catkey_id_ssim
+
   ##
   # Access a SolrDocument's catkey
   # @return [String, nil]
   def catkey
-    fetch(:catkey_id_ssim).first
-  rescue KeyError
+    fetch(FIELD_CATKEY_ID).first
+  rescue KeyError, NoMethodError
+    nil
+  end
+
+  ##
+  # Access a SolrDocument's catkey identifier
+  # @return [String, nil]
+  def catkey_id
+    catkey.gsub(/^catkey:/, '')
+  rescue NoMethodError
     nil
   end
 end

--- a/app/models/concerns/collection_concern.rb
+++ b/app/models/concerns/collection_concern.rb
@@ -1,0 +1,42 @@
+module CollectionConcern
+  extend Blacklight::Solr::Document
+
+  FIELD_COLLECTION_ID = :is_member_of_collection_ssim
+  FIELD_COLLECTION_TITLE = :collection_title_ssim
+
+  ##
+  # Access a SolrDocument's *first* Collection druid
+  # @return [String, nil]
+  def collection_id
+    collection_ids.first
+  rescue NoMethodError
+    nil
+  end
+
+  ##
+  # Access a SolrDocument's Collection(s) druid
+  # @return [Array<String>, nil]
+  def collection_ids
+    fetch(FIELD_COLLECTION_ID)
+  rescue KeyError
+    nil
+  end
+
+  ##
+  # Access a SolrDocument's *first* Collection title
+  # @return [String, nil]
+  def collection_title
+    collection_titles.first
+  rescue NoMethodError
+    nil
+  end
+
+  ##
+  # Access a SolrDocument's Collection(s) title
+  # @return [Array<String>, nil]
+  def collection_titles
+    fetch(FIELD_COLLECTION_TITLE)
+  rescue KeyError
+    nil
+  end
+end

--- a/app/models/concerns/title_concern.rb
+++ b/app/models/concerns/title_concern.rb
@@ -1,0 +1,14 @@
+module TitleConcern
+  extend Blacklight::Solr::Document
+
+  FIELD_TITLE = :dc_title_ssi
+
+  ##
+  # Access a SolrDocument's title
+  # @return [String, nil]
+  def title
+    fetch(FIELD_TITLE)
+  rescue KeyError
+    nil
+  end
+end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -43,49 +43,22 @@ class Report
         :sort => false, :default => true, :width => 100
       },
       {
-        :field => 'is_governed_by_ssim', :label => 'Admin Policy ID',
-        :proc => lambda { |doc| doc['is_governed_by_ssim'].first.split(/:/).last },
+        :field => SolrDocument::FIELD_APO_ID, :label => 'Admin Policy ID',
+        :proc => lambda { |doc| doc[SolrDocument::FIELD_APO_ID].first.split(/:/).last },
         :sort => false, :default => false, :width => 100
       },
       {
-        :field => 'apo', :label => 'Admin Policy (all)',
-        :proc => lambda { |doc| doc['apo_title_ssim'] },
-        :solr_fields => ['apo_title_ssim'],
+        :field => SolrDocument::FIELD_APO_TITLE, :label => 'Admin Policy',
         :sort => false, :default => true, :width => 100
       },
       {
-        :field => 'nonhydrus_apo', :label => 'Admin Policy (Non-Hydrus)',
-        :proc => lambda { |doc| doc['nonhydrus_apo_title_ssim'] },
-        :solr_fields => ['nonhydrus_apo_title_ssim'],
-        :sort => false, :default => true, :width => 100
-      },
-      {
-        :field => 'hydrus_apo', :label => 'Hydrus Admin Policy',
-        :proc => lambda { |doc| doc['hydrus_apo_title_ssim'] },
-        :solr_fields => ['hydrus_apo_title_ssim'],
-        :sort => false, :default => true, :width => 100
-      },
-      {
-        :field => 'is_member_of_collection_ssim', :label => 'Collection ID',
-        :proc => lambda { |doc| doc['is_member_of_collection_ssim'].map{|col| col.split(/:/).last }},
+        :field => SolrDocument::FIELD_COLLECTION_ID, :label => 'Collection ID',
+        :proc => lambda { |doc| doc[SolrDocument::FIELD_COLLECTION_ID].map{|id| id.split(/:/).last } },
         :sort => false, :default => false, :width => 100
       },
       {
-        :field => 'collection', :label => 'Collection (all)',
-        :proc => lambda { |doc| doc['collection_title_ssim'] },
-        :solr_fields => ['collection_title_ssim'],
-        :sort => false, :default => false, :width => 100
-      },
-      {
-        :field => 'nonhydrus_collection', :label => 'Collection (Non-Hydrus)',
-        :proc => lambda { |doc| doc['nonhydrus_collection_title_ssim'] },
-        :solr_fields => ['nonhydrus_collection_title_ssim'],
-        :sort => false, :default => false, :width => 100
-      },
-      {
-        :field => 'hydrus_collection', :label => 'Hydrus Collection',
-        :proc => lambda { |doc| doc['hydrus_collection_title_ssim'] },
-        :solr_fields => ['hydrus_collection_title_ssim'],
+        :field => SolrDocument::FIELD_COLLECTION_TITLE, :label => 'Collection',
+        :proc => lambda { |doc| doc[SolrDocument::FIELD_COLLECTION_TITLE].join(',') },
         :sort => false, :default => false, :width => 100
       },
       {
@@ -109,7 +82,7 @@ class Report
         :sort => true, :default => false, :width => 100
       },
       {
-        :field => 'catkey_id_ssim', :label => 'Catkey',
+        :field => SolrDocument::FIELD_CATKEY_ID, :label => 'Catkey',
         :sort => true, :default => false, :width => 100
       },
       {

--- a/app/models/robot.rb
+++ b/app/models/robot.rb
@@ -37,6 +37,6 @@ class Robot < ActiveRecord::Base
   end
 
   def recent_work
-    Dor::SearchService.query("wf_#{wf}_#{process}_dttsi:[NOW-7HOURS-1HOUR  TO NOW]", {:rows => 20, :fl => 'id,dc_title_tesim,apo_title_ssim'})['response']['docs']
+    Dor::SearchService.query("wf_#{wf}_#{process}_dttsi:[NOW-7HOURS-1HOUR  TO NOW]", {:rows => 20, :fl => "id,dc_title_tesim,#{SolrDocument::FIELD_APO_TITLE}"})['response']['docs']
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -2,8 +2,11 @@
 class SolrDocument
 
   include Blacklight::Solr::Document
+  include ApoConcern
   include CatkeyConcern
+  include CollectionConcern
   include DruidConcern
+  include TitleConcern
 
   # self.unique_key = 'id'
 
@@ -27,7 +30,7 @@ class SolrDocument
   # Recommendation: Use field names from Dublin Core
   use_extension(Blacklight::Solr::Document::DublinCore)
   field_semantics.merge!(
-    :title    => 'dc_title_ssi',
+    :title    => FIELD_TITLE,
     :author   => 'dc_creator_ssi',
     :language => 'public_dc_language_tesim',
     :format   => 'public_dc_format_tesim'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,7 +70,7 @@ class User < ActiveRecord::Base
   # @return [Array<Array<String>>] Sorted array of pairs of strings, each pair like: ["Title (PID)", "PID"]
   def permitted_collections
     q = 'objectType_ssim:collection AND !project_tag_ssim:"Hydrus" '
-    q += permitted_apos.map {|pid| 'is_governed_by_ssim:"info:fedora/' + pid + '"'}.join(' OR ') unless is_admin
+    q += permitted_apos.map {|pid| "#{SolrDocument::FIELD_APO_ID}:\"info:fedora/#{pid}\""}.join(' OR ') unless is_admin
     result = Blacklight.solr.find({:q => q, :rows => 1000, :fl => 'id,tag_ssim,dc_title_tesim'}).docs
 
     # result = Dor::SearchService.query(q, :rows => 1000, :fl => 'id,tag_ssim,dc_title_tesim').docs

--- a/fedora_conf/data/dd327qr3670.xml
+++ b/fedora_conf/data/dd327qr3670.xml
@@ -1,0 +1,587 @@
+<foxml:digitalObject VERSION="1.1" PID="druid:dd327qr3670"
+xmlns:foxml="info:fedora/fedora-system:def/foxml#"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
+<foxml:objectProperties>
+<foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="Agrreement for Department of Special Collections and University Archives"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE="DOR"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="2011-07-05T17:12:18.779Z"/>
+<foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE="2013-12-10T19:04:01.943Z"/>
+</foxml:objectProperties>
+<foxml:datastream ID="AUDIT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
+<foxml:datastreamVersion ID="AUDIT.0" LABEL="Audit Trail for this object" CREATED="2011-07-05T17:12:18.779Z" MIMETYPE="text/xml" FORMAT_URI="info:fedora/fedora-system:format/xml.fedora.audit">
+<foxml:xmlContent>
+<audit:auditTrail xmlns:audit="info:fedora/fedora-system:def/audit#">
+<audit:record ID="AUDREC1">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>content01</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2011-09-19T17:54:36.962Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC2">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>content02</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2011-09-19T17:55:11.287Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC3">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>contentMetadata</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2011-09-27T15:21:40.979Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC4">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>contentMetadata</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2011-09-27T15:22:48.703Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC5">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>workflows</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2012-05-07T23:21:24.101Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC6">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>descMetadata</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2012-05-07T23:21:24.657Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC7">
+<audit:process type="Fedora API-M"/>
+<audit:action>setDatastreamVersionable</audit:action>
+<audit:componentID>descMetadata</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2012-05-07T23:21:24.657Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC8">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>identityMetadata</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2012-05-07T23:21:25.455Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC9">
+<audit:process type="Fedora API-M"/>
+<audit:action>setDatastreamVersionable</audit:action>
+<audit:componentID>identityMetadata</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2012-05-07T23:21:25.455Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC10">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>events</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2012-05-07T23:21:26.177Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC11">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>RELS-EXT</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2012-05-07T23:21:27.209Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC12">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>contentMetadata</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2012-05-07T23:21:27.982Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC13">
+<audit:process type="Fedora API-M"/>
+<audit:action>setDatastreamVersionable</audit:action>
+<audit:componentID>contentMetadata</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2012-05-07T23:21:27.982Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC14">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>DC</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-01-28T22:56:18.503Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC15">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>descMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-01-28T22:56:38.664Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC16">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>contentMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-02-12T19:35:21.035Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC17">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>identityMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-02-12T19:49:49.358Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC18">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>descMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-02-12T20:01:18.193Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC19">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>descMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-02-12T20:04:28.846Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC20">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>descMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-02-12T20:05:50.459Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC21">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>identityMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-10-28T23:42:30.509Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC22">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>lmcrae</audit:responsibility>
+<audit:date>2013-12-10T18:51:51.477Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC23">
+<audit:process type="Fedora API-M"/>
+<audit:action>purgeDatastream</audit:action>
+<audit:componentID>content01</audit:componentID>
+<audit:responsibility>lmcrae</audit:responsibility>
+<audit:date>2013-12-10T18:58:50.845Z</audit:date>
+<audit:justification>Purged datastream (ID=content01), versions ranging from the beginning of time to the end of time.  This resulted in the permanent removal of 1 datastream version(s) (2011-09-19T10:54:36.962Z) and all associated audit records.</audit:justification>
+</audit:record>
+<audit:record ID="AUDREC24">
+<audit:process type="Fedora API-M"/>
+<audit:action>purgeDatastream</audit:action>
+<audit:componentID>content02</audit:componentID>
+<audit:responsibility>lmcrae</audit:responsibility>
+<audit:date>2013-12-10T18:58:55.326Z</audit:date>
+<audit:justification>Purged datastream (ID=content02), versions ranging from the beginning of time to the end of time.  This resulted in the permanent removal of 1 datastream version(s) (2011-09-19T10:55:11.287Z) and all associated audit records.</audit:justification>
+</audit:record>
+<audit:record ID="AUDREC25">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>identityMetadata</audit:componentID>
+<audit:responsibility>lmcrae</audit:responsibility>
+<audit:date>2013-12-10T18:59:15.418Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC26">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByReference</audit:action>
+<audit:componentID>workflows</audit:componentID>
+<audit:responsibility>workflow@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2013-12-10T19:00:05.902Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC27">
+<audit:process type="Fedora API-M"/>
+<audit:action>setDatastreamVersionable</audit:action>
+<audit:componentID>workflows</audit:componentID>
+<audit:responsibility>workflow@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2013-12-10T19:00:05.902Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC28">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>rightsMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2013-12-10T19:00:30.245Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC29">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>technicalMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2013-12-10T19:02:00.735Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC30">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByReference</audit:action>
+<audit:componentID>technicalMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2013-12-10T19:02:00.848Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC31">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>identityMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2013-12-10T19:02:17.276Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC32">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByReference</audit:action>
+<audit:componentID>events</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2013-12-10T19:02:17.414Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC33">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>provenanceMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2013-12-10T19:04:01.943Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+</audit:auditTrail>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="RELS-EXT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="RELS-EXT.1" LABEL="RDF Statements about this object" CREATED="2012-05-07T23:21:27.209Z" MIMETYPE="application/rdf+xml" FORMAT_URI="info:fedora/fedora-system:FedoraRELSExt-1.0" SIZE="458">
+<foxml:xmlContent>
+<rdf:RDF xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about="info:fedora/druid:dd327qr3670">
+    <hydra:isGovernedBy rdf:resource="info:fedora/druid:hv992ry2431"></hydra:isGovernedBy>
+    <fedora-model:hasModel rdf:resource="info:fedora/afmodel:Dor_Item"></fedora-model:hasModel>
+  </rdf:Description>
+</rdf:RDF>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="RELS-EXT.0" LABEL="RDF Statements about this object" CREATED="2011-07-05T17:12:18.916Z" MIMETYPE="application/rdf+xml" FORMAT_URI="info:fedora/fedora-system:FedoraRELSExt-1.0" SIZE="463">
+<foxml:xmlContent>
+<rdf:RDF xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rel="info:fedora/fedora-system:def/relations-external#">
+           <rdf:Description rdf:about="info:fedora/druid:dd327qr3670">
+               <hydra:isGovernedBy rdf:resource="info:fedora/druid:hv992ry2431"></hydra:isGovernedBy>
+            </rdf:Description>
+         </rdf:RDF>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="contentMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="contentMetadata.5" LABEL="Content Metadata" CREATED="2012-05-07T23:21:27.982Z" MIMETYPE="text/xml" SIZE="780">
+<foxml:xmlContent>
+<contentMetadata objectId="druid:dd327qr3670" type="agreement">
+  <resource data="content" id="deposit_agreement" type="document">
+    <file format="TEXT" id="OpLvlAgrmt_SpecColl_v01.docx" mimetype="application/msword" preserve="yes" publish="no" shelve="yes" size="29750">
+      <checksum type="md5">c55902247fe8bbc94ec2f99092713470</checksum>
+      <checksum type="sha1">d05188244e1a23c20d94757cd49091161365dcf4</checksum>
+    </file>
+    <file format="PDF" id="OpLvlAgrmt_SpecColl_v01_pdfa-1b.pdf" mimetype="application/pdf" preserve="yes" publish="no" shelve="yes" size="93157">
+      <checksum type="md5">cb8992554490930ee92f7ddef4862413</checksum>
+      <checksum type="sha1">060c43f1b902b4ace09b8204e3d96c8e2b542e2d</checksum>
+    </file>
+  </resource>
+</contentMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="contentMetadata.6" LABEL="Content Metadata" CREATED="2013-02-12T19:35:21.035Z" MIMETYPE="text/xml" SIZE="771">
+<foxml:xmlContent>
+<contentMetadata objectId="druid:dd327qr3670" type="file">
+  <resource data="content" id="deposit_agreement" type="file">
+    <file format="TEXT" id="OpLvlAgrmt_SpecColl_v01.docx" mimetype="application/msword" preserve="yes" publish="no" shelve="yes" size="29750">
+      <checksum type="md5">c55902247fe8bbc94ec2f99092713470</checksum>
+      <checksum type="sha1">d05188244e1a23c20d94757cd49091161365dcf4</checksum>
+    </file>
+    <file format="PDF" id="OpLvlAgrmt_SpecColl_v01_pdfa-1b.pdf" mimetype="application/pdf" preserve="yes" publish="no" shelve="yes" size="93157">
+      <checksum type="md5">cb8992554490930ee92f7ddef4862413</checksum>
+      <checksum type="sha1">060c43f1b902b4ace09b8204e3d96c8e2b542e2d</checksum>
+    </file>
+  </resource>
+</contentMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="descMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="descMetadata.2" LABEL="Descriptive Metadata" CREATED="2012-05-07T23:21:24.657Z" MIMETYPE="text/xml" SIZE="720">
+<foxml:xmlContent>
+<mods version="3.3">
+           <titleInfo>
+             <title>Agrreement for Department of Special Collections and University Archives</title>
+           </titleInfo>
+           <name type="corporate">
+             <namePart>Stanford University Libraries, Stanford Digital Repository</namePart>
+             <role>
+               <text>creator</text>
+             </role>
+           </name>
+           <typeOfResource>text</typeOfResource>
+           <genre>internal document</genre>
+           <originInfo>
+             <publisher>Stanford University Libraries</publisher>
+             <dateIssued>2011</dateIssued>
+           </originInfo>
+           <language authority="iso639-2b">eng</language>
+         </mods>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="descMetadata.3" LABEL="Descriptive Metadata" CREATED="2013-01-28T22:56:38.664Z" MIMETYPE="text/xml" SIZE="566">
+<foxml:xmlContent>
+<mods version="3.3">
+  <titleInfo>
+    <title>Agreement for Department of Special Collections and University Archives</title>
+  </titleInfo>
+  <name type="corporate">
+    <namePart>Stanford University Libraries, Stanford Digital Repository</namePart>
+    <role>
+      <text>creator</text>
+    </role>
+  </name>
+  <typeOfResource>text</typeOfResource>
+  <genre>internal document</genre>
+  <originInfo>
+    <publisher>Stanford University Libraries</publisher>
+    <dateIssued>2011</dateIssued>
+  </originInfo>
+  <language authority="iso639-2b">eng</language>
+</mods>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="descMetadata.4" LABEL="Descriptive Metadata" CREATED="2013-02-12T20:01:18.193Z" MIMETYPE="text/xml" SIZE="753">
+<foxml:xmlContent>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd">
+  <titleInfo>
+    <title>Agreement for Department of Special Collections and University Archives</title>
+  </titleInfo>
+  <name type="corporate">
+    <namePart>Stanford University Libraries, Stanford Digital Repository</namePart>
+    <role>
+      <text>creator</text>
+    </role>
+  </name>
+  <typeOfResource>text</typeOfResource>
+  <genre>internal document</genre>
+  <originInfo>
+    <publisher>Stanford University Libraries</publisher>
+    <dateIssued>2011</dateIssued>
+  </originInfo>
+  <language authority="iso639-2b">eng</language>
+</mods>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="descMetadata.5" LABEL="Descriptive Metadata" CREATED="2013-02-12T20:04:28.846Z" MIMETYPE="text/xml" SIZE="802">
+<foxml:xmlContent>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd">
+  <titleInfo>
+    <title>Agreement for Department of Special Collections and University Archives</title>
+  </titleInfo>
+  <name type="corporate">
+    <namePart>Stanford University Libraries, Stanford Digital Repository</namePart>
+    <role>
+      <text>creator</text>
+    </role>
+  </name>
+  <typeOfResource>text</typeOfResource>
+  <genre>internal document</genre>
+  <originInfo>
+    <publisher>Stanford University Libraries</publisher>
+    <dateIssued>2011</dateIssued>
+  </originInfo>
+  <language>
+    <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+  </language>
+</mods>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="descMetadata.6" LABEL="Descriptive Metadata" CREATED="2013-02-12T20:05:50.459Z" MIMETYPE="text/xml" SIZE="846">
+<foxml:xmlContent>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd">
+  <titleInfo>
+    <title>Agreement for Department of Special Collections and University Archives</title>
+  </titleInfo>
+  <name type="corporate">
+    <namePart>Stanford University Libraries, Stanford Digital Repository</namePart>
+    <role>
+      <roleTerm authority="marcrelator" type="text">creator</roleTerm>
+    </role>
+  </name>
+  <typeOfResource>text</typeOfResource>
+  <genre>internal document</genre>
+  <originInfo>
+    <publisher>Stanford University Libraries</publisher>
+    <dateIssued>2011</dateIssued>
+  </originInfo>
+  <language>
+    <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+  </language>
+</mods>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="identityMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="identityMetadata.2" LABEL="Identity Metadata" CREATED="2012-05-07T23:21:25.455Z" MIMETYPE="text/xml" SIZE="485">
+<foxml:xmlContent>
+<identityMetadata>
+  <objectLabel>Agrreement for Department of Special Collections and University Archives</objectLabel>
+  <tag>DOR : Agreement</tag>
+  <adminPolicy>druid:nt592gh9590</adminPolicy>
+  <objectType>agreement</objectType>
+  <otherId name="uuid">23fcaec0-e2e7-11e0-9572-0800200c9a66</otherId>
+  <objectId>druid:dd327qr3670</objectId>
+  <objectCreator>DOR</objectCreator>
+  <agreementId>druid:tx617qp8040</agreementId>
+  <tag>Remediated By : 3.6.2</tag>
+</identityMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="identityMetadata.3" LABEL="Identity Metadata" CREATED="2013-02-12T19:49:49.358Z" MIMETYPE="text/xml" SIZE="503">
+<foxml:xmlContent>
+<identityMetadata>
+  <objectLabel>Agreement for Department of Special Collections and University Archives</objectLabel>
+  <tag>DOR : Agreement</tag>
+  <adminPolicy>druid:nt592gh9590</adminPolicy>
+  <objectType>agreement</objectType>
+  <otherId name="uuid">23fcaec0-e2e7-11e0-9572-0800200c9a66</otherId>
+  <objectId>druid:dd327qr3670</objectId>
+  <objectCreator>DOR</objectCreator>
+  <sourceId source="sul">SDR_DepositAgreement_SPECCOLL</sourceId>
+  <tag>Remediated By : 3.6.2</tag>
+</identityMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="identityMetadata.4" LABEL="Identity Metadata" CREATED="2013-10-28T23:42:30.509Z" MIMETYPE="text/xml" SIZE="474">
+<foxml:xmlContent>
+<identityMetadata>
+  <objectLabel>Agreement for Department of Special Collections and University Archives</objectLabel>
+  <adminPolicy>druid:nt592gh9590</adminPolicy>
+  <objectType>agreement</objectType>
+  <otherId name="uuid">23fcaec0-e2e7-11e0-9572-0800200c9a66</otherId>
+  <objectId>druid:dd327qr3670</objectId>
+  <objectCreator>DOR</objectCreator>
+  <sourceId source="sul">SDR_DepositAgreement_SPECCOLL</sourceId>
+  <tag>Remediated By : 3.6.2</tag>
+</identityMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="identityMetadata.5" LABEL="Identity Metadata" CREATED="2013-12-10T18:59:15.418Z" MIMETYPE="text/xml" SIZE="427">
+<foxml:xmlContent>
+<identityMetadata>
+  <objectLabel>Agreement for Department of Special Collections and University Archives</objectLabel>
+  <objectType>agreement</objectType>
+  <otherId name="uuid">23fcaec0-e2e7-11e0-9572-0800200c9a66</otherId>
+  <objectId>druid:dd327qr3670</objectId>
+  <objectCreator>DOR</objectCreator>
+  <sourceId source="sul">SDR_DepositAgreement_SPECCOLL</sourceId>
+  <tag>Remediated By : 3.6.2</tag>
+</identityMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="identityMetadata.6" LABEL="Identity Metadata" CREATED="2013-12-10T19:02:17.276Z" MIMETYPE="text/xml" SIZE="428">
+<foxml:xmlContent>
+<identityMetadata>
+  <objectLabel>Agreement for Department of Special Collections and University Archives</objectLabel>
+  <objectType>agreement</objectType>
+  <otherId name="uuid">23fcaec0-e2e7-11e0-9572-0800200c9a66</otherId>
+  <objectId>druid:dd327qr3670</objectId>
+  <objectCreator>DOR</objectCreator>
+  <sourceId source="sul">SDR_DepositAgreement_SPECCOLL</sourceId>
+  <tag>Remediated By : 3.25.3</tag>
+</identityMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="DC" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
+<foxml:datastreamVersion ID="DC.2" LABEL="Dublin Core Record for this object" CREATED="2013-01-28T22:56:18.503Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" SIZE="516">
+<foxml:xmlContent>
+<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+  <dc:title>Agreement for Department of Special Collections and University Archives</dc:title>
+  <dc:identifier>uuid:23fcaec0-e2e7-11e0-9572-0800200c9a66</dc:identifier>
+  <dc:identifier>druid:dd327qr3670</dc:identifier>
+</oai_dc:dc>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="versionMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="versionMetadata.0" LABEL="Version Metadata" CREATED="2013-12-10T18:51:51.477Z" MIMETYPE="text/xml" SIZE="165">
+<foxml:xmlContent>
+<versionMetadata objectId="druid:dd327qr3670">
+  <version tag="1.0.0" versionId="1">
+    <description>Initial Version</description>
+  </version>
+</versionMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="rightsMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="rightsMetadata.0" LABEL="Rights Metadata" CREATED="2013-12-10T19:00:30.245Z" MIMETYPE="text/xml" SIZE="572">
+<foxml:xmlContent>
+<rightsMetadata>
+  <copyright>
+    <human type="copyright">This work is copyrighted by the creator.</human>
+  </copyright>
+  <access type="discover">
+    <world></world>
+  </access>
+  <access type="read">
+    <human>This document is available only to the Stanford faculty, staff and student
+            community</human>
+    <machine>
+      <group>stanford</group>
+    </machine>
+  </access>
+  <use>
+    <human type="creativecommons">Attribution Non-Commercial Share Alike license</human>
+    <machine type="creativecommons">by-nc-sa</machine>
+  </use>
+</rightsMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="provenanceMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="provenanceMetadata.0" LABEL="Provenance Metadata" CREATED="2013-12-10T19:04:01.943Z" MIMETYPE="text/xml" SIZE="265">
+<foxml:xmlContent>
+<provenanceMetadata objectId="druid:dd327qr3670">
+  <agent name="DOR">
+    <what object="druid:dd327qr3670">
+      <event when="2013-12-10T11:04:01-08:00" who="DOR-accessionWF">DOR Common Accessioning completed</event>
+    </what>
+  </agent>
+</provenanceMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+</foxml:digitalObject>

--- a/fedora_conf/data/druids
+++ b/fedora_conf/data/druids
@@ -44,3 +44,7 @@ druid:ti057vk7675   Stanford University Libraries - Exceptional Collections
 druid:ti057vk7676   Stanford University Libraries - Uncommon Collections
 druid:ti057vk7677   Stanford University Libraries - Odd Collections
 druid:tm388wy6148   accessionWF
+druid:dd327qr3670   Agreement for Department of Special Collections and University Archives
+druid:fg464dn8891   State Banking Commission Annual Reports
+druid:pb873ty1662   Annual report of the State Corporation Commission showing the condition of the incorporated state banks and other institutions operating in Virginia at the close of business
+druid:qq613vj0238   Annual Report of the State Corporation Commission, Virginia, 1927-28, 1930-43

--- a/fedora_conf/data/fg464dn8891.xml
+++ b/fedora_conf/data/fg464dn8891.xml
@@ -1,0 +1,913 @@
+<foxml:digitalObject VERSION="1.1" PID="druid:fg464dn8891"
+xmlns:foxml="info:fedora/fedora-system:def/foxml#"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
+<foxml:objectProperties>
+<foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="State Banking Commission Annual Reports"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE="argo.stanford.edu"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="2014-07-31T22:53:36.613Z"/>
+<foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE="2015-10-14T17:22:37.665Z"/>
+</foxml:objectProperties>
+<foxml:datastream ID="AUDIT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
+<foxml:datastreamVersion ID="AUDIT.0" LABEL="Audit Trail for this object" CREATED="2014-07-31T22:53:36.613Z" MIMETYPE="text/xml" FORMAT_URI="info:fedora/fedora-system:format/xml.fedora.audit">
+<foxml:xmlContent>
+<audit:auditTrail xmlns:audit="info:fedora/fedora-system:def/audit#">
+<audit:record ID="AUDREC1">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>RELS-EXT</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:53:36.740Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC2">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>identityMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:53:36.841Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC3">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>workflows</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:53:36.945Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC4">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:53:37.062Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC5">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>RELS-EXT</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:53:40.535Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC6">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>identityMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:53:40.725Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC7">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>descMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:53:40.817Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC8">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>administrativeMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:53:40.912Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC9">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>roleMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:53:41.005Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC10">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>defaultObjectRights</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:53:41.098Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC11">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:53:41.185Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC12">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>rightsMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:54:13.940Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC13">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:55:47.081Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC14">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>identityMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:55:56.742Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC15">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>events</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:55:56.840Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC16">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:56:36.543Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC17">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>administrativeMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:56:36.636Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC18">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>provenanceMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:57:57.505Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC19">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T23:05:30.232Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC20">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T23:07:10.048Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC21">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T23:09:12.139Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC22">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>administrativeMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T23:09:12.241Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC23">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-08-04T15:31:11.466Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC24">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-08-04T17:15:08.911Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC25">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-08-04T17:15:10.492Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC26">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-08-04T17:16:32.339Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC27">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-08-04T17:18:45.133Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC28">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>administrativeMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-08-04T17:18:45.229Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC29">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-08-04T17:18:58.182Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC30">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-08-06T17:09:25.860Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC31">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-08-06T17:11:09.650Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC32">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>administrativeMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-08-06T17:11:09.762Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC33">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-08-06T22:27:16.559Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC34">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>RELS-EXT</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-09-04T23:25:19.912Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC35">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByReference</audit:action>
+<audit:componentID>descMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-09-04T23:25:20.010Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC36">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-09-04T23:25:20.180Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC37">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>administrativeMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-09-04T23:25:20.278Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC38">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>roleMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-09-04T23:25:20.374Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC39">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>defaultObjectRights</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-09-04T23:25:20.534Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC40">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-03-02T15:32:06.238Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC41">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-03-02T15:33:33.403Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC42">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-03-02T15:34:40.592Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC43">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>administrativeMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-03-02T15:34:40.719Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC44">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-06-17T20:57:53.423Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC45">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-06-17T21:01:15.209Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC46">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>administrativeMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-06-17T21:01:15.306Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC47">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-06-17T21:12:17.260Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC48">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-06-17T21:13:20.703Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC49">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>administrativeMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-06-17T21:13:20.821Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC50">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-09-14T21:50:36.714Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC51">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-09-14T21:55:34.779Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC52">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>administrativeMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-09-14T21:55:34.856Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC53">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-10-14T17:10:11.717Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC54">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-10-14T17:10:56.338Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC55">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>administrativeMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-10-14T17:10:56.451Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC56">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-10-14T17:22:37.665Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+</audit:auditTrail>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="DC" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="DC1.0" LABEL="Dublin Core Record for this object" CREATED="2014-07-31T22:53:36.613Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" SIZE="409">
+<foxml:xmlContent>
+<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+  <dc:title>State Banking Commission Annual Reports</dc:title>
+  <dc:identifier>druid:fg464dn8891</dc:identifier>
+</oai_dc:dc>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="RELS-EXT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="RELS-EXT.0" LABEL="Fedora Object-to-Object Relationship Metadata" CREATED="2014-07-31T22:53:36.740Z" MIMETYPE="application/rdf+xml" SIZE="471">
+<foxml:xmlContent>
+<rdf:RDF xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about="info:fedora/druid:fg464dn8891">
+    <hydra:isGovernedBy rdf:resource="info:fedora/druid:hv992ry2431"></hydra:isGovernedBy>
+    <fedora-model:hasModel rdf:resource="info:fedora/afmodel:Dor_AdminPolicyObject"></fedora-model:hasModel>
+  </rdf:Description>
+</rdf:RDF>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="RELS-EXT.1" LABEL="Fedora Object-to-Object Relationship Metadata" CREATED="2014-07-31T22:53:40.535Z" MIMETYPE="application/rdf+xml" SIZE="576">
+<foxml:xmlContent>
+<rdf:RDF xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about="info:fedora/druid:fg464dn8891">
+    <hydra:isGovernedBy rdf:resource="info:fedora/druid:hv992ry2431"></hydra:isGovernedBy>
+    <hydra:referencesAgreement rdf:resource="info:fedora/druid:dd327qr3670"></hydra:referencesAgreement>
+    <fedora-model:hasModel rdf:resource="info:fedora/afmodel:Dor_AdminPolicyObject"></fedora-model:hasModel>
+  </rdf:Description>
+</rdf:RDF>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="RELS-EXT.2" LABEL="Fedora Object-to-Object Relationship Metadata" CREATED="2014-09-04T23:25:19.912Z" MIMETYPE="application/rdf+xml" SIZE="576">
+<foxml:xmlContent>
+<rdf:RDF xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about="info:fedora/druid:fg464dn8891">
+    <hydra:isGovernedBy rdf:resource="info:fedora/druid:hv992ry2431"></hydra:isGovernedBy>
+    <hydra:referencesAgreement rdf:resource="info:fedora/druid:dd327qr3670"></hydra:referencesAgreement>
+    <fedora-model:hasModel rdf:resource="info:fedora/afmodel:Dor_AdminPolicyObject"></fedora-model:hasModel>
+  </rdf:Description>
+</rdf:RDF>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="identityMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="identityMetadata.0" LABEL="Identity Metadata" CREATED="2014-07-31T22:53:36.841Z" MIMETYPE="text/xml" SIZE="343">
+<foxml:xmlContent>
+<identityMetadata>
+  <objectId>druid:fg464dn8891</objectId>
+  <objectCreator>DOR</objectCreator>
+  <objectLabel>State Banking Commission Annual Reports</objectLabel>
+  <objectType>adminPolicy</objectType>
+  <adminPolicy>druid:hv992ry2431</adminPolicy>
+  <otherId name="uuid">801a45f8-1905-11e4-8e6a-0050569b3c3c</otherId>
+</identityMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="identityMetadata.1" LABEL="Identity Metadata" CREATED="2014-07-31T22:53:40.725Z" MIMETYPE="text/xml" SIZE="380">
+<foxml:xmlContent>
+<identityMetadata>
+  <objectId>druid:fg464dn8891</objectId>
+  <objectCreator>DOR</objectCreator>
+  <objectLabel>State Banking Commission Annual Reports</objectLabel>
+  <objectType>adminPolicy</objectType>
+  <adminPolicy>druid:hv992ry2431</adminPolicy>
+  <otherId name="uuid">801a45f8-1905-11e4-8e6a-0050569b3c3c</otherId>
+  <tag>Registered By : llam813</tag>
+</identityMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="identityMetadata.2" LABEL="Identity Metadata" CREATED="2014-07-31T22:55:56.742Z" MIMETYPE="text/xml" SIZE="417">
+<foxml:xmlContent>
+<identityMetadata>
+  <objectId>druid:fg464dn8891</objectId>
+  <objectCreator>DOR</objectCreator>
+  <objectLabel>State Banking Commission Annual Reports</objectLabel>
+  <objectType>adminPolicy</objectType>
+  <adminPolicy>druid:hv992ry2431</adminPolicy>
+  <otherId name="uuid">801a45f8-1905-11e4-8e6a-0050569b3c3c</otherId>
+  <tag>Registered By : llam813</tag>
+  <tag>Remediated By : 4.6.6.2</tag>
+</identityMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="workflows" STATE="A" CONTROL_GROUP="E" VERSIONABLE="true">
+<foxml:datastreamVersion ID="workflows.0" LABEL="Workflows" CREATED="2014-07-31T22:53:36.945Z" MIMETYPE="application/xml">
+<foxml:contentLocation TYPE="URL" REF="https://lyberservices-prod.stanford.edu/workflow/dor/objects/druid:fg464dn8891/workflows"/>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="administrativeMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="administrativeMetadata.0" LABEL="Administrative Metadata" CREATED="2014-07-31T22:53:40.912Z" MIMETYPE="text/xml" SIZE="273">
+<foxml:xmlContent>
+<administrativeMetadata>
+  <descMetadata>
+    <format>MODS</format>
+    <source>Symphony</source>
+  </descMetadata>
+  <registration>
+    <collection id="druid:kk203bw3276"></collection>
+    <workflow id="dpgImageWF"></workflow>
+  </registration>
+</administrativeMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="administrativeMetadata.1" LABEL="Administrative Metadata" CREATED="2014-07-31T22:56:36.636Z" MIMETYPE="text/xml" SIZE="326">
+<foxml:xmlContent>
+<administrativeMetadata>
+  <descMetadata>
+    <format>MODS</format>
+    <source>Symphony</source>
+  </descMetadata>
+  <registration>
+    <collection id="druid:kk203bw3276"></collection>
+    <workflow id="dpgImageWF"></workflow>
+    <collection id="druid:pb873ty1662"></collection>
+  </registration>
+</administrativeMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="administrativeMetadata.2" LABEL="Administrative Metadata" CREATED="2014-07-31T23:09:12.241Z" MIMETYPE="text/xml" SIZE="379">
+<foxml:xmlContent>
+<administrativeMetadata>
+  <descMetadata>
+    <format>MODS</format>
+    <source>Symphony</source>
+  </descMetadata>
+  <registration>
+    <collection id="druid:kk203bw3276"></collection>
+    <workflow id="dpgImageWF"></workflow>
+    <collection id="druid:pb873ty1662"></collection>
+    <collection id="druid:zx663qq1749"></collection>
+  </registration>
+</administrativeMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="administrativeMetadata.3" LABEL="Administrative Metadata" CREATED="2014-08-04T17:18:45.229Z" MIMETYPE="text/xml" SIZE="432">
+<foxml:xmlContent>
+<administrativeMetadata>
+  <descMetadata>
+    <format>MODS</format>
+    <source>Symphony</source>
+  </descMetadata>
+  <registration>
+    <collection id="druid:kk203bw3276"></collection>
+    <workflow id="dpgImageWF"></workflow>
+    <collection id="druid:pb873ty1662"></collection>
+    <collection id="druid:zx663qq1749"></collection>
+    <collection id="druid:nq832zg5474"></collection>
+  </registration>
+</administrativeMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="administrativeMetadata.4" LABEL="Administrative Metadata" CREATED="2014-08-06T17:11:09.762Z" MIMETYPE="text/xml" SIZE="485">
+<foxml:xmlContent>
+<administrativeMetadata>
+  <descMetadata>
+    <format>MODS</format>
+    <source>Symphony</source>
+  </descMetadata>
+  <registration>
+    <collection id="druid:kk203bw3276"></collection>
+    <workflow id="dpgImageWF"></workflow>
+    <collection id="druid:pb873ty1662"></collection>
+    <collection id="druid:zx663qq1749"></collection>
+    <collection id="druid:nq832zg5474"></collection>
+    <collection id="druid:fb337wh0818"></collection>
+  </registration>
+</administrativeMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="administrativeMetadata.5" LABEL="Administrative Metadata" CREATED="2014-09-04T23:25:20.278Z" MIMETYPE="text/xml" SIZE="485">
+<foxml:xmlContent>
+<administrativeMetadata>
+  <descMetadata>
+    <format>MODS</format>
+    <source>Symphony</source>
+  </descMetadata>
+  <registration>
+    <collection id="druid:kk203bw3276"></collection>
+    <workflow id="dpgImageWF"></workflow>
+    <collection id="druid:pb873ty1662"></collection>
+    <collection id="druid:zx663qq1749"></collection>
+    <collection id="druid:nq832zg5474"></collection>
+    <collection id="druid:fb337wh0818"></collection>
+  </registration>
+</administrativeMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="administrativeMetadata.6" LABEL="Administrative Metadata" CREATED="2015-03-02T15:34:40.719Z" MIMETYPE="text/xml" SIZE="538">
+<foxml:xmlContent>
+<administrativeMetadata>
+  <descMetadata>
+    <format>MODS</format>
+    <source>Symphony</source>
+  </descMetadata>
+  <registration>
+    <collection id="druid:kk203bw3276"></collection>
+    <workflow id="dpgImageWF"></workflow>
+    <collection id="druid:pb873ty1662"></collection>
+    <collection id="druid:zx663qq1749"></collection>
+    <collection id="druid:nq832zg5474"></collection>
+    <collection id="druid:fb337wh0818"></collection>
+    <collection id="druid:kd973gk0505"></collection>
+  </registration>
+</administrativeMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="administrativeMetadata.7" LABEL="Administrative Metadata" CREATED="2015-06-17T21:01:15.306Z" MIMETYPE="text/xml" SIZE="591">
+<foxml:xmlContent>
+<administrativeMetadata>
+  <descMetadata>
+    <format>MODS</format>
+    <source>Symphony</source>
+  </descMetadata>
+  <registration>
+    <collection id="druid:kk203bw3276"></collection>
+    <workflow id="dpgImageWF"></workflow>
+    <collection id="druid:pb873ty1662"></collection>
+    <collection id="druid:zx663qq1749"></collection>
+    <collection id="druid:nq832zg5474"></collection>
+    <collection id="druid:fb337wh0818"></collection>
+    <collection id="druid:kd973gk0505"></collection>
+    <collection id="druid:jm980xw3297"></collection>
+  </registration>
+</administrativeMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="administrativeMetadata.8" LABEL="Administrative Metadata" CREATED="2015-06-17T21:13:20.821Z" MIMETYPE="text/xml" SIZE="644">
+<foxml:xmlContent>
+<administrativeMetadata>
+  <descMetadata>
+    <format>MODS</format>
+    <source>Symphony</source>
+  </descMetadata>
+  <registration>
+    <collection id="druid:kk203bw3276"></collection>
+    <workflow id="dpgImageWF"></workflow>
+    <collection id="druid:pb873ty1662"></collection>
+    <collection id="druid:zx663qq1749"></collection>
+    <collection id="druid:nq832zg5474"></collection>
+    <collection id="druid:fb337wh0818"></collection>
+    <collection id="druid:kd973gk0505"></collection>
+    <collection id="druid:jm980xw3297"></collection>
+    <collection id="druid:fz658ss5788"></collection>
+  </registration>
+</administrativeMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="administrativeMetadata.9" LABEL="Administrative Metadata" CREATED="2015-09-14T21:55:34.856Z" MIMETYPE="text/xml" SIZE="697">
+<foxml:xmlContent>
+<administrativeMetadata>
+  <descMetadata>
+    <format>MODS</format>
+    <source>Symphony</source>
+  </descMetadata>
+  <registration>
+    <collection id="druid:kk203bw3276"></collection>
+    <workflow id="dpgImageWF"></workflow>
+    <collection id="druid:pb873ty1662"></collection>
+    <collection id="druid:zx663qq1749"></collection>
+    <collection id="druid:nq832zg5474"></collection>
+    <collection id="druid:fb337wh0818"></collection>
+    <collection id="druid:kd973gk0505"></collection>
+    <collection id="druid:jm980xw3297"></collection>
+    <collection id="druid:fz658ss5788"></collection>
+    <collection id="druid:vh782pm7216"></collection>
+  </registration>
+</administrativeMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="administrativeMetadata.10" LABEL="Administrative Metadata" CREATED="2015-10-14T17:10:56.451Z" MIMETYPE="text/xml" SIZE="750">
+<foxml:xmlContent>
+<administrativeMetadata>
+  <descMetadata>
+    <format>MODS</format>
+    <source>Symphony</source>
+  </descMetadata>
+  <registration>
+    <collection id="druid:kk203bw3276"></collection>
+    <workflow id="dpgImageWF"></workflow>
+    <collection id="druid:pb873ty1662"></collection>
+    <collection id="druid:zx663qq1749"></collection>
+    <collection id="druid:nq832zg5474"></collection>
+    <collection id="druid:fb337wh0818"></collection>
+    <collection id="druid:kd973gk0505"></collection>
+    <collection id="druid:jm980xw3297"></collection>
+    <collection id="druid:fz658ss5788"></collection>
+    <collection id="druid:vh782pm7216"></collection>
+    <collection id="druid:gg191kg3953"></collection>
+  </registration>
+</administrativeMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="roleMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="roleMetadata.0" LABEL="Role Metadata" CREATED="2014-07-31T22:53:41.005Z" MIMETYPE="text/xml" SIZE="432">
+<foxml:xmlContent>
+<roleMetadata>
+  <role type="dor-apo-manager">
+    <group>
+      <identifier type="workgroup">dlss:developers</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:pmag-staff</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:dpg-staff</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">sdr:metadata-staff</identifier>
+    </group>
+  </role>
+</roleMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="roleMetadata.1" LABEL="Role Metadata" CREATED="2014-09-04T23:25:20.374Z" MIMETYPE="text/xml" SIZE="432">
+<foxml:xmlContent>
+<roleMetadata>
+  <role type="dor-apo-manager">
+    <group>
+      <identifier type="workgroup">dlss:developers</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:pmag-staff</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:dpg-staff</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">sdr:metadata-staff</identifier>
+    </group>
+  </role>
+</roleMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="defaultObjectRights" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="defaultObjectRights.0" LABEL="Default Object Rights" CREATED="2014-07-31T22:53:41.098Z" MIMETYPE="text/xml" SIZE="670">
+<foxml:xmlContent>
+<rightsMetadata>
+  <access type="discover">
+    <machine>
+      <world></world>
+    </machine>
+  </access>
+  <access type="read">
+    <machine>
+      <world></world>
+    </machine>
+  </access>
+  <use>
+    <human type="useAndReproduction">These works have been digitized and made accessible with the permission of the State.  States may limit further reuse.  Please contact govinfolib@lists.stanford.edu with questions about reuse or access.</human>
+    <human type="creativeCommons"></human>
+    <machine type="creativeCommons"></machine>
+  </use>
+  <copyright>
+    <human>Copyright © Stanford University. All Rights Reserved.</human>
+  </copyright>
+</rightsMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="defaultObjectRights.1" LABEL="Default Object Rights" CREATED="2014-09-04T23:25:20.534Z" MIMETYPE="text/xml" SIZE="670">
+<foxml:xmlContent>
+<rightsMetadata>
+  <access type="discover">
+    <machine>
+      <world></world>
+    </machine>
+  </access>
+  <access type="read">
+    <machine>
+      <world></world>
+    </machine>
+  </access>
+  <use>
+    <human type="useAndReproduction">These works have been digitized and made accessible with the permission of the State.  States may limit further reuse.  Please contact govinfolib@lists.stanford.edu with questions about reuse or access.</human>
+    <human type="creativeCommons"></human>
+    <machine type="creativeCommons"></machine>
+  </use>
+  <copyright>
+    <human>Copyright © Stanford University. All Rights Reserved.</human>
+  </copyright>
+</rightsMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="rightsMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="rightsMetadata.0" LABEL="Rights Metadata" CREATED="2014-07-31T22:54:13.940Z" MIMETYPE="text/xml" SIZE="572">
+<foxml:xmlContent>
+<rightsMetadata>
+  <copyright>
+    <human type="copyright">This work is copyrighted by the creator.</human>
+  </copyright>
+  <access type="discover">
+    <world></world>
+  </access>
+  <access type="read">
+    <human>This document is available only to the Stanford faculty, staff and student
+            community</human>
+    <machine>
+      <group>stanford</group>
+    </machine>
+  </access>
+  <use>
+    <human type="creativecommons">Attribution Non-Commercial Share Alike license</human>
+    <machine type="creativecommons">by-nc-sa</machine>
+  </use>
+</rightsMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="events" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
+<foxml:datastreamVersion ID="events.0" LABEL="Events" CREATED="2014-07-31T22:55:56.840Z" MIMETYPE="text/xml" SIZE="146">
+<foxml:xmlContent>
+<events>
+  <event type="remediation" when="2014-07-31T15:55:56-07:00" who="Dor::Identifiable 3.6.1">Record Remediation Version</event>
+</events>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="provenanceMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="provenanceMetadata.0" LABEL="Provenance Metadata" CREATED="2014-07-31T22:57:57.505Z" MIMETYPE="text/xml" SIZE="265">
+<foxml:xmlContent>
+<provenanceMetadata objectId="druid:fg464dn8891">
+  <agent name="DOR">
+    <what object="druid:fg464dn8891">
+      <event when="2014-07-31T15:57:57-07:00" who="DOR-accessionWF">DOR Common Accessioning completed</event>
+    </what>
+  </agent>
+</provenanceMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="versionMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
+<foxml:datastreamVersion ID="versionMetadata.28" LABEL="Version Metadata" CREATED="2015-10-14T17:22:37.665Z" MIMETYPE="text/xml" SIZE="165">
+<foxml:xmlContent>
+<versionMetadata objectId="druid:fg464dn8891">
+  <version tag="1.0.0" versionId="1">
+    <description>Initial Version</description>
+  </version>
+</versionMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+</foxml:digitalObject>

--- a/fedora_conf/data/load_order
+++ b/fedora_conf/data/load_order
@@ -46,3 +46,7 @@ kv840rx2720.xml
 hj185vb7593.xml
 pv820dk6668.xml
 tm388wy6148.xml
+dd327qr3670.xml
+fg464dn8891.xml
+pb873ty1662.xml
+qq613vj0238.xml

--- a/fedora_conf/data/pb873ty1662.xml
+++ b/fedora_conf/data/pb873ty1662.xml
@@ -1,0 +1,207 @@
+<foxml:digitalObject VERSION="1.1" PID="druid:pb873ty1662"
+xmlns:foxml="info:fedora/fedora-system:def/foxml#"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
+<foxml:objectProperties>
+<foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="Annual report of the State Corporation Commission showing the condition of the incorporated state banks and other institutions operating in Virginia at the close of business"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE="argo.stanford.edu"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="2014-07-31T22:56:35.559Z"/>
+<foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE="2014-07-31T23:01:45.441Z"/>
+</foxml:objectProperties>
+<foxml:datastream ID="AUDIT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
+<foxml:datastreamVersion ID="AUDIT.0" LABEL="Audit Trail for this object" CREATED="2014-07-31T22:56:35.559Z" MIMETYPE="text/xml" FORMAT_URI="info:fedora/fedora-system:format/xml.fedora.audit">
+<foxml:xmlContent>
+<audit:auditTrail xmlns:audit="info:fedora/fedora-system:def/audit#">
+<audit:record ID="AUDREC1">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>RELS-EXT</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:56:35.683Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC2">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>identityMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:56:35.773Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC3">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>workflows</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:56:35.899Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC4">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>rightsMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:56:36.020Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC5">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:56:36.142Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC6">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>descMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:57:05.996Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC7">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>identityMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:59:01.772Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC8">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>events</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T22:59:01.872Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC9">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>provenanceMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-07-31T23:01:45.441Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+</audit:auditTrail>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="DC" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="DC1.0" LABEL="Dublin Core Record for this object" CREATED="2014-07-31T22:56:35.559Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" SIZE="543">
+<foxml:xmlContent>
+<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+  <dc:title>Annual report of the State Corporation Commission showing the condition of the incorporated state banks and other institutions operating in Virginia at the close of business</dc:title>
+  <dc:identifier>druid:pb873ty1662</dc:identifier>
+</oai_dc:dc>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="RELS-EXT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="RELS-EXT.0" LABEL="Fedora Object-to-Object Relationship Metadata" CREATED="2014-07-31T22:56:35.683Z" MIMETYPE="application/rdf+xml" SIZE="464">
+<foxml:xmlContent>
+<rdf:RDF xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about="info:fedora/druid:pb873ty1662">
+    <hydra:isGovernedBy rdf:resource="info:fedora/druid:fg464dn8891"></hydra:isGovernedBy>
+    <fedora-model:hasModel rdf:resource="info:fedora/afmodel:Dor_Collection"></fedora-model:hasModel>
+  </rdf:Description>
+</rdf:RDF>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="identityMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="identityMetadata.0" LABEL="Identity Metadata" CREATED="2014-07-31T22:56:35.773Z" MIMETYPE="text/xml" SIZE="518">
+<foxml:xmlContent>
+<identityMetadata>
+  <objectId>druid:pb873ty1662</objectId>
+  <objectCreator>DOR</objectCreator>
+  <objectLabel>Annual report of the State Corporation Commission showing the condition of the incorporated state banks and other institutions operating in Virginia at the close of business</objectLabel>
+  <objectType>collection</objectType>
+  <adminPolicy>druid:fg464dn8891</adminPolicy>
+  <otherId name="catkey">420563</otherId>
+  <otherId name="uuid">eb4da2a2-1905-11e4-8e6a-0050569b3c3c</otherId>
+</identityMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="identityMetadata.1" LABEL="Identity Metadata" CREATED="2014-07-31T22:59:01.772Z" MIMETYPE="text/xml" SIZE="555">
+<foxml:xmlContent>
+<identityMetadata>
+  <objectId>druid:pb873ty1662</objectId>
+  <objectCreator>DOR</objectCreator>
+  <objectLabel>Annual report of the State Corporation Commission showing the condition of the incorporated state banks and other institutions operating in Virginia at the close of business</objectLabel>
+  <objectType>collection</objectType>
+  <adminPolicy>druid:fg464dn8891</adminPolicy>
+  <otherId name="catkey">420563</otherId>
+  <otherId name="uuid">eb4da2a2-1905-11e4-8e6a-0050569b3c3c</otherId>
+  <tag>Remediated By : 4.6.6.2</tag>
+</identityMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="workflows" STATE="A" CONTROL_GROUP="E" VERSIONABLE="true">
+<foxml:datastreamVersion ID="workflows.0" LABEL="Workflows" CREATED="2014-07-31T22:56:35.899Z" MIMETYPE="application/xml">
+<foxml:contentLocation TYPE="URL" REF="https://lyberservices-prod.stanford.edu/workflow/dor/objects/druid:pb873ty1662/workflows"/>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="rightsMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="rightsMetadata.0" LABEL="Rights Metadata" CREATED="2014-07-31T22:56:36.020Z" MIMETYPE="text/xml" SIZE="670">
+<foxml:xmlContent>
+<rightsMetadata>
+  <access type="discover">
+    <machine>
+      <world></world>
+    </machine>
+  </access>
+  <access type="read">
+    <machine>
+      <world></world>
+    </machine>
+  </access>
+  <use>
+    <human type="useAndReproduction">These works have been digitized and made accessible with the permission of the State.  States may limit further reuse.  Please contact govinfolib@lists.stanford.edu with questions about reuse or access.</human>
+    <human type="creativeCommons"></human>
+    <machine type="creativeCommons"></machine>
+  </use>
+  <copyright>
+    <human>Copyright © Stanford University. All Rights Reserved.</human>
+  </copyright>
+</rightsMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="versionMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
+<foxml:datastreamVersion ID="versionMetadata.0" LABEL="Version Metadata" CREATED="2014-07-31T22:56:36.142Z" MIMETYPE="text/xml" SIZE="136">
+<foxml:xmlContent>
+<versionMetadata>
+  <version tag="1.0.0" versionId="1">
+    <description>Initial Version</description>
+  </version>
+</versionMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="events" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
+<foxml:datastreamVersion ID="events.0" LABEL="Events" CREATED="2014-07-31T22:59:01.872Z" MIMETYPE="text/xml" SIZE="146">
+<foxml:xmlContent>
+<events>
+  <event type="remediation" when="2014-07-31T15:59:01-07:00" who="Dor::Identifiable 3.6.1">Record Remediation Version</event>
+</events>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="provenanceMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="provenanceMetadata.0" LABEL="Provenance Metadata" CREATED="2014-07-31T23:01:45.441Z" MIMETYPE="text/xml" SIZE="265">
+<foxml:xmlContent>
+<provenanceMetadata objectId="druid:pb873ty1662">
+  <agent name="DOR">
+    <what object="druid:pb873ty1662">
+      <event when="2014-07-31T16:01:45-07:00" who="DOR-accessionWF">DOR Common Accessioning completed</event>
+    </what>
+  </agent>
+</provenanceMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+</foxml:digitalObject>

--- a/fedora_conf/data/qq613vj0238.xml
+++ b/fedora_conf/data/qq613vj0238.xml
@@ -1,0 +1,274 @@
+<foxml:digitalObject VERSION="1.1" PID="druid:qq613vj0238"
+xmlns:foxml="info:fedora/fedora-system:def/foxml#"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
+<foxml:objectProperties>
+<foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="Annual Report of the State Corporation Commission, Virginia, 1927-28, 1930-43"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE="argo.stanford.edu"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="2014-08-01T00:03:40.533Z"/>
+<foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE="2014-08-11T20:02:17.403Z"/>
+</foxml:objectProperties>
+<foxml:datastream ID="AUDIT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
+<foxml:datastreamVersion ID="AUDIT.0" LABEL="Audit Trail for this object" CREATED="2014-08-01T00:03:40.533Z" MIMETYPE="text/xml" FORMAT_URI="info:fedora/fedora-system:format/xml.fedora.audit">
+<foxml:xmlContent>
+<audit:auditTrail xmlns:audit="info:fedora/fedora-system:def/audit#">
+<audit:record ID="AUDREC1">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>RELS-EXT</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-08-01T00:03:40.659Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC2">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>identityMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-08-01T00:03:40.755Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC3">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>workflows</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-08-01T00:03:40.876Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC4">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>descMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-08-01T00:03:41.003Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC5">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>rightsMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-08-01T00:03:41.237Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC6">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-08-01T00:03:41.359Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC7">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByReference</audit:action>
+<audit:componentID>workflows</audit:componentID>
+<audit:responsibility>workflow@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-08-11T19:08:30.089Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC8">
+<audit:process type="Fedora API-M"/>
+<audit:action>setDatastreamVersionable</audit:action>
+<audit:componentID>workflows</audit:componentID>
+<audit:responsibility>workflow@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-08-11T19:08:30.089Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC9">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByReference</audit:action>
+<audit:componentID>workflows</audit:componentID>
+<audit:responsibility>workflow@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-08-11T19:54:47.157Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC10">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>contentMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-08-11T19:56:19.855Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC11">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>technicalMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-08-11T19:59:05.582Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC12">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByReference</audit:action>
+<audit:componentID>technicalMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-08-11T19:59:09.807Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC13">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>identityMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-08-11T20:00:16.300Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC14">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>events</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-08-11T20:00:16.402Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC15">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>provenanceMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-08-11T20:02:17.403Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+</audit:auditTrail>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="DC" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="DC1.0" LABEL="Dublin Core Record for this object" CREATED="2014-08-01T00:03:40.533Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" SIZE="447">
+<foxml:xmlContent>
+<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+  <dc:title>Annual Report of the State Corporation Commission, Virginia, 1927-28, 1930-43</dc:title>
+  <dc:identifier>druid:qq613vj0238</dc:identifier>
+</oai_dc:dc>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="RELS-EXT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="RELS-EXT.0" LABEL="Fedora Object-to-Object Relationship Metadata" CREATED="2014-08-01T00:03:40.659Z" MIMETYPE="application/rdf+xml" SIZE="721">
+<foxml:xmlContent>
+<rdf:RDF xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about="info:fedora/druid:qq613vj0238">
+    <hydra:isGovernedBy rdf:resource="info:fedora/druid:fg464dn8891"></hydra:isGovernedBy>
+    <fedora-model:hasModel rdf:resource="info:fedora/afmodel:Dor_Item"></fedora-model:hasModel>
+    <fedora:isMemberOf rdf:resource="info:fedora/druid:pb873ty1662"></fedora:isMemberOf>
+    <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:pb873ty1662"></fedora:isMemberOfCollection>
+  </rdf:Description>
+</rdf:RDF>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="identityMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="identityMetadata.0" LABEL="Identity Metadata" CREATED="2014-08-01T00:03:40.755Z" MIMETYPE="text/xml" SIZE="797">
+<foxml:xmlContent>
+<identityMetadata>
+  <sourceId source="sul">36105011952764</sourceId>
+  <objectId>druid:qq613vj0238</objectId>
+  <objectCreator>DOR</objectCreator>
+  <objectLabel>Annual Report of the State Corporation Commission, Virginia, 1927-28, 1930-43</objectLabel>
+  <objectType>item</objectType>
+  <adminPolicy>druid:fg464dn8891</adminPolicy>
+  <otherId name="label"></otherId>
+  <otherId name="uuid">4872ca9e-190f-11e4-9f5c-0050569b3c3c</otherId>
+  <tag>Process : Content Type : Book (flipbook, ltr)</tag>
+  <tag>Project : State Banking Commission Annual Reports</tag>
+  <tag>DPG : State Banking Commission Annual Reports</tag>
+  <tag>DPG : State Banking Commission Annual Reports : Virginia</tag>
+  <tag>DPG : Curator Request : Kasianovitz</tag>
+  <tag>Registered By : llam813</tag>
+</identityMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="identityMetadata.1" LABEL="Identity Metadata" CREATED="2014-08-11T20:00:16.300Z" MIMETYPE="text/xml" SIZE="834">
+<foxml:xmlContent>
+<identityMetadata>
+  <sourceId source="sul">36105011952764</sourceId>
+  <objectId>druid:qq613vj0238</objectId>
+  <objectCreator>DOR</objectCreator>
+  <objectLabel>Annual Report of the State Corporation Commission, Virginia, 1927-28, 1930-43</objectLabel>
+  <objectType>item</objectType>
+  <adminPolicy>druid:fg464dn8891</adminPolicy>
+  <otherId name="label"></otherId>
+  <otherId name="uuid">4872ca9e-190f-11e4-9f5c-0050569b3c3c</otherId>
+  <tag>Process : Content Type : Book (flipbook, ltr)</tag>
+  <tag>Project : State Banking Commission Annual Reports</tag>
+  <tag>DPG : State Banking Commission Annual Reports</tag>
+  <tag>DPG : State Banking Commission Annual Reports : Virginia</tag>
+  <tag>DPG : Curator Request : Kasianovitz</tag>
+  <tag>Registered By : llam813</tag>
+  <tag>Remediated By : 4.6.6.2</tag>
+</identityMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="workflows" STATE="A" CONTROL_GROUP="E" VERSIONABLE="false">
+<foxml:datastreamVersion ID="workflows.0" LABEL="Workflows" CREATED="2014-08-01T00:03:40.876Z" MIMETYPE="application/xml">
+<foxml:contentLocation TYPE="URL" REF="https://lyberservices-prod.stanford.edu/workflow/dor/objects/druid:qq613vj0238/workflows"/>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="workflows.2" LABEL="Workflow" CREATED="2014-08-11T19:54:47.157Z" MIMETYPE="application/xml">
+<foxml:contentLocation TYPE="URL" REF="https://lyberservices-prod.stanford.edu/workflow/dor/objects/druid:qq613vj0238/workflows"/>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="rightsMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="rightsMetadata.0" LABEL="Rights Metadata" CREATED="2014-08-01T00:03:41.237Z" MIMETYPE="text/xml" SIZE="670">
+<foxml:xmlContent>
+<rightsMetadata>
+  <access type="discover">
+    <machine>
+      <world></world>
+    </machine>
+  </access>
+  <access type="read">
+    <machine>
+      <world></world>
+    </machine>
+  </access>
+  <use>
+    <human type="useAndReproduction">These works have been digitized and made accessible with the permission of the State.  States may limit further reuse.  Please contact govinfolib@lists.stanford.edu with questions about reuse or access.</human>
+    <human type="creativeCommons"></human>
+    <machine type="creativeCommons"></machine>
+  </use>
+  <copyright>
+    <human>Copyright © Stanford University. All Rights Reserved.</human>
+  </copyright>
+</rightsMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="versionMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
+<foxml:datastreamVersion ID="versionMetadata.0" LABEL="Version Metadata" CREATED="2014-08-01T00:03:41.359Z" MIMETYPE="text/xml" SIZE="136">
+<foxml:xmlContent>
+<versionMetadata>
+  <version tag="1.0.0" versionId="1">
+    <description>Initial Version</description>
+  </version>
+</versionMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="events" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
+<foxml:datastreamVersion ID="events.0" LABEL="Events" CREATED="2014-08-11T20:00:16.402Z" MIMETYPE="text/xml" SIZE="146">
+<foxml:xmlContent>
+<events>
+  <event type="remediation" when="2014-08-11T13:00:15-07:00" who="Dor::Identifiable 3.6.1">Record Remediation Version</event>
+</events>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="provenanceMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="provenanceMetadata.0" LABEL="Provenance Metadata" CREATED="2014-08-11T20:02:17.403Z" MIMETYPE="text/xml" SIZE="265">
+<foxml:xmlContent>
+<provenanceMetadata objectId="druid:qq613vj0238">
+  <agent name="DOR">
+    <what object="druid:qq613vj0238">
+      <event when="2014-08-11T13:02:17-07:00" who="DOR-accessionWF">DOR Common Accessioning completed</event>
+    </what>
+  </agent>
+</provenanceMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+</foxml:digitalObject>

--- a/spec/helpers/argo_helper_spec.rb
+++ b/spec/helpers/argo_helper_spec.rb
@@ -20,55 +20,57 @@ describe ArgoHelper, :type => :helper do
   end
   describe 'render_buttons' do
     before :each do
+      @item_id = 'druid:zt570tx3016'
+      @apo_id = 'druid:hv992ry2431'
       @object = instantiate_fixture('druid_zt570tx3016', Dor::Item)
-      @doc = {'id' => 'something', 'is_governed_by_ssim' => ['apo_druid']}
+      @doc = SolrDocument.new({'id' => @item_id, SolrDocument::FIELD_APO_ID => [@apo_id]})
       @usr = double()
       allow(@usr).to receive(:is_admin).and_return(true)
       allow(@usr).to receive(:groups).and_return([])
       allow(@usr).to receive(:is_manager).and_return(false)
-      allow(@usr).to receive(:roles).with('apo_druid').and_return([])
+      allow(@usr).to receive(:roles).with(@apo_id).and_return([])
       allow(Dor::WorkflowService).to receive(:get_active_lifecycle).and_return(true)
       allow(Dor::WorkflowService).to receive(:get_lifecycle).and_return(true)
       allow(helper).to receive(:current_user).and_return(@usr)
       allow(@object).to receive(:can_manage_item?).and_return(true)
-      allow(@object).to receive(:pid).and_return('druid:123')
+      allow(@object).to receive(:pid).and_return(@item_id)
       desc_md = double(Dor::DescMetadataDS)
       id_md   = double(Dor::DescMetadataDS)
       apo     = double()
       allow(desc_md).to receive(:new?).and_return(true)
       allow(id_md).to receive(:ng_xml).and_return(Nokogiri::XML('<identityMetadata><identityMetadata>'))
-      allow(apo).to receive(:pid).and_return('apo:druid')
+      allow(apo).to receive(:pid).and_return(@apo_id)
       allow(@object).to receive(:datastreams).and_return({'contentMetadata' => nil, 'descMetadata' => desc_md, 'identityMetadata' => id_md})
       allow(@object).to receive(:admin_policy_object).and_return(apo)
-      allow(Dor).to receive(:find).and_return(@object)
+      allow(Dor).to receive(:find).with(@item_id).and_return(@object)
     end
     describe 'visibility with new descMetadata' do
       let(:default_buttons) do
         [
           {
             label: 'Reindex',
-            url: '/dor/reindex/something'
+            url: "/dor/reindex/#{@item_id}"
           },
           {
             label: 'Republish',
-            url: '/dor/republish/something',
-            check_url: '/workflow_service/something/published'
+            url: "/dor/republish/#{@item_id}",
+            check_url: "/workflow_service/#{@item_id}/published"
           },
           {
             label: 'Change source id',
-            url: '/items/something/source_id_ui'
+            url: "/items/#{@item_id}/source_id_ui"
           },
           {
             label: 'Edit tags',
-            url: '/items/something/tags_ui'
+            url: "/items/#{@item_id}/tags_ui"
           },
           {
             label: 'Edit collections',
-            url: '/items/something/collection_ui'
+            url: "/items/#{@item_id}/collection_ui"
           },
           {
             label: 'Set content type',
-            url: '/items/something/content_type'
+            url: "/items/#{@item_id}/content_type"
           }
         ]
       end
@@ -91,7 +93,7 @@ describe ArgoHelper, :type => :helper do
         buttons = helper.render_buttons(@doc)
         default_buttons.push({
           label: 'Update embargo',
-          url: '/items/something/embargo_form'
+          url: "/items/#{@item_id}/embargo_form"
         }).each do |button|
           expect(buttons).to include(button)
         end

--- a/spec/models/access_controls_enforcement_spec.rb
+++ b/spec/models/access_controls_enforcement_spec.rb
@@ -17,19 +17,19 @@ describe 'Argo::AccessControlsEnforcement', :type => :model do
       allow(@user).to receive(:permitted_apos).and_return(['druid:cb081vd1895'])
       solr_params = {}
       @obj.apply_gated_discovery(solr_params, @user)
-      expect(solr_params).to eq({:fq => ["is_governed_by_ssim:(\"info:fedora/druid:cb081vd1895\")"]})
+      expect(solr_params).to eq({:fq => ["#{SolrDocument::FIELD_APO_ID}:(\"info:fedora/druid:cb081vd1895\")"]})
     end
     it 'should add to an existing fq' do
       allow(@user).to receive(:permitted_apos).and_return(['druid:cb081vd1895'])
-      solr_params = {:fq => ['is_governed_by_ssim:(info\\:fedora/druid\\:ab123cd4567)']}
+      solr_params = {:fq => ["#{SolrDocument::FIELD_APO_ID}:(info\\:fedora/druid\\:ab123cd4567)"]}
       @obj.apply_gated_discovery(solr_params, @user)
-      expect(solr_params).to eq({:fq => ['is_governed_by_ssim:(info\\:fedora/druid\\:ab123cd4567)', "is_governed_by_ssim:(\"info:fedora/druid:cb081vd1895\")"]})
+      expect(solr_params).to eq({:fq => ["#{SolrDocument::FIELD_APO_ID}:(info\\:fedora/druid\\:ab123cd4567)", "#{SolrDocument::FIELD_APO_ID}:(\"info:fedora/druid:cb081vd1895\")"]})
     end
     it 'should build a valid query if there arent any apos' do
       allow(@user).to receive(:permitted_apos).and_return([])
       solr_params = {}
       @obj.apply_gated_discovery(solr_params, @user)
-      expect(solr_params).to eq({:fq => ['is_governed_by_ssim:(dummy_value)']})
+      expect(solr_params).to eq({:fq => ["#{SolrDocument::FIELD_APO_ID}:(dummy_value)"]})
     end
     it 'should return no fq if the @user is a repository admin' do
       allow(@user).to receive(:permitted_apos).and_return([])

--- a/spec/models/concerns/apo_concern_spec.rb
+++ b/spec/models/concerns/apo_concern_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe ApoConcern do
+  let(:document) { SolrDocument.new(document_attributes) }
+  describe '#apo' do
+    context 'with data' do
+      let(:document_attributes) { { SolrDocument::FIELD_APO_ID => ['info:fedora/druid:abc'], SolrDocument::FIELD_APO_TITLE => ['My title'] } }
+      it 'should have an APO' do
+        expect(document.apo_id).to eq('info:fedora/druid:abc')
+        expect(document.apo_pid).to eq('druid:abc')
+        expect(document.apo_title).to eq('My title')
+      end
+    end
+
+    context 'with Uber-y data' do
+      let(:document_attributes) { { :id => SolrDocument::UBER_APO_ID, SolrDocument::FIELD_TITLE => 'My title' } }
+      it 'should handle an Uber-APO' do
+        expect(document.apo_id).to eq(SolrDocument::UBER_APO_ID)
+        expect(document.apo_pid).to eq(SolrDocument::UBER_APO_ID)
+        expect(document.apo_title).to eq('My title')
+      end
+    end
+
+    context 'without data' do
+      let(:document_attributes) { { } }
+      it 'should handle missing APO' do
+        expect(document.apo_id).to be_nil
+        expect(document.apo_pid).to be_nil
+        expect(document.apo_title).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/concerns/catkey_concern_spec.rb
+++ b/spec/models/concerns/catkey_concern_spec.rb
@@ -4,15 +4,17 @@ describe CatkeyConcern do
   let(:document) { SolrDocument.new(document_attributes) }
   describe '#catkey' do
     describe 'without one present' do
-      let(:document_attributes) { { not_a_catkey: '8675309' } }
+      let(:document_attributes) { { } }
       it 'should return nil' do
         expect(document.catkey).to be_nil
+        expect(document.catkey_id).to be_nil
       end
     end
     describe 'when a catkey is present' do
-      let(:document_attributes) { { catkey_id_ssim: ['8675309'] } }
+      let(:document_attributes) { { SolrDocument::FIELD_CATKEY_ID => ['catkey:8675309'] } }
       it 'should return catkey value' do
-        expect(document.catkey).to eq '8675309'
+        expect(document.catkey).to eq 'catkey:8675309'
+        expect(document.catkey_id).to eq '8675309'
       end
     end
   end

--- a/spec/models/concerns/collection_concern_spec.rb
+++ b/spec/models/concerns/collection_concern_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe CollectionConcern do
+  let(:document) { SolrDocument.new(document_attributes) }
+
+  describe '#collection' do
+    context 'with data' do
+      let(:document_attributes) { { SolrDocument::FIELD_COLLECTION_ID => ['druid:abc', 'druid:def'], SolrDocument::FIELD_COLLECTION_TITLE => ['Abc', 'Def'] } }
+      it 'should have a Collections' do
+        expect(document.collection_id).to eq('druid:abc')
+        expect(document.collection_ids).to eq(['druid:abc', 'druid:def'])
+        expect(document.collection_title).to eq('Abc')
+        expect(document.collection_titles).to eq(['Abc', 'Def'])
+      end
+    end
+
+    context 'without data' do
+      let(:document_attributes) { {  } }
+      it 'should handle no Collections' do
+        expect(document.collection_id).to be_nil
+        expect(document.collection_ids).to be_nil
+        expect(document.collection_title).to be_nil
+        expect(document.collection_titles).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/concerns/title_concern_spec.rb
+++ b/spec/models/concerns/title_concern_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe TitleConcern do
+  let(:document) { SolrDocument.new(document_attributes) }
+
+  describe '#title' do
+    context 'with data' do
+      let(:document_attributes) { { SolrDocument::FIELD_TITLE => 'My title' } }
+      it 'should have a title' do
+        expect(document.title).to eq('My title')
+      end
+    end
+
+    context 'without data' do
+      let(:document_attributes) { { } }
+      it 'should handle missing title' do
+        expect(document.title).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -74,5 +74,4 @@ describe SolrDocument, :type => :model do
       expect(versions['2']).to match a_hash_including(:tag => '1.1.0', :desc => 'Minor change')
     end
   end
-
 end


### PR DESCRIPTION
This fixes #75. 

The PR consolidates access to the `SolrDocument` APO druid value, for example, by providing a constant for `is_governed_by_ssim`, and a method `apo_id` to read the value. It does this for APO druid, APO title, Collection druid(s), and Collection title(s).

I've marked it work in progress because I need to test it with items that have collections (we currently don't have local fixtures for that).

@mejackreed I tried to address your comment in #75, but I'd like to pair up to review this PR. I have questions about when something is a `SolrDocument` vs. a simple `Hash`, for example.