### PR TITLE
fix the way the jqgrid css gets required

### DIFF
--- a/app/assets/stylesheets/registration.css
+++ b/app/assets/stylesheets/registration.css
@@ -1,5 +1,5 @@
 /*
- *=require ./ui.jqgrid.css
+ *=require jqgrid-jquery-rails
  *=require_tree ./registration
  *=require jquery-ui/custom-theme/jquery-ui-1.8.13.custom.css
  */


### PR DESCRIPTION
as per the docs for the jqgrid asset pipeline gem:  https://github.com/jhx/gem-jqgrid-jquery-rails#usage

prior to this fix, i was getting an error when deploying to stage:
```
DEBUG [33c337eb] 	rake aborted!
DEBUG [33c337eb] 	Sprockets::FileNotFound: couldn't find file './ui.jqgrid.css' under '/opt/app/lyberadmin/argo/releases/20151119040508/app/assets/stylesheets' with type 'text/css'
DEBUG [33c337eb] 	/opt/app/lyberadmin/argo/releases/20151119040508/app/assets/stylesheets/registration.css:2
```

i was once again able to deploy `jm_stage-b_testing` after rebasing it off this branch.


actually, now i'm not so sure this is the right thing to do.  is this line supposed to obviate the need for what i'm doing in this PR?
https://github.com/sul-dlss/argo/pull/213/files#diff-f859e2848b07324f808ce1a5ccd9fcbaR13

@mejackreed?