### PR TITLE
Update mods_display gem to latest, which addresses Ruby 2.2 warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,7 +271,7 @@ GEM
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.2)
-    minitest (5.8.2)
+    minitest (5.8.3)
     moab-versioning (1.4.4)
       confstruct
       json
@@ -282,7 +282,7 @@ GEM
       iso-639
       nokogiri
       nom-xml (~> 0.5.2)
-    mods_display (0.3.3)
+    mods_display (0.3.5)
       i18n
       stanford-mods
     multi_json (1.11.2)
@@ -295,7 +295,7 @@ GEM
     net-ssh (2.6.8)
     netrc (0.11.0)
     newrelic_rpm (3.14.0.305)
-    nokogiri (1.6.6.2)
+    nokogiri (1.6.6.4)
       mini_portile (~> 0.6.0)
     nokogiri-happymapper (0.5.9)
       nokogiri (~> 1.5)
@@ -466,7 +466,7 @@ GEM
       net-scp (>= 1.1.2)
       net-ssh
       term-ansicolor
-    stanford-mods (1.1.5)
+    stanford-mods (1.2.1)
       mods (~> 2.0.2)
     stomp (1.3.4)
     sul_styles (0.3.0)


### PR DESCRIPTION
While we are at it, update Nokogiri to 1.6.3.3 to address upstream security issues