### PR TITLE
adds All Workflows link in the header

### DIFF
--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -26,6 +26,8 @@
       </li>
     <% end %>
 
+    <li><%= link_to "All&nbsp;Workflows".html_safe, report_workflow_grid_path %></li>
+
     <li><%= link_to "Register&nbsp;Items".html_safe, register_items_path %></li>
 
     <%if current_user.is_admin or current_user.is_manager %>


### PR DESCRIPTION
Fixes #64.

This PR adds an `all` parameter to the `/report/workflow_grid` route. If it is passed in (no value needed), then it will reset the facets (by calling `facet_tree` with no arguments).