### PR TITLE
update Uber-APO with version from production

### DIFF
--- a/fedora_conf/data/hv992ry2431.xml
+++ b/fedora_conf/data/hv992ry2431.xml
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <foxml:digitalObject VERSION="1.1" PID="druid:hv992ry2431"
 xmlns:foxml="info:fedora/fedora-system:def/foxml#"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
 <foxml:objectProperties>
 <foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
-<foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="Internal Objects"/>
-<foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE="DOR"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="[Internal System Objects]"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE=""/>
 <foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="2011-04-18T18:18:53.666Z"/>
-<foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE="2014-09-02T21:24:11.298Z"/>
+<foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE="2015-11-11T22:28:43.765Z"/>
 </foxml:objectProperties>
 <foxml:datastream ID="AUDIT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
 <foxml:datastreamVersion ID="AUDIT.0" LABEL="Audit Trail for this object" CREATED="2011-04-18T18:18:53.666Z" MIMETYPE="text/xml" FORMAT_URI="info:fedora/fedora-system:format/xml.fedora.audit">
@@ -176,50 +175,50 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
 </audit:record>
 <audit:record ID="AUDREC21">
 <audit:process type="Fedora API-M"/>
-<audit:action>modifyDatastreamByValue</audit:action>
-<audit:componentID>identityMetadata</audit:componentID>
+<audit:action>modifyObject</audit:action>
+<audit:componentID></audit:componentID>
 <audit:responsibility>fedoraAdmin</audit:responsibility>
-<audit:date>2011-10-31T22:26:23.365Z</audit:date>
-<audit:justification>Fedora FUSE FS</audit:justification>
+<audit:date>2011-10-31T22:20:57.516Z</audit:date>
+<audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC22">
 <audit:process type="Fedora API-M"/>
 <audit:action>modifyDatastreamByValue</audit:action>
-<audit:componentID>identityMetadata</audit:componentID>
+<audit:componentID>DC</audit:componentID>
 <audit:responsibility>fedoraAdmin</audit:responsibility>
-<audit:date>2011-11-07T02:10:48.083Z</audit:date>
+<audit:date>2011-10-31T22:21:12.479Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC23">
 <audit:process type="Fedora API-M"/>
-<audit:action>addDatastream</audit:action>
-<audit:componentID>workflows</audit:componentID>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>identityMetadata</audit:componentID>
 <audit:responsibility>fedoraAdmin</audit:responsibility>
-<audit:date>2012-01-28T01:35:58.251Z</audit:date>
+<audit:date>2011-10-31T22:23:12.596Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC24">
 <audit:process type="Fedora API-M"/>
-<audit:action>modifyObject</audit:action>
-<audit:componentID></audit:componentID>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>identityMetadata</audit:componentID>
 <audit:responsibility>fedoraAdmin</audit:responsibility>
-<audit:date>2012-03-01T09:02:48.898Z</audit:date>
+<audit:date>2011-11-07T02:10:13.940Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC25">
 <audit:process type="Fedora API-M"/>
-<audit:action>modifyDatastreamByValue</audit:action>
-<audit:componentID>identityMetadata</audit:componentID>
+<audit:action>modifyObject</audit:action>
+<audit:componentID></audit:componentID>
 <audit:responsibility>fedoraAdmin</audit:responsibility>
-<audit:date>2012-03-01T09:03:29.648Z</audit:date>
+<audit:date>2012-03-01T09:04:31.692Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC26">
 <audit:process type="Fedora API-M"/>
-<audit:action>modifyObject</audit:action>
-<audit:componentID></audit:componentID>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>identityMetadata</audit:componentID>
 <audit:responsibility>fedoraAdmin</audit:responsibility>
-<audit:date>2012-03-01T09:03:50.630Z</audit:date>
+<audit:date>2012-03-01T09:04:42.891Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC27">
@@ -227,7 +226,7 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
 <audit:action>modifyDatastreamByValue</audit:action>
 <audit:componentID>identityMetadata</audit:componentID>
 <audit:responsibility>fedoraAdmin</audit:responsibility>
-<audit:date>2012-04-09T22:41:24.309Z</audit:date>
+<audit:date>2012-04-09T22:41:11.661Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC28">
@@ -235,7 +234,7 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
 <audit:action>modifyDatastreamByValue</audit:action>
 <audit:componentID>DC</audit:componentID>
 <audit:responsibility>fedoraAdmin</audit:responsibility>
-<audit:date>2012-05-06T19:21:42.642Z</audit:date>
+<audit:date>2012-05-06T19:21:59.249Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC29">
@@ -243,7 +242,7 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
 <audit:action>modifyDatastreamByValue</audit:action>
 <audit:componentID>administrativeMetadata</audit:componentID>
 <audit:responsibility>fedoraAdmin</audit:responsibility>
-<audit:date>2012-05-06T19:23:16.499Z</audit:date>
+<audit:date>2012-05-06T19:23:46.116Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC30">
@@ -251,159 +250,655 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
 <audit:action>modifyDatastreamByValue</audit:action>
 <audit:componentID>identityMetadata</audit:componentID>
 <audit:responsibility>fedoraAdmin</audit:responsibility>
-<audit:date>2012-07-03T21:22:11.811Z</audit:date>
+<audit:date>2012-05-07T23:35:02.081Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC31">
 <audit:process type="Fedora API-M"/>
-<audit:action>modifyObject</audit:action>
-<audit:componentID></audit:componentID>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>events</audit:componentID>
 <audit:responsibility>fedoraAdmin</audit:responsibility>
-<audit:date>2012-07-03T21:23:20.072Z</audit:date>
+<audit:date>2012-05-07T23:35:02.229Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC32">
 <audit:process type="Fedora API-M"/>
-<audit:action>modifyDatastreamByValue</audit:action>
-<audit:componentID>administrativeMetadata</audit:componentID>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>RELS-EXT</audit:componentID>
 <audit:responsibility>fedoraAdmin</audit:responsibility>
-<audit:date>2012-08-23T18:28:52.615Z</audit:date>
+<audit:date>2012-05-07T23:35:02.374Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC33">
 <audit:process type="Fedora API-M"/>
 <audit:action>modifyDatastreamByValue</audit:action>
-<audit:componentID>roleMetadata</audit:componentID>
-<audit:responsibility>dlss-dev-jdeering.stanford.edu</audit:responsibility>
-<audit:date>2012-12-10T19:37:51.465Z</audit:date>
+<audit:componentID>identityMetadata</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2012-07-03T21:21:23.545Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC34">
 <audit:process type="Fedora API-M"/>
-<audit:action>modifyDatastreamByValue</audit:action>
-<audit:componentID>roleMetadata</audit:componentID>
-<audit:responsibility>argo-test.stanford.edu</audit:responsibility>
-<audit:date>2013-01-09T23:21:32.674Z</audit:date>
+<audit:action>modifyObject</audit:action>
+<audit:componentID></audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2012-07-03T21:23:24.349Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC35">
 <audit:process type="Fedora API-M"/>
 <audit:action>modifyDatastreamByValue</audit:action>
-<audit:componentID>roleMetadata</audit:componentID>
-<audit:responsibility>argo-test.stanford.edu</audit:responsibility>
-<audit:date>2013-01-11T01:52:59.065Z</audit:date>
+<audit:componentID>administrativeMetadata</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2012-08-23T18:32:26.352Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC36">
 <audit:process type="Fedora API-M"/>
 <audit:action>modifyDatastreamByValue</audit:action>
-<audit:componentID>DC</audit:componentID>
-<audit:responsibility>argo-test.stanford.edu</audit:responsibility>
-<audit:date>2013-01-11T01:53:20.766Z</audit:date>
+<audit:componentID>roleMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-01-09T19:46:09.240Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC37">
 <audit:process type="Fedora API-M"/>
 <audit:action>modifyDatastreamByValue</audit:action>
 <audit:componentID>roleMetadata</audit:componentID>
-<audit:responsibility>argo-test.stanford.edu</audit:responsibility>
-<audit:date>2013-01-11T17:06:24.673Z</audit:date>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-01-09T20:02:51.570Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC38">
 <audit:process type="Fedora API-M"/>
 <audit:action>modifyDatastreamByValue</audit:action>
 <audit:componentID>roleMetadata</audit:componentID>
-<audit:responsibility>argo-test.stanford.edu</audit:responsibility>
-<audit:date>2013-01-12T00:51:41.660Z</audit:date>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-01-09T20:03:23.104Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC39">
 <audit:process type="Fedora API-M"/>
-<audit:action>addDatastream</audit:action>
-<audit:componentID>descMetadata</audit:componentID>
-<audit:responsibility>wmene</audit:responsibility>
-<audit:date>2013-02-13T17:59:15.985Z</audit:date>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>DC</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-01-11T01:51:37.232Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC40">
 <audit:process type="Fedora API-M"/>
-<audit:action>modifyDatastreamByReference</audit:action>
-<audit:componentID>workflows</audit:componentID>
-<audit:responsibility>workflows@sul-lyberservices-dev.stanford.edu</audit:responsibility>
-<audit:date>2013-02-13T18:01:29.520Z</audit:date>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>roleMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-01-11T01:52:25.981Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC41">
 <audit:process type="Fedora API-M"/>
-<audit:action>setDatastreamVersionable</audit:action>
-<audit:componentID>workflows</audit:componentID>
-<audit:responsibility>workflows@sul-lyberservices-dev.stanford.edu</audit:responsibility>
-<audit:date>2013-02-13T18:01:29.520Z</audit:date>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>roleMetadata</audit:componentID>
+<audit:responsibility>lmcrae</audit:responsibility>
+<audit:date>2013-01-15T17:27:13.271Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC42">
 <audit:process type="Fedora API-M"/>
-<audit:action>modifyDatastreamByValue</audit:action>
-<audit:componentID>identityMetadata</audit:componentID>
-<audit:responsibility>robots@sul-lyberservices-test.stanford.edu</audit:responsibility>
-<audit:date>2014-08-20T22:28:51.843Z</audit:date>
-<audit:justification></audit:justification>
+<audit:action>purgeDatastream</audit:action>
+<audit:componentID>RELS-EXT</audit:componentID>
+<audit:responsibility>lmcrae</audit:responsibility>
+<audit:date>2013-01-15T17:32:10.369Z</audit:date>
+<audit:justification>Purged datastream (ID=RELS-EXT), versions ranging from the beginning of time to the end of time.  This resulted in the permanent removal of 1 datastream version(s) (2012-05-07T16:35:02.374Z) and all associated audit records.</audit:justification>
 </audit:record>
 <audit:record ID="AUDREC43">
 <audit:process type="Fedora API-M"/>
 <audit:action>addDatastream</audit:action>
 <audit:componentID>RELS-EXT</audit:componentID>
-<audit:responsibility>robots@sul-lyberservices-test.stanford.edu</audit:responsibility>
-<audit:date>2014-08-20T22:28:52.051Z</audit:date>
+<audit:responsibility>lmcrae</audit:responsibility>
+<audit:date>2013-01-15T17:32:47.144Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC44">
 <audit:process type="Fedora API-M"/>
-<audit:action>addDatastream</audit:action>
-<audit:componentID>events</audit:componentID>
-<audit:responsibility>robots@sul-lyberservices-test.stanford.edu</audit:responsibility>
-<audit:date>2014-08-20T22:28:52.215Z</audit:date>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>RELS-EXT</audit:componentID>
+<audit:responsibility>lmcrae</audit:responsibility>
+<audit:date>2013-01-15T17:34:56.187Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC45">
 <audit:process type="Fedora API-M"/>
 <audit:action>addDatastream</audit:action>
-<audit:componentID>versionMetadata</audit:componentID>
-<audit:responsibility>robots@sul-lyberservices-test.stanford.edu</audit:responsibility>
-<audit:date>2014-08-20T22:28:52.350Z</audit:date>
+<audit:componentID>workflows</audit:componentID>
+<audit:responsibility>workflow@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2013-02-12T04:02:16.252Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC46">
 <audit:process type="Fedora API-M"/>
-<audit:action>modifyDatastreamByValue</audit:action>
-<audit:componentID>RELS-EXT</audit:componentID>
-<audit:responsibility>argo-test.stanford.edu</audit:responsibility>
-<audit:date>2014-08-22T21:08:00.240Z</audit:date>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>rightsMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2013-02-12T04:13:33.137Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC47">
 <audit:process type="Fedora API-M"/>
-<audit:action>modifyDatastreamByValue</audit:action>
+<audit:action>addDatastream</audit:action>
 <audit:componentID>descMetadata</audit:componentID>
-<audit:responsibility>argo-test.stanford.edu</audit:responsibility>
-<audit:date>2014-08-25T21:02:47.128Z</audit:date>
+<audit:responsibility>wmene</audit:responsibility>
+<audit:date>2013-02-12T18:19:10.628Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC48">
 <audit:process type="Fedora API-M"/>
-<audit:action>modifyDatastreamByValue</audit:action>
-<audit:componentID>DC</audit:componentID>
-<audit:responsibility>argo-test.stanford.edu</audit:responsibility>
-<audit:date>2014-08-25T21:03:34.877Z</audit:date>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>provenanceMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2013-02-12T18:32:02.796Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 <audit:record ID="AUDREC49">
 <audit:process type="Fedora API-M"/>
 <audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>identityMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2013-02-12T18:44:38.279Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC50">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByReference</audit:action>
+<audit:componentID>events</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2013-02-12T18:44:38.412Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC51">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2013-02-12T18:44:38.716Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC52">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
 <audit:componentID>roleMetadata</audit:componentID>
-<audit:responsibility>argo-test.stanford.edu</audit:responsibility>
-<audit:date>2014-09-02T21:24:11.298Z</audit:date>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-02-24T23:01:58.902Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC53">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>roleMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-02-24T23:04:03.285Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC54">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>roleMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-03-06T04:49:43.927Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC55">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>roleMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-03-06T04:51:19.715Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC56">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>roleMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-03-07T18:46:50.544Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC57">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>roleMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-03-27T07:24:05.727Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC58">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>roleMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-03-27T17:51:44.210Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC59">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>roleMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-05-20T21:56:53.106Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC60">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>roleMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-05-20T22:06:11.709Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC61">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-10-02T19:56:57.368Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC62">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-10-22T04:29:25.767Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC63">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyObject</audit:action>
+<audit:componentID></audit:componentID>
+<audit:responsibility>lmcrae</audit:responsibility>
+<audit:date>2014-01-29T19:00:59.968Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC64">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>identityMetadata</audit:componentID>
+<audit:responsibility>lmcrae</audit:responsibility>
+<audit:date>2014-01-29T19:01:13.213Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC65">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyObject</audit:action>
+<audit:componentID></audit:componentID>
+<audit:responsibility>lmcrae</audit:responsibility>
+<audit:date>2014-01-29T19:04:16.663Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC66">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>DC</audit:componentID>
+<audit:responsibility>lmcrae</audit:responsibility>
+<audit:date>2014-01-29T19:04:29.064Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC67">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>descMetadata</audit:componentID>
+<audit:responsibility>lmcrae</audit:responsibility>
+<audit:date>2014-01-29T19:06:45.765Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC68">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>roleMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-04-23T20:42:10.784Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC69">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>roleMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-04-23T20:47:36.426Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC70">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>preassembly@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-07-17T23:55:00.903Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC71">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByReference</audit:action>
+<audit:componentID>workflows</audit:componentID>
+<audit:responsibility>workflow@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-07-17T23:55:01.120Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC72">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>preassembly@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-07-17T23:55:01.620Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC73">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>roleMetadata</audit:componentID>
+<audit:responsibility>preassembly@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-07-17T23:55:01.758Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC74">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>preassembly@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-07-18T00:01:56.189Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC75">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>roleMetadata</audit:componentID>
+<audit:responsibility>preassembly@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-07-18T00:01:56.310Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC76">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>roleMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-07-18T18:03:37.519Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC77">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-08-06T22:27:24.888Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC78">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByReference</audit:action>
+<audit:componentID>workflows</audit:componentID>
+<audit:responsibility>workflow@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-08-06T22:27:25.816Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC79">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByReference</audit:action>
+<audit:componentID>events</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2014-08-06T22:27:26.100Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC80">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>rightsMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-08-06T22:28:00.523Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC81">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>identityMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-08-07T06:28:26.241Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC82">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByReference</audit:action>
+<audit:componentID>events</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-08-07T06:28:26.372Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC83">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>provenanceMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2014-08-07T06:29:09.562Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC84">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-04-06T21:17:40.067Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC85">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByReference</audit:action>
+<audit:componentID>workflows</audit:componentID>
+<audit:responsibility>workflow@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2015-04-06T21:17:41.597Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC86">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-04-06T21:17:42.817Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC87">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByReference</audit:action>
+<audit:componentID>events</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-04-06T21:17:42.930Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC88">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>rightsMetadata</audit:componentID>
+<audit:responsibility>lmcrae</audit:responsibility>
+<audit:date>2015-04-06T21:19:17.578Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC89">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>defaultObjectRights</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-04-06T21:19:45.480Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC90">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>defaultObjectRights</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-04-06T21:20:39.274Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC91">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>rightsMetadata</audit:componentID>
+<audit:responsibility>lmcrae</audit:responsibility>
+<audit:date>2015-04-06T21:21:08.077Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC92">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-04-06T21:21:55.966Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC93">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByReference</audit:action>
+<audit:componentID>events</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-04-06T21:21:56.573Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC94">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>identityMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2015-04-06T21:23:28.754Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC95">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByReference</audit:action>
+<audit:componentID>events</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2015-04-06T21:23:28.876Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC96">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>provenanceMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2015-04-06T21:24:27.069Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC97">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByReference</audit:action>
+<audit:componentID>workflows</audit:componentID>
+<audit:responsibility>workflow@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2015-04-06T21:27:22.946Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC98">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>RELS-EXT</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-09-10T21:36:21.358Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC99">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>descMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-09-10T21:36:21.632Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC100">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-09-10T21:36:21.798Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC101">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>administrativeMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-09-10T21:36:21.905Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC102">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>roleMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-09-10T21:36:22.013Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC103">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>defaultObjectRights</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-09-10T21:36:22.146Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC104">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>roleMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-11-11T22:18:33.394Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC105">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-11-11T22:20:05.801Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC106">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByReference</audit:action>
+<audit:componentID>events</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-11-11T22:20:09.738Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC107">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>versionMetadata</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-11-11T22:20:10.126Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC108">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByReference</audit:action>
+<audit:componentID>events</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2015-11-11T22:24:42.742Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC109">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>identityMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2015-11-11T22:27:14.490Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC110">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByReference</audit:action>
+<audit:componentID>events</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2015-11-11T22:27:14.641Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC111">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>provenanceMetadata</audit:componentID>
+<audit:responsibility>robots@sul-lyberservices-prod.stanford.edu</audit:responsibility>
+<audit:date>2015-11-11T22:28:43.765Z</audit:date>
 <audit:justification></audit:justification>
 </audit:record>
 </audit:auditTrail>
@@ -411,10 +906,19 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
 </foxml:datastreamVersion>
 </foxml:datastream>
 <foxml:datastream ID="DC" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
-<foxml:datastreamVersion ID="DC.11" LABEL="Dublin Core Record for this object" CREATED="2012-05-06T19:21:42.642Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" SIZE="423">
+<foxml:datastreamVersion ID="DC.12" LABEL="Dublin Core Record for this object" CREATED="2012-05-06T19:21:59.249Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" SIZE="423">
 <foxml:xmlContent>
 <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
   <dc:title>Default Admin Policy</dc:title>
+  <dc:identifier>druid:hv992ry2431</dc:identifier>
+  <dc:language>eng</dc:language>
+</oai_dc:dc>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="DC.11" LABEL="Dublin Core Record for this object" CREATED="2011-10-31T22:21:12.479Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" SIZE="424">
+<foxml:xmlContent>
+<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+  <dc:title>Default Admin. Policy</dc:title>
   <dc:identifier>druid:hv992ry2431</dc:identifier>
   <dc:language>eng</dc:language>
 </oai_dc:dc>
@@ -518,7 +1022,7 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
 </oai_dc:dc>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
-<foxml:datastreamVersion ID="DC.12" LABEL="Dublin Core Record for this object" CREATED="2013-01-11T01:53:20.766Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" SIZE="419">
+<foxml:datastreamVersion ID="DC.13" LABEL="Dublin Core Record for this object" CREATED="2013-01-11T01:51:37.232Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" SIZE="419">
 <foxml:xmlContent>
 <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
   <dc:title>Internal Objects</dc:title>
@@ -527,7 +1031,7 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
 </oai_dc:dc>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
-<foxml:datastreamVersion ID="DC.13" LABEL="Dublin Core Record for this object" CREATED="2014-08-25T21:03:34.877Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" SIZE="428">
+<foxml:datastreamVersion ID="DC.14" LABEL="Dublin Core Record for this object" CREATED="2014-01-29T19:04:29.064Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" SIZE="428">
 <foxml:xmlContent>
 <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
   <dc:title>[Internal System Objects]</dc:title>
@@ -538,7 +1042,7 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
 </foxml:datastreamVersion>
 </foxml:datastream>
 <foxml:datastream ID="administrativeMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
-<foxml:datastreamVersion ID="administrativeMetadata.5" LABEL="Administrative Metadata" CREATED="2012-08-23T18:28:52.615Z" MIMETYPE="text/xml" SIZE="2083">
+<foxml:datastreamVersion ID="administrativeMetadata.5" LABEL="Administrative Metadata" CREATED="2012-08-23T18:32:26.352Z" MIMETYPE="text/xml" SIZE="2083">
 <foxml:xmlContent>
 <administrativeMetadata>
   <descMetadata>
@@ -592,7 +1096,7 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
 </administrativeMetadata>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
-<foxml:datastreamVersion ID="administrativeMetadata.4" LABEL="Administrative Metadata" CREATED="2012-05-06T19:23:16.499Z" MIMETYPE="text/xml" SIZE="2083">
+<foxml:datastreamVersion ID="administrativeMetadata.4" LABEL="Administrative Metadata" CREATED="2012-05-06T19:23:46.116Z" MIMETYPE="text/xml" SIZE="2083">
 <foxml:xmlContent>
 <administrativeMetadata>
   <descMetadata>
@@ -882,6 +1386,60 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
 </administrativeMetadata>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
+<foxml:datastreamVersion ID="administrativeMetadata.6" LABEL="Administrative Metadata" CREATED="2015-09-10T21:36:21.905Z" MIMETYPE="text/xml" SIZE="2083">
+<foxml:xmlContent>
+<administrativeMetadata>
+  <descMetadata>
+    <format>MODS</format>
+    <source>Symphony</source>
+  </descMetadata>
+  <contact id="sunetid:mbklein" type="user">
+    <name>Michael B. Klein</name>
+    <organization>DLSS</organization>
+    <email>mbklein@stanford.edu</email>
+  </contact>
+  <rights>
+    <copyright useDefault="true"></copyright>
+    <use>
+      <defaultLicense override="yes" type="CreativeCommons" value="by-sa"></defaultLicense>
+    </use>
+    <use>
+      <access override="yes"></access>
+    </use>
+  </rights>
+  <relationships></relationships>
+  <registration>
+    <itemTag>AdminPolicy : Personal Papers</itemTag>
+    <workflow id="digitizationWF">
+      <process lifecycle="registered" name="initiate" status="completed"></process>
+      <process name="digitize" status="waiting"></process>
+      <process name="start-accession" status="waiting"></process>
+    </workflow>
+  </registration>
+  <deposit>
+    <depositStatus>closed</depositStatus>
+    <approval required="no"></approval>
+    <termsOfDeposit> By depositing stuff you agree... </termsOfDeposit>
+    <embargo default="6 months" maximum="2 years" minimum="0"></embargo>
+  </deposit>
+  <accessioning>
+    <workflow id="accessionWF">
+      <process lifecycle="submitted" name="start-accession" status="completed"></process>
+      <process name="content-metadata" status="waiting"></process>
+      <process lifecycle="described" name="descriptive-metadata" status="waiting"></process>
+      <process name="rights-metadata" status="waiting"></process>
+      <process name="technical-metadata" status="waiting"></process>
+      <process name="provenance-metadata" status="waiting"></process>
+      <process name="remediate-object" status="waiting"></process>
+      <process name="shelve" status="waiting"></process>
+      <process lifecycle="published" name="publish" status="waiting"></process>
+      <process name="sdr-ingest-transfer" status="waiting"></process>
+      <process lifecycle="accessioned" name="cleanup" status="waiting"></process>
+    </workflow>
+  </accessioning>
+</administrativeMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
 </foxml:datastream>
 <foxml:datastream ID="defaultObjectRights" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
 <foxml:datastreamVersion ID="defaultObjectRights.4" LABEL="Default Object Rights" CREATED="2011-05-23T17:22:27.144Z" MIMETYPE="text/xml" SIZE="572">
@@ -998,9 +1556,59 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
 </rightsMetadata>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
+<foxml:datastreamVersion ID="defaultObjectRights.5" LABEL="Default Object Rights" CREATED="2015-04-06T21:19:45.480Z" MIMETYPE="text/xml" SIZE="177">
+<foxml:xmlContent>
+<rightsMetadata>
+  <access type="discover">
+    <none></none>
+  </access>
+  <access type="read">
+    <machine>
+      <none></none>
+    </machine>
+  </access>
+</rightsMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="defaultObjectRights.6" LABEL="Default Object Rights" CREATED="2015-04-06T21:20:39.274Z" MIMETYPE="text/xml" SIZE="208">
+<foxml:xmlContent>
+<rightsMetadata>
+  <access type="discover">
+    <machine>
+      <none></none>
+    </machine>
+  </access>
+  <access type="read">
+    <machine>
+      <none></none>
+    </machine>
+  </access>
+</rightsMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="defaultObjectRights.7" LABEL="Default Object Rights" CREATED="2015-09-10T21:36:22.146Z" MIMETYPE="text/xml" SIZE="315">
+<foxml:xmlContent>
+<rightsMetadata>
+  <access type="discover">
+    <machine>
+      <none></none>
+    </machine>
+  </access>
+  <access type="read">
+    <machine>
+      <none></none>
+    </machine>
+  </access>
+  <use>
+    <human type="creativeCommons"></human>
+    <machine type="creativeCommons"></machine>
+  </use>
+</rightsMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
 </foxml:datastream>
 <foxml:datastream ID="identityMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
-<foxml:datastreamVersion ID="identityMetadata.6" LABEL="Identity Metadata" CREATED="2012-07-03T21:22:11.811Z" MIMETYPE="text/xml" SIZE="361">
+<foxml:datastreamVersion ID="identityMetadata.7" LABEL="Identity Metadata" CREATED="2012-07-03T21:21:23.545Z" MIMETYPE="text/xml" SIZE="396">
 <foxml:xmlContent>
 <identityMetadata>
   <objectId>druid:hv992ry2431</objectId>
@@ -1009,10 +1617,24 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
   <objectDescription>Default Administrative Policy Object</objectDescription>
   <otherId name="uuid">661e629a-24c8-2ef3-227e-883eb4e2c6d4</otherId>
   <agreementId>druid:tx617qp8040</agreementId>
+  <tag>Remediated By : 3.6.2</tag>
 </identityMetadata>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
-<foxml:datastreamVersion ID="identityMetadata.5" LABEL="Identity Metadata" CREATED="2012-04-09T22:41:24.309Z" MIMETYPE="text/xml" SIZE="365">
+<foxml:datastreamVersion ID="identityMetadata.6" LABEL="Identity Metadata" CREATED="2012-05-07T23:35:02.081Z" MIMETYPE="text/xml" SIZE="400">
+<foxml:xmlContent>
+<identityMetadata>
+  <objectId>druid:hv992ry2431</objectId>
+  <objectType>adminPolicy</objectType>
+  <objectLabel>Default Admin Policy</objectLabel>
+  <objectDescription>Default Administrative Policy Object</objectDescription>
+  <otherId name="uuid">661e629a-24c8-2ef3-227e-883eb4e2c6d4</otherId>
+  <agreementId>druid:tx617qp8040</agreementId>
+  <tag>Remediated By : 3.6.2</tag>
+</identityMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="identityMetadata.5" LABEL="Identity Metadata" CREATED="2012-04-09T22:41:11.661Z" MIMETYPE="text/xml" SIZE="365">
 <foxml:xmlContent>
 <identityMetadata>
   <objectId>druid:hv992ry2431</objectId>
@@ -1024,7 +1646,7 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
 </identityMetadata>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
-<foxml:datastreamVersion ID="identityMetadata.4" LABEL="Identity Metadata" CREATED="2012-03-01T09:03:29.648Z" MIMETYPE="text/xml" SIZE="318">
+<foxml:datastreamVersion ID="identityMetadata.4" LABEL="Identity Metadata" CREATED="2012-03-01T09:04:42.891Z" MIMETYPE="text/xml" SIZE="318">
 <foxml:xmlContent>
 <identityMetadata>
   <objectId>druid:hv992ry2431</objectId>
@@ -1035,7 +1657,7 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
 </identityMetadata>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
-<foxml:datastreamVersion ID="identityMetadata.3" LABEL="Identity Metadata" CREATED="2011-11-07T02:10:48.083Z" MIMETYPE="text/xml" SIZE="319">
+<foxml:datastreamVersion ID="identityMetadata.3" LABEL="Identity Metadata" CREATED="2011-11-07T02:10:13.940Z" MIMETYPE="text/xml" SIZE="319">
 <foxml:xmlContent>
 <identityMetadata>
   <objectId>druid:hv992ry2431</objectId>
@@ -1046,7 +1668,7 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
 </identityMetadata>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
-<foxml:datastreamVersion ID="identityMetadata.2" LABEL="Identity Metadata" CREATED="2011-10-31T22:26:23.365Z" MIMETYPE="text/xml" SIZE="368">
+<foxml:datastreamVersion ID="identityMetadata.2" LABEL="Identity Metadata" CREATED="2011-10-31T22:23:12.596Z" MIMETYPE="text/xml" SIZE="368">
 <foxml:xmlContent>
 <identityMetadata>
   <objectId>druid:hv992ry2431</objectId>
@@ -1082,7 +1704,7 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
 </identityMetadata>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
-<foxml:datastreamVersion ID="identityMetadata.7" LABEL="Identity Metadata" CREATED="2014-08-20T22:28:51.843Z" MIMETYPE="text/xml" SIZE="397">
+<foxml:datastreamVersion ID="identityMetadata.8" LABEL="Identity Metadata" CREATED="2013-02-12T18:44:38.279Z" MIMETYPE="text/xml" SIZE="397">
 <foxml:xmlContent>
 <identityMetadata>
   <objectId>druid:hv992ry2431</objectId>
@@ -1091,7 +1713,59 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
   <objectDescription>Default Administrative Policy Object</objectDescription>
   <otherId name="uuid">661e629a-24c8-2ef3-227e-883eb4e2c6d4</otherId>
   <agreementId>druid:tx617qp8040</agreementId>
-  <tag>Remediated By : 4.13.0</tag>
+  <tag>Remediated By : 3.22.1</tag>
+</identityMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="identityMetadata.9" LABEL="Identity Metadata" CREATED="2014-01-29T19:01:13.213Z" MIMETYPE="text/xml" SIZE="406">
+<foxml:xmlContent>
+<identityMetadata>
+  <objectId>druid:hv992ry2431</objectId>
+  <objectType>adminPolicy</objectType>
+  <objectLabel>[Internal System Objects]</objectLabel>
+  <objectDescription>Default Administrative Policy Object</objectDescription>
+  <otherId name="uuid">661e629a-24c8-2ef3-227e-883eb4e2c6d4</otherId>
+  <agreementId>druid:tx617qp8040</agreementId>
+  <tag>Remediated By : 3.22.1</tag>
+</identityMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="identityMetadata.10" LABEL="Identity Metadata" CREATED="2014-08-07T06:28:26.241Z" MIMETYPE="text/xml" SIZE="407">
+<foxml:xmlContent>
+<identityMetadata>
+  <objectId>druid:hv992ry2431</objectId>
+  <objectType>adminPolicy</objectType>
+  <objectLabel>[Internal System Objects]</objectLabel>
+  <objectDescription>Default Administrative Policy Object</objectDescription>
+  <otherId name="uuid">661e629a-24c8-2ef3-227e-883eb4e2c6d4</otherId>
+  <agreementId>druid:tx617qp8040</agreementId>
+  <tag>Remediated By : 4.6.6.2</tag>
+</identityMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="identityMetadata.11" LABEL="Identity Metadata" CREATED="2015-04-06T21:23:28.754Z" MIMETYPE="text/xml" SIZE="406">
+<foxml:xmlContent>
+<identityMetadata>
+  <objectId>druid:hv992ry2431</objectId>
+  <objectType>adminPolicy</objectType>
+  <objectLabel>[Internal System Objects]</objectLabel>
+  <objectDescription>Default Administrative Policy Object</objectDescription>
+  <otherId name="uuid">661e629a-24c8-2ef3-227e-883eb4e2c6d4</otherId>
+  <agreementId>druid:tx617qp8040</agreementId>
+  <tag>Remediated By : 4.17.1</tag>
+</identityMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="identityMetadata.12" LABEL="Identity Metadata" CREATED="2015-11-11T22:27:14.490Z" MIMETYPE="text/xml" SIZE="406">
+<foxml:xmlContent>
+<identityMetadata>
+  <objectId>druid:hv992ry2431</objectId>
+  <objectType>adminPolicy</objectType>
+  <objectLabel>[Internal System Objects]</objectLabel>
+  <objectDescription>Default Administrative Policy Object</objectDescription>
+  <otherId name="uuid">661e629a-24c8-2ef3-227e-883eb4e2c6d4</otherId>
+  <agreementId>druid:tx617qp8040</agreementId>
+  <tag>Remediated By : 4.22.3</tag>
 </identityMetadata>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
@@ -1123,39 +1797,32 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
 </roleMetadata>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
-<foxml:datastreamVersion ID="roleMetadata.1" LABEL="Role Metadata" CREATED="2012-12-10T19:37:51.465Z" MIMETYPE="text/xml" SIZE="687">
+<foxml:datastreamVersion ID="roleMetadata.1" LABEL="Role Metadata" CREATED="2013-01-09T19:46:09.240Z" MIMETYPE="text/xml" SIZE="177">
 <foxml:xmlContent>
 <roleMetadata>
   <role type="manager">
     <person>
-      <identifier type="sunetid">mbklein</identifier>
-      <name>Klein, Michael</name>
-    </person>
-    <person>
       <identifier type="sunetid">lmcrae</identifier>
       <name>McRae, Lynn</name>
     </person>
-    <person>
-      <identifier type="sunetid">jdeering</identifier>
-      <name>Deering, Jonathan</name>
-    </person>
   </role>
-  <role type="depositor">
-    <person>
-      <identifier type="sunetid">labware</identifier>
-      <name>Labware, Hydra</name>
-    </person>
+</roleMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="roleMetadata.2" LABEL="Role Metadata" CREATED="2013-01-09T20:02:51.570Z" MIMETYPE="text/xml" SIZE="154">
+<foxml:xmlContent>
+<roleMetadata>
+  <role type="manager">
     <group>
-      <identifier type="workgroup">dlss:labstaff</identifier>
-      <name>Scanning Lab Staff</name>
+      <identifier type="workgroup">dlss:dor-admin</identifier>
     </group>
   </role>
 </roleMetadata>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
-<foxml:datastreamVersion ID="roleMetadata.2" LABEL="Role Metadata" CREATED="2013-01-09T23:21:32.674Z" MIMETYPE="text/xml" SIZE="162">
+<foxml:datastreamVersion ID="roleMetadata.3" LABEL="Role Metadata" CREATED="2013-01-09T20:03:23.104Z" MIMETYPE="text/xml" SIZE="191">
 <foxml:xmlContent>
-<roleMetadata>
+<roleMetadata objectId="druid:hv992ry2431">
   <role type="dor-apo-manager">
     <group>
       <identifier type="workgroup">dlss:dor-admin</identifier>
@@ -1164,9 +1831,9 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
 </roleMetadata>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
-<foxml:datastreamVersion ID="roleMetadata.3" LABEL="Role Metadata" CREATED="2013-01-11T01:52:59.065Z" MIMETYPE="text/xml" SIZE="163">
+<foxml:datastreamVersion ID="roleMetadata.4" LABEL="Role Metadata" CREATED="2013-01-11T01:52:25.981Z" MIMETYPE="text/xml" SIZE="192">
 <foxml:xmlContent>
-<roleMetadata>
+<roleMetadata objectId="druid:hv992ry2431">
   <role type="dor-apo-manager">
     <group>
       <identifier type="workgroup">dlss:developers</identifier>
@@ -1175,32 +1842,27 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
 </roleMetadata>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
-<foxml:datastreamVersion ID="roleMetadata.4" LABEL="Role Metadata" CREATED="2013-01-11T17:06:24.673Z" MIMETYPE="text/xml" SIZE="155">
+<foxml:datastreamVersion ID="roleMetadata.5" LABEL="Role Metadata" CREATED="2013-01-15T17:27:13.271Z" MIMETYPE="text/xml" SIZE="280">
 <foxml:xmlContent>
-<roleMetadata>
-  <role type="manager">
+<roleMetadata objectId="druid:hv992ry2431">
+  <role type="dor-apo-manager">
     <group>
       <identifier type="workgroup">dlss:developers</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:dor-admin</identifier>
     </group>
   </role>
 </roleMetadata>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
-<foxml:datastreamVersion ID="roleMetadata.5" LABEL="Role Metadata" CREATED="2013-01-12T00:51:41.660Z" MIMETYPE="text/xml" SIZE="163">
+<foxml:datastreamVersion ID="roleMetadata.6" LABEL="Role Metadata" CREATED="2013-02-24T23:01:58.902Z" MIMETYPE="text/xml" SIZE="281">
 <foxml:xmlContent>
-<roleMetadata>
+<roleMetadata objectId="druid:hv992ry2431">
   <role type="dor-apo-manager">
     <group>
       <identifier type="workgroup">dlss:developers</identifier>
     </group>
-  </role>
-</roleMetadata>
-</foxml:xmlContent>
-</foxml:datastreamVersion>
-<foxml:datastreamVersion ID="roleMetadata.6" LABEL="Role Metadata" CREATED="2014-09-02T21:24:11.298Z" MIMETYPE="text/xml" SIZE="163">
-<foxml:xmlContent>
-<roleMetadata>
-  <role type="dor-apo-manager">
     <group>
       <identifier type="workgroup">dlss:pmag-staff</identifier>
     </group>
@@ -1208,59 +1870,583 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
 </roleMetadata>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
-</foxml:datastream>
-<foxml:datastream ID="workflows" STATE="A" CONTROL_GROUP="E" VERSIONABLE="false">
-<foxml:datastreamVersion ID="workflows.0" LABEL="workflows" CREATED="2012-01-28T01:35:58.251Z" MIMETYPE="application/xml">
-<foxml:contentLocation TYPE="URL" REF="https://lyberservices-test.stanford.edu/workflow/dor/objects/druid:hv992ry2431/workflows"/>
-</foxml:datastreamVersion>
-<foxml:datastreamVersion ID="workflows.1" LABEL="Workflow" CREATED="2013-02-13T18:01:29.520Z" MIMETYPE="application/xml">
-<foxml:contentLocation TYPE="URL" REF="https://lyberservices-test.stanford.edu/workflow/dor/objects/druid:hv992ry2431/workflows"/>
-</foxml:datastreamVersion>
-</foxml:datastream>
-<foxml:datastream ID="RELS-EXT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
-<foxml:datastreamVersion ID="RELS-EXT.0" LABEL="Fedora Object-to-Object Relationship Metadata" CREATED="2014-08-20T22:28:52.051Z" MIMETYPE="application/rdf+xml" SIZE="315">
+<foxml:datastreamVersion ID="roleMetadata.7" LABEL="Role Metadata" CREATED="2013-02-24T23:04:03.285Z" MIMETYPE="text/xml" SIZE="406">
 <foxml:xmlContent>
-<rdf:RDF xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-  <rdf:Description rdf:about="info:fedora/druid:hv992ry2431">
-    <fedora-model:hasModel rdf:resource="info:fedora/afmodel:Dor_Item"></fedora-model:hasModel>
-  </rdf:Description>
-</rdf:RDF>
+<roleMetadata objectId="druid:hv992ry2431">
+  <role type="dor-adminr">
+    <group>
+      <identifier type="workgroup">dlss:dor-admin</identifier>
+    </group>
+  </role>
+  <role type="dor-apo-manager">
+    <group>
+      <identifier type="workgroup">dlss:developers</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:pmag-staff</identifier>
+    </group>
+  </role>
+</roleMetadata>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
-<foxml:datastreamVersion ID="RELS-EXT.1" LABEL="Fedora Object-to-Object Relationship Metadata" CREATED="2014-08-22T21:08:00.240Z" MIMETYPE="application/rdf+xml" SIZE="328">
+<foxml:datastreamVersion ID="roleMetadata.8" LABEL="Role Metadata" CREATED="2013-03-06T04:49:43.927Z" MIMETYPE="text/xml" SIZE="502">
 <foxml:xmlContent>
-<rdf:RDF xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<roleMetadata objectId="druid:hv992ry2431">
+  <role type="dor-adminr">
+    <group>
+      <identifier type="workgroup">dlss:dor-admin</identifier>
+    </group>
+  </role>
+  <role type="dor-apo-manager">
+    <group>
+      <identifier type="workgroup">dlss:sdr-administrator</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:developers</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:pmag-staff</identifier>
+    </group>
+  </role>
+</roleMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="roleMetadata.9" LABEL="Role Metadata" CREATED="2013-03-06T04:51:19.715Z" MIMETYPE="text/xml" SIZE="413">
+<foxml:xmlContent>
+<roleMetadata objectId="druid:hv992ry2431">
+  <role type="dor-admin">
+    <group>
+      <identifier type="workgroup">dlss:sdr-administrator</identifier>
+    </group>
+  </role>
+  <role type="dor-apo-manager">
+    <group>
+      <identifier type="workgroup">dlss:developers</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:pmag-staff</identifier>
+    </group>
+  </role>
+</roleMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="roleMetadata.10" LABEL="Role Metadata" CREATED="2013-03-07T18:46:50.544Z" MIMETYPE="text/xml" SIZE="515">
+<foxml:xmlContent>
+<roleMetadata objectId="druid:hv992ry2431">
+  <role type="dor-admin">
+    <group>
+      <identifier type="workgroup">dlss:sdr-administrator</identifier>
+    </group>
+  </role>
+  <role type="dor-apo-manager">
+    <group>
+      <identifier type="workgroup">dlss:developers</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:pmag-staff</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:production-coordinators</identifier>
+    </group>
+  </role>
+</roleMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="roleMetadata.11" LABEL="Role Metadata" CREATED="2013-03-27T07:24:05.727Z" MIMETYPE="text/xml" SIZE="761">
+<foxml:xmlContent>
+<roleMetadata objectId="druid:hv992ry2431">
+  <role type="dor-admin">
+    <group>
+      <identifier type="workgroup">dlss:dor-admin</identifier>
+    </group>
+  </role>
+  <role type="dor-manager">
+    <group>
+      <identifier type="workgroup">dlss:dor-manager</identifier>
+    </group>
+  </role>
+  <role type="dor-viewer">
+    <group>
+      <identifier type="workgroup">dlss:dor-viewer</identifier>
+    </group>
+  </role>
+  <role type="dor-apo-manager">
+    <group>
+      <identifier type="workgroup">dlss:developers</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:pmag-staff</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:production-coordinators</identifier>
+    </group>
+  </role>
+</roleMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="roleMetadata.12" LABEL="Role Metadata" CREATED="2013-03-27T17:51:44.210Z" MIMETYPE="text/xml" SIZE="724">
+<foxml:xmlContent>
+<roleMetadata objectId="druid:hv992ry2431">
+  <role type="dor-admin">
+    <group>
+      <identifier type="workgroup">dlss:dor-admin</identifier>
+    </group>
+  </role>
+  <role type="dor-manager">
+    <group>
+      <identifier type="workgroup">dlss:dor-manager</identifier>
+    </group>
+  </role>
+  <role type="dor-apo-manager">
+    <group>
+      <identifier type="workgroup">dlss:dor-viewer</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:developers</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:pmag-staff</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:production-coordinators</identifier>
+    </group>
+  </role>
+</roleMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="roleMetadata.13" LABEL="Role Metadata" CREATED="2013-05-20T21:56:53.106Z" MIMETYPE="text/xml" SIZE="789">
+<foxml:xmlContent>
+<roleMetadata objectId="druid:hv992ry2431">
+  <role type="dor-admin">
+    <group>
+      <identifier type="workgroup">dlss:dor-admin</identifier>
+      <identifier type="workgroup">dlss:dor-manager</identifier>
+    </group>
+  </role>
+  <role type="dor-manager">
+    <group>
+      <identifier type="workgroup">dlss:dor-manager</identifier>
+    </group>
+  </role>
+  <role type="dor-apo-manager">
+    <group>
+      <identifier type="workgroup">dlss:dor-viewer</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:developers</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:pmag-staff</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:production-coordinators</identifier>
+    </group>
+  </role>
+</roleMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="roleMetadata.14" LABEL="Role Metadata" CREATED="2013-05-20T22:06:11.709Z" MIMETYPE="text/xml" SIZE="814">
+<foxml:xmlContent>
+<roleMetadata objectId="druid:hv992ry2431">
+  <role type="dor-admin">
+    <group>
+      <identifier type="workgroup">dlss:dor-admin</identifier>
+    </group>
+  </role>
+  <role type="dor-manager">
+    <group>
+      <identifier type="workgroup">dlss:dor-manager</identifier>
+    </group>
+  </role>
+  <role type="dor-apo-manager">
+    <group>
+      <identifier type="workgroup">dlss:dor-viewer</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:developers</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:pmag-staff</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:production-coordinators</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:dor-manager</identifier>
+    </group>
+  </role>
+</roleMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="roleMetadata.15" LABEL="Role Metadata" CREATED="2014-04-23T20:42:10.784Z" MIMETYPE="text/xml" SIZE="904">
+<foxml:xmlContent>
+<roleMetadata objectId="druid:hv992ry2431">
+  <role type="dor-admin">
+    <group>
+      <identifier type="workgroup">dlss:dor-admin</identifier>
+    </group>
+  </role>
+  <role type="dor-manager">
+    <group>
+      <identifier type="workgroup">dlss:dor-manager</identifier>
+    </group>
+  </role>
+  <role type="dor-apo-manager">
+    <group>
+      <identifier type="workgroup">dlss:dor-viewer</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:developers</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:pmag-staff</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:production-coordinators</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:dor-manager</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">sdr:map-hourlies</identifier>
+    </group>
+  </role>
+</roleMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="roleMetadata.16" LABEL="Role Metadata" CREATED="2014-04-23T20:47:36.426Z" MIMETYPE="text/xml" SIZE="814">
+<foxml:xmlContent>
+<roleMetadata objectId="druid:hv992ry2431">
+  <role type="dor-admin">
+    <group>
+      <identifier type="workgroup">dlss:dor-admin</identifier>
+    </group>
+  </role>
+  <role type="dor-manager">
+    <group>
+      <identifier type="workgroup">dlss:dor-manager</identifier>
+    </group>
+  </role>
+  <role type="dor-apo-manager">
+    <group>
+      <identifier type="workgroup">dlss:dor-viewer</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:developers</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:pmag-staff</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:production-coordinators</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:dor-manager</identifier>
+    </group>
+  </role>
+</roleMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="roleMetadata.17" LABEL="Role Metadata" CREATED="2014-07-17T23:55:01.758Z" MIMETYPE="text/xml" SIZE="888">
+<foxml:xmlContent>
+<roleMetadata objectId="druid:hv992ry2431">
+  <role type="dor-admin">
+    <group>
+      <identifier type="workgroup">dlss:dor-admin</identifier>
+    </group>
+  </role>
+  <role type="dor-manager">
+    <group>
+      <identifier type="workgroup">dlss:dor-manager</identifier>
+    </group>
+  </role>
+  <role type="dor-apo-manager">
+    <group>
+      <identifier type="workgroup">dlss:dor-viewer</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:developers</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">sdr:metadata-staff</identifier>
+    </group>
+  </role>
+  <group>
+    <identifier type="workgroup">dlss:pmag-staff</identifier>
+  </group>
+  <group>
+    <identifier type="workgroup">dlss:production-coordinators</identifier>
+  </group>
+  <group>
+    <identifier type="workgroup">dlss:dor-manager</identifier>
+  </group>
+</roleMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="roleMetadata.18" LABEL="Role Metadata" CREATED="2014-07-18T00:01:56.310Z" MIMETYPE="text/xml" SIZE="711">
+<foxml:xmlContent>
+<roleMetadata objectId="druid:hv992ry2431">
+  <role type="dor-admin">
+    <group>
+      <identifier type="workgroup">dlss:dor-admin</identifier>
+    </group>
+  </role>
+  <role type="dor-manager">
+    <group>
+      <identifier type="workgroup">dlss:dor-manager</identifier>
+    </group>
+  </role>
+  <role type="dor-apo-manager">
+    <group>
+      <identifier type="workgroup">dlss:dor-viewer</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:developers</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">sdr:metadata-staff</identifier>
+    </group>
+  </role>
+  <group>
+    <identifier type="workgroup">sdr:metadata-staff</identifier>
+  </group>
+</roleMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="roleMetadata.19" LABEL="Role Metadata" CREATED="2014-07-18T18:03:37.519Z" MIMETYPE="text/xml" SIZE="906">
+<foxml:xmlContent>
+<roleMetadata objectId="druid:hv992ry2431">
+  <role type="dor-admin">
+    <group>
+      <identifier type="workgroup">dlss:dor-admin</identifier>
+    </group>
+  </role>
+  <role type="dor-manager">
+    <group>
+      <identifier type="workgroup">dlss:dor-manager</identifier>
+    </group>
+  </role>
+  <role type="dor-apo-manager">
+    <group>
+      <identifier type="workgroup">dlss:dor-viewer</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:developers</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">sdr:metadata-staff</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:pmag-staff</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:production-coordinators</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:dor-manager</identifier>
+    </group>
+  </role>
+</roleMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="roleMetadata.20" LABEL="Role Metadata" CREATED="2015-09-10T21:36:22.013Z" MIMETYPE="text/xml" SIZE="654">
+<foxml:xmlContent>
+<roleMetadata objectId="druid:hv992ry2431">
+  <role type="dor-apo-manager">
+    <group>
+      <identifier type="workgroup">dlss:dor-viewer</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:developers</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">sdr:metadata-staff</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:pmag-staff</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:production-coordinators</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:dor-manager</identifier>
+    </group>
+  </role>
+</roleMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="roleMetadata.21" LABEL="Role Metadata" CREATED="2015-11-11T22:18:33.394Z" MIMETYPE="text/xml" SIZE="742">
+<foxml:xmlContent>
+<roleMetadata objectId="druid:hv992ry2431">
+  <role type="dor-apo-manager">
+    <group>
+      <identifier type="workgroup">dlss:dor-viewer</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:developers</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">sdr:metadata-staff</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:pmag-staff</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:production-coordinators</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">sdr:spec-staff</identifier>
+    </group>
+    <group>
+      <identifier type="workgroup">dlss:dor-manager</identifier>
+    </group>
+  </role>
+</roleMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="rightsMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="rightsMetadata.0" LABEL="Rights Metadata" CREATED="2013-02-12T04:13:33.137Z" MIMETYPE="text/xml" SIZE="572">
+<foxml:xmlContent>
+<rightsMetadata>
+  <copyright>
+    <human type="copyright">This work is copyrighted by the creator.</human>
+  </copyright>
+  <access type="discover">
+    <world></world>
+  </access>
+  <access type="read">
+    <human>This document is available only to the Stanford faculty, staff and student
+            community</human>
+    <machine>
+      <group>stanford</group>
+    </machine>
+  </access>
+  <use>
+    <human type="creativecommons">Attribution Non-Commercial Share Alike license</human>
+    <machine type="creativecommons">by-nc-sa</machine>
+  </use>
+</rightsMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="rightsMetadata.1" LABEL="Rights Metadata" CREATED="2014-08-06T22:28:00.523Z" MIMETYPE="text/xml" SIZE="572">
+<foxml:xmlContent>
+<rightsMetadata>
+  <copyright>
+    <human type="copyright">This work is copyrighted by the creator.</human>
+  </copyright>
+  <access type="discover">
+    <world></world>
+  </access>
+  <access type="read">
+    <human>This document is available only to the Stanford faculty, staff and student
+            community</human>
+    <machine>
+      <group>stanford</group>
+    </machine>
+  </access>
+  <use>
+    <human type="creativecommons">Attribution Non-Commercial Share Alike license</human>
+    <machine type="creativecommons">by-nc-sa</machine>
+  </use>
+</rightsMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="rightsMetadata.2" LABEL="Rights Metadata" CREATED="2015-04-06T21:19:17.578Z" MIMETYPE="text/xml" SIZE="177">
+<foxml:xmlContent>
+<rightsMetadata>
+  <access type="discover">
+    <none></none>
+  </access>
+  <access type="read">
+    <machine>
+      <none></none>
+    </machine>
+  </access>
+</rightsMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="rightsMetadata.3" LABEL="Rights Metadata" CREATED="2015-04-06T21:21:08.077Z" MIMETYPE="text/xml" SIZE="208">
+<foxml:xmlContent>
+<rightsMetadata>
+  <access type="discover">
+    <machine>
+      <none></none>
+    </machine>
+  </access>
+  <access type="read">
+    <machine>
+      <none></none>
+    </machine>
+  </access>
+</rightsMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="provenanceMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="provenanceMetadata.0" LABEL="Provenance Metadata" CREATED="2013-02-12T18:32:02.796Z" MIMETYPE="text/xml" SIZE="183">
+<foxml:xmlContent>
+<agent name="DOR">
+  <what object="druid:hv992ry2431">
+    <event when="2013-02-12T10:32:02-08:00" who="DOR-accessionWF">DOR Common Accessioning completed</event>
+  </what>
+</agent>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="provenanceMetadata.1" LABEL="Provenance Metadata" CREATED="2014-08-07T06:29:09.562Z" MIMETYPE="text/xml" SIZE="265">
+<foxml:xmlContent>
+<provenanceMetadata objectId="druid:hv992ry2431">
+  <agent name="DOR">
+    <what object="druid:hv992ry2431">
+      <event when="2014-08-06T23:29:09-07:00" who="DOR-accessionWF">DOR Common Accessioning completed</event>
+    </what>
+  </agent>
+</provenanceMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="provenanceMetadata.2" LABEL="Provenance Metadata" CREATED="2015-04-06T21:24:27.069Z" MIMETYPE="text/xml" SIZE="265">
+<foxml:xmlContent>
+<provenanceMetadata objectId="druid:hv992ry2431">
+  <agent name="DOR">
+    <what object="druid:hv992ry2431">
+      <event when="2015-04-06T14:24:26-07:00" who="DOR-accessionWF">DOR Common Accessioning completed</event>
+    </what>
+  </agent>
+</provenanceMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="provenanceMetadata.3" LABEL="Provenance Metadata" CREATED="2015-11-11T22:28:43.765Z" MIMETYPE="text/xml" SIZE="265">
+<foxml:xmlContent>
+<provenanceMetadata objectId="druid:hv992ry2431">
+  <agent name="DOR">
+    <what object="druid:hv992ry2431">
+      <event when="2015-11-11T14:28:43-08:00" who="DOR-accessionWF">DOR Common Accessioning completed</event>
+    </what>
+  </agent>
+</provenanceMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="workflows" STATE="A" CONTROL_GROUP="E" VERSIONABLE="false">
+<foxml:datastreamVersion ID="workflows.4" LABEL="Workflow" CREATED="2015-04-06T21:27:22.946Z" MIMETYPE="application/xml">
+<foxml:contentLocation TYPE="URL" REF="https://lyberservices-prod.stanford.edu/workflow/dor/objects/druid:hv992ry2431/workflows"/>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="RELS-EXT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
+<foxml:datastreamVersion ID="RELS-EXT.2" LABEL="RDF Relationships" CREATED="2015-09-10T21:36:21.358Z" MIMETYPE="text/xml" SIZE="576">
+<foxml:xmlContent>
+<rdf:RDF xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
   <rdf:Description rdf:about="info:fedora/druid:hv992ry2431">
+    <hydra:isGovernedBy rdf:resource="info:fedora/druid:hv992ry2431"></hydra:isGovernedBy>
+    <hydra:referencesAgreement rdf:resource="info:fedora/druid:wv961pm7301"></hydra:referencesAgreement>
     <fedora-model:hasModel rdf:resource="info:fedora/afmodel:Dor_AdminPolicyObject"></fedora-model:hasModel>
   </rdf:Description>
 </rdf:RDF>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
 </foxml:datastream>
-<foxml:datastream ID="events" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
-<foxml:datastreamVersion ID="events.0" LABEL="Events" CREATED="2014-08-20T22:28:52.215Z" MIMETYPE="text/xml" SIZE="394">
-<foxml:xmlContent>
-<events>
-  <event type="remediation" when="2014-08-20T15:28:51-07:00" who="Dor::Identifiable 3.6.1">Assert correct models</event>
-  <event type="remediation" when="2014-08-20T15:28:51-07:00" who="Dor::Identifiable 3.6.1">Record Remediation Version</event>
-  <event type="remediation" when="2014-08-20T15:28:51-07:00" who="Dor::Versionable 3.12.2">Add missing versionMetadata</event>
-</events>
-</foxml:xmlContent>
-</foxml:datastreamVersion>
-</foxml:datastream>
-<foxml:datastream ID="versionMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
-<foxml:datastreamVersion ID="versionMetadata.0" LABEL="Version Metadata" CREATED="2014-08-20T22:28:52.350Z" MIMETYPE="text/xml" SIZE="136">
-<foxml:xmlContent>
-<versionMetadata>
-  <version tag="1.0.0" versionId="1">
-    <description>Initial Version</description>
-  </version>
-</versionMetadata>
-</foxml:xmlContent>
-</foxml:datastreamVersion>
-</foxml:datastream>
 <foxml:datastream ID="descMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
-<foxml:datastreamVersion ID="descMetadata.1" LABEL="" CREATED="2014-08-25T21:02:47.128Z" MIMETYPE="text/xml" SIZE="388">
+<foxml:datastreamVersion ID="descMetadata.2" LABEL="Descriptive Metadata" CREATED="2015-09-10T21:36:21.632Z" MIMETYPE="text/xml" SIZE="388">
 <foxml:xmlContent>
 <mods:mods xmlns:mods="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd">
   <mods:titleInfo>
@@ -1268,6 +2454,28 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
   </mods:titleInfo>
   <mods:identifier type="druid">hv992ry2431</mods:identifier>
 </mods:mods>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="versionMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
+<foxml:datastreamVersion ID="versionMetadata.12" LABEL="Version Metadata" CREATED="2015-11-11T22:20:10.126Z" MIMETYPE="text/xml" SIZE="793">
+<foxml:xmlContent>
+<versionMetadata objectId="druid:hv992ry2431">
+  <version tag="1.0.0" versionId="1">
+    <description>Initial Version</description>
+  </version>
+  <version tag="2.0.0" versionId="2">
+    <description></description>
+  </version>
+  <version tag="2.1.0" versionId="3">
+    <description>Fix rightsMetadata and defaultObjectRights. Make it just discover=none and access=none.</description>
+  </version>
+  <version tag="2.1.1" versionId="4">
+    <description>Add sdr:spec-staff workgroup to allow APO editing and collection-creation of their materials.
+
+NOTE: we have used this work-around to give DPG and SPEC privileges that should not be universal - remove non-admin workgroups from uber APO when ticket for APO editing in current sprint is closed.</description>
+  </version>
+</versionMetadata>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
 </foxml:datastream>


### PR DESCRIPTION
This is the current version of the `[Internal System Objects]` uber-APO. You will need to reload your developer Fedora instances with it.