### PR TITLE
Lookup repo for WF reset link

### DIFF
--- a/app/helpers/workflow_helper.rb
+++ b/app/helpers/workflow_helper.rb
@@ -38,8 +38,14 @@ module WorkflowHelper
 
   def render_workflow_reset_link(wf_hash, name, process, status)
     return unless wf_hash[process] && wf_hash[process][status] && wf_hash[process][status][:_]
-    new_params = add_facet_params('wf_wps_ssim', [name, process, status].compact.join(':')).merge(:controller => 'report', :action => 'reset', :reset_workflow => name, :reset_step => process)
-    raw ' | ' + link_to('reset', new_params, :remote => true)
+    new_params = add_facet_params(
+      'wf_wps_ssim',
+      [name, process, status].compact.join(':'))
+        .merge(
+          reset_workflow: name,
+          reset_step: process
+        )
+    raw ' | ' + link_to('reset', report_reset_path(new_params), remote: true, method: :post)
   end
 
   def render_workflow_item_count(wf_hash, name, process, status)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,7 @@ Argo::Application.routes.draw do
   match '/report/bulk', :to => 'report#bulk', :via => [:get, :post], :as => 'report_bulk'
   match 'report/pids', :to => 'report#pids', :via => [:get, :post], :as => 'report_pids'
   match '/report/workflow_grid', :to => 'report#workflow_grid', :via => [:get, :post], :as => 'report_workflow_grid'
-  match 'report/reset', :to => 'report#reset', :via => [:get, :post], :as => 'report_reset'
+  match 'report/reset', :to => 'report#reset', :via => [:post], :as => 'report_reset'
   match 'discovery', :to => 'discovery#index', :via => [:get, :post], :as => 'discovery'
   match '/discovery/data', :to => 'discovery#data', :via => [:get, :post], :as => 'discovery_data'
   match 'discovery/download', :to => 'discovery#download', :via => [:get, :post], :as => 'discovery_download'

--- a/spec/helpers/workflow_helper_spec.rb
+++ b/spec/helpers/workflow_helper_spec.rb
@@ -31,4 +31,44 @@ describe WorkflowHelper, :type => :helper do
       expect(result).to eq('-')
     end
   end
+  describe '#render_workflow_reset_link' do
+    let(:name) { 'accessionWF' }
+    let(:process) { 'descriptive-metadata' }
+    let(:status) { 'error' }
+    let(:blacklight_config) { Blacklight::Configuration.new }
+    before(:each) do
+      allow(helper).to receive(:blacklight_config).and_return blacklight_config
+    end
+    describe 'wf_hash structure' do
+      it 'without process' do
+        wf_hash = {}
+        expect(helper
+          .render_workflow_reset_link(wf_hash, name, process, status)).to be_nil
+      end
+      it 'without status' do
+        wf_hash = { process => {}}
+        expect(helper
+          .render_workflow_reset_link(wf_hash, name, process, status)).to be_nil
+      end
+      it 'without trailing _' do
+        wf_hash = { process => { status => { }}}
+        expect(helper
+          .render_workflow_reset_link(wf_hash, name, process, status)).to be_nil
+      end
+      it 'with all' do
+        wf_hash = { process => { status => { _: '' } }}
+        expect(helper
+          .render_workflow_reset_link(wf_hash, name, process, status))
+            .to_not be_nil
+      end
+    end
+    describe 'reset link' do
+      it '' do
+        wf_hash = { process => { status => { _: '' } }}
+        link = helper.render_workflow_reset_link(wf_hash, name, process, status)
+        expect(link).to have_css 'a[data-remote="true"][rel="nofollow"]' \
+          '[data-method="post"]', text: 'reset'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #73 

Also removes the `GET` verb from this route. This action isn't idempotent, and really shouldn't respond to `GET`