### PR TITLE
reimplement CSV output for report downloads

### DIFF
--- a/app/controllers/discovery_controller.rb
+++ b/app/controllers/discovery_controller.rb
@@ -41,6 +41,6 @@ class DiscoveryController < CatalogController
     response.headers['Content-Type'] = 'application/octet-stream'
     response.headers['Content-Disposition'] = 'attachment; filename=report.csv'
     response.headers['Last-Modified'] = Time.now.ctime.to_s
-    self.response_body = Discovery.new(params, fields).csv2
+    self.response_body = Discovery.new(params, fields).to_csv
   end
 end

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -62,7 +62,7 @@ class ReportController < CatalogController
     response.headers['Content-Type'] = 'application/octet-stream'
     response.headers['Content-Disposition'] = 'attachment; filename=report.csv'
     response.headers['Last-Modified'] = Time.now.ctime.to_s
-    self.response_body = Report.new(params, fields).csv2
+    self.response_body = Report.new(params, fields).to_csv
   end
 
   # an ajax call to reset workflow states for objects

--- a/app/models/concerns/csv_concern.rb
+++ b/app/models/concerns/csv_concern.rb
@@ -1,0 +1,22 @@
+require 'csv'
+
+module CsvConcern
+  ##
+  # Converts the `report_data` into CSV data
+  # TODO: this method uses data iteration and `get_search_results` assumed to be in the model already
+  #
+  # @return [String] data in CSV format
+  def to_csv
+    @params[:page] = 1    
+    CSV.generate(force_quotes: true) do |csv|
+      csv << @fields.map { |f| f[:label] } # header
+      while @document_list.length > 0
+        report_data.each do |record|
+          csv << @fields.map { |f| record[f[:field]].to_s }
+        end
+        @params[:page] += 1
+        (@response, @document_list) = get_search_results
+      end
+    end
+  end
+end

--- a/app/models/discovery.rb
+++ b/app/models/discovery.rb
@@ -1,7 +1,10 @@
+require 'csv'
+
 class Discovery
   include BlacklightSolrExtensions
   include Blacklight::Configurable
   include Blacklight::SolrHelper
+  include CsvConcern
 
   attr_reader :response, :document_list, :num_found, :params
 
@@ -140,29 +143,6 @@ class Discovery
 
   def report_data
     docs_to_records(@document_list)
-  end
-
-  def csv2
-    headings = ''
-    rows = ''
-    @fields.each do |f|
-      label = f[:label] ? f[:label] : f[:field]
-      headings += label + ','
-    end
-
-    while @document_list.length > 0
-      records = docs_to_records(@document_list)
-      records.each do |record|
-        rows += "\r\n"
-        row = @fields.collect { |f| record[f[:field]] }
-        row.each do |field|
-          rows << '"' + field.to_s + '"' + ','
-        end
-      end
-      @params[:page] += 1
-      (@response, @document_list) = get_search_results
-    end
-    headings + rows
   end
 
   protected

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -2,6 +2,7 @@ class Report
   include BlacklightSolrExtensions
   include Blacklight::Configurable
   include Blacklight::SolrHelper
+  include CsvConcern
 
   class << self
     include DorObjectHelper
@@ -206,29 +207,6 @@ class Report
     docs_to_records(@document_list)
   end
 
-  def csv2
-    @params[:page] = 1
-    headings = ''
-    rows = ''
-    @fields.each do |f|
-      headings += f[:label] + ','
-    end
-
-    while @document_list.length > 0
-      records = docs_to_records(@document_list)
-      records.each do |record|
-        rows += "\r\n"
-        row = @fields.collect { |f| record[f[:field]] }
-        row.each do |field|
-          rows << '"' + field.to_s + '"' + ','
-        end
-      end
-      @params[:page] += 1
-      (@response, @document_list) = get_search_results
-    end
-    headings + rows
-  end
-
   protected
 
   def docs_to_records(docs, fields = blacklight_config.report_fields)
@@ -244,5 +222,4 @@ class Report
     end
     result
   end
-
 end

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -1,15 +1,27 @@
 require 'spec_helper'
 
 describe DiscoveryController, :type => :controller do
+  before :each do
+    log_in_as_mock_user(subject)
+    allow_any_instance_of(User).to receive(:groups).and_return(['sdr:administrator-role'])
+  end
+
   describe ':data' do
     it 'should fetch json data with the gdor fields in it' do
-      log_in_as_mock_user(subject)
-      allow_any_instance_of(User).to receive(:groups).and_return(['sdr:administrator-role'])
       get :data, :format => :json, :rows => 5
       json_body = JSON.parse(response.body)
       expect(json_body).to match a_hash_including('rows')
       expect(json_body['rows']).not_to be_nil
       expect(json_body['rows'].first).to match a_hash_including('sw_format_tesim')
+    end
+  end
+
+  describe 'download' do
+    it 'should download valid CSV data' do
+      get :download
+      expect(response.status).to eq(200)
+      expect(response.header['Content-Disposition']).to eq('attachment; filename=report.csv')
+      expect { CSV.parse(response.body) }.not_to raise_error
     end
   end
 end

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -63,4 +63,12 @@ describe ReportController, :type => :controller do
       expect(response.status).to eq 200
     end
   end
+  describe 'download' do
+    it 'should download valid CSV data' do
+      get :download
+      expect(response.status).to eq(200)
+      expect(response.header['Content-Disposition']).to eq('attachment; filename=report.csv')
+      expect { CSV.parse(response.body) }.not_to raise_error
+    end
+  end
 end

--- a/spec/models/discovery_spec.rb
+++ b/spec/models/discovery_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe Discovery, :type => :model do
+  context 'csv' do
+    before :each do
+      @csv = subject.to_csv
+    end
+    it 'should generate data in valid CSV format' do
+      expect { CSV.parse(@csv) }.not_to raise_error
+    end
+    it 'should generate many rows of data' do
+      rows = CSV.parse(@csv)
+      expect(rows.is_a?(Array)).to be_truthy
+      expect(rows.length).to be > 1   # at least headers + data
+      expect(rows[0].length).to eq(15) # default headers
+    end
+    it 'should force double quotes for all fields' do
+      expect(@csv[0]).to eq('"')
+    end
+  end
+end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe Report, :type => :model do
+  context 'csv' do
+    before :each do
+      @csv = subject.to_csv
+    end
+
+    it 'should generate data in valid CSV format' do
+      expect { CSV.parse(@csv) }.not_to raise_error
+    end
+
+    it 'should generate many rows of data' do
+      rows = CSV.parse(@csv)
+      expect(rows.is_a?(Array)).to be_truthy
+      expect(rows.length).to be > 1    # at least headers + data
+      expect(rows[0].length).to eq(24) # default headers
+    end
+
+    it 'should force double quotes for all fields' do
+      expect(@csv[0]).to eq('"')
+    end
+
+    it 'should handle a title with double quotes in it' do
+      found_example = false
+      CSV.parse(@csv).each do |row|
+        if row[0] == 'hj185vb7593'
+          expect(row[2]).to eq('Slides, IA 11, Geodesic Domes, Double Skin "Growth" House, N.C. State, 1953')
+          found_example = true
+          break
+        end
+      end
+      expect(found_example).to be_truthy
+    end
+
+    it 'should handle a multivalued fields' do
+      found_example = false
+      CSV.parse(@csv).each do |row|
+        if row[0] == 'xb482bw3979'
+          expect(row[11].split('; ').length).to eq(2)
+          found_example = true
+          break
+        end
+      end
+      expect(found_example).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
Fixes #80 

This PR uses the built-in Ruby `csv` package to generate the report downloads for Report and Discovery views, and adds tests. Note that the `ReportController` and `DiscoveryController` suffer from copy-n-paste code.