### PR TITLE
upgrade dor-services and webmock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,6 @@ gem 'blacklight', '~> 5.9.0' # TODO: BL >= 5.10.x has new deprecation warnings v
 gem 'blacklight-hierarchy'
 gem 'blacklight-marc'
 gem 'dor-services', '~> 5.0', :git => 'https://github.com/sul-dlss/dor-services.git', :branch => 'develop'
-gem 'dor-workflow-service', '~> 1.7'
 gem 'is_it_working-cbeer'
 gem 'jettywrapper'
 gem 'moab-versioning'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,16 +7,15 @@ GIT
 
 GIT
   remote: https://github.com/sul-dlss/dor-services.git
-  revision: 4c077e0fbea5fad04a8cf0ceb2f9da60b4173d6a
+  revision: 764ce0f299b987237a482ac550bc39b442a62474
   branch: develop
   specs:
     dor-services (5.2.0)
       active-fedora (~> 6.0)
       activesupport (>= 3.2.18)
-      addressable (= 2.3.5)
       confstruct (~> 0.2.7)
       dor-rights-auth (~> 1.0, >= 1.0.1)
-      dor-workflow-service (~> 1.7, >= 1.7.1)
+      dor-workflow-service (~> 1.8, >= 1.8.0)
       druid-tools (~> 0.4, >= 0.4.1)
       equivalent-xml (~> 0.5, >= 0.5.1)
       json (~> 1.8.1)
@@ -93,7 +92,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.3.5)
+    addressable (2.3.8)
     arel (6.0.3)
     autoprefixer-rails (6.0.3)
       execjs
@@ -170,7 +169,7 @@ GEM
       simplecov (~> 0.10.0)
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
-    crack (0.4.2)
+    crack (0.4.3)
       safe_yaml (~> 1.0.0)
     daemons (1.2.3)
     deep_merge (1.0.1)
@@ -188,9 +187,11 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dor-rights-auth (1.0.1)
       nokogiri
-    dor-workflow-service (1.7.7)
+    dor-workflow-service (1.8.0)
       activesupport (>= 3.2.1, < 5)
       confstruct (>= 0.2.7, < 2)
+      faraday (~> 0.9.2)
+      net-http-persistent (~> 2.9.4)
       nokogiri (~> 1.6.0)
       rest-client (~> 1.7)
       retries
@@ -209,6 +210,7 @@ GEM
       diff-lcs (~> 1.1)
       mime-types (~> 1.15)
       posix-spawn (~> 0.3.6)
+    hashdiff (0.2.3)
     hooks (0.3.6)
       uber (~> 0.0.4)
     http-cookie (1.0.2)
@@ -264,7 +266,7 @@ GEM
     mediashelf-loggable (0.4.10)
     method_source (0.8.2)
     mime-types (1.25.1)
-    mini_portile (0.6.2)
+    mini_portile2 (2.0.0)
     minitest (5.8.3)
     moab-versioning (1.4.4)
       confstruct
@@ -287,6 +289,7 @@ GEM
     multi_json (1.11.2)
     multipart-post (2.0.0)
     mysql2 (0.3.20)
+    net-http-persistent (2.9.4)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-sftp (2.1.2)
@@ -294,8 +297,8 @@ GEM
     net-ssh (2.6.8)
     netrc (0.11.0)
     newrelic_rpm (3.14.0.305)
-    nokogiri (1.6.6.4)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.6.7)
+      mini_portile2 (~> 2.0.0.rc2)
     nokogiri-happymapper (0.5.9)
       nokogiri (~> 1.5)
     nokogiri-pretty (0.1.0)
@@ -467,7 +470,7 @@ GEM
       net-scp (>= 1.1.2)
       net-ssh
       term-ansicolor
-    stanford-mods (1.3.0)
+    stanford-mods (1.3.1)
       mods (~> 2.0.2)
     stomp (1.3.4)
     sul_styles (0.3.0)
@@ -499,9 +502,10 @@ GEM
       raindrops (~> 0.7)
     uuidtools (2.1.5)
     validatable (1.6.7)
-    webmock (1.17.4)
-      addressable (>= 2.2.7)
+    webmock (1.22.3)
+      addressable (>= 2.3.6)
       crack (>= 0.3.2)
+      hashdiff
     websocket (1.2.2)
     websocket-driver (0.6.2)
       websocket-extensions (>= 0.1.0)
@@ -534,7 +538,6 @@ DEPENDENCIES
   delayed_job
   delayed_job_active_record
   dor-services (~> 5.0)!
-  dor-workflow-service (~> 1.7)
   equivalent-xml (>= 0.6.0)
   http_logger
   is_it_working-cbeer


### PR DESCRIPTION
This PR upgrades to the latest `develop` dor-services code which brings in the faraday and net-http-persistent gems, and also upgrades web mock (which the upgrade to dor-services allows to go to 1.23.x)

To correctly use the persistent connections in development, `webmock` must be disabled -- not loaded by bundler at all. To do this, you'll need to comment out the initializer and the Gemfile.