### PR TITLE
Ensure that specs only connect to localhost or webmocks

### DIFF
--- a/app/models/index_queue.rb
+++ b/app/models/index_queue.rb
@@ -35,7 +35,7 @@ class IndexQueue
       timeout: timeout,
       open_timeout: timeout
     )
-  rescue SocketError
+  rescue SocketError, RestClient::Exception
     raise Argo::Exceptions::IndexQueueRequestFailed,
           "Request to index queue at #{url} failed"
   end

--- a/config/initializers/webmock.rb
+++ b/config/initializers/webmock.rb
@@ -1,14 +1,23 @@
-def mock_workflow_requests
+##
+# We need to include webmock in both the development and
+# test environments because `argo:repo:load` will try to
+# contact the workflow service during Solrization.
+#
+# Note that requiring webmock breaks Net::HTTP::Persistent so
+# it should NOT be bundled in a production (or stage) deployment.
+#
+if !Settings.DISABLE_WEBMOCK && (Rails.env.development? || Rails.env.test?)
+  require 'webmock'
+  include WebMock::API
+  WebMock.allow_net_connect!
+
+  # mock_workflow_requests
   escaped_url = Settings.WORKFLOW_URL.gsub('/', '\/')
   stub_request(:get, /#{escaped_url}workflow_archive.*/).
     to_return(body: '<objects count="1"/>')
   stub_request(:get, /#{escaped_url}dor.*/).
     to_return(body: '<workflows/>')
-end
 
-if Rails.env.development? || Rails.env.test?
-  require 'webmock'
-  include WebMock::API
-  WebMock.allow_net_connect!
-  mock_workflow_requests unless Settings.DISABLE_WEBMOCK
+  # mock_status_requests
+  stub_request(:get, Settings.STATUS_INDEXER_URL).to_return(status: 404)
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,9 @@ end
 Capybara.javascript_driver = :poltergeist
 Capybara.default_wait_time = 10
 
+# When running specs, we require that all outside connection be mocked up
+WebMock.disable_net_connect!(allow_localhost: true)
+
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
 #


### PR DESCRIPTION
This PR requires that all specs connect only to localhost or web mocks (via `stub_request`).

In unrelated work, I found that we were connecting to "status.example.edu" so there's a fix to the IndexQueue model and a webmock for that URL.

I've also added a comment about how webmock is used in the different environments