### PR TITLE
fix cert_file and key_file settings to not assume path is relative to argo app root

### DIFF
--- a/config/environments/dor_production.rb
+++ b/config/environments/dor_production.rb
@@ -1,9 +1,7 @@
-cert_dir = File.expand_path(File.join(File.dirname(__FILE__), '../certs'))
-
 Dor.configure do
   ssl do
-    cert_file File.join(cert_dir, Settings.SSL.CERT_FILE)
-    key_file File.join(cert_dir, Settings.SSL.KEY_FILE)
+    cert_file Settings.SSL.CERT_FILE
+    key_file Settings.SSL.KEY_FILE
     key_pass Settings.SSL.KEY_PASS
   end
 


### PR DESCRIPTION
line up the prod config with the style of the other instances, so that deployment works.