### PR TITLE
prefer using window.location over document.location

### DIFF
--- a/app/assets/javascripts/modules/date_range_query.js
+++ b/app/assets/javascripts/modules/date_range_query.js
@@ -42,7 +42,7 @@
       $button.on('click', function(e) {
         e.preventDefault();
         var query = assembleQuery($el, facet);
-        document.location = path + '?' + query;
+        window.location.href = path + '?' + query;
       });
     });
 


### PR DESCRIPTION
This is what we do in GeoBlacklight, seeing if it makes a difference here in Argo.