### PR TITLE
Issue289

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -46,7 +46,7 @@ class CatalogController < ApplicationController
     config.add_index_field SolrDocument::FIELD_COLLECTION_ID, label: 'Collection',        helper_method: :links_to_collections
     config.add_index_field 'project_tag_ssim',                label: 'Project',           link_to_search: true
     config.add_index_field 'identifier_tesim',                label: 'IDs',               helper_method: :value_for_identifier_tesim
-    config.add_index_field 'originInfo_date_created_tesim',   label: 'Created'
+    config.add_index_field 'originInfo_date_created_tesim',   label: 'Created',           helper_method: :value_for_date
     config.add_index_field 'obj_label_ssim',                  label: 'Label'
     config.add_index_field 'source_id_ssim',                  label: 'Source'
     config.add_index_field 'wf_error_ssim',                   label: 'Error',             helper_method: :value_for_wf_error

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -46,7 +46,7 @@ class CatalogController < ApplicationController
     config.add_index_field SolrDocument::FIELD_COLLECTION_ID, label: 'Collection',        helper_method: :links_to_collections
     config.add_index_field 'project_tag_ssim',                label: 'Project',           link_to_search: true
     config.add_index_field 'identifier_tesim',                label: 'IDs',               helper_method: :value_for_identifier_tesim
-    config.add_index_field 'originInfo_date_created_tesim',   label: 'Created',           helper_method: :value_for_date_as_localtime
+    config.add_index_field 'originInfo_date_created_tesim',   label: 'Created'
     config.add_index_field 'obj_label_ssim',                  label: 'Label'
     config.add_index_field 'source_id_ssim',                  label: 'Source'
     config.add_index_field 'wf_error_ssim',                   label: 'Error',             helper_method: :value_for_wf_error

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -46,7 +46,7 @@ class CatalogController < ApplicationController
     config.add_index_field SolrDocument::FIELD_COLLECTION_ID, label: 'Collection',        helper_method: :links_to_collections
     config.add_index_field 'project_tag_ssim',                label: 'Project',           link_to_search: true
     config.add_index_field 'identifier_tesim',                label: 'IDs',               helper_method: :value_for_identifier_tesim
-    config.add_index_field 'originInfo_date_created_tesim',   label: 'Created',           helper_method: :value_for_date
+    config.add_index_field 'originInfo_date_created_tesim',   label: 'Created',           helper_method: :value_for_date_as_localtime
     config.add_index_field 'obj_label_ssim',                  label: 'Label'
     config.add_index_field 'source_id_ssim',                  label: 'Source'
     config.add_index_field 'wf_error_ssim',                   label: 'Error',             helper_method: :value_for_wf_error

--- a/app/helpers/value_helper.rb
+++ b/app/helpers/value_helper.rb
@@ -69,9 +69,14 @@ module ValueHelper
     end.join('<br>').html_safe
   end
 
+  # Discussed removing this method because the field should not be modified.
   def value_for_originInfo_date_created_tesim(args)
-    val = Time.parse(args[:document][args[:field]].first)
+    field_value = args[:document][args[:field]].first
+    # Try to parse the string as a time value
+    val = Time.parse(field_value)
     val.localtime.strftime '%Y.%m.%d %H:%M%p'
+  rescue
+    field_value
   end
 
   def value_for_identifier_tesim(args)

--- a/app/helpers/value_helper.rb
+++ b/app/helpers/value_helper.rb
@@ -69,14 +69,14 @@ module ValueHelper
     end.join('<br>').html_safe
   end
 
-  # Discussed removing this method because the field should not be modified.
-  def value_for_date(args)
+  # @return [String]
+  def value_for_date_as_localtime(args)
     date_value = args[:document][args[:field]].first
     # Try to return the date in local time zone;
     # assume it can be parsed according to app time zone.
     return '' if date_value.nil?
     val = Time.zone.parse(date_value)
-    return date_value if val.nil?
+    return date_value.to_s if val.nil?
     val.localtime.strftime '%Y.%m.%d %H:%M%p'
   rescue ArgumentError
     date_value.to_s

--- a/app/helpers/value_helper.rb
+++ b/app/helpers/value_helper.rb
@@ -70,13 +70,16 @@ module ValueHelper
   end
 
   # Discussed removing this method because the field should not be modified.
-  def value_for_originInfo_date_created_tesim(args)
-    field_value = args[:document][args[:field]].first
-    # Try to parse the string as a time value
-    val = Time.parse(field_value)
+  def value_for_date(args)
+    date_value = args[:document][args[:field]].first
+    # Try to return the date in local time zone;
+    # assume it can be parsed according to app time zone.
+    return '' if date_value.nil?
+    val = Time.zone.parse(date_value)
+    return date_value if val.nil?
     val.localtime.strftime '%Y.%m.%d %H:%M%p'
-  rescue
-    field_value
+  rescue ArgumentError
+    date_value.to_s
   end
 
   def value_for_identifier_tesim(args)

--- a/lib/tasks/argo.rake
+++ b/lib/tasks/argo.rake
@@ -261,9 +261,12 @@ namespace :argo do
   end
 
   def load_order_files(fedora_files)
+    data_path = File.expand_path('../../../fedora_conf/data/', __FILE__)
     file_list = []
     fedora_files.each do |file|
-      file_list.push(File.join(File.expand_path('../../../fedora_conf/data/', __FILE__), file.strip))
+      file_name = file.strip
+      next if file_name.empty?
+      file_list.push(File.join(data_path, file_name))
     end
     file_list
   end

--- a/spec/helpers/value_helper_spec.rb
+++ b/spec/helpers/value_helper_spec.rb
@@ -38,14 +38,14 @@ RSpec.describe ValueHelper do
       value = [nil, 'anything_after_first_element_ignored']
       document = SolrDocument.new({ field => value })
       args = { document: document, field: field }
-      expect(helper.value_for_date(args)).to eq('')
+      expect(helper.value_for_date_as_localtime(args)).to eq('')
     end
     it 'returns the value if it cannot parse the date' do
       field = 'originInfo_date_created_tesim'
       value = ['1966', 'anything_after_first_element_ignored']
       document = SolrDocument.new({ field => value })
       args = { document: document, field: field }
-      expect(helper.value_for_date(args)).to eq(value.first)
+      expect(helper.value_for_date_as_localtime(args)).to eq(value.first)
     end
     it 'returns a normalized local time for a valid time stamp' do
       now_utc = Time.zone.now.to_s
@@ -54,7 +54,7 @@ RSpec.describe ValueHelper do
       value = [now_utc, 'anything_after_first_element_ignored']
       document = SolrDocument.new({ field => value })
       args = { document: document, field: field }
-      expect(helper.value_for_date(args)).to eq(now_loc)
+      expect(helper.value_for_date_as_localtime(args)).to eq(now_loc)
     end
   end
 end

--- a/spec/helpers/value_helper_spec.rb
+++ b/spec/helpers/value_helper_spec.rb
@@ -31,4 +31,25 @@ RSpec.describe ValueHelper do
       expect(helper.links_to_collections(args)).to have_css 'br'
     end
   end
+
+  describe 'originInfo_date_created_tesim' do
+    it 'does not modify a year string' do
+      field = 'originInfo_date_created_tesim'
+      value = ['1966', 'anything_after_first_element_ignored']
+      document = SolrDocument.new({ field => value })
+      args = { document: document, field: field }
+      expect(helper.value_for_originInfo_date_created_tesim(args))
+        .to eq(value.first)
+    end
+    it 'does normalize a time stamp string' do
+      now_utc = Time.now.utc.to_s
+      now_loc = Time.parse(now_utc).localtime.strftime '%Y.%m.%d %H:%M%p'
+      field = 'originInfo_date_created_tesim'
+      value = [now_utc, 'anything_after_first_element_ignored']
+      document = SolrDocument.new({ field => value })
+      args = { document: document, field: field }
+      expect(helper.value_for_originInfo_date_created_tesim(args))
+        .to eq(now_loc)
+    end
+  end
 end

--- a/spec/helpers/value_helper_spec.rb
+++ b/spec/helpers/value_helper_spec.rb
@@ -32,24 +32,29 @@ RSpec.describe ValueHelper do
     end
   end
 
-  describe 'originInfo_date_created_tesim' do
-    it 'does not modify a year string' do
+  describe 'value_for_date' do
+    it 'returns "" for nil' do
+      field = 'originInfo_date_created_tesim'
+      value = [nil, 'anything_after_first_element_ignored']
+      document = SolrDocument.new({ field => value })
+      args = { document: document, field: field }
+      expect(helper.value_for_date(args)).to eq('')
+    end
+    it 'returns the value if it cannot parse the date' do
       field = 'originInfo_date_created_tesim'
       value = ['1966', 'anything_after_first_element_ignored']
       document = SolrDocument.new({ field => value })
       args = { document: document, field: field }
-      expect(helper.value_for_originInfo_date_created_tesim(args))
-        .to eq(value.first)
+      expect(helper.value_for_date(args)).to eq(value.first)
     end
-    it 'does normalize a time stamp string' do
-      now_utc = Time.now.utc.to_s
-      now_loc = Time.parse(now_utc).localtime.strftime '%Y.%m.%d %H:%M%p'
+    it 'returns a normalized local time for a valid time stamp' do
+      now_utc = Time.zone.now.to_s
+      now_loc = Time.zone.parse(now_utc).localtime.strftime '%Y.%m.%d %H:%M%p'
       field = 'originInfo_date_created_tesim'
       value = [now_utc, 'anything_after_first_element_ignored']
       document = SolrDocument.new({ field => value })
       args = { document: document, field: field }
-      expect(helper.value_for_originInfo_date_created_tesim(args))
-        .to eq(now_loc)
+      expect(helper.value_for_date(args)).to eq(now_loc)
     end
   end
 end


### PR DESCRIPTION
First attempt to address one error in the display of a Revs object, to address #289.  Unable to get the argo-stage object data into a fixture to completely test this fix.  The additional spec does test just this helper method.  Although travis CI, hound, coveralls etc. can evaluate this PR to some extent, the PR branch might have to be pushed to argo-stage to better evaluate how it behaves with the data noted in #289.