### PR TITLE
Remove Solr field helper: value_for_originInfo_date_created_tesim

### DIFF
--- a/app/helpers/value_helper.rb
+++ b/app/helpers/value_helper.rb
@@ -69,11 +69,6 @@ module ValueHelper
     end.join('<br>').html_safe
   end
 
-  def value_for_originInfo_date_created_tesim(args)
-    val = Time.parse(args[:document][args[:field]].first)
-    val.localtime.strftime '%Y.%m.%d %H:%M%p'
-  end
-
   def value_for_identifier_tesim(args)
     val = args[:document][args[:field]]
     Array(val).reject { |v| v == args[:document]['id'] }.sort.uniq.join(', ')

--- a/app/views/catalog/_show_field_list.html.erb
+++ b/app/views/catalog/_show_field_list.html.erb
@@ -1,18 +1,20 @@
 <dl class="document-metadata dl-horizontal dl-invert">
   <% field_names.each do |solr_fname| -%>
     <% if document_has? document, solr_fname %>
-      <% begin %>
-        <dt class="blacklight-<%= solr_fname.parameterize %>"><%= render_document_show_field_label :field => solr_fname %></dt>
-        <dd class="blacklight-<%= solr_fname.parameterize %>">
-          <%= render_document_show_field_value :document => document, :field => solr_fname %>
-        </dd>
-      <% rescue NameError
-         Rails.logger.info "Error rendering #{solr_fname}"
-         end %>
+      <dt class="blacklight-<%= solr_fname.parameterize %>">
+        <%= render_document_show_field_label :field => solr_fname %>
+      </dt>
+      <dd class="blacklight-<%= solr_fname.parameterize %>">
+        <%= render_document_show_field_value :document => document, :field => solr_fname %>
+      </dd>
     <% else %>
       <% if solr_fname == 'metadata_source_ssi' %>
-        <dt class="blacklight-<%= solr_fname.parameterize %>"><%= render_document_show_field_label :field => solr_fname %></dt>
-        <dd class="blacklight-<%= solr_fname.parameterize %>"><%= metadata_source object %></dd>
+        <dt class="blacklight-<%= solr_fname.parameterize %>">
+          <%= render_document_show_field_label :field => solr_fname %>
+        </dt>
+        <dd class="blacklight-<%= solr_fname.parameterize %>">
+          <%= metadata_source object %>
+        </dd>
       <% end %>
     <% end -%>
   <% end -%>

--- a/spec/views/catalog/_show_field_list.html.erb_spec.rb
+++ b/spec/views/catalog/_show_field_list.html.erb_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+RSpec.describe 'catalog/_show_field_list.html.erb' do
+  context 'originInfo_date_created_tesim' do
+    let(:field) { 'originInfo_date_created_tesim' }
+    let(:label) { 'Created' }
+    before(:each) do
+      @config = Blacklight::Configuration.new do |config|
+        config.add_index_field field, label: label
+        config.add_show_field field, :label => label
+      end
+      allow(view).to receive(:blacklight_config).and_return(@config)
+      allow(view).to receive(:field_names).and_return([field])
+    end
+    def validate_rendering(field_value)
+      document = SolrDocument.new(id: 1, field => field_value)
+      allow(view).to receive(:document).and_return(document)
+      render
+      expect(rendered).to have_css ".blacklight-#{field.downcase}"
+      expect(rendered).to include label
+      expect(rendered).to include field_value.map(&:to_s).join(', ')
+    end
+    it 'displays a valid field value' do
+      field_value = ['1966', '1986']
+      validate_rendering(field_value)
+    end
+    it 'returns "" for nil' do
+      field_value = [nil, 'does_not_have_to_be_date_value']
+      validate_rendering(field_value)
+    end
+  end
+end


### PR DESCRIPTION
Second attempt to resolve https://github.com/sul-dlss/argo/issues/289

With further discussion, we resolved to remove a value helper method.  This allows blacklight defaults to display the field 'originInfo_date_created_tesim'.  This PR may require view specs to ensure blacklight behavior for this field is consistent with requirements.