### PR TITLE
fix JavaScript errors in Register Items modal dialog

### DIFF
--- a/app/assets/javascripts/registration/grid.js
+++ b/app/assets/javascripts/registration/grid.js
@@ -429,9 +429,9 @@ var gridContext = function() {
       $('#object_type').change(function(evt) {
         var sender = evt.target
         var valid_controls = {
-          'item'       : ["object_type", "apo_id", "rights", "id_source", "workflow_id", "content_type", "mdform_id", "project", "registered_by", "tags_0", "tags_1", "tags_2", "tags_3", "tag_4", "collection"],
-          'set'        : ["object_type", "apo_id", "rights", "id_source", "mdform_id", "project", "registered_by", "tags_0", "tags_1", "tags_2", "tags_3"],
-          'collection' : ["object_type", "apo_id", "rights", "id_source", "mdform_id", "project", "registered_by", "tags_0", "tags_1", "tags_2", "tags_3"],
+          'item'       : ["object_type", "apo_id", "rights", "id_source", "workflow_id", "content_type", "project", "registered_by", "tags_0", "tags_1", "tags_2", "tags_3", "tag_4", "collection"],
+          'set'        : ["object_type", "apo_id", "rights", "id_source", "project", "registered_by", "tags_0", "tags_1", "tags_2", "tags_3"],
+          'collection' : ["object_type", "apo_id", "rights", "id_source", "project", "registered_by", "tags_0", "tags_1", "tags_2", "tags_3"],
           'adminPolicy': ["object_type", "registered_by"],
           'workflow'   : ["object_type", "registered_by"]
         }
@@ -525,19 +525,6 @@ var gridContext = function() {
           }
         })
 
-        $.ajax({
-          type: 'GET',
-          url: pathTo('/registration/form_list'),
-          dataType: 'json',
-          data: { apo_id: $('#apo_id').val() },
-          success: function(response,status,xhr) {
-            if (response) {
-              var optionsHtml = '<option value="">None</option>'
-              optionsHtml += response.map(function(v) { return '<option value="'+v[0]+'">'+v[1]+'</option>' }).join('');
-              $('#mdform_id').html(optionsHtml);
-            }
-          }
-        })
       });
 
       $('#specify').dialog({

--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -168,4 +168,11 @@ module RegistrationHelper
     table_data
   end
 
+  private
+
+  # @param [String] s string to truncate at word boundary
+  # @param [Integer] truncate_limit character limit for truncation target
+  def short_label(s, truncate_limit = 60)
+    s.truncate(truncate_limit, separator: /\s/)
+  end
 end

--- a/app/views/items/register.html.erb
+++ b/app/views/items/register.html.erb
@@ -16,7 +16,6 @@
         <div class="property-item spacer"></div>
         <div class="property-item"><label for='workflow_id'>Initial Workflow</label><%= select_tag :workflow_id, '', :'data-rcparam' => 'workflowId' %></div>
         <div class="property-item"><label for='content_type'>Content Type</label><%= select_tag :content_type, options_for_select(valid_content_types), :class => 'tag-field', :'data-tagname' => 'Process : Content Type' %></div>
-        <div class="property-item"><label for='mdform_id'>MDtoolkit Form</label><%= select_tag :mdform_id, '', :class => 'tag-field', :'data-tagname' => 'MDForm' %></div>
         <div class="property-item break"><label for='project'>Project Name</label><%= text_field_tag :project, nil, :class => 'tag-field', :'data-tagname' => 'Project', :'data-rcparam' => 'projectName' %></div>
         <div class="property-item wide"><label for='tag_1'>Tags</label>
           <span id="tags" style="width: auto">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,7 +141,6 @@ Argo::Application.routes.draw do
   namespace :registration do
     get '/', :action => :form
     get 'tracksheet'
-    get 'form_list'
     get 'collection_list'
     get 'workflow_list'
     get 'rights_list'

--- a/spec/helpers/registration_helper_spec.rb
+++ b/spec/helpers/registration_helper_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RegistrationHelper do
-  it 'does something' do
-
+  it 'tests nothing' do
+    skip
   end
 end


### PR DESCRIPTION
This PR fixes #320. The JavaScript errors were from AJAX queries that were throwing 500 errors, and from a request timeout to an old URL. I removed that lyberapps-prod URL and deleted the MDSource pulldown (see comments). I also made the `collection_list` route more fault-tolerant when collections referenced in the APO do not exist in Solr and/or DOR. It also now truncates long collection titles. I also made the Workflow pulldown have unique values. Finally, I added spec tests for collection_list and workflow_list routes, neither of which existed prior.