### PR TITLE
remove old APO reindex code

### DIFF
--- a/app/controllers/apo_controller.rb
+++ b/app/controllers/apo_controller.rb
@@ -273,11 +273,6 @@ class ApoController < ApplicationController
 
   private
 
-  def reindex(obj)
-    doc = obj.to_solr
-    Dor::SearchService.solr.add(doc, :add_attributes => {:commitWithin => 1000})
-  end
-
   def create_obj
     raise 'missing druid' unless params[:id]
     @object = Dor.find params[:id] # , :lightweight => true


### PR DESCRIPTION
This PR removes the private `reindex` method in `ApoController`. It's no longer used.