### PR TITLE
Moves Blacklight globably in Argo to communication with Solr over POS…

### DIFF
--- a/app/models/concerns/permitted_queries.rb
+++ b/app/models/concerns/permitted_queries.rb
@@ -1,0 +1,66 @@
+##
+# Determine user authorization based on index
+class PermittedQueries
+  include Blacklight::SolrHelper
+
+  attr_reader :groups, :known_roles, :is_admin
+
+  ##
+  # @params groups
+  # @params [Boolean] is_admin
+  # @params [Array<String>] known_roles
+  def initialize(groups, known_roles, is_admin)
+    @groups = groups
+    @known_roles = known_roles
+    @is_admin = is_admin
+  end
+
+  ##
+  # Ported over code from `app/models/user.rb`
+  # Also queries Solr based on groups
+  # @return [Array[String]] list of DRUIDs from APOs that this User can view
+  def permitted_apos
+    query = groups.map { |g| g.gsub(':', '\:') }.join(' OR ')
+    q = 'apo_role_group_manager_ssim:(' + query + ') OR apo_role_person_manager_ssim:(' + query + ')'
+    known_roles.each do |role|
+      q += ' OR apo_role_' + role + '_ssim:(' + query + ')'
+    end
+    q = 'objectType_ssim:adminPolicy' if is_admin
+    resp = solr_repository.search(
+      q: q,
+      rows: 1000,
+      fl: 'id',
+      fq: '!project_tag_ssim:"Hydrus"'
+    )['response']['docs']
+    resp.map { |doc| doc['id'] }
+  end
+
+  ##
+  # Ported over code from `app/models/user.rb`
+  # Queries Solr yet again! But in a different way! Doesn't use filter query.
+  # FIXME: seems to include display logic
+  # @return [Array<Array<String>>] Sorted array of pairs of strings, each pair like: ["Title (PID)", "PID"]
+  def permitted_collections
+    q = 'objectType_ssim:collection AND !project_tag_ssim:"Hydrus" '
+    q += permitted_apos.map { |pid| "#{SolrDocument::FIELD_APO_ID}:\"info:fedora/#{pid}\"" }.join(' OR ') unless is_admin
+    result = solr_repository.search(
+      q: q,
+      rows: 1000,
+      fl: 'id,tag_ssim,dc_title_tesim'
+    ).docs
+
+    result.sort! do |a, b|
+      a['dc_title_tesim'].to_s <=> b['dc_title_tesim'].to_s
+    end
+
+    [['None', '']] + result.map do |doc|
+      [Array(doc['dc_title_tesim']).first + ' (' + doc['id'].to_s + ')', doc['id'].to_s]
+    end
+  end
+
+  private
+
+  def blacklight_config
+    @blacklight_config ||= CatalogController.blacklight_config.configure
+  end
+end

--- a/config/initializers/blacklight.rb
+++ b/config/initializers/blacklight.rb
@@ -1,0 +1,3 @@
+##
+# Configure Blacklight to use POST as the default HTTP method
+Blacklight::Configuration.default_values[:http_method] = :post

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -125,5 +125,8 @@ describe CatalogController, :type => :controller do
         expect(field[1].show).to be_falsey if raw_fields.include?(field[0])
       end
     end
+    it 'should use POST as the http method' do
+      expect(config.http_method).to eq :post
+    end
   end
 end

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -24,4 +24,10 @@ describe DiscoveryController, :type => :controller do
       expect { CSV.parse(response.body) }.not_to raise_error
     end
   end
+  describe 'config' do
+    let(:config) { controller.blacklight_config }
+    it 'should use POST as the http method' do
+      expect(config.http_method).to eq :post
+    end
+  end
 end

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -71,4 +71,10 @@ describe ReportController, :type => :controller do
       expect { CSV.parse(response.body) }.not_to raise_error
     end
   end
+  describe 'config' do
+    let(:config) { controller.blacklight_config }
+    it 'should use POST as the http method' do
+      expect(config.http_method).to eq :post
+    end
+  end
 end

--- a/spec/models/concerns/permitted_queries_spec.rb
+++ b/spec/models/concerns/permitted_queries_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe PermittedQueries do
+  describe '#permitted_apos' do
+    let(:user) { User.find_or_create_by_remoteuser 'test_user' }
+    let(:many_groups) { (0..30).map { |num| "workgroup:workgroup_#{num}" } }
+    context 'with large Solr query' do
+      it 'does not raise an RSolr::Error::Http-413 Request Entity Too Large' do
+        user.set_groups_to_impersonate many_groups
+        expect{user.permitted_apos}.to_not raise_error
+        expect(user.permitted_apos).to be_an Array
+      end
+    end
+  end
+  describe '#permitted_collections' do
+    let(:user) { User.find_or_create_by_remoteuser 'test_user' }
+    let(:many_groups) { (0..30).map { |num| "workgroup:workgroup_#{num}" } }
+    context 'with large Solr query' do
+      it 'does not raise an RSolr::Error::Http-413 Request Entity Too Large' do
+        user.set_groups_to_impersonate many_groups
+        expect{user.permitted_collections}.to_not raise_error
+        expect(user.permitted_collections).to be_an Array
+      end
+    end
+    it 'returns an array' do
+      expect(user.permitted_collections).to eq [['None', '']]
+    end
+  end
+end


### PR DESCRIPTION
…T. This alleviates issues with GET URIs being too long. Also extracts permitted queries out of the User model into its own class.

This PR makes no assumptions about the logic contained in `#permitted_collections` and `#permitted_apos` but does test the POST functionality and output type.

Closes #321 Closes #355 