### PR TITLE
refactor homepage to shortcircuit HTTP Solr call

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -120,4 +120,10 @@ class User < ActiveRecord::Base
   def login
     webauth ? webauth.login : sunetid
   end
+
+  ##
+  # @return [Boolean]
+  def can_view_something?
+    is_admin || is_manager || is_viewer || permitted_apos.length > 0
+  end
 end

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,13 +1,14 @@
 
 <h3>Welcome to Argo!</h3>
-<%
-user=current_user
-if user.permitted_apos.length>0 or user.is_admin or user.is_manager or user.is_viewer%>
-<p>Enter one or more search terms or select a facet on the left to begin.</p>
-<%else%>
-<p>You dont appear to have permission to view any items in Argo. Please contact an administrator.</p>
-<%end%>
+<% if current_user.can_view_something? %>
+  <p>
+    Enter one or more search terms or select a facet on the left to begin.
+  </p>
+<% else %>
+  <p>
+    You do not appear to have permission to view any items in Argo. Please contact an administrator.
+  </p>
+<% end %>
 <img src="https://sulstats.stanford.edu/render/?width=400&height=300&from=-3months&target=stats.sdr.preservation.terabytes&lineMode=connected&title=SDR%20Preserved%20Terabytes&hideLegend=true" alt="sdr preserved terabytes graph"/>
 
 <img src="https://sulstats.stanford.edu/render/?width=400&height=300&from=-3months&lineMode=connected&title=SDR%20Preserved%20Objects&hideLegend=true&logBase=0&target=stats.sdr.preservation.objects" alt="sdr preserved objects graph"/>
-

--- a/spec/features/date_range_form_spec.rb
+++ b/spec/features/date_range_form_spec.rb
@@ -8,7 +8,8 @@ RSpec.feature 'Date range form', js: true do
       logged_in?: true,
       permitted_apos: [],
       is_admin: true,
-      roles: []
+      roles: [],
+      can_view_something?: true
     )
     allow_any_instance_of(ApplicationController).to receive(:current_user).
       and_return(@current_user)

--- a/spec/features/full_width_spec.rb
+++ b/spec/features/full_width_spec.rb
@@ -7,7 +7,8 @@ feature 'Full width' do
       login: 'sunetid',
       logged_in?: true,
       permitted_apos: [],
-      is_admin: true
+      is_admin: true,
+      can_view_something?: true
     )
     allow_any_instance_of(ApplicationController).to receive(:current_user).
       and_return(@current_user)

--- a/spec/features/indexer_backlog_spec.rb
+++ b/spec/features/indexer_backlog_spec.rb
@@ -7,7 +7,8 @@ feature 'Indexer Backlog status', js: true do
       login: 'sunetid',
       logged_in?: true,
       permitted_apos: [],
-      is_admin: true
+      is_admin: true,
+      can_view_something?: true
     )
     allow_any_instance_of(ApplicationController).to receive(:current_user).
       and_return(@current_user)

--- a/spec/integration/item_displays_spec.rb
+++ b/spec/integration/item_displays_spec.rb
@@ -4,7 +4,7 @@ describe 'mods_view', :type => :request do
   before :each do
     @object = instantiate_fixture('druid_zt570tx3016', Dor::Item)
     allow(Dor::Item).to receive(:find).and_return(@object)
-    @current_user = double(:webauth_user, :login => 'sunetid', :logged_in? => true, :privgroup => ADMIN_GROUPS.first)
+    @current_user = double(:webauth_user, :login => 'sunetid', :logged_in? => true, :privgroup => ADMIN_GROUPS.first, can_view_something?: true)
     allow(@current_user).to receive(:is_admin).and_return(true)
     allow(@current_user).to receive(:roles).and_return([])
     allow(@current_user).to receive(:is_manager).and_return(false)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -159,6 +159,41 @@ describe User, :type => :model do
       expect(user.is_viewer ).to be_falsey
     end
   end
+  describe '#can_view_something?' do
+    it 'returns false' do
+      expect(subject.can_view_something?).to be_falsey
+    end
+    context 'when admin' do
+      it 'returns true' do
+        expect(subject).to receive(:is_admin).and_return(true)
+        expect(subject.can_view_something?).to be_truthy
+      end
+    end
+    context 'when manager' do
+      it 'returns true' do
+        expect(subject).to receive(:is_admin).and_return(false)
+        expect(subject).to receive(:is_manager).and_return(true)
+        expect(subject.can_view_something?).to be_truthy
+      end
+    end
+    context 'when viewer' do
+      it 'returns true' do
+        expect(subject).to receive(:is_admin).and_return(false)
+        expect(subject).to receive(:is_manager).and_return(false)
+        expect(subject).to receive(:is_viewer).and_return(true)
+        expect(subject.can_view_something?).to be_truthy
+      end
+    end
+    context 'with permitted_apos' do
+      it 'returns true' do
+        expect(subject).to receive(:is_admin).and_return(false)
+        expect(subject).to receive(:is_manager).and_return(false)
+        expect(subject).to receive(:is_viewer).and_return(false)
+        expect(subject).to receive(:permitted_apos).and_return([1])
+        expect(subject.can_view_something?).to be_truthy
+      end
+    end
+  end
 
   # TODO
   describe 'permitted_apos' do

--- a/spec/views/catalog/_home_text.html.erb_spec.rb
+++ b/spec/views/catalog/_home_text.html.erb_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe 'catalog/_home_text.html.erb' do
+  it 'as someone who can view something' do
+    expect(view).to receive_message_chain(:current_user, :can_view_something?) { true }
+    render
+    expect(rendered).to have_css 'p', text: 'Enter one or more search terms ' \
+      'or select a facet on the left to begin.'
+    expect(rendered).to have_css 'img', count: 2
+  end
+  it 'as one who cannot view anything' do
+    expect(view).to receive_message_chain(:current_user, :can_view_something?) { false }
+    render
+    expect(rendered).to have_css 'p', text: 'You do not appear to have ' \
+      'permission to view any items in Argo. Please contact an administrator.'
+    expect(rendered).to have_css 'img', count: 2
+  end
+end


### PR DESCRIPTION
Previously HTTP Solr call was initiated on every homepage load. This should be able to shortcircuit some of those.