### PR TITLE
avoid commitWithin when updating index for items controller

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -593,7 +593,8 @@ class ItemsController < ApplicationController
     end
     @object.create_workflow(params[:wf])
 
-    # sync up the workflows datastream with workflow service and force a reindex before redirection
+    # We need to sync up the workflows datastream with workflow service (using #find)
+    # and then force a committed Solr update before redirection.
     reindex Dor::Item.find(params[:id])
     Dor::SearchService.solr.commit
 
@@ -607,8 +608,7 @@ class ItemsController < ApplicationController
   private
 
   def reindex(item)
-    doc = item.to_solr
-    Dor::SearchService.solr.add(doc, :add_attributes => {:commitWithin => 1000})
+    Dor::SearchService.solr.add item.to_solr
   end
 
   # Filters


### PR DESCRIPTION
This PR makes explicit whether to execute a synchronous Solr update (with a `.commit`) or an asynchronous Solr update (without a `.commit` and using the default `commitWithin` value). The default Solr behavior for commiting adds is dependant on its configuration. See https://wiki.apache.org/solr/CommitWithin for details.

In this PR, the default behavior for the `reindex` route is a synchronous index update. This mimics the previous very short `commitWithin` value (1 second) for reindexing. I've added an `asynchronous=true` flag that you can pass `reindex` to skip the commit. Same with the Item routes, it uses synchronous updates since it was using a very short `commitWithin` value.

I've also changed the status value for objects not found to `404`, and added synchronous vs asynchronous tests.