### PR TITLE
validate whether the XML can be parsed before form submission

### DIFF
--- a/app/assets/javascripts/jquery.persistentModal.js
+++ b/app/assets/javascripts/jquery.persistentModal.js
@@ -49,6 +49,13 @@
 
         // show the current modal
         modalForTarget().modal('show');
+
+        // Fire an event when the modal is loaded
+        var e = $.Event('loaded.persistent-modal');
+        $('body').trigger(e);
+        if (e.isDefaultPrevented()) {
+          return;
+        }
       }
 
       function receiveAjax(data) {      

--- a/app/assets/javascripts/modules/datastream_edit.js
+++ b/app/assets/javascripts/modules/datastream_edit.js
@@ -1,0 +1,38 @@
+/*global Blacklight */
+'use strict';
+
+(function($) {
+  /*
+    jQuery plugin that validates datastream XML editor to ensure the XML
+    is parseable before the user submits the datastream update.
+  */
+  $.fn.datastreamXmlEdit = function() {
+    return this.each(function() {
+      $.validator.addMethod('xmlWellFormedness', function (value) {
+        try {
+          return $.parseXML(value) != null;
+        } catch(err) { 
+          return false; 
+        }
+      }, 'XML must be well-formed.');
+      $('#xmlEditForm').validate({
+        rules: {
+          content: {
+            required: true,
+            xmlWellFormedness: true
+          }
+        }
+      });
+    });
+  };
+})(jQuery);
+
+/*
+   Because we are in a modal dialog we need to use the 'loaded' event
+   to trigger the form validation setup.
+ */
+Blacklight.onLoad(function() {
+  $('body').on('loaded.persistent-modal', function() {
+    $('#xmlEditForm').datastreamXmlEdit();
+  });
+});

--- a/app/assets/stylesheets/argo/argo.sass
+++ b/app/assets/stylesheets/argo/argo.sass
@@ -144,7 +144,7 @@ table
   pre
     border: none !important
     white-space: pre-wrap
-    font-family: consolas,andale mono,monospace
+    font-family: monospace
 .nonblockingForm
   display: inline
 .ui-dialog
@@ -183,3 +183,6 @@ button.close
 #bulk-spreadsheet-warning
   color: $color-cardinal-red
 
+#xmlEditForm
+  textarea
+    font-family: monospace

--- a/app/views/catalog/_aspect_partials/_ds.html.erb
+++ b/app/views/catalog/_aspect_partials/_ds.html.erb
@@ -2,11 +2,15 @@
   if(params[:edit])
     if @user and (@user.is_admin or (@obj.can_manage_content?(@user.roles(@obj.admin_policy_object.pid)) and @obj.can_manage_desc_metadata?(@user.roles(@obj.admin_policy_object.pid)))) 
 %>
-      <%= form_tag url_for(:controller => :items, :action => :datastream_update), :method => :POST do%>
+      <%= form_tag url_for(:controller => :items, :action => :datastream_update), :id => 'xmlEditForm', :method => :POST do%>
         <input type="hidden" name="id" value="<%=@obj.pid %>" />
         <input name="dsid" id="datastream" type="hidden" value="<%=params[:dsid]%>"/>
-        <textarea name="content" id="content"><%=@obj.datastreams[params[:dsid]].content.to_s %></textarea><br/>
-        <button type="submit" id="update">Update Datastream</button>
+        <div class="form-group">
+          <textarea name="content" id="content"><%=@obj.datastreams[params[:dsid]].content.to_s %></textarea>
+        </div>
+        <div class="form-group">
+          <button type="submit" id="update" class="btn btn-primary">Update Datastream</button>
+        </div>
       <% end %>
 <%
     end


### PR DESCRIPTION
This PR fixes #78. It uses the jQuery validation plugin and jQuery `parseXML` to verify that the XML in the data stream edit modal dialog is parseable before form submission.