### PR TITLE
use a different object to add workflow to

### DIFF
--- a/spec/features/workflow_service_creation_spec.rb
+++ b/spec/features/workflow_service_creation_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature 'Workflow Service Creation' do
       .and_return(current_user)
   end
   scenario 'redirect and display on show page' do
-    visit add_workflow_item_path 'druid:hj185vb7593'
+    visit add_workflow_item_path 'druid:qq613vj0238'
     click_button 'Add'
     within '.flash_messages' do
       expect(page).to have_css '.alert.alert-info', text: 'Added accessionWF'


### PR DESCRIPTION
This PR will fix the following spec errors in development branches. You'll need to rebuild your test Solr core though:

```
Failures:

  1) Item view metadata MD Source is "DOR"
     Failure/Error: expect(page).to have_css 'dd', text: 'v1 Unknown Status'
       expected to find css "dd" with text "v1 Unknown Status" but there were no matches. Also found "druid:hj185vb7593", "item", "image", "DOR", "Stanford University Libraries - Special Collections", "Fuller Slides", "fuller:M1090_S15_B02_F01_0126", "M1090_S15_B02_F01_0126", "fuller:M1090_S15_B02_F01_0126, uuid:ad2d8894-7eba-11e1-b714-0016034322e7", "Project : Fuller SlidesRegistered By : renzo", "v1 In accessioning", which matched the selector but not all filters.
     # ./spec/features/item_view_metadata_spec.rb:42:in `block (3 levels) in <top (required)>'
     # /Users/drh/.rvm/gems/ruby-2.2.2/gems/capybara-2.5.0/lib/capybara/session.rb:290:in `within'
     # /Users/drh/.rvm/gems/ruby-2.2.2/gems/capybara-2.5.0/lib/capybara/dsl.rb:51:in `block (2 levels) in <module:DSL>'
     # ./spec/features/item_view_metadata_spec.rb:19:in `block (2 levels) in <top (required)>'

  2) Search results contains appropriate metadata fields
     Failure/Error: expect(page).to have_css 'dd', text: 'v1 Unknown Status'
       expected to find css "dd" with text "v1 Unknown Status" but there were no matches. Also found "druid:hj185vb7593", "item", "image", "v1 In accessioning", "Stanford University Libraries - Special Collections", "Fuller Slides", "fuller:M1090_S15_B02_F01_0126, uuid:ad2d8894-7eba-11e1-b714-0016034322e7", "M1090_S15_B02_F01_0126", "fuller:M1090_S15_B02_F01_0126", "53.2 MB", which matched the selector but not all filters.
     # ./spec/features/search_results_spec.rb:54:in `block (4 levels) in <top (required)>'
     # /Users/drh/.rvm/gems/ruby-2.2.2/gems/capybara-2.5.0/lib/capybara/session.rb:290:in `within'
     # /Users/drh/.rvm/gems/ruby-2.2.2/gems/capybara-2.5.0/lib/capybara/dsl.rb:51:in `block (2 levels) in <module:DSL>'
     # ./spec/features/search_results_spec.rb:46:in `block (3 levels) in <top (required)>'
     # /Users/drh/.rvm/gems/ruby-2.2.2/gems/capybara-2.5.0/lib/capybara/session.rb:290:in `within'
     # /Users/drh/.rvm/gems/ruby-2.2.2/gems/capybara-2.5.0/lib/capybara/dsl.rb:51:in `block (2 levels) in <module:DSL>'
     # ./spec/features/search_results_spec.rb:45:in `block (2 levels) in <top (required)>'

Finished in 36.3 seconds (files took 7.1 seconds to load)
392 examples, 2 failures, 8 pending

```