### PR TITLE
Fixes Register Items exception for missing method object_location

### DIFF
--- a/app/controllers/dor/objects_controller.rb
+++ b/app/controllers/dor/objects_controller.rb
@@ -1,8 +1,6 @@
 class Dor::ObjectsController < ApplicationController
+  include ApplicationHelper # for fedora_base
   before_filter :munge_parameters
-
-  def index
-  end
 
   def create
     if params[:collection] && params[:collection].length == 0
@@ -12,30 +10,23 @@ class Dor::ObjectsController < ApplicationController
     pid = response[:pid]
 
     respond_to do |format|
-      format.json { render :json => response, :location => help.object_location(pid) }
-      format.xml  { render :xml  => response, :location => help.object_location(pid) }
-      format.text { render :text => pid, :location => help.object_location(pid) }
-      format.html { redirect_to help.object_location(pid) }
+      format.json { render :json => response, :location => object_location(pid) }
+      format.xml  { render :xml  => response, :location => object_location(pid) }
+      format.text { render :text => pid, :location => object_location(pid) }
+      format.html { redirect_to object_location(pid) }
     end
   rescue Dor::ParameterError => e
     render :text => e.message, :status => 400
   rescue Dor::DuplicateIdError => e
-    render :text => e.message, :status => 409, :location => help.object_location(e.pid)
+    render :text => e.message, :status => 409, :location => object_location(e.pid)
   rescue StandardError => e
     logger.info e.inspect.to_s
     raise
   end
 
-  def show
-  end
+  private
 
-  def edit
+  def object_location(pid)
+    fedora_base.merge("objects/#{pid}").to_s
   end
-
-  def update
-  end
-
-  def destroy
-  end
-
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,10 +9,6 @@ module ApplicationHelper
     URI.parse(Dor::Config.fedora.safeurl.sub(/\/*$/, '/'))
   end
 
-  def object_location(pid)
-    fedora_base.merge("objects/#{pid}").to_s
-  end
-
   def inflect(str, num)
     '%d %s' % [num, (num == 1 ? str.singularize : str.pluralize)]
   end

--- a/app/views/dor/label.html.erb
+++ b/app/views/dor/label.html.erb
@@ -1,2 +1,0 @@
-<h1>Dor#label</h1>
-<p>Find me in app/views/dor/label.html.erb</p>

--- a/app/views/dor/objects/create.html.erb
+++ b/app/views/dor/objects/create.html.erb
@@ -1,2 +1,0 @@
-<h1>Dor::Objects#create</h1>
-<p>Find me in app/views/dor/objects/create.html.erb</p>

--- a/app/views/dor/objects/destroy.html.erb
+++ b/app/views/dor/objects/destroy.html.erb
@@ -1,2 +1,0 @@
-<h1>Dor::Objects#destroy</h1>
-<p>Find me in app/views/dor/objects/destroy.html.erb</p>

--- a/app/views/dor/objects/edit.html.erb
+++ b/app/views/dor/objects/edit.html.erb
@@ -1,2 +1,0 @@
-<h1>Dor::Objects#edit</h1>
-<p>Find me in app/views/dor/objects/edit.html.erb</p>

--- a/app/views/dor/objects/index.html.erb
+++ b/app/views/dor/objects/index.html.erb
@@ -1,2 +1,0 @@
-<h1>Dor::Objects#index</h1>
-<p>Find me in app/views/dor/objects/index.html.erb</p>

--- a/app/views/dor/objects/show.html.erb
+++ b/app/views/dor/objects/show.html.erb
@@ -1,2 +1,0 @@
-<h1>Dor::Objects#show</h1>
-<p>Find me in app/views/dor/objects/show.html.erb</p>

--- a/app/views/dor/objects/update.html.erb
+++ b/app/views/dor/objects/update.html.erb
@@ -1,2 +1,0 @@
-<h1>Dor::Objects#update</h1>
-<p>Find me in app/views/dor/objects/update.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,11 +162,11 @@ Argo::Application.routes.draw do
     match 'reindex/:pid',   :action => :reindex, :as => 'reindex', :via => [:get, :post]
     match 'delete_from_index/:pid', :action => :delete_from_index, :via => [:get, :post]
     get 'index_exceptions'
-    resources :objects
+    resources :objects, :only => :create # we only implement create for object registration
   end
 
   namespace :legacy do
-    resources :objects
+    resources :objects # TODO: do we know what this does?
   end
 
   get 'index_queue/depth', to: 'index_queue#depth'

--- a/fedora_conf/data/druids
+++ b/fedora_conf/data/druids
@@ -48,3 +48,4 @@ druid:dd327qr3670   Agreement for Department of Special Collections and Universi
 druid:fg464dn8891   State Banking Commission Annual Reports
 druid:pb873ty1662   Annual report of the State Corporation Commission showing the condition of the incorporated state banks and other institutions operating in Virginia at the close of business
 druid:qq613vj0238   Annual Report of the State Corporation Commission, Virginia, 1927-28, 1930-43
+druid:fy957df3135   digitizationWF

--- a/fedora_conf/data/fy957df3135.xml
+++ b/fedora_conf/data/fy957df3135.xml
@@ -1,0 +1,363 @@
+<foxml:digitalObject VERSION="1.1" PID="druid:fy957df3135"
+xmlns:foxml="info:fedora/fedora-system:def/foxml#"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
+<foxml:objectProperties>
+<foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="digitizationWF"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE="fedoraAdmin"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="2011-10-26T23:24:03.796Z"/>
+<foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE="2014-09-10T18:27:07.030Z"/>
+</foxml:objectProperties>
+<foxml:datastream ID="AUDIT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
+<foxml:datastreamVersion ID="AUDIT.0" LABEL="Audit Trail for this object" CREATED="2011-10-26T23:24:03.796Z" MIMETYPE="text/xml" FORMAT_URI="info:fedora/fedora-system:format/xml.fedora.audit">
+<foxml:xmlContent>
+<audit:auditTrail xmlns:audit="info:fedora/fedora-system:def/audit#">
+<audit:record ID="AUDREC1">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>workflowDefinition</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2011-10-26T23:24:04.009Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC2">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>descMetadata</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2011-10-26T23:24:04.134Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC3">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>technicalMetadata</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2011-10-26T23:24:04.327Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC4">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>defaultObjectRights</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2011-10-26T23:24:04.493Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC5">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>identityMetadata</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2011-10-26T23:24:04.638Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC6">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>roleMetadata</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2011-10-26T23:24:04.804Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC7">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>RELS-EXT</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2011-10-26T23:24:04.983Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC8">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>provenanceMetadata</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2011-10-26T23:24:05.233Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC9">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>administrativeMetadata</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2011-10-26T23:24:05.446Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC10">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>rightsMetadata</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2011-10-26T23:24:05.638Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC11">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>DC</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2011-10-26T23:24:05.930Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC12">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>contentMetadata</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2011-10-26T23:24:06.256Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC13">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>workflowDefinition</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2011-10-26T23:31:33.382Z</audit:date>
+<audit:justification>Fedora FUSE FS</audit:justification>
+</audit:record>
+<audit:record ID="AUDREC14">
+<audit:process type="Fedora API-M"/>
+<audit:action>addDatastream</audit:action>
+<audit:componentID>workflows</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2012-01-28T01:22:31.124Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC15">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>workflowDefinition</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2012-04-30T18:08:14.744Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC16">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>workflowDefinition</audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2012-04-30T18:08:59.076Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC17">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>RELS-EXT</audit:componentID>
+<audit:responsibility>lmcrae</audit:responsibility>
+<audit:date>2013-01-11T01:27:44.177Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC18">
+<audit:process type="Fedora API-M"/>
+<audit:action>modifyDatastreamByValue</audit:action>
+<audit:componentID>workflowDefinition</audit:componentID>
+<audit:responsibility>argo.stanford.edu</audit:responsibility>
+<audit:date>2013-02-26T20:57:00.490Z</audit:date>
+<audit:justification></audit:justification>
+</audit:record>
+<audit:record ID="AUDREC19">
+<audit:process type="Fedora API-M"/>
+<audit:action>purgeDatastream</audit:action>
+<audit:componentID>administrativeMetadata</audit:componentID>
+<audit:responsibility>lmcrae</audit:responsibility>
+<audit:date>2014-09-10T18:26:22.063Z</audit:date>
+<audit:justification>Purged datastream (ID=administrativeMetadata), versions ranging from the beginning of time to the end of time.  This resulted in the permanent removal of 1 datastream version(s) (2011-10-26T16:24:05.446Z) and all associated audit records.</audit:justification>
+</audit:record>
+<audit:record ID="AUDREC20">
+<audit:process type="Fedora API-M"/>
+<audit:action>purgeDatastream</audit:action>
+<audit:componentID>defaultObjectRights</audit:componentID>
+<audit:responsibility>lmcrae</audit:responsibility>
+<audit:date>2014-09-10T18:26:28.897Z</audit:date>
+<audit:justification>Purged datastream (ID=defaultObjectRights), versions ranging from the beginning of time to the end of time.  This resulted in the permanent removal of 1 datastream version(s) (2011-10-26T16:24:04.493Z) and all associated audit records.</audit:justification>
+</audit:record>
+<audit:record ID="AUDREC21">
+<audit:process type="Fedora API-M"/>
+<audit:action>purgeDatastream</audit:action>
+<audit:componentID>roleMetadata</audit:componentID>
+<audit:responsibility>lmcrae</audit:responsibility>
+<audit:date>2014-09-10T18:26:45.430Z</audit:date>
+<audit:justification>Purged datastream (ID=roleMetadata), versions ranging from the beginning of time to the end of time.  This resulted in the permanent removal of 1 datastream version(s) (2011-10-26T16:24:04.804Z) and all associated audit records.</audit:justification>
+</audit:record>
+<audit:record ID="AUDREC22">
+<audit:process type="Fedora API-M"/>
+<audit:action>purgeDatastream</audit:action>
+<audit:componentID>technicalMetadata</audit:componentID>
+<audit:responsibility>lmcrae</audit:responsibility>
+<audit:date>2014-09-10T18:26:55.089Z</audit:date>
+<audit:justification>Purged datastream (ID=technicalMetadata), versions ranging from the beginning of time to the end of time.  This resulted in the permanent removal of 1 datastream version(s) (2011-10-26T16:24:04.327Z) and all associated audit records.</audit:justification>
+</audit:record>
+<audit:record ID="AUDREC23">
+<audit:process type="Fedora API-M"/>
+<audit:action>purgeDatastream</audit:action>
+<audit:componentID>contentMetadata</audit:componentID>
+<audit:responsibility>lmcrae</audit:responsibility>
+<audit:date>2014-09-10T18:27:07.030Z</audit:date>
+<audit:justification>Purged datastream (ID=contentMetadata), versions ranging from the beginning of time to the end of time.  This resulted in the permanent removal of 1 datastream version(s) (2011-10-26T16:24:06.256Z) and all associated audit records.</audit:justification>
+</audit:record>
+</audit:auditTrail>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="DC" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="DC.1" LABEL="Dublin Core Record for this object" CREATED="2011-10-26T23:24:05.930Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" SIZE="415">
+<foxml:xmlContent>
+<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+  <dc:title>digitizationWF</dc:title>
+  <dc:creator>DOR</dc:creator>
+  <dc:identifier>druid:fy957df3135</dc:identifier>
+</oai_dc:dc>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="DC1.0" LABEL="Dublin Core Record for this object" CREATED="2011-10-26T23:24:03.796Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" SIZE="384">
+<foxml:xmlContent>
+<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+  <dc:title>digitizationWF</dc:title>
+  <dc:identifier>druid:fy957df3135</dc:identifier>
+</oai_dc:dc>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="RELS-EXT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="RELS-EXT.0" LABEL="RDF Statements about this object" CREATED="2011-10-26T23:24:04.983Z" MIMETYPE="text/xml" SIZE="286">
+<foxml:xmlContent>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about="info:fedora/druid:fy957df3135">
+    <hasModel xmlns="info:fedora/fedora-system:def/model#" rdf:resource="info:fedora/afmodel:Dor_WorkflowObject"></hasModel>
+  </rdf:Description>
+</rdf:RDF>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="RELS-EXT.1" LABEL="RDF Statements about this object" CREATED="2013-01-11T01:27:44.177Z" MIMETYPE="text/xml" SIZE="618">
+<foxml:xmlContent>
+<rdf:RDF xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about="info:fedora/druid:fy957df3135">
+    <hydra:isGovernedBy rdf:resource="info:fedora/druid:hv992ry2431"></hydra:isGovernedBy>
+    <hydra:referencesAgreement rdf:resource="info:fedora/druid:xf765cv5573"></hydra:referencesAgreement>
+    <fedora-model:hasModel xmlns="info:fedora/fedora-system:def/model#" rdf:resource="info:fedora/afmodel:Dor_WorkflowObject"></fedora-model:hasModel>
+  </rdf:Description>
+</rdf:RDF>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="descMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="descMetadata.0" LABEL="Descriptive Metadata" CREATED="2011-10-26T23:24:04.134Z" MIMETYPE="text/xml" SIZE="13">
+<foxml:xmlContent>
+<xml></xml>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="identityMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="identityMetadata.0" LABEL="Identity Metadata" CREATED="2011-10-26T23:24:04.638Z" MIMETYPE="text/xml" SIZE="298">
+<foxml:xmlContent>
+<identityMetadata>
+  <objectId>druid:fy957df3135</objectId>
+  <objectType>workflow</objectType>
+  <objectCreator>DOR</objectCreator>
+  <otherId name="uuid">97c47b80-0029-11e1-b134-dc2b61fffec6</otherId>
+  <agreementId>druid:xf765cv5573</agreementId>
+  <tag>Project : DOR</tag>
+</identityMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="provenanceMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="provenanceMetadata.0" LABEL="Provenance Metadata" CREATED="2011-10-26T23:24:05.233Z" MIMETYPE="text/xml" SIZE="13">
+<foxml:xmlContent>
+<xml></xml>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="rightsMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="rightsMetadata.0" LABEL="Rights Metadata" CREATED="2011-10-26T23:24:05.638Z" MIMETYPE="text/xml" SIZE="13">
+<foxml:xmlContent>
+<xml></xml>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="workflowDefinition" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="workflowDefinition.3" LABEL="Workflow Definition" CREATED="2012-04-30T18:08:59.076Z" MIMETYPE="text/xml" SIZE="495">
+<foxml:xmlContent>
+<workflow-def id="digitizationWF" repository="dor">
+  <process lifecycle="registered" name="initiate" sequence="1">
+    <label>Initiate digitization workflow</label>
+  </process>
+  <process lifecycle="digitized" name="digitize" sequence="2">
+    <prereq>initiate</prereq>
+    <label>Place-holder step for digitization processes</label>
+  </process>
+  <process name="start-accession" sequence="3">
+    <prereq>digitize</prereq>
+    <label>Start accessioning</label>
+  </process>
+</workflow-def>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="workflowDefinition.2" LABEL="Workflow Definition" CREATED="2012-04-30T18:08:14.744Z" MIMETYPE="text/xml" SIZE="490">
+<foxml:xmlContent>
+<workflow-def id="digitizationWF" repository="dor">
+  <process lifecycle="registered" name="initiate" sequence="1"></process>
+  <label>Initiate digitization workflow</label>
+  <process lifecycle="digitized" name="digitize" sequence="2">
+    <prereq>initiate</prereq>
+    <label>Place-holder step for digitization processes</label>
+  </process>
+  <process name="start-accession" sequence="3">
+    <prereq>digitize</prereq>
+    <label>Start accessioning</label>
+  </process>
+</workflow-def>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="workflowDefinition.1" LABEL="Workflow Definition" CREATED="2011-10-26T23:31:33.382Z" MIMETYPE="text/xml" SIZE="340">
+<foxml:xmlContent>
+<workflow-def id="digitizationWF" repository="dor">
+  <process lifecycle="registered" name="initiate" sequence="1"></process>
+  <process lifecycle="digitized" name="digitize" sequence="2">
+    <prereq>initiate</prereq>
+  </process>
+  <process name="start-accession" sequence="3">
+    <prereq>digitize</prereq>
+  </process>
+</workflow-def>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="workflowDefinition.0" LABEL="Workflow Definition" CREATED="2011-10-26T23:24:04.009Z" MIMETYPE="text/xml" SIZE="347">
+<foxml:xmlContent>
+<workflow-def id="digitizationWF" repository="dor">
+  <process lifecycle="registered" name="initiate" sequence="1"></process>
+  <process lifecycle="digitized" name="digitize" sequence="2">
+    <prereq>initiate</prereq>
+  </process>
+  <process name="start-accession" sequence="3">
+    <prereq>start-accession</prereq>
+  </process>
+</workflow-def>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+<foxml:datastreamVersion ID="workflowDefinition.4" LABEL="Workflow Definition" CREATED="2013-02-26T20:57:00.490Z" MIMETYPE="text/xml" SIZE="514">
+<foxml:xmlContent>
+<workflow-def id="digitizationWF" repository="dor">
+  <process lifecycle="registered" name="initiate" sequence="1" status="completed">
+    <label>Initiate digitization workflow</label>
+  </process>
+  <process lifecycle="digitized" name="digitize" sequence="2">
+    <prereq>initiate</prereq>
+    <label>Place-holder step for digitization processes</label>
+  </process>
+  <process name="start-accession" sequence="3">
+    <prereq>digitize</prereq>
+    <label>Start accessioning</label>
+  </process>
+</workflow-def>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="workflows" STATE="A" CONTROL_GROUP="E" VERSIONABLE="true">
+<foxml:datastreamVersion ID="workflows.0" LABEL="workflows" CREATED="2012-01-28T01:22:31.124Z" MIMETYPE="application/xml">
+<foxml:contentLocation TYPE="URL" REF="https://lyberservices-test.stanford.edu/workflow/dor/objects/druid:fy957df3135/workflows"/>
+</foxml:datastreamVersion>
+</foxml:datastream>
+</foxml:digitalObject>

--- a/fedora_conf/data/load_order
+++ b/fedora_conf/data/load_order
@@ -50,3 +50,4 @@ dd327qr3670.xml
 fg464dn8891.xml
 pb873ty1662.xml
 qq613vj0238.xml
+fy957df3135.xml

--- a/spec/controllers/dor/objects_controller_spec.rb
+++ b/spec/controllers/dor/objects_controller_spec.rb
@@ -1,0 +1,5 @@
+describe Dor::ObjectsController, :type => :controller do
+  it 'tests nothing' do
+    skip
+  end
+end

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -19,7 +19,7 @@ feature 'Search results' do
     end
     within '#sortAndPerPage' do
       within '.page_links' do
-        expect(page).to have_css '.page_entries', text: '1 - 10 of 37'
+        expect(page).to have_css '.page_entries', text: '1 - 10 of 38'
         expect(page).to have_css 'a', text: 'Next »'
       end
     end


### PR DESCRIPTION
This PR fixes the Register Items exceptions, does some cleanup, and adds a development fixture for the `digitizationWF`. The cleanup is that we were only implementing the create (POST) to `/dor/objects` that's used by the Register Items UI, so I removed the unimplemented routes. I also moved `object_location` from ApplicationHelper to a private method inside the controller. There was also no spec file corresponding to the objects controller, so I created a stub spec.

Fixes #320 