### PR TITLE
Make style consistent between View MODS and Dublin Core

### DIFF
--- a/app/assets/stylesheets/argo/argo.sass
+++ b/app/assets/stylesheets/argo/argo.sass
@@ -113,7 +113,8 @@ table
   float: left
 .register-role-input
   width: 845px
-#mods_view
+
+.metadata-display
   dl
     dt
       float: left
@@ -149,14 +150,6 @@ table
   display: inline
 .ui-dialog
   top: 200px !important
-.lightBox
-  dl.defList
-    dt
-      text-align: left
-      padding: 2px 0px
-      width: 10%
-    dd
-      width: 85%
 
 #documents+.pagination
   border-top-width: 1px

--- a/app/views/catalog/_aspect_partials/_dc.html.erb
+++ b/app/views/catalog/_aspect_partials/_dc.html.erb
@@ -8,7 +8,8 @@
 <h3>
   <%= @obj.label %>
 </h3>
-<dl class="defList">
+<div class="metadata-display">
+<dl>  
   <% 
     dc_xml.xpath('/oai_dc:dc/*').each do |node|
       field_name = node.name.humanize
@@ -22,3 +23,4 @@
     end
   -%>
 </dl>
+</div>

--- a/app/views/items/purl_preview.html.erb
+++ b/app/views/items/purl_preview.html.erb
@@ -1,6 +1,6 @@
 <div data-ajax-modal="container">
-  <div id="mods_view">
-    <h3><%=render_mods_display(@mods_display).title.first.html_safe%></h3>
+  <h3><%=render_mods_display(@mods_display).title.first.html_safe%></h3>
+  <div class="metadata-display">
     <%=render_mods_display(@mods_display).body.html_safe%>
   </div>
 </div>


### PR DESCRIPTION
This PR fixes #330. See issue for screenshots. It makes the MODS and Dublin Core views use the same style for their `<dl><dt><dd>` data listings