### PR TITLE
Fixing some deploy and configuration issues

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -25,7 +25,7 @@ set :deploy_to, '/home/lyberadmin/argo'
 # set :pty, true
 
 # Default value for :linked_files is []
-set :linked_files, %w(config/database.yml config/solr.yml config/default_htaccess_directives)
+set :linked_files, %w(config/database.yml config/secrets.yml config/solr.yml config/default_htaccess_directives)
 
 # Default value for linked_dirs is []
 set :linked_dirs, %w(log config/certs config/settings tmp/pids tmp/cache tmp/sockets vendor/bundle public/system)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,9 +36,6 @@ Argo::Application.configure do
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
 
-  # Raise exceptions instead of rendering exception templates
-  config.action_dispatch.show_exceptions = false
-
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -36,9 +36,6 @@ Argo::Application.configure do
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
 
-  # Raise exceptions instead of rendering exception templates
-  config.action_dispatch.show_exceptions = false
-
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.


### PR DESCRIPTION
Closes #372 Closes #333 

 - fixes an unlinked secrets.yml file
 - deletes a holdover legacy rails configuration

This now enables default Rails exception page handling and works with squash.

Big thanks @eefahy for helping and @drh-stanford for finally coming up with the solution. :clap: 