### PR TITLE
Upgrade to v7.2.0 of hydra-jetty

### DIFF
--- a/lib/tasks/argo.rake
+++ b/lib/tasks/argo.rake
@@ -68,7 +68,7 @@ namespace :argo do
   end
 
   namespace :jetty do
-    WRAPPER_VERSION = 'v7.1.0' # this version has the most recent Fedora 3.x release (Fedora 3.7 and Solr 4.9)
+    WRAPPER_VERSION = 'v7.2.0' # the most recent Fedora 3.x release (Fedora 3.8.1 and Solr 4.10.2)
 
     desc "Get fresh hydra-jetty [target tag, default: #{WRAPPER_VERSION}] -- DELETES/REPLACES SOLR AND FEDORA"
     task :clean, [:target] do |t, args|


### PR DESCRIPTION
This PR upgrades our hydra-jetty instance to the tip of the `7.x-stable` branch which has Fedora 3.8.1 and Solr 4.10.2. See https://github.com/projecthydra/hydra-jetty/issues/40  Addresses #100 