### PR TITLE
Change source id

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ group :test, :development do
   gem 'poltergeist'
   gem 'capybara_discoball'
   gem 'wfs_rails', '~> 0.0.2'
+  gem 'database_cleaner'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,6 +175,7 @@ GEM
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
     daemons (1.2.3)
+    database_cleaner (1.5.1)
     deep_merge (1.0.1)
     delayed_job (4.1.1)
       activesupport (>= 3.0, < 5.0)
@@ -547,6 +548,7 @@ DEPENDENCIES
   confstruct (~> 0.2.4)
   coveralls
   daemons
+  database_cleaner
   delayed_job
   delayed_job_active_record
   dor-services (~> 5.0)!

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -15,15 +15,6 @@ class ItemsController < ApplicationController
     @mods_display = ModsDisplayObject.new(@object.descMetadata.ng_xml.to_s)
   end
 
-  def on_hold
-    %w(accession2WF accessionWF).each do |k|
-      return true if @object.workflows.include?(k) && Dor::WorkflowService.get_workflow_status('dor', pid, k, 'sdr-ingest-transfer') == 'hold'
-    end
-    false
-  rescue
-    false
-  end
-
   # open a new version if needed. 400 if the item is in a state that doesnt allow opening a version.
   def prepare
     if can_open_version? @object.pid
@@ -638,8 +629,8 @@ class ItemsController < ApplicationController
 
   def enforce_versioning
     # if this object has been submitted, doesnt have an open version, and isnt sitting at sdr-ingest with a hold, they cannot change it.
-    return true if @object.allows_modification? || on_hold
-    render :status => :forbidden, :text => 'Object cannot be modified in its current state.'
+    return true if @object.allows_modification?
+    render status: :forbidden, text: 'Object cannot be modified in its current state.'
     false
   end
 end

--- a/spec/features/item_source_id_change_spec.rb
+++ b/spec/features/item_source_id_change_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+RSpec.feature 'Item source id change' do
+  let(:current_user) do
+    double(
+      :webauth_user,
+      login: 'sunetid',
+      logged_in?: true,
+      permitted_apos: [],
+      is_admin: true,
+      roles: [],
+      groups: []
+    )
+  end
+  before do
+    allow_any_instance_of(ItemsController).to receive(:current_user)
+      .and_return(current_user)
+  end
+  feature 'when modification is not allowed' do
+    scenario 'cannot change the source id' do
+      expect_any_instance_of(Dor::Item)
+        .to receive(:allows_modification?).and_return(false)
+      visit source_id_ui_item_path 'druid:kv840rx2720'
+      fill_in 'new_id', with: 'sulair:newSource'
+      click_button 'Update'
+      expect(page).to have_css 'body', text: 'Object cannot be modified in ' \
+        'its current state.'
+    end
+  end
+  feature 'when modification is allowed' do
+    scenario 'changes the source id' do
+      expect_any_instance_of(CatalogController).to receive(:current_user)
+        .at_least(1).times.and_return(current_user)
+      expect_any_instance_of(Dor::Item)
+        .to receive(:allows_modification?).and_return(true)
+      visit source_id_ui_item_path 'druid:kv840rx2720'
+      fill_in 'new_id', with: 'sulair:newSource'
+      click_button 'Update'
+      expect(page).to have_css '.alert.alert-info', text: 'Source Id for ' \
+        'druid:kv840rx2720 has been updated!'
+    end
+  end
+end

--- a/spec/features/item_view_metadata_spec.rb
+++ b/spec/features/item_view_metadata_spec.rb
@@ -1,17 +1,20 @@
 require 'spec_helper'
 
 feature 'Item view metadata' do
-  before do
-    @current_user = double(
+  let(:current_user) do
+    double(
       :webauth_user,
       login: 'sunetid',
       logged_in?: true,
       permitted_apos: [],
       is_admin: true,
-      roles: []
+      roles: [],
+      groups: []
     )
-    allow_any_instance_of(ApplicationController).to receive(:current_user)
-      .and_return(@current_user)
+  end
+  before do
+    expect_any_instance_of(CatalogController).to receive(:current_user)
+      .at_least(1).times.and_return(current_user)
   end
 
   scenario 'MD Source is "DOR"' do

--- a/spec/features/report_view_spec.rb
+++ b/spec/features/report_view_spec.rb
@@ -1,16 +1,20 @@
 require 'spec_helper'
 
 feature 'Report view' do
-  before :each do
-    @current_user = double(
+  let(:current_user) do
+    double(
       :webauth_user,
       login: 'sunetid',
       logged_in?: true,
       permitted_apos: [],
-      is_admin: true
+      is_admin: true,
+      roles: [],
+      groups: []
     )
-    allow_any_instance_of(ApplicationController).to receive(:current_user).
-      and_return(@current_user)
+  end
+  before :each do
+    allow_any_instance_of(ReportController).to receive(:current_user).
+      and_return(current_user)
   end
   scenario 'shows table without error' do
     visit report_path f: { objectType_ssim: ['item'] }

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -1,16 +1,20 @@
 require 'spec_helper'
 
 feature 'Search results' do
-  before :each do
-    @current_user = double(
+  let(:current_user) do
+    double(
       :webauth_user,
       login: 'sunetid',
       logged_in?: true,
       permitted_apos: [],
-      is_admin: true
+      is_admin: true,
+      roles: [],
+      groups: []
     )
-    allow_any_instance_of(ApplicationController).to receive(:current_user).
-      and_return(@current_user)
+  end
+  before :each do
+    allow_any_instance_of(CatalogController).to receive(:current_user).
+      and_return(current_user)
   end
   scenario 'contains Blacklight default index page tools' do
     visit catalog_index_path f: { empties: ['no_rights_characteristics'] }

--- a/spec/features/view_switcher_spec.rb
+++ b/spec/features/view_switcher_spec.rb
@@ -1,44 +1,55 @@
 require 'spec_helper'
 
 RSpec.feature 'View switcher' do
-  before :each do
-    @current_user = double(
+  let(:current_user) do
+    double(
       :webauth_user,
       login: 'sunetid',
       logged_in?: true,
       permitted_apos: [],
       is_admin: true,
+      roles: [],
+      groups: [],
       permitted_collections: []
     )
-    allow_any_instance_of(ApplicationController).to receive(:current_user).
-      and_return(@current_user)
   end
+
   feature 'is present' do
     scenario 'bulk update' do
+      expect_any_instance_of(ReportController).to receive(:current_user)
+        .at_least(1).times.and_return(current_user)
       visit report_bulk_url f: { objectType_ssim: ['item'] }
       within '.report-toggle' do
         expect(page).to have_css 'li.active a', text: 'Bulk Update View'
       end
     end
     scenario 'catalog results' do
+      expect_any_instance_of(CatalogController).to receive(:current_user)
+        .at_least(1).times.and_return(current_user)
       visit catalog_index_path f: { objectType_ssim: ['item'] }
       within '.report-toggle' do
         expect(page).to have_css 'ul.dropdown-menu-right li.active a', text: 'Results View'
       end
     end
     scenario 'report view' do
-      visit report_url f: { objectType_ssim: ['item'] }
+      expect_any_instance_of(ReportController).to receive(:current_user)
+        .at_least(1).times.and_return(current_user)
+      visit report_path f: { objectType_ssim: ['item'] }
       within '.report-toggle' do
         expect(page).to have_css 'li.active a', text: 'Report View'
       end
     end
     scenario 'discovery report' do
+      expect_any_instance_of(DiscoveryController).to receive(:current_user)
+        .at_least(1).times.and_return(current_user)
       visit discovery_url f: { objectType_ssim: ['item'] }
       within '.report-toggle' do
         expect(page).to have_css 'li.active a', text: 'Discovery Report View'
       end
     end
     scenario 'workflow grid' do
+      expect_any_instance_of(ReportController).to receive(:current_user)
+        .at_least(1).times.and_return(current_user)
       visit report_workflow_grid_url f: { objectType_ssim: ['item'] }
       within '.report-toggle' do
         expect(page).to have_css 'li.active a', text: 'Workflow Grid View'

--- a/spec/integration/report_spec.rb
+++ b/spec/integration/report_spec.rb
@@ -1,14 +1,21 @@
 require 'spec_helper'
 
 describe ReportController, :type => :feature do
+  let(:current_user) do
+    double(
+      :webauth_user,
+      login: 'sunetid',
+      logged_in?: true,
+      permitted_apos: [],
+      is_admin: true,
+      roles: [],
+      groups: [],
+      permitted_collections: []
+    )
+  end
   before :each do
-    webauth = double('WebAuth', :login => 'sunetid', :attributes => {'DISPLAYNAME' => 'Example User'}, :privgroup => ADMIN_GROUPS.first)
-    @current_user = User.find_or_create_by_webauth(webauth)
-    ##
-    # A higher level up the inheritance chain stub of `ApplicationController` is
-    # insufficient here, due to a possible bug in rspec-mocks or our overuse of
-    # `allow_any_instance_of`.
-    allow_any_instance_of(CatalogController).to receive(:current_user).and_return(@current_user)
+    expect_any_instance_of(ReportController).to receive(:current_user)
+      .at_least(1).times.and_return(current_user)
   end
   describe 'bulk' do
     it 'should return a page with the expected elements' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,7 +43,20 @@ RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   # Run each example in an ActiveRecord transaction
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
+
+  config.before :each do
+    if Capybara.current_driver == :rack_test
+      DatabaseCleaner.strategy = :transaction
+    else
+      DatabaseCleaner.strategy = :truncation
+    end
+    DatabaseCleaner.start
+  end
+
+  config.after do
+    DatabaseCleaner.clean
+  end
 
   # If true, the base class of anonymous controllers will be inferred
   # automatically. This will be the default behavior in future versions of


### PR DESCRIPTION
Closes #84 

Adds in DatabaseCleaner around specs for test cleaning up (specifically works now around WFS actions). If the test is a JS spec it will use `truncation` strategy, for rack based specs it will use `transaction`.

Also removes legacy custom Argo logic for version enforcing in favor of standard DorServices call. Note: this change effects all `ItemController` specs as it removes the outdated `#on_hold` method from that controller.

557abf7b6e6184c1e8951bbf44d4af77e680f188 also adds more specific expectations for for our `allow_any`'s . These greedy mocks seem to cause chaos and don't always decompose between specs.