### PR TITLE
add facet resource route for controllers that subclass CatalogController

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,9 +39,28 @@ Argo::Application.routes.draw do
   match 'report/reset',    :to => 'report#reset',    :via => [:post],       :as => 'report_reset'
   match 'report/workflow_grid', :to => 'report#workflow_grid', :via => [:get, :post], :as => 'report_workflow_grid'
 
+  ##
+  # This route provides access to CatalogController#facet so facet links can be
+  # generated.
+  resources :report, only: [] do
+    member do
+      get :facet
+    end
+  end
+
   match 'discovery',          :to => 'discovery#index',    :via => [:get, :post], :as => 'discovery'
   match 'discovery/data',     :to => 'discovery#data',     :via => [:get, :post], :as => 'discovery_data'
   match 'discovery/download', :to => 'discovery#download', :via => [:get, :post], :as => 'discovery_download'
+
+  ##
+  # This route provides access to CatalogController#facet so facet links can be
+  # generated.
+  resources :discovery, only: [] do
+    member do
+      get :facet
+    end
+  end
+
   match 'apo/is_valid_role_list', :to => 'apo#is_valid_role_list_endpoint', :via => [:get, :post], :as => 'is_valid_role_list'
 
   root :to => 'catalog#index'

--- a/spec/routing/discovery_routing_spec.rb
+++ b/spec/routing/discovery_routing_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec.describe DiscoveryController do
+  describe 'routing' do
+    it 'routes to to #facet' do
+      expect(get: '/discovery/topic_ssim/facet')
+        .to route_to('discovery#facet', id: 'topic_ssim')
+    end
+  end
+end

--- a/spec/routing/report_routing_spec.rb
+++ b/spec/routing/report_routing_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec.describe ReportController do
+  describe 'routing' do
+    it 'routes to to #facet' do
+      expect(get: '/report/topic_ssim/facet')
+        .to route_to('report#facet', id: 'topic_ssim')
+    end
+  end
+end


### PR DESCRIPTION
Closes #400 

The problem here is that classes that subclass `CatalogController` should provide the `facet` resource member route. Since we don't have fixtures in our dev/test data that reach the 10 limit threshold we weren't seeing this bug locally. I added the routing specs so if someone removes the route, our build will fail.

Confirmed this fix on dev.