### PR TITLE
return 404 status code when objects are missing

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,8 @@ class ApplicationController < ActionController::Base
   before_filter :authorize!
   before_filter :fedora_setup
 
+  rescue_from ActiveFedora::ObjectNotFoundError, with: -> { render text: 'Object Not Found', status: :not_found }
+
   helper_method :current_or_guest_user
 
   include Rack::Webauth::Helpers

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -604,14 +604,9 @@ class ItemsController < ApplicationController
   # Filters
   def create_obj
     raise 'missing druid' unless params[:id]
-    begin
-      @object = Dor::Item.find params[:id]
-      @apo = @object.admin_policy_object
-      @apo = ( @apo ? @apo.pid : '' )
-    rescue ActiveFedora::ObjectNotFoundError # => e
-      render :status => 500, :text => 'Object doesnt exist in Fedora.'
-      return
-    end
+    @object = Dor::Item.find params[:id]
+    @apo = @object.admin_policy_object
+    @apo = ( @apo ? @apo.pid : '' )
   end
 
   def save_and_reindex

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -129,4 +129,13 @@ describe CatalogController, :type => :controller do
       expect(config.http_method).to eq :post
     end
   end
+  describe 'error handling' do
+    let(:druid) { 'druid:zz999zz9999' }
+    it 'should 404 on missing item' do
+      expect(subject).to receive(:current_user).and_return(double('WebAuth', is_admin: true)).twice
+      expect(Dor).to receive(:find).with(druid).and_raise(ActiveFedora::ObjectNotFoundError)
+      get 'show', :id => druid
+      expect(response).to have_http_status(:not_found)
+    end
+  end
 end

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -408,7 +408,12 @@ describe ItemsController, :type => :controller do
     it 'should fetch the workflow on valid parameters' do
       expect(@item.workflows).to receive(:get_workflow)
       get :workflow_view, id: @pid, wf_name: 'accessionWF', repo: 'dor', format: :html
-      expect(response.status).to eq 200
+      expect(response).to have_http_status(:ok)
+    end
+    it 'should 404 on missing item' do
+      expect(Dor::Item).to receive(:find).with(@pid).and_raise(ActiveFedora::ObjectNotFoundError)
+      get :workflow_view, id: @pid, wf_name: 'accessionWF', repo: 'dor', format: :html
+      expect(response).to have_http_status(:not_found)
     end
   end
   describe '#workflow_update' do

--- a/spec/controllers/registration_controller_spec.rb
+++ b/spec/controllers/registration_controller_spec.rb
@@ -222,7 +222,8 @@ describe RegistrationController, :type => :controller do
     end
 
     it 'should handle a bogus APO' do
-      expect { get 'collection_list', apo_id: 'druid:aa111bb2222' }.to raise_error(ActiveFedora::ObjectNotFoundError)
+      get 'collection_list', apo_id: 'druid:aa111bb2222'
+      expect(response).to have_http_status(:not_found)
     end
 
     it 'should handle an APO with no collections' do


### PR DESCRIPTION
This PR fixes #401 by returning status code 404 when any controller throws out an `ActiveFedora::ObjectNotFoundError`. Previously we were returning status code 500 which causes squash to report missing objects as software bugs.