### PR TITLE
use show page size for index thumb, also move away from legacy "thumb…

### DIFF
--- a/app/assets/stylesheets/argo/document.sass
+++ b/app/assets/stylesheets/argo/document.sass
@@ -2,10 +2,6 @@ div.document
   h3.index_title
     margin-left: 1.5em
     text-indent: -1.5em
-  div.index-thumb-container
-    float: left
-    width: 100px
-    margin: 4px 2em 4px 0px
   div.document-thumb-container
     float: right
     margin-bottom: 1em

--- a/app/helpers/argo_helper.rb
+++ b/app/helpers/argo_helper.rb
@@ -63,7 +63,7 @@ module ArgoHelper
     return nil unless fname
     fname = File.basename(fname, File.extname(fname))
     druid = doc['id'].to_s.split(/:/).last
-    url = "#{Argo::Config.urls.stacks}/#{druid}/#{fname}_thumb"
+    url = "#{Argo::Config.urls.stacks}/iiif/#{druid}%2F#{fname}/full/!400,400/0/default.jpg"
     {:fname => fname, :druid => druid, :url => url}
   end
 
@@ -79,7 +79,7 @@ module ArgoHelper
   end
 
   def render_index_thumbnail(doc, options = {})
-    render_thumbnail_helper doc, 'index-thumb', '', 'max-width:80px;max-height:80px;'
+    render_thumbnail_helper doc, 'index-thumb', '', 'max-width:240px;max-height:240px;'
   end
 
   # override blacklight so apo and collection facets list title rather than druid. This will go away when we modify the index to include title with druid

--- a/spec/helpers/argo_helper_spec.rb
+++ b/spec/helpers/argo_helper_spec.rb
@@ -3,18 +3,18 @@ describe ArgoHelper, :type => :helper do
   describe 'render_document_show_thumbnail' do
     it 'should include a thumbnail url' do
       doc = {'first_shelved_image_ss' => 'testimage.jp2'}
-      expect(helper.render_document_show_thumbnail(doc)  ).to  \
-        match(/src=".*testimage_thumb"/                  ).and \
-        match(/style="max-width:240px;max-height:240px;"/).and \
+      expect(helper.render_document_show_thumbnail(doc)            ).to  \
+        match(%r{src=".*testimage\/full\/!400,400\/0\/default.jpg"}).and \
+        match(/style="max-width:240px;max-height:240px;"/          ).and \
         match(/alt=""/)
     end
   end
   describe 'render_index_thumbnail' do
     it 'should include a thumbnail url' do
       doc = {'first_shelved_image_ss' => 'testimage.jp2'}
-      expect(helper.render_index_thumbnail(doc)  ).to  \
-        match(/src=".*testimage_thumb"/                  ).and \
-        match(/style="max-width:80px;max-height:80px;"/).and \
+      expect(helper.render_index_thumbnail(doc)                    ).to  \
+        match(%r{src=".*testimage\/full\/!400,400\/0\/default.jpg"}).and \
+        match(/style="max-width:240px;max-height:240px;"/          ).and \
         match(/alt=""/)
     end
   end


### PR DESCRIPTION
…" endpoint to iiif way

Grabs the 400px on the long edge image and displays it using the same width/height limitations as show page (240px/240px).

Closes #404 

![screen shot 2016-01-07 at 11 44 10 am](https://cloud.githubusercontent.com/assets/1656824/12176154/069f8cac-b534-11e5-80e6-b7c3b254555a.png)
