### PR TITLE
remove broken render_facet_value helper

### DIFF
--- a/app/helpers/argo_helper.rb
+++ b/app/helpers/argo_helper.rb
@@ -82,12 +82,6 @@ module ArgoHelper
     render_thumbnail_helper doc, 'index-thumb', '', 'max-width:80px;max-height:80px;'
   end
 
-  # override blacklight so apo and collection facets list title rather than druid. This will go away when we modify the index to include title with druid
-  def render_facet_value(facet_solr_field, item, options = {})
-    display_value = item.value =~ /druid:/ ? label_for_druid(item.value) : item.value
-    (link_to_unless(options[:suppress_link], ((item.label if item.respond_to?(:label)) || display_value), add_facet_params_and_redirect(facet_solr_field, item.value), :class => 'facet_select') + ' ' + render_facet_count(item.hits)).html_safe
-  end
-
   def render_document_sections(doc, action_name)
     dor_object = @obj # Dor.find doc['id'].to_s, :lightweight => true
     format = document_partial_name(doc)

--- a/spec/helpers/argo_helper_spec.rb
+++ b/spec/helpers/argo_helper_spec.rb
@@ -100,4 +100,10 @@ describe ArgoHelper, :type => :helper do
       end
     end
   end
+  describe 'render_facet_value' do
+    it 'should not override Blacklight version' do
+      expect(helper.respond_to?(:render_facet_value)).to be_truthy
+      expect(helper.method(:render_facet_value).owner).to eq(Blacklight::FacetsHelperBehavior)
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes #402. It removes the overridden method `render_facet_value`. This method was added circa 2011 and isn't needed anymore as far as I can tell. To test, I changed the catalog controller to use very short `limit:` parameters (e.g., 2). The APO and Collection facet values are titles (which the original comment said they weren't).

![screen shot 2016-01-07 at 11 42 20 am](https://cloud.githubusercontent.com/assets/1861171/12180878/e0b99bae-b533-11e5-9811-1a14082aaa00.png)

![screen shot 2016-01-07 at 11 41 55 am](https://cloud.githubusercontent.com/assets/1861171/12180881/e376943c-b533-11e5-9476-c80347c844c1.png)
