### PR TITLE
Revert "gitignore my local development files"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,3 @@ config/settings/*.local.yml
 config/environments/*.local.yml
 
 vendor/ruby/
-
-# Ignore sublime text files
-*.sublime-*
-

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,5 +1,0 @@
-argo_jetty_start.sh
-argo_setup.sh
-argo_start.sh
-argo_stop.sh
-


### PR DESCRIPTION
This reverts commit 33fd2395a12df8ffc36442799503efd109d6253f.

I propose this commit gets reverted as it was committed straight to `develop` without going through a review. Furthermore, there are ways to accomplish this for locally for a developer without committing it to a project. I think these two articles should help accomplish this goal.

See:
 - https://help.github.com/articles/ignoring-files/#explicit-repository-excludes
 - https://help.github.com/articles/ignoring-files/#create-a-global-gitignore