### PR TITLE
enable non-referrer HTTP requests to return appropriate status and body

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -78,4 +78,15 @@ class ApplicationController < ActionController::Base
     true
   end
 
+  ##
+  # A ported over Rails 5 enhancement to ActionPack
+  # @see https://github.com/rails/rails/commit/13fd5586cef628a71e0e2900820010742a911099
+  def redirect_back(fallback_location:, **args)
+    if (referer = request.headers['Referer'])
+      redirect_to referer, **args
+    else
+      redirect_to fallback_location, **args
+    end
+  end
+
 end

--- a/app/controllers/dor_controller.rb
+++ b/app/controllers/dor_controller.rb
@@ -46,10 +46,16 @@ class DorController < ApplicationController
     @solr_doc = Argo::Indexer.reindex_pid params[:pid], index_logger
     Dor::SearchService.solr.commit # reindex_pid doesn't commit, but callers of this method may expect the update to be committed immediately
     flash[:notice] = "Successfully updated index for #{params[:pid]}"
-    redirect_to :back
+    render status: 200, text: flash[:notice] and return unless request.headers['Referer']
+    redirect_back(
+      fallback_location: proc { catalog_path(params[:pid])}
+    )
   rescue ActiveFedora::ObjectNotFoundError # => e
     flash[:error] = 'Object does not exist in Fedora.'
-    redirect_to :back
+    render status: 404, text: flash[:error] and return unless request.headers['Referer']
+    redirect_back(
+      fallback_location: proc { catalog_path(params[:pid])}
+    )
   end
 
   def delete_from_index


### PR DESCRIPTION
Closes #434 
Closes #433 

Ports in a new Rails 5 method which gives us a redirect back with a fallback path.

This PR now handles the following cases:

 - Within Argo (or another application) following a link to the reindex endpoint will return a user to `:back` or `catalog_index` (show page) (fallback case)
 - An external application hitting that endpoint (no "Referer" header) will get a 200 with text body or a 404 with text body