### PR TITLE
Enable simplecov with coveralls

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,12 +168,13 @@ GEM
       activesupport (>= 3.0)
       deep_merge (~> 1.0.0)
     confstruct (0.2.7)
-    coveralls (0.8.3)
+    coveralls (0.8.10)
       json (~> 1.8)
       rest-client (>= 1.6.8, < 2)
-      simplecov (~> 0.10.0)
+      simplecov (~> 0.11.0)
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
+      tins (~> 1.6.0)
     daemons (1.2.3)
     database_cleaner (1.5.1)
     deep_merge (1.0.1)
@@ -455,7 +456,7 @@ GEM
       multi_json (~> 1.0)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
-    simplecov (0.10.0)
+    simplecov (0.11.1)
       docile (~> 1.1.0)
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
@@ -606,4 +607,4 @@ DEPENDENCIES
   wfs_rails (~> 0.0.2)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,19 +6,16 @@ require 'capybara/rspec'
 require 'capybara/poltergeist'
 require 'equivalent-xml/rspec_matchers'
 
-# require 'coveralls'
-# Coveralls.wear!('rails')
-
 require 'simplecov'
 require 'coveralls'
 SimpleCov.profiles.define 'argo' do
   add_filter 'spec'
   add_filter 'vendor'
 end
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
-]
+])
 SimpleCov.start 'argo'
 
 Capybara.register_driver :poltergeist do |app|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,3 @@
-if ENV['COVERAGE'] && RUBY_VERSION =~ /^1.9/
-  require 'simplecov'
-  SimpleCov.start
-end
-
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
@@ -10,8 +5,21 @@ require 'capybara/rails'
 require 'capybara/rspec'
 require 'capybara/poltergeist'
 require 'equivalent-xml/rspec_matchers'
+
+# require 'coveralls'
+# Coveralls.wear!('rails')
+
+require 'simplecov'
 require 'coveralls'
-Coveralls.wear!('rails')
+SimpleCov.profiles.define 'argo' do
+  add_filter 'spec'
+  add_filter 'vendor'
+end
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov::Formatter::HTMLFormatter,
+  Coveralls::SimpleCov::Formatter
+]
+SimpleCov.start 'argo'
 
 Capybara.register_driver :poltergeist do |app|
   Capybara::Poltergeist::Driver.new(app, {timeout: 60})


### PR DESCRIPTION
This is designed to enable SimpleCov coverage reports in ./coverage on laptop development, so that the coverage data can be viewed immediately, regardless of travis/coveralls functionality.  The coveralls functionality should be preserved, according to their website docs, see https://coveralls.zendesk.com/hc/en-us/articles/201769485-Ruby-Rails

A similar example of this working is in the triannon project at:
https://github.com/sul-dlss/triannon/blob/master/spec/spec_helper.rb#L12-L29

And the coveralls reports are working, see:
https://coveralls.io/github/sul-dlss/triannon
