### PR TITLE
override solr facet.limit configuration for hierarchical facets

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -72,7 +72,7 @@ class CatalogController < ApplicationController
     # exploded_tag_ssim indexes all tag prefixes (see IdentityMetadataDS#to_solr for a more exact
     # description), whereas tag_ssim only indexes whole tags.  we want to facet on exploded_tag_ssim
     # to get the hierarchy.
-    config.add_facet_field 'exploded_tag_ssim',               label: 'Tag',                 partial: 'blacklight/hierarchy/facet_hierarchy'
+    config.add_facet_field 'exploded_tag_ssim',               label: 'Tag',                 limit: 9999, partial: 'blacklight/hierarchy/facet_hierarchy'
     config.add_facet_field 'objectType_ssim',                 label: 'Object Type',         limit: 10
     config.add_facet_field 'content_type_ssim',               label: 'Content Type',        limit: 10
     config.add_facet_field 'rights_primary_ssi',              label: 'Access Rights',       limit: 10
@@ -84,9 +84,9 @@ class CatalogController < ApplicationController
     config.add_facet_field 'current_version_isi',             label: 'Version',             limit: 10
     config.add_facet_field 'processing_status_text_ssi',      label: 'Processing Status',   limit: 10
     config.add_facet_field 'released_to_ssim',                label: 'Released To',         limit: 10
-    config.add_facet_field 'wf_wps_ssim',                     label: 'Workflows (WPS)',     limit: 10, partial: 'blacklight/hierarchy/facet_hierarchy'
-    config.add_facet_field 'wf_wsp_ssim',                     label: 'Workflows (WSP)',     partial: 'blacklight/hierarchy/facet_hierarchy'
-    config.add_facet_field 'wf_swp_ssim',                     label: 'Workflows (SWP)',     partial: 'blacklight/hierarchy/facet_hierarchy'
+    config.add_facet_field 'wf_wps_ssim',                     label: 'Workflows (WPS)',     limit: 9999, partial: 'blacklight/hierarchy/facet_hierarchy'
+    config.add_facet_field 'wf_wsp_ssim',                     label: 'Workflows (WSP)',     limit: 9999, partial: 'blacklight/hierarchy/facet_hierarchy'
+    config.add_facet_field 'wf_swp_ssim',                     label: 'Workflows (SWP)',     limit: 9999, partial: 'blacklight/hierarchy/facet_hierarchy'
     config.add_facet_field 'has_model_ssim',                  label: 'Object Model',        limit: 10
 
     ## This is the costlier way to do this.  Instead convert this logic to delivering new values to a new field.  Then use normal add_facet_field.


### PR DESCRIPTION
This PR fixes #371 by overriding the `facet.limit` Solr configuration for hierarchical facets. The decision to make the limit's 9999 here is that we're not able to guarantee that the Solr `facet.limit` parameter is appropriately large enough, and on our Solr cluster core it's set to 10.