### PR TITLE
Checks to see if #render_document_index_label is passed in its first …

### DIFF
--- a/app/presenters/argo_presenter.rb
+++ b/app/presenters/argo_presenter.rb
@@ -3,10 +3,16 @@ class ArgoPresenter < Blacklight::DocumentPresenter
 
   ##
   # Override default Blacklight presenter method, to provide citation when
-  # rendering the index title label
+  # rendering the index title label. Because of some strangeness with the
+  # #render_thumbnail_tag method from Blacklight, we need to check if its not
+  # the default id and if so call super.
   # @see https://github.com/projectblacklight/blacklight/blob/c04e80b690bdbd71482d3d91cc168d194d0b6a51/app/presenters/blacklight/document_presenter.rb#L110
-  def render_document_index_label(_field, _opts = {})
-    render_citation(@document)
+  def render_document_index_label(field, _opts = {})
+    if field != @document.id
+      super
+    else
+      render_citation(@document)
+    end
   end
 
   ##

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -73,4 +73,8 @@ feature 'Search results' do
     expect(page).to have_css 'dt', text: 'Collection:'
     expect(page).to have_css 'dd a', text: /Annual report/
   end
+  scenario 'contains document image thumbnail' do
+    visit catalog_index_path f: { objectType_ssim: ['item'] }
+    expect(page).to have_css '.document-thumbnail a img'
+  end
 end


### PR DESCRIPTION
…argument is the title (a druid). Calls super if so, because of some logic in Blacklight::CatalogHelperBehavior#render_thumbnail_tag

Closes #448 

This doesn't feel good, but there is a yet to be implemented upstream Blacklight fix that needs to addressed.