### PR TITLE
Blacklight natively gives us some logging for the Solr query already,…

### DIFF
--- a/app/models/argo/access_controls_enforcement.rb
+++ b/app/models/argo/access_controls_enforcement.rb
@@ -27,7 +27,6 @@ module Argo
         pids = pids.join(' OR ')
       end
       solr_parameters[:fq] << "#{SolrDocument::FIELD_APO_ID}:(#{pids})"
-      logger.debug("Solr parameters: #{ solr_parameters.inspect }")
       solr_parameters
     end
   end


### PR DESCRIPTION
… this is repetitive https://github.com/projectblacklight/blacklight/blob/6dcf39f908de702f2d5cc7cc8a4046b2d126badb/lib/blacklight/solr/repository.rb#L42

This seems repetitive... am I missing something? Maybe a previous version of Blacklight didn't do this?

