### PR TITLE
change method param name, not to confuse the future

### DIFF
--- a/app/models/argo/access_controls_enforcement.rb
+++ b/app/models/argo/access_controls_enforcement.rb
@@ -3,7 +3,7 @@ module Argo
   module AccessControlsEnforcement
     extend ActiveSupport::Concern
 
-    def add_access_controls_to_solr_params(solr_parameters, user)
+    def add_access_controls_to_solr_params(solr_parameters, user_params)
       apply_gated_discovery(solr_parameters, @user)
     end
 


### PR DESCRIPTION
Makes this consistent with what Blacklight calls things, and could trip up a future someone with confusing similar argument names (but totally different things) for `#apply_gated_discovery`