### PR TITLE
drop unused LOG_FILE constant

### DIFF
--- a/config/initializers/indexer.rb
+++ b/config/initializers/indexer.rb
@@ -1,1 +1,0 @@
-LOG_FILE = 'log/indexer.log'


### PR DESCRIPTION
this LOG_FILE constant doesn't appear to be referenced anywhere in the application.  additionally, there are log file related things in the settings, so this could be confusing.  seems like the right thing to do is to remove it.