### PR TITLE
Status controller handles exception

### DIFF
--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -23,7 +23,7 @@ class StatusController < ApplicationController
       render :status => 500, :text => "Nothing indexed recently. Even after saving '#{params[:test_obj]}'."
       return
     end
-  rescue ActiveFedora::ObjectNotFoundError
+  rescue ActiveFedora::ObjectNotFoundError, Rubydora::FedoraInvalidRequest
     render :status => 404, :text => "No object '#{params[:test_obj]}' found"
   end
 


### PR DESCRIPTION
Fixes a spec failure, i.e.
```
  1) StatusController log with test_obj should 404 instead of 500 on bad IDs
     Failure/Error: get 'log', :test_obj => 'junk'
     Rubydora::FedoraInvalidRequest:
       See logger for details
     # ./app/controllers/status_controller.rb:17:in `log'
     # ./spec/controllers/status_controller_spec.rb:52:in `block (3 levels) in <top (required)>'
```
