### PR TITLE
fix severity type pulldown in Close Version UI

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,7 +38,7 @@ class ItemsController < ApplicationController
     @changed_severity = which_severity_changed(get_current_version_tag(@object), get_prior_version_tag(@object))
     @severity_selected = {}
     [:major, :minor, :admin].each do |severity|
-      @severity_selected[severity] = (@changed_severity == severity ? ' selected' : '')
+      @severity_selected[severity] = (@changed_severity == severity)
     end
   end
 
@@ -355,7 +355,7 @@ class ItemsController < ApplicationController
         if params[:bulk]
           format.html {render :status => :ok, :text => 'Version Closed.'}
         else
-          format.any { redirect_to catalog_path(params[:id]), :notice => 'Version ' + @object.current_version + ' of ' + params[:id] + ' has been closed!' }
+          format.any { redirect_to catalog_path(params[:id]), :notice => 'Version ' + @object.current_version + ' of ' + @object.pid + ' has been closed!' }
         end
       end
     rescue Dor::Exception # => e

--- a/app/views/items/_close_version_ui.html.erb
+++ b/app/views/items/_close_version_ui.html.erb
@@ -3,8 +3,8 @@
     <label for="severity">Type</label>
     <select id="severity" name="severity" class='form-control'>
       <%- # loop through the severity levels and pre-select the one that was chosen when opening the version -%>
-      <% @severity_levels.try(:each) do |severity| %>
-        <option value="<%=severity.to_s-%>"<%=@severity_selected[severity]-%>><%=severity.to_s.capitalize-%></option>
+      <% @severity_selected.keys.each do |severity| %>
+        <option value="<%=severity.to_s-%>"<%=@severity_selected[severity] ? ' selected' : ''-%>><%=severity.to_s.capitalize-%></option>
       <% end %>
     </select>
   </div>

--- a/app/views/items/close_version_ui.js.erb
+++ b/app/views/items/close_version_ui.js.erb
@@ -1,5 +1,5 @@
 <div class='modal-header'>
-    <button type='button' class='ajax-modal-close close' data-dismiss='modal' aria-hidden='true'>×</button>
+  <button type='button' class='ajax-modal-close close' data-dismiss='modal' aria-hidden='true'>×</button>
   <h3 class='modal-title'>Close version</h3>
 </div>
 

--- a/spec/views/items/_close_version_ui.html.erb_spec.rb
+++ b/spec/views/items/_close_version_ui.html.erb_spec.rb
@@ -4,10 +4,14 @@ RSpec.describe 'items/_close_version_ui.html.erb' do
   let(:object) { double('object', pid: 'druid:abc123')}
   it 'renders the partial content' do
     assign(:object, object)
+    assign(:severity_selected, {major: false, minor: true, admin: nil})
     render
     expect(rendered).to have_css 'form'
     expect(rendered).to have_css '.form-group label', text: 'Type'
-    expect(rendered).to have_css '.form-group select.form-control'
+    expect(rendered).to have_css '.form-group select.form-control option[selected]', text: 'Minor'
+    expect(rendered).to have_css '.form-group select.form-control option[value="major"]'
+    expect(rendered).to have_css '.form-group select.form-control option[value="minor"]'
+    expect(rendered).to have_css '.form-group select.form-control option[value="admin"]'
     expect(rendered)
       .to have_css '.form-group label', text: 'Version description'
     expect(rendered).to have_css '.form-group textarea.form-control'


### PR DESCRIPTION
This PR fixes #409. The modal dialog has the type values filled in and uses the style of the other modals. I've also added tests for the presence of the Type pulldown menu.

![screen shot 2016-02-02 at 3 31 23 pm](https://cloud.githubusercontent.com/assets/1861171/12768069/1b901ff8-c9c2-11e5-81d1-ca2c98e5a3f4.png)

upon a version close, you'll get a notice:

![screen shot 2016-02-02 at 3 30 22 pm](https://cloud.githubusercontent.com/assets/1861171/12768071/1e37d89a-c9c2-11e5-96af-7b34c0563cfa.png)
