### PR TITLE
use globally defined content types, and add in support for video and …

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -547,7 +547,7 @@ class ItemsController < ApplicationController
   end
   # set the content type in the content metadata
   def set_content_type
-    unless %w(book file image map manuscript).include? params[:new_content_type]
+    unless Constants::CONTENT_TYPES.include? params[:new_content_type]
       render :status => :forbidden, :text => 'Invalid new content type.'
       return
     end

--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -1,9 +1,0 @@
-module ReportHelper
-  def content_types
-    %w(image book file manuscript map)
-  end
-
-  def resource_types
-    %w(image page file)
-  end
-end

--- a/app/views/items/_content_type.html.erb
+++ b/app/views/items/_content_type.html.erb
@@ -5,8 +5,8 @@
 <%= form_tag url_for(:controller => :items, :action => :set_content_type, :id => @object.pid), id: "content_type_form" do %>
   <% old_content_type = begin @object.contentMetadata.contentType[0] rescue '' end  %>
   <% old_resource_type = begin @object.contentMetadata.ng_xml.xpath('/contentMetadata/resource')[0]['type'] rescue '' end %>
-  <% display_content_types = [['none', '']] + content_types %>
-  <% display_resource_types = [['none', '']] + resource_types %>
+  <% display_content_types = [['none', '']] + Constants::CONTENT_TYPES %>
+  <% display_resource_types = [['none', '']] + Constants::RESOURCE_TYPES %>
   <div class='form-group'>
     <label>Old content type</label>
     <%=old_content_type%><%=hidden_field_tag :old_content_type, old_content_type %>

--- a/app/views/report/bulk.html.erb
+++ b/app/views/report/bulk.html.erb
@@ -170,9 +170,9 @@ ul li{
       end
     end
     current_content_types = [['none', '']] + current_content_types
-    current_resource_types = [['none', '']] + resource_types
-    new_content_types = [['none', '']] + content_types
-    new_resource_types = [['none', '']] + resource_types
+    current_resource_types = [['none', '']] + Constants::RESOURCE_TYPES
+    new_content_types = [['none', '']] + Constants::CONTENT_TYPES
+    new_resource_types = [['none', '']] + Constants::RESOURCE_TYPES
   %>
   <h1>Set content and resource types</h1>
   <p>

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -7,4 +7,6 @@ module Constants
     ['Dark (Preserve Only)', 'dark'],
     ['Citation Only', 'none']
   ]
+  CONTENT_TYPES = %w(image book file manuscript map media).freeze
+  RESOURCE_TYPES = %w(image page file audio video).freeze
 end

--- a/spec/lib/constants_spec.rb
+++ b/spec/lib/constants_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe Constants do
+  it 'has correct CONTENT_TYPES defined' do
+    expect(Constants::CONTENT_TYPES).to include(
+      'image', 'book', 'file', 'manuscript', 'map', 'media'
+    )
+  end
+  it 'has correct RESOURCE_TYPES defined' do
+    expect(Constants::RESOURCE_TYPES).to include(
+      'image', 'page', 'file', 'audio', 'video'
+    )
+  end
+end

--- a/spec/views/items/_content_type.html.erb_spec.rb
+++ b/spec/views/items/_content_type.html.erb_spec.rb
@@ -15,9 +15,16 @@ RSpec.describe 'items/_content_type.html.erb' do
     expect(rendered).to have_css 'form .form-group label', text: 'Old resource type'
     expect(rendered).to have_css 'select.form-control#old_resource_type'
     expect(rendered).to have_css 'form .form-group label', text: 'New content type'
+    Constants::CONTENT_TYPES.each do |type|
+      expect(rendered).to have_css 'form select option', text: type
+    end
+    expect(rendered).to have_css 'form select option', text: 'none', count: 3
     expect(rendered).to have_css 'select.form-control#new_content_type'
     expect(rendered).to have_css 'form .form-group label', text: 'New resource type'
     expect(rendered).to have_css 'select.form-control#new_resource_type'
+    Constants::RESOURCE_TYPES.each do |type|
+      expect(rendered).to have_css 'form select option', text: type
+    end
     expect(rendered).to have_css 'form button.btn.btn-primary', text: 'Update'
   end
 end


### PR DESCRIPTION
…audio

Closes #68 

<img width="940" alt="screen shot 2016-02-03 at 1 06 11 pm" src="https://cloud.githubusercontent.com/assets/1656824/12797109/331a028c-ca77-11e5-9579-f5b370cd2957.png">
<img width="997" alt="screen shot 2016-02-03 at 1 05 59 pm" src="https://cloud.githubusercontent.com/assets/1656824/12797108/3316f9d4-ca77-11e5-84cb-944263fb2918.png">
