### PR TITLE
change Republish button to use flash message

### DIFF
--- a/app/controllers/dor_controller.rb
+++ b/app/controllers/dor_controller.rb
@@ -67,6 +67,6 @@ class DorController < ApplicationController
   def republish
     obj = Dor::Item.find(params[:pid])
     obj.publish_metadata_remotely
-    render :text => 'Republished! You still need to use the normal versioning process to make sure your changes are preserved.'
+    redirect_to catalog_path(params[:pid]), notice: 'Republished! You still need to use the normal versioning process to make sure your changes are preserved.'
   end
 end

--- a/app/helpers/argo_helper.rb
+++ b/app/helpers/argo_helper.rb
@@ -137,7 +137,8 @@ module ArgoHelper
       buttons << {
         url: url_for(:controller => :dor, :action => :republish, :pid => pid),
         label: 'Republish',
-        check_url: workflow_service_published_path(pid)
+        check_url: workflow_service_published_path(pid),
+        new_page: true
       }
 
       buttons << {

--- a/spec/controllers/dor_controller_spec.rb
+++ b/spec/controllers/dor_controller_spec.rb
@@ -113,6 +113,7 @@ describe DorController, :type => :controller do
       expect(mock_item).to receive(:publish_metadata_remotely)
       allow(Dor::Item).to receive(:find).and_return(mock_item)
       get :republish, :pid => 'druid:123'
+      expect(response).to have_http_status(:found)
     end
   end
 end

--- a/spec/helpers/argo_helper_spec.rb
+++ b/spec/helpers/argo_helper_spec.rb
@@ -55,7 +55,8 @@ describe ArgoHelper, :type => :helper do
           {
             label: 'Republish',
             url: "/dor/republish/#{@item_id}",
-            check_url: "/workflow_service/#{@item_id}/published"
+            check_url: "/workflow_service/#{@item_id}/published",
+            new_page: true
           },
           {
             label: 'Change source id',


### PR DESCRIPTION
This PR addresses part of #414. It changes the Republish button to use flash messages on the subsequent `/catalog` page via the standard redirect pattern.