### PR TITLE
convert Files dialog to new modal infrastructure

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -196,6 +196,17 @@ class ItemsController < ApplicationController
   end
 
   ##
+  # Brings up a modal dialog that lists all locations of the file
+  # @option params [String] `:file` the filename for which to locate
+  def file
+    fail ArgumentError, 'Missing file parameter' unless params[:file].present?
+    @available_in_workspace_error = nil
+    @available_in_workspace = @object.list_files.include?(params[:file]) # NOTE: ideally this should be async
+  rescue Net::SSH::Exception => e
+    @available_in_workspace_error = "#{e.class}: #{e}"
+  end
+
+  ##
   # @option params [String] `:content` the XML with which to replace the datastream
   # @option params [String] `:dsid` the identifier for the datastream, e.g., `identityMetadata`
   # @option params [String] `:id` the druid to modify

--- a/app/views/items/_file.html.erb
+++ b/app/views/items/_file.html.erb
@@ -1,0 +1,27 @@
+<div class="container"><%# Need additional container here %>
+  <div class="row">
+    Workspace:
+  <% if @available_in_workspace %>
+    <%= link_to params[:file], "/items/#{params[:id]}/file/?file=#{params[:file]}" -%>
+  <% else %>
+    not available <span class="text-danger"><%= @available_in_workspace_error -%></span>
+  <% end %>
+  </div>
+
+<%# TODO: Use the contentMetadata OM for parsing metadata record %>
+<% @object.contentMetadata.ng_xml.search("//file[@id='#{params[:file]}']").each do |file| %>
+<%   if file['shelve'] == 'yes' %>
+      <div class="row">
+        Stacks:
+        <%= link_to params[:file], stacks_url_full_size(@object, params[:file]) -%>
+      </div>
+<%   end %>
+<%# TODO: has_been_accessioned? is deprecated, migrate to async call %>
+<%   if file['preserve'] == 'yes' && has_been_accessioned?(@object.pid) %>
+      <div class="row">
+        Preservation:
+        <%= link_to params[:file], url_for(:controller => :items, :action => :get_preserved_file, :id => params[:id], :file => params[:file], :version => last_accessioned_version(@object)) -%>
+      </div>
+<%   end %>
+<% end %>
+</div>

--- a/app/views/items/file.html.erb
+++ b/app/views/items/file.html.erb
@@ -1,25 +1,4 @@
-<% content_ds = @object.datastreams['contentMetadata'] %>
-<%
-  # @NOTE: list_files performs remote SSH connection, may fail!
-  # @TODO: do list_files inside app and pass files to template for render, or ideally make it async
-  if @object.list_files.include?(params[:file])
-    link = "/items/#{params[:id]}/file/?file=#{params[:file]}"
-    %>
-    Workspace: <%= link_to params[:file], link %>
-    <%
-  end
-  content_ds.ng_xml.search('//file[@id=\'' + params[:file] + '\']').each do |file|
-    if file['shelve'] == 'yes'
-      %>
-      <br/>Stacks: <%= link_to params[:file], stacks_url_full_size(@object, params[:file]) %>
-      <%
-    end
-    if has_been_accessioned?(@object.pid) && file['preserve'] == 'yes'
-      %>
-      <br/>Preservation: <%=link_to params[:file], url_for(:controller => :items, :action => :get_preserved_file, :id => params[:id], :file => params[:file], :version => last_accessioned_version(@object))%>
-      <%
-    end
-  end
-
-  %>
-  <br/><button onclick="$('.lightBox').dialog('close');return false;">Cancel</button>
+<div class='container'>
+  <h1>Files</h1>
+  <%= render partial: 'file' %>
+</div>

--- a/app/views/items/file.js.erb
+++ b/app/views/items/file.js.erb
@@ -1,0 +1,8 @@
+<div class='modal-header'>
+  <button type='button' class='ajax-modal-close close' data-dismiss='modal' aria-hidden='true'>×</button>
+  <h3 class='modal-title'>Files</h3>
+</div>
+
+<div class='modal-body'>
+  <%= render partial: 'file' %>
+</div>

--- a/spec/views/items/_file.html.erb_spec.rb
+++ b/spec/views/items/_file.html.erb_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+RSpec.describe 'items/_file.html.erb' do
+  let(:contentMetadata) do
+    cm = Dor::ContentMetadataDS.new
+    cm.content = '<contentMetadata type="image" objectId="rn653dy9317">
+  <resource type="image" sequence="106" id="rn653dy9317_106">
+    <label>Image 106</label>
+    <file mimetype="image/jp2" publish="yes" shelve="yes" format="JPEG2000" preserve="yes" size="3305991" id="M1090_S15_B01_F07_0106.jp2">
+      <imageData width="5102" height="3426"/>
+      <attr name="representation">uncropped</attr>
+      <checksum type="sha1">fd28e74b3139b04a0e5c5c3d3263598f629f8967</checksum>
+      <checksum type="md5">244cbb3960407f59ac77a916870e0502</checksum>
+    </file>
+    <file mimetype="image/tiff" publish="no" shelve="no" format="TIFF" preserve="yes" size="52467428" id="M1090_S15_B01_F07_0106.tif">
+      <imageData width="5102" height="3426"/>
+      <attr name="representation">uncropped</attr>
+      <checksum type="sha1">cf336c4f714b180a09bbfefde159d689e1d517bd</checksum>
+      <checksum type="md5">56978088366e66f87d4d5a531f2fea04</checksum>
+    </file>
+  </resource>
+</contentMetadata>'
+    cm
+  end
+  let(:obj) { double(pid: 'druid:rn653dy9317', contentMetadata: contentMetadata) }
+  it 'renders the partial content' do
+    assign(:object, obj)
+    assign(:available_in_workspace, true)
+    assign(:available_in_workspace_error, nil)
+    expect(view).to receive(:params).and_return({ file: 'M1090_S15_B01_F07_0106.jp2', id: 'druid:rn653dy9317' }).at_least(1)
+    expect(view).to receive(:has_been_accessioned?).with(obj.pid).and_return(true)
+    expect(view).to receive(:last_accessioned_version).with(obj).and_return('1.0.0')
+
+    render
+
+    expect(rendered).to have_css 'div.row[1]', text: 'Workspace'
+    expect(rendered).to have_css 'div.row[2]', text: 'Stacks'
+    expect(rendered).to have_css 'div.row[3]', text: 'Preservation'
+  end
+end

--- a/spec/views/items/file.html.erb_spec.rb
+++ b/spec/views/items/file.html.erb_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec.describe 'items/file.html.erb' do
+  it 'renders the HTML template' do
+    stub_template 'items/_file.html.erb' => 'stubbed_file'
+    render
+    expect(rendered).to have_css '.container h1', text: 'Files'
+    expect(rendered).to have_css '.container', text: 'stubbed_file'
+  end
+end

--- a/spec/views/items/file.js.erb_spec.rb
+++ b/spec/views/items/file.js.erb_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec.describe 'items/file.js.erb' do
+  it 'renders the JS template' do
+    stub_template 'items/_file.html.erb' => 'stubbed_file'
+    render
+    expect(rendered).to have_css '.modal-header h3.modal-title', text: 'Files'
+    expect(rendered).to have_css '.modal-body', text: 'stubbed_file'
+  end
+end


### PR DESCRIPTION
This PR fixes #414 for the File modal dialog (the dialog is launched from the file links in the Content section of the show page). Screenshots are in #414. 

I've also added some tests that were absent from the previous implementation. The route is called `file` and I didn't change that. I did migrate the `list_files` call from the view to the controller -- it does SFTP calls. I switched the if statement for `has_been_accessioned?` to skip the WorkflowService call if the file is not marked 'preserve=yes' and `last_accessioned_version` also calls the WorkflowService synchronously.