### PR TITLE
remove link styling for robots queue

### DIFF
--- a/app/views/report/workflow_grid.html.erb
+++ b/app/views/report/workflow_grid.html.erb
@@ -22,6 +22,6 @@
 
 <div id="content" class="col-md-9 col-sm-8">
   <%= render 'catalog/report_view_toggle' %>
-  <div style="float:right"><a href="<%= robot_status_url -%>" target="_blank">Robots queue/job status</a></div>
+  <a href="<%= robot_status_url -%>" target="_blank">Robots queue/job status</a>
   <%= render :partial => 'workflow_grid' %>
 </div>


### PR DESCRIPTION
This PR partially address #267 by relocating the Robots queue hyperlink to after the view menu

![screen shot 2016-02-11 at 12 14 57 pm](https://cloud.githubusercontent.com/assets/1861171/12989224/58a4d44e-d0b9-11e5-984c-1ea11987d319.png)
