### PR TITLE
[WIP] add externalFile support to Contents section

### DIFF
--- a/app/assets/stylesheets/argo/document.sass
+++ b/app/assets/stylesheets/argo/document.sass
@@ -75,16 +75,13 @@ h3.section-head
   clear: both
 
 ul.resource-tree
-  margin: 0
+  padding-left: 0px
   li
-    padding-left: 8px
     list-style-type: none
     span.label
       color: gray
       &:after
         content: ':'
-    ul
-      margin: 0
 
 table.detail
   thead

--- a/app/views/catalog/_show_sections/_default_contents.html.erb
+++ b/app/views/catalog/_show_sections/_default_contents.html.erb
@@ -1,100 +1,142 @@
-<% if object.datastreams.keys.include?('contentMetadata') &&
-  (not object.datastreams['contentMetadata'].new?) && object.datastreams['contentMetadata'].metadata? %>
-  <% content_ds = object.datastreams['contentMetadata'] %>
-  <% admin_policy_object = @apo %>
-  <div style="clear:left">
-    <ul class="resource-tree">
-      <li>
-        <% if document.preservation_size.present? %>
+<%# TODO: DRY up code here - major duplication due to nested resources support %>
+<div style="clear:left">
+  <ul class="resource-tree">
+  <% if object.datastreams.keys.include?('contentMetadata') && (not object.datastreams['contentMetadata'].new?) && object.datastreams['contentMetadata'].metadata? %>
+    <li>
+      <% if document.preservation_size.present? %>
+        <div>
           <span class="label">Preservation Size</span>
-          <%= number_to_human_size(document.preservation_size) %>
-          <br/>
-        <%end%>
+          <%= number_to_human_size(document.preservation_size) -%>
+        </div>
+      <% end %>
+      <div>
         <span class="label">Type</span>
-        <%= content_ds.ng_xml.root['type'] %>
-        <ul>
-          <% apo_pid = nil
-          if admin_policy_object
-            apo_pid = admin_policy_object.pid
-          end
-          
-          can_manage = current_user.is_admin || current_user.is_manager || (apo_pid && object.can_manage_content?(current_user.roles(apo_pid)))
-          can_view = current_user.is_admin || current_user.is_manager || (apo_pid && object.can_view_content?(current_user.roles(apo_pid)))
-          version_open = can_close_version? object.pid
+        <%= object.datastreams['contentMetadata'].contentType.first -%>
+      </div>
+      <ul>
+      <%
+        apo_pid = @apo.nil? ? nil : @apo.pid
+        can_manage = current_user.is_admin ||
+                     current_user.is_manager ||
+                     (!apo_pid.nil? && object.can_manage_content?(current_user.roles(apo_pid)))
+        can_view = current_user.is_admin ||
+                   current_user.is_manager ||
+                   (!apo_pid.nil? && object.can_view_content?(current_user.roles(apo_pid)))
+        version_open = can_close_version? object.pid
 
-          content_ds.ng_xml.xpath('/contentMetadata/resource').each_with_index do |resource, index| %>
-            <li class="resource">
-              <span class="label">Resource (<%=index+1%>)</span> <%= resource['type']%>
-              <%if can_manage && version_open
-                edit_resource_link="/items/#{params[:id]}/resource/?edit=true&resource=#{resource['id']}"%>
-                <%= link_to "(edit)", edit_resource_link, :data => {ajax_modal: 'trigger'} %>
-              <%end%>
-              <% if resource.at('label') %>
-                <li><span class="label">Label</span> <%= resource.at('label').text %></li>
-              <% end %>
-              <ul>
-                <% children = resource.children
-                inner_index = 0
-                children.each do |child|
-                  if child.node_name() == 'resource'
-                    inner_index = inner_index+1 %>
-                    <li class="resource">
-                      <span class="label">Resource (<%=inner_index%>)</span>
-                      <%= child['type']%>
-                      <%if can_manage && version_open
-                        edit_resource_link = '/items/'+params[:id]+'/resource/?edit=true&resource='+child['id'] %>
-                        <%= link_to "(edit)", edit_resource_link, :data => {ajax_modal: 'trigger'} %>
-                      <%end%>
-                      <ul>
-                        <% if child.at('label') %>
-                          <li> <span class="label">Label</span> <%= child.at('label').text %></li>
-                        <% end %>
-                        <% child.xpath('file').each do |file| %>
-                          <li class="file">
-                            <span class="label">File</span>
-                            <% if can_manage %>
-                              <% manage_file_link = '/items/'+params[:id]+'/file_list/?file='+URI.escape(file['id']) %>
-                              <%= link_to file['id'], manage_file_link, :data => {ajax_modal: 'trigger'} %>
-                            <%else%>
-                              <%=file['id']%>
-                            <%end%>
-                            (<%= file['mimetype'] %>, 
-                             <%= number_to_human_size(file['size']) %>,
-                             <%= ['publish','shelve','preserve'].reject { |a| file[a] != 'yes' }.join('/') %>)
-                          </li>
-                        <% end %>
-                      </ul>
-                    </li>
-                  <% end %>
-                <% end %>
-                
-                <% resource.xpath('file').each do |file| %>
-                  <li class="file">
-                    <span class="label">File</span>
-                    <%if can_view 
-                      file_link = '/items/'+params[:id]+'/file_list/?file='+URI.escape(file['id']) %>
-                      <%= link_to file['id'], file_link, :data => {ajax_modal: 'trigger'} %>
-                    <%else%>
-                      <%=file['id']%>
-                    <%end%>
-                    (<%= file['mimetype'] %>, <%= number_to_human_size(file['size']) %>,
-                     <%= ['publish','shelve','preserve'].reject { |a| file[a] != 'yes' }.join('/') %>)
+        object.datastreams['contentMetadata'].ng_xml.xpath('/contentMetadata/resource').each_with_index do |resource, index| %>
+          <li class="resource">
+            <span class="label">
+              Resource (<%= index+1 -%>)
+            </span> <%= resource['type'] -%>
+            <% if can_manage && version_open
+                 edit_resource_link="/items/#{params[:id]}/resource/?edit=true&resource=#{resource['id']}" %>
+              <%= link_to "(edit)", edit_resource_link, :data => {ajax_modal: 'trigger'} -%>
+            <% end %>
+            <% if resource.at('label') %>
+              <li>
+                <span class="label">
+                  Label
+                </span>
+                <%= resource.at('label').text -%>
+              </li>
+            <% end %>
+            <ul>
+             <%
+              # handle first-level of nested resources
+              inner_index = 0
+              resource.children.each do |child|
+                if child.node_name == 'resource'
+                  inner_index = inner_index+1 %>
+                  <li class="resource">
+                    <span class="label">
+                      Resource (<%= inner_index -%>)
+                    </span>
+                    <%= child['type'] -%>
+                    <% if can_manage && version_open
+                         edit_resource_link = '/items/'+params[:id]+'/resource/?edit=true&resource='+child['id'] %>
+                      <%= link_to "(edit)", edit_resource_link, :data => {ajax_modal: 'trigger'} -%>
+                    <% end %>
+                    <ul>
+                      <% if child.at('label') %>
+                        <li>
+                          <span class="label">
+                            Label
+                          </span>
+                          <%= child.at('label').text -%>
+                        </li>
+                      <% end %>
+                      <% child.xpath('file').each do |file| %>
+                        <li class="file">
+                          <span class="label">
+                            File
+                          </span>
+                          <% if can_manage %>
+                            <% manage_file_link = '/items/'+params[:id]+'/file_list/?file='+URI.escape(file['id']) %>
+                            <%= link_to file['id'], manage_file_link, :data => {ajax_modal: 'trigger'} -%>
+                          <% else %>
+                            <%= file['id'] -%>
+                          <% end %>
+                          (<%= file['mimetype'] -%>,
+                           <%= number_to_human_size(file['size']) -%>,
+                           <%= ['publish','shelve','preserve'].reject { |a| file[a] != 'yes' }.join('/') -%>)
+                        </li>
+                      <% end %>
+                      <%# show external links to files %>
+                      <% child.xpath('externalFile').each do |external_file| %>
+                        <li class="external-file">
+                          <span class="label">
+                            External File
+                          </span>
+                          <%= external_file['fileId'] -%>
+                          (from <%= link_to external_file['objectId'], catalog_path(external_file['objectId']) -%>,
+                           resource <%= external_file['resourceId'] -%>)
+                        </li>
+                      <% end %>
+                    </ul>
                   </li>
                 <% end %>
-                
-              </ul>
-            </li>
-          <% end %>
-        </ul>
-      </li>
-    </ul>
-  </div>
-<% else %>
-  <div style="clear:left">
-    <ul class="resource-tree">
-      <li>
-        <span class="label">Preservation Size</span> 0 bytes
-      </li>
-    </ul>
-  </div>
-<% end %>
+              <% end %>
+              <% resource.xpath('file').each do |file| %>
+                <li class="file">
+                  <span class="label">
+                    File
+                  </span>
+                  <% if can_view 
+                       file_link = '/items/'+params[:id]+'/file_list/?file='+URI.escape(file['id']) %>
+                    <%= link_to file['id'], file_link, :data => {ajax_modal: 'trigger'} -%>
+                  <% else %>
+                    <%= file['id'] -%>
+                  <% end %>
+                  (<%= file['mimetype'] -%>,
+                   <%= number_to_human_size(file['size']) -%>,
+                   <%= ['publish','shelve','preserve'].reject { |a| file[a] != 'yes' }.join('/') -%>)
+                </li>
+              <% end %>
+              <%# show external links to files %>
+              <% resource.xpath('externalFile').each do |external_file| %>
+                <li class="external-file">
+                  <span class="label">
+                    External File
+                  </span>
+                  <%= external_file['fileId'] -%>
+                  (from <%= link_to external_file['objectId'], catalog_path(external_file['objectId']) -%>,
+                   resource <%= external_file['resourceId'] -%>)
+                </li>
+              <% end %>
+            </ul>
+          </li>
+        <% end %>
+      </ul>
+    </li>
+  <% else %>
+  <%# empty contentMetadata %>
+    <li>
+      <span class="label">
+        Preservation Size
+      </span>
+      0 bytes
+    </li>
+  <% end %>
+  </ul>
+</div>


### PR DESCRIPTION
This PR fixes #485. It adds External File information into the Contents section of the catalog show page. The `_default_contents.html.erb` has ZERO tests, and all the data parsing, etc. is done in the view that is far from DRY. I did a major overhaul of the code formatting for the view to make it more readable hopefully. The only real part I added was the support for the `externalFile` elements. To test it, you need to create a contentMetadata datastream that has data as described in #485. If the manual testing is not acceptable, then I'd prefer to refactor how the view works (recommendations?). I also made some minor adjustments to the CSS styling.

Here's what the new display looks like:

![screen shot 2016-02-12 at 12 17 25 pm](https://cloud.githubusercontent.com/assets/1861171/13020039/f7b181da-d187-11e5-943f-c4639db42f37.png)
