### PR TITLE
Prevent crash when retrieving roles for an APO identifier that is nil.

### DIFF
--- a/app/helpers/argo_helper.rb
+++ b/app/helpers/argo_helper.rb
@@ -102,7 +102,6 @@ module ArgoHelper
   def render_buttons(doc, object = nil)
     pid = doc['id']
     object ||= Dor.find(pid)
-    # wf_stuff.include? 'accessionWF:completed:publish'
 
     apo_pid = doc.apo_pid
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,7 @@ class User < ActiveRecord::Base
   # @param [String] DRUID, fully qualified
   # @return [Array[String]] list of roles
   def roles(pid)
+    return [] if pid.nil?
     @role_cache ||= {}
     return @role_cache[pid] if @role_cache[pid]
 

--- a/spec/helpers/argo_helper_spec.rb
+++ b/spec/helpers/argo_helper_spec.rb
@@ -100,6 +100,13 @@ describe ArgoHelper, :type => :helper do
           expect(buttons).to include(button)
         end
       end
+      it 'should not generate errors given an object that has no associated APO' do
+        allow(@doc).to receive(:apo_pid).and_return(nil)
+        allow(@usr).to receive(:roles).with(nil).and_return([])
+        buttons = helper.render_buttons(@doc)
+        expect(buttons).not_to be_nil
+        expect(buttons.length).to be > 0
+      end
     end
   end
   describe 'render_facet_value' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 require 'spec_helper'
 
 describe User, :type => :model do
@@ -127,6 +125,9 @@ describe User, :type => :model do
       expect(Dor::SearchService).to receive(:query).once
       @user.roles('pid')
       @user.roles('pid')
+    end
+    it 'should return an empty array given a nil pid' do
+      expect(@user.roles(nil)).to eq([])
     end
   end
 


### PR DESCRIPTION
Fixes #334 