### PR TITLE
Use get_metadata_source() in dor_object_helper, a function that actua…

### DIFF
--- a/app/views/catalog/_show_field_list.html.erb
+++ b/app/views/catalog/_show_field_list.html.erb
@@ -7,15 +7,13 @@
       <dd class="blacklight-<%= solr_fname.parameterize %>">
         <%= render_document_show_field_value :document => document, :field => solr_fname %>
       </dd>
-    <% else %>
-      <% if solr_fname == 'metadata_source_ssi' %>
+    <% elsif solr_fname == 'metadata_source_ssi' %>
         <dt class="blacklight-<%= solr_fname.parameterize %>">
           <%= render_document_show_field_label :field => solr_fname %>
         </dt>
         <dd class="blacklight-<%= solr_fname.parameterize %>">
-          <%= metadata_source object %>
+          <%= get_metadata_source object %>
         </dd>
-      <% end %>
     <% end -%>
   <% end -%>
 </dl>

--- a/spec/views/catalog/_show_field_list.html.erb_spec.rb
+++ b/spec/views/catalog/_show_field_list.html.erb_spec.rb
@@ -28,5 +28,22 @@ RSpec.describe 'catalog/_show_field_list.html.erb' do
       field_value = [nil, 'does_not_have_to_be_date_value']
       validate_rendering(field_value)
     end
+
+    context 'when field is metadata_source_ssi' do
+      let(:field) { 'metadata_source_ssi' }
+      let(:label) { 'MD Source' }
+
+      it 'renders a document with no metadata_source_ssi without crashing' do
+        id_metadata = double('identity_metadata')
+        mock_obj = double('Dor::Item', { :identityMetadata => id_metadata })
+        allow(id_metadata).to receive(:otherId).with('mdtoolkit').and_return(['1']) # Non-zero length array of any value OK
+        allow(view).to receive(:object).and_return(mock_obj)
+        document = SolrDocument.new(id: 1)
+        allow(view).to receive(:document).and_return(document)
+        render
+        expect(rendered).not_to be_nil
+        expect(rendered).to have_css('dt', text: 'MD Source:')
+      end
+    end
   end
 end


### PR DESCRIPTION
…lly exists. This pull request cleans up the logic in _show_field_list.html.erb and changes it to reference the function get_metadata_source(). This should have been done when the metadata_source() method in dor_object_helper was renamed to get_metadata_source().