### PR TITLE
Remove cruft from tests.

### DIFF
--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -302,7 +302,7 @@ describe ItemsController, :type => :controller do
         expect { post 'datastream_update', :id => @pid, :content => xml }.to raise_error(ArgumentError)
       end
 
-      it 'should display an error message if an invalid APO is entered as governor', :focus => true do
+      it 'should display an error message if an invalid APO is entered as governor' do
         @mock_ds = double(Dor::ContentMetadataDS)
         allow(@mock_ds).to receive(:content=).and_return(true)
         allow(@item).to receive(:to_solr).and_raise(ActiveFedora::ObjectNotFoundError)

--- a/spec/features/bulk_screen_spec.rb
+++ b/spec/features/bulk_screen_spec.rb
@@ -15,7 +15,7 @@ feature 'Bulk actions view', js: true do
     expect_any_instance_of(ApplicationController).to receive(:current_user).at_least(:once).and_return(@current_user)
   end
 
-  scenario 'basic page renders ok', :focus => true do
+  scenario 'basic page renders ok' do
     visit report_bulk_path
 
     expect(page).to have_css('h1', 'Bulk update operations')


### PR DESCRIPTION
This removes the "focus" attribute from a couple of tests, which was accidentally left in.