### PR TITLE
switch to released dor-services version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'active-fedora'
 gem 'blacklight', '~> 5.9.0' # TODO: BL >= 5.10.x has new deprecation warnings vs <= 5.9.x, will investigate and unpin after current upgrade stuff has settled
 gem 'blacklight-hierarchy'
 gem 'blacklight-marc'
-gem 'dor-services', '~> 5.0', :git => 'https://github.com/sul-dlss/dor-services.git', :branch => 'develop'
+gem 'dor-services', '~> 5.3', '>= 5.3.4'
 gem 'is_it_working-cbeer'
 gem 'jettywrapper'
 gem 'moab-versioning'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,42 +5,6 @@ GIT
     rack-webauth (0.1.3)
       rack
 
-GIT
-  remote: https://github.com/sul-dlss/dor-services.git
-  revision: fcf348f8d6a6ccb3d2fd318119a8fc65fd353b26
-  branch: develop
-  specs:
-    dor-services (5.3.2)
-      active-fedora (~> 6.0)
-      activesupport (>= 3.2.18)
-      confstruct (~> 0.2.7)
-      dor-rights-auth (~> 1.0, >= 1.0.2)
-      dor-workflow-service (~> 1.8)
-      druid-tools (~> 0.4, >= 0.4.1)
-      equivalent-xml (~> 0.5, >= 0.5.1)
-      json (~> 1.8.1)
-      lyber-utils (~> 0.1.2)
-      moab-versioning (~> 1.4.4)
-      modsulator (~> 0.0.7)
-      net-sftp (~> 2.1.2)
-      net-ssh (~> 2.6.5)
-      nokogiri (~> 1.6)
-      nokogiri-pretty (~> 0.1)
-      om (~> 3.0)
-      osullivan (~> 0.0.3)
-      progressbar (~> 0.21)
-      rdf (~> 1.1.7)
-      rest-client (~> 1.7)
-      retries
-      rsolr-ext (~> 1.0.3)
-      ruby-cache (~> 0.3.0)
-      ruby-graphviz
-      rubydora (~> 1.6.5)
-      solrizer (~> 3.0)
-      stanford-mods (= 1.3.3)
-      systemu (~> 2.6)
-      uuidtools (~> 2.1.4)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -199,6 +163,36 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dor-rights-auth (1.0.2)
       nokogiri
+    dor-services (5.3.4)
+      active-fedora (~> 6.0)
+      activesupport (>= 3.2.18)
+      confstruct (~> 0.2.7)
+      dor-rights-auth (~> 1.0, >= 1.0.2)
+      dor-workflow-service (~> 1.8)
+      druid-tools (~> 0.4, >= 0.4.1)
+      equivalent-xml (~> 0.5, >= 0.5.1)
+      json (~> 1.8.1)
+      lyber-utils (~> 0.1.2)
+      moab-versioning (~> 2.0)
+      modsulator (~> 0.0.7)
+      net-sftp (~> 2.1.2)
+      net-ssh (~> 2.6.5)
+      nokogiri (~> 1.6)
+      nokogiri-pretty (~> 0.1)
+      om (~> 3.0)
+      osullivan (~> 0.0.3)
+      progressbar (~> 0.21)
+      rdf (~> 1.1.7)
+      rest-client (~> 1.7)
+      retries
+      rsolr-ext (~> 1.0.3)
+      ruby-cache (~> 0.3.0)
+      ruby-graphviz
+      rubydora (~> 1.6.5)
+      solrizer (~> 3.0)
+      stanford-mods (= 1.5.3)
+      systemu (~> 2.6)
+      uuidtools (~> 2.1.4)
     dor-workflow-service (1.8.0)
       activesupport (>= 3.2.1, < 5)
       confstruct (>= 0.2.7, < 2)
@@ -279,7 +273,7 @@ GEM
     mime-types (1.25.1)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
-    moab-versioning (1.4.4)
+    moab-versioning (2.0.0)
       confstruct
       json
       nokogiri
@@ -494,7 +488,8 @@ GEM
       net-scp (>= 1.1.2)
       net-ssh
       term-ansicolor
-    stanford-mods (1.3.3)
+    stanford-mods (1.5.3)
+      activesupport
       mods (~> 2.0.2)
     stomp (1.3.4)
     sul_styles (0.3.0)
@@ -563,7 +558,7 @@ DEPENDENCIES
   delayed_job
   delayed_job_active_record
   dlss-capistrano (~> 3.1)
-  dor-services (~> 5.0)!
+  dor-services (~> 5.3, >= 5.3.4)
   equivalent-xml (>= 0.6.0)
   factory_girl_rails
   http_logger


### PR DESCRIPTION
* specify use of the latest released dor-services 5.x (starting with the now current 5.3.4)
* bundle update dor-services