### PR TITLE
Remove outdated dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,8 +57,6 @@ gem 'sul_styles', '~> 0.3.0' # later versions require ruby 2.1 or higher
 
 group :test, :development do
   gem 'http_logger'
-  gem 'selenium-webdriver'
-  gem 'unicorn'
   gem 'rspec-rails', '~> 3'
   gem 'capybara'
   gem 'rack-test', :require => 'rack/test'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,7 +382,6 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
-    raindrops (0.15.0)
     rake (10.5.0)
     rdf (1.1.17.1)
       link_header (~> 0.0, >= 0.0.8)
@@ -454,11 +453,6 @@ GEM
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
     scrub_rb (1.0.1)
-    selenium-webdriver (2.49.0)
-      childprocess (~> 0.5)
-      multi_json (~> 1.0)
-      rubyzip (~> 1.0)
-      websocket (~> 1.0)
     simplecov (0.11.1)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -515,13 +509,8 @@ GEM
       unf_ext
     unf_ext (0.0.7.2)
     unicode (0.4.4.2)
-    unicorn (5.0.1)
-      kgio (~> 2.6)
-      rack
-      raindrops (~> 0.7)
     uuidtools (2.1.5)
     validatable (1.6.7)
-    websocket (1.2.2)
     websocket-driver (0.6.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -598,7 +587,6 @@ DEPENDENCIES
   ruby-graphviz
   ruby-prof
   sass-rails
-  selenium-webdriver
   simplecov
   solrizer
   sprockets (~> 3.4)
@@ -610,7 +598,6 @@ DEPENDENCIES
   therubyracer (~> 0.11)
   uglifier (>= 1.0.3)
   unicode
-  unicorn
   wfs_rails (~> 0.0.2)
 
 BUNDLED WITH


### PR DESCRIPTION
 - Selenium-Webrick is no longer needed, as we use poltergeist
 - Unicorn is not needed, we use the default Rails server Webrick