### PR TITLE
reindex and commit newly registered objects before returning

### DIFF
--- a/app/controllers/dor/objects_controller.rb
+++ b/app/controllers/dor/objects_controller.rb
@@ -9,6 +9,16 @@ class Dor::ObjectsController < ApplicationController
     response = Dor::RegistrationService.create_from_request(params)
     pid = response[:pid]
 
+    #
+    # we need to reindex and *commit* this new object so that source id checks
+    # (which read from the index) work in future registrations.
+    #
+    # TODO: thus note that this create endpoint will have race conditions if the client
+    # sends registration requests concurrently -- ideally this registration should be
+    # a serialized process
+    #
+    Dor::IndexingService.reindex_pid_list([pid], true)
+
     respond_to do |format|
       format.json { render :json => response, :location => object_location(pid) }
       format.xml  { render :xml  => response, :location => object_location(pid) }

--- a/spec/controllers/dor/objects_controller_spec.rb
+++ b/spec/controllers/dor/objects_controller_spec.rb
@@ -10,6 +10,9 @@ describe Dor::ObjectsController, :type => :controller do
       expect(Dor::RegistrationService)
         .to receive(:create_from_request)
         .and_return(dor_registration)
+      expect(Dor::IndexingService)
+        .to receive(:reindex_pid_list)
+        .with([dor_registration[:pid]], true) # commits reindex
       post :create
     end
   end


### PR DESCRIPTION
This PR fixes #531 by using the dor-services IndexingService to synchronously update the index, without waiting for the reindexing pipeline to engage. @jmartin-sul can you please review this?