### PR TITLE
cap for stage-a & prod-a

### DIFF
--- a/config/deploy/prod-a.rb
+++ b/config/deploy/prod-a.rb
@@ -1,0 +1,8 @@
+server 'argo-prod-a.stanford.edu', user: 'lyberadmin', roles: %w(web db app)
+
+Capistrano::OneTimeKey.generate_one_time_key!
+set :rails_env, 'production'
+
+set :deploy_to, '/opt/app/lyberadmin/argo'
+
+set :delayed_job_workers, 16

--- a/config/deploy/stage-a.rb
+++ b/config/deploy/stage-a.rb
@@ -1,0 +1,8 @@
+server 'argo-stage-a.stanford.edu', user: 'lyberadmin', roles: %w(web db app)
+
+Capistrano::OneTimeKey.generate_one_time_key!
+set :rails_env, 'staging'
+
+set :deploy_to, '/opt/app/lyberadmin/argo'
+
+set :delayed_job_workers, 10


### PR DESCRIPTION
Adds capistrano for new load balancer ready nodes. After I rebuild `argo-stage-b` and `argo-prod-b` to use the remote mysql machine I will clean up these cap environments to deploy both `-a` and `-b` nodes at the same time.