### PR TITLE
Consistent use of @obj in catalog controller

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -207,7 +207,7 @@ class CatalogController < ApplicationController
   end
 
   def bulk_upload_form
-    @object = Dor.find params[:id]
+    @obj = Dor.find params[:id]
   end
 
   # Lets the user start a bulk metadata job (i.e. upload a metadata spreadsheet/XML file).

--- a/app/views/catalog/bulk_upload_form.html.erb
+++ b/app/views/catalog/bulk_upload_form.html.erb
@@ -1,20 +1,20 @@
 <div data-ajax-modal="container">
     <div id="spreadsheet-upload-container">
-	<%= form_tag(upload_path(@object.id), multipart: true) do %>
+	<%= form_tag(upload_path(@obj.id), multipart: true) do %>
         <div id="bulk-upload-form" class="container-fluid">
 	    <div class="row spreadsheet-row">
 		<div class="col-md-10">
 		    <strong>Submit MODS descriptive metadata for bulk processing</strong>
 		</div>
 		<div class="col-md-2 spreadsheet-right">
-		    <%= link_to('Help', bulk_jobs_help_path(@object.id), :data => { ajax_modal: 'trigger' }) %>
+		    <%= link_to('Help', bulk_jobs_help_path(@obj.id), :data => { ajax_modal: 'trigger' }) %>
 		</div>
 	    </div>
 	    <div class="row spreadsheet-row">
 		<div class="col-md-2 spreadsheet-file-action-column"><strong>1. Select</strong></div>
 		<div class="col-md-4 spreadsheet-file-upload-column">
 		    <%= file_field_tag :spreadsheet_file, onchange: 'validate_spreadsheet_filetype()' %>
-		    <input type="hidden" name="druid" value="<%=@object.id %>" />
+		    <input type="hidden" name="druid" value="<%=@obj.id %>" />
 		</div>
 	    </div>
     	    <div class="row spreadsheet-row">


### PR DESCRIPTION
Pulled out of https://github.com/sul-dlss/argo/pull/532

The motivation for this is simply consistent use of `@obj` in the catalog controller.  Although other controllers may use `@object`, changing the catalog controller and all it's views to match may be a much bigger task than making the bulk action(s) and views use `@obj`.

This is ready for review and I'm guessing @tingulfsen could review this one.