### PR TITLE
Consolidate Argo user groups/roles in the User model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,12 +3,36 @@ class User < ActiveRecord::Base
   include Blacklight::User
   has_many :bulk_actions
 
+  # The code base requires Arrays for these constants, for intersection ops.
+  ADMIN_GROUPS = %w(workgroup:sdr:administrator-role).freeze
+  MANAGER_GROUPS = %w(workgroup:sdr:manager-role).freeze
+  VIEWER_GROUPS = %w(workgroup:sdr:viewer-role).freeze
+
+  # TODO: redefine `KNOWN_ROLES` using Dor::Governable.
+  # The KNOWN_ROLES should be consistent with Dor::Governable so that the
+  # set intersections can work as required.
+  # This depends on changes in dor-services, e.g.
+  # https://github.com/sul-dlss/dor-services/pull/150
+  # Dor::Governable::KNOWN_ROLES
+
+  # @return [Array<String>] list of roles the user can adopt
+  KNOWN_ROLES = %w(
+    dor-apo-creator
+    dor-apo-depositor
+    dor-apo-manager
+    dor-apo-metadata
+    dor-apo-reviewer
+    dor-apo-viewer
+    sdr-administrator
+    sdr-viewer
+  ).freeze
+
   attr_accessor :webauth
 
   delegate :permitted_apos, :permitted_collections, to: :permitted_queries
 
   def permitted_queries
-    @permitted_queries ||= PermittedQueries.new(groups, known_roles, is_admin)
+    @permitted_queries ||= PermittedQueries.new(groups, KNOWN_ROLES, is_admin)
   end
 
   def self.find_or_create_by_webauth(webauth)
@@ -26,67 +50,74 @@ class User < ActiveRecord::Base
     webauth.attributes['DISPLAYNAME'] || webauth.login
   end
 
-  @role_cache = {}
-
   # Queries Solr for a given record, returning synthesized role strings that are defined. Searches:
   # (1) for User by sunet id
   # (2) groups actually contains the sunetid, so it is just looking at different solr fields
   # NOTE: includes legacy roles that have to be translated
-  # @param [String] DRUID, fully qualified
-  # @return [Array[String]] list of roles
+  # @param [String] Object identifier (PID)
+  # @return [Array<String>] set of roles permitted for PID
   def roles(pid)
-    return [] if pid.nil?
+    return [] if pid.blank?
     @role_cache ||= {}
     return @role_cache[pid] if @role_cache[pid]
-
-    resp = Dor::SearchService.query('id:"' + pid + '"')['response']['docs'].first || {}
-    toret = []
-    my_groups = groups
-    %w(apo_role_group_manager_ssim apo_role_person_manager_ssim).each do |key|
-      toret << 'dor-apo-manager' if resp[key] && (resp[key] & my_groups).length > 0
+    # Try to retrieve a Solr doc
+    obj_doc = Dor::SearchService.query('id:"' + pid + '"')['response']['docs'].first || {}
+    return [] if obj_doc.empty?
+    pid_roles = Set.new
+    # Determine whether user has 'dor-apo-manager' role
+    solr_apo_roles = %w(apo_role_group_manager_ssim apo_role_person_manager_ssim)
+    pid_roles << 'dor-apo-manager' if solr_apo_roles.any? {|r| solr_role_allowed?(obj_doc, r)}
+    # Check additional known roles
+    KNOWN_ROLES.each do |role|
+      solr_apo_roles = ["apo_role_#{role}_ssim", "apo_role_person_#{role}_ssim"]
+      pid_roles << role if solr_apo_roles.any? {|r| solr_role_allowed?(obj_doc, r)}
     end
-
-    known_roles.each do |role|
-      ["apo_role_#{role}_ssim", "apo_role_person_#{role}_ssim"].each do |key|
-        toret << role if resp[key] && (resp[key] & my_groups).length > 0
-      end
-    end
-    @role_cache[pid] = toret # store this for now, there may be several role related calls
-    toret
+    # store and return an array of roles (Set.sort is an Array)
+    @role_cache[pid] = pid_roles.sort
   end
 
-  # @return [Array<String>] list of apos the user is allowed to view
-  def known_roles
-    ['dor-administrator', 'sdr-administrator', 'dor-viewer', 'sdr-viewer', 'dor-apo-creator', 'dor-apo-manager', 'dor-apo-depositor', 'dor-apo-reviewer', 'dor-apo-metadata', 'dor-apo-viewer']
+  # Validate a user belongs to a workgroup allowed to access a DOR object
+  # @param dor_doc [Hash] A Solr document for a DOR object
+  # @param role [String] Role to be validated for the DOR object
+  def solr_role_allowed?(solr_doc, solr_role)
+    # solr_doc[solr_role] returns an array of groups permitted to adopt the role
+    !(solr_doc[solr_role] & groups).blank?
   end
 
-  @groups_to_impersonate = nil
-  # Allow a repository admin to see the repository as if they had a different set of permissions
-  # @param [Array<String>] set of groups
+  # Allow a repository admin to see the repository with different permissions
+  # @param grps [Array<String>|String|nil] set of groups
   def set_groups_to_impersonate(grps)
-    @groups_to_impersonate = grps
+    # remove any existing impersonation (see #groups below)
+    @role_cache = {}
+    @groups_to_impersonate = if grps.blank?
+                               nil
+                             else
+                               grps.instance_of?(String) ? [grps] : grps
+                             end
   end
 
   def groups
-    return @groups_to_impersonate if @groups_to_impersonate
-    perm_keys = ["sunetid:#{login}"]
-    return perm_keys unless webauth && webauth.privgroup.present?
-    perm_keys + webauth.privgroup.split(/\|/).collect { |g| "workgroup:#{g}" }
+    return @groups_to_impersonate unless @groups_to_impersonate.blank?
+    @groups ||= begin
+      perm_keys = ["sunetid:#{login}"]
+      return perm_keys unless webauth && webauth.privgroup.present?
+      perm_keys + webauth.privgroup.split(/\|/).map {|g| "workgroup:#{g}"}
+    end
   end
 
   # @return [Boolean] is the user a repository wide administrator
   def is_admin
-    !(groups & ADMIN_GROUPS).empty?
+    !(groups & ADMIN_GROUPS).blank?
+  end
+
+  # @return [Boolean] is the user a repository wide manager
+  def is_manager
+    !(groups & MANAGER_GROUPS).blank?
   end
 
   # @return [Boolean] is the user a repository wide viewer
   def is_viewer
-    !(groups & VIEWER_GROUPS).empty?
-  end
-
-  # @return [Boolean] is the user a repo wide manager
-  def is_manager
-    !(groups & MANAGER_GROUPS).empty?
+    !(groups & VIEWER_GROUPS).blank?
   end
 
   # https://github.com/bbatsov/ruby-style-guide#alias-method-lexically

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -1,3 +1,0 @@
-ADMIN_GROUPS = ['workgroup:sdr:administrator-role', 'workgroup:dlss:dor-admin']
-VIEWER_GROUPS = ['workgroup:sdr:viewer-role', 'workgroup:dlss:dor-viewer']
-MANAGER_GROUPS = ['workgroup:sdr:manager-role', 'workgroup:dlss:dor-manager']

--- a/lib/tasks/argo.rake
+++ b/lib/tasks/argo.rake
@@ -295,10 +295,11 @@ namespace :argo do
     unless facet.nil?
       facets = facet.items.map(&:value)
       priv_groups = facets.select { |v| v =~ /^workgroup:/ }
-      priv_groups += (ADMIN_GROUPS + VIEWER_GROUPS + MANAGER_GROUPS) # we know that we always want these built-in groups to be part of .htaccess
-      priv_groups.uniq! # no need to repeat ourselves (mostly there in case the builtin groups are already listed in APOs)
-
-      directives += priv_groups.collect { |v|
+      # we always want these built-in groups to be part of .htaccess
+      priv_groups += User::ADMIN_GROUPS
+      priv_groups += User::MANAGER_GROUPS
+      priv_groups += User::VIEWER_GROUPS
+      directives += priv_groups.uniq.map { |v|
         ["Require privgroup #{v.split(/:/, 2).last}", "WebAuthLdapPrivgroup #{v.split(/:/, 2).last}"]
       }.flatten
 

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -5,11 +5,17 @@ describe ItemsController, :type => :controller do
     @item = double(Dor::Item)
     @pid  = 'druid:oo201oo0001'
     @current_user = User.find_or_create_by_webauth(
-      double('webauth', :login => 'sunetid', :attributes => { 'DISPLAYNAME' => 'Rando User'}, :logged_in? => true, :privgroup => ADMIN_GROUPS.first)
+      double(
+        'webauth',
+        :login => 'sunetid',
+        :attributes => { 'DISPLAYNAME' => 'Rando User'},
+        :logged_in? => true,
+        :privgroup => User::ADMIN_GROUPS.first
+      )
     )
     allow(@current_user).to receive(:is_admin).and_return(true)
-    allow(@current_user).to receive(:roles).and_return([])
     allow(@current_user).to receive(:is_manager).and_return(false)
+    allow(@current_user).to receive(:roles).and_return([])
     allow_any_instance_of(ItemsController).to receive(:current_user).and_return(@current_user)
     allow(Dor::Item).to receive(:find).with(@pid).and_return(@item)
     idmd = double()

--- a/spec/controllers/registration_controller_spec.rb
+++ b/spec/controllers/registration_controller_spec.rb
@@ -3,7 +3,12 @@ require 'spec_helper'
 describe RegistrationController, :type => :controller do
   before :each do
     @item = double(Dor::Item)
-    @current_user = double(:webauth_user, :login => 'sunetid', :logged_in? => true, :privgroup => ADMIN_GROUPS.first)
+    @current_user = double(
+      :webauth_user,
+      :login => 'sunetid',
+      :logged_in? => true,
+      :privgroup => User::ADMIN_GROUPS.first
+    )
     allow(@current_user).to receive(:is_admin).and_return(true)
     allow(controller).to receive(:current_user).and_return(@current_user)
     allow(Dor::Item).to receive(:find).and_return(@item)

--- a/spec/integration/about_page_spec.rb
+++ b/spec/integration/about_page_spec.rb
@@ -2,10 +2,15 @@ require 'spec_helper'
 
 describe 'about_page', :type => :request do
   before :each do
-    @current_user = double(:webauth_user, :login => 'sunetid', :logged_in? => true, :privgroup => ADMIN_GROUPS.first)
+    @current_user = double(
+      :webauth_user,
+      :login => 'sunetid',
+      :logged_in? => true,
+      :privgroup => User::ADMIN_GROUPS.first
+    )
     allow(@current_user).to receive(:is_admin).and_return(true)
-    allow(@current_user).to receive(:roles).and_return([])
     allow(@current_user).to receive(:is_manager).and_return(false)
+    allow(@current_user).to receive(:roles).and_return([])
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@current_user)
   end
 

--- a/spec/integration/apo_spec.rb
+++ b/spec/integration/apo_spec.rb
@@ -1,11 +1,16 @@
 require 'spec_helper'
 
 def user_stub
-  webauth = double('WebAuth', :login => 'sunetid', :attributes => {'DISPLAYNAME' => 'Example User'}, :privgroup => ADMIN_GROUPS.first)
+  webauth = double(
+    'WebAuth',
+    :login => 'sunetid',
+    :attributes => {'DISPLAYNAME' => 'Example User'},
+    :privgroup => User::ADMIN_GROUPS.first
+  )
   @current_user = User.find_or_create_by_webauth(webauth)
   allow(@current_user).to receive(:is_admin).and_return(true)
-  allow(@current_user).to receive(:roles).and_return([])
   allow(@current_user).to receive(:is_manager).and_return(false)
+  allow(@current_user).to receive(:roles).and_return([])
   allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@current_user)
 end
 

--- a/spec/integration/item_displays_spec.rb
+++ b/spec/integration/item_displays_spec.rb
@@ -4,10 +4,16 @@ describe 'mods_view', :type => :request do
   before :each do
     @object = instantiate_fixture('druid_zt570tx3016', Dor::Item)
     allow(Dor::Item).to receive(:find).and_return(@object)
-    @current_user = double(:webauth_user, :login => 'sunetid', :logged_in? => true, :privgroup => ADMIN_GROUPS.first, can_view_something?: true)
+    @current_user = double(
+      :webauth_user,
+      :login => 'sunetid',
+      :logged_in? => true,
+      :privgroup => User::ADMIN_GROUPS.first,
+      can_view_something?: true
+    )
     allow(@current_user).to receive(:is_admin).and_return(true)
-    allow(@current_user).to receive(:roles).and_return([])
     allow(@current_user).to receive(:is_manager).and_return(false)
+    allow(@current_user).to receive(:roles).and_return([])
     allow(@current_user).to receive(:permitted_apos).and_return([])
 
     ##

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,8 @@
 require 'spec_helper'
 
+# General documentation about roles and permissions is on SUL Consul at
+# https://consul.stanford.edu/display/chimera/Repository+Roles+and+Permissions
+
 describe User, :type => :model do
   describe '.find_or_create_by_webauth' do
     it 'should work' do
@@ -40,94 +43,216 @@ describe User, :type => :model do
   end
 
   describe 'is_admin' do
+    it 'is aliased to is_admin?' do
+      allow(subject).to receive(:groups).and_return(User::ADMIN_GROUPS)
+      expect(subject).to respond_to('is_admin?')
+      expect(subject.is_admin).to be true
+      expect(subject.is_admin?).to be true
+      expect(subject.is_admin).to be subject.is_admin?
+    end
     it 'should be true if the group is an admin group' do
       allow(subject).to receive(:groups).and_return(['workgroup:sdr:administrator-role'])
-      expect(subject.is_admin).to be_truthy
+      expect(subject.is_admin).to be true
     end
-    it 'should be true if the group is a deprecated admin group' do
+    it 'should be false if the group is a deprecated admin group' do
       allow(subject).to receive(:groups).and_return(['workgroup:dlss:dor-admin'])
-      expect(subject.is_admin).to be_truthy
+      expect(subject.is_admin).to be false
     end
-    it 'should be false otherwise' do
+    it 'should be false for a blank group' do
       allow(subject).to receive(:groups).and_return([])
-      expect(subject.is_admin).to be_falsey
+      expect(subject.is_admin).to be false
+      allow(subject).to receive(:groups).and_return(nil)
+      expect(subject.is_admin).to be false
     end
-    it 'should be false even with an inadequate group membership' do
-      allow(subject).to receive(:groups).and_return(['workgroup:dlss:not_an_admin'])
-      expect(subject.is_admin).to be_falsey
-      expect(subject.is_admin?).to be_falsey
+    it 'should be false with an inadequate group membership' do
+      allow(subject).to receive(:groups).and_return(['workgroup:dlss:not-admin'])
+      expect(subject.is_admin).to be false
+    end
+    it 'should be true for ADMIN_GROUPS' do
+      allow(subject).to receive(:groups).and_return(User::ADMIN_GROUPS)
+      expect(subject.is_admin).to be true
+    end
+    it 'should be false for MANAGER_GROUPS' do
+      allow(subject).to receive(:groups).and_return(User::MANAGER_GROUPS)
+      expect(subject.is_admin).to be false
+    end
+    it 'should be false for VIEWER_GROUPS' do
+      allow(subject).to receive(:groups).and_return(User::VIEWER_GROUPS)
+      expect(subject.is_admin).to be false
     end
   end
 
   describe 'is_manager' do
+    it 'is aliased to is_manager?' do
+      allow(subject).to receive(:groups).and_return(User::MANAGER_GROUPS)
+      expect(subject).to respond_to('is_manager?')
+      expect(subject.is_manager).to be true
+      expect(subject.is_manager?).to be true
+      expect(subject.is_manager).to be subject.is_manager?
+    end
     it 'should be true if the group is a manager group' do
       allow(subject).to receive(:groups).and_return(['workgroup:sdr:manager-role'])
-      expect(subject.is_manager).to be_truthy
+      expect(subject.is_manager).to be true
     end
-    it 'should be true if the group is a deprecated manager group' do
+    it 'should be false if the group is a deprecated manager group' do
       allow(subject).to receive(:groups).and_return(['workgroup:dlss:dor-manager'])
-      expect(subject.is_manager).to be_truthy
+      expect(subject.is_manager).to be false
     end
-    it 'should be false otherwise' do
+    it 'should be false for a blank group' do
       allow(subject).to receive(:groups).and_return([])
-      expect(subject.is_manager).to be_falsey
-      expect(subject.is_manager?).to be_falsey
+      expect(subject.is_manager).to be false
+      allow(subject).to receive(:groups).and_return(nil)
+      expect(subject.is_manager).to be false
+    end
+    it 'should be false with an inadequate group membership' do
+      allow(subject).to receive(:groups).and_return(['workgroup:dlss:not-manager'])
+      expect(subject.is_manager).to be false
+    end
+    it 'should be false for ADMIN_GROUPS' do
+      allow(subject).to receive(:groups).and_return(User::ADMIN_GROUPS)
+      expect(subject.is_manager).to be false
+    end
+    it 'should be true for MANAGER_GROUPS' do
+      allow(subject).to receive(:groups).and_return(User::MANAGER_GROUPS)
+      expect(subject.is_manager).to be true
+    end
+    it 'should be false for VIEWER_GROUPS' do
+      allow(subject).to receive(:groups).and_return(User::VIEWER_GROUPS)
+      expect(subject.is_manager).to be false
     end
   end
 
   describe 'is_viewer' do
+    it 'is aliased to is_viewer?' do
+      allow(subject).to receive(:groups).and_return(User::VIEWER_GROUPS)
+      expect(subject).to respond_to('is_viewer?')
+      expect(subject.is_viewer).to be true
+      expect(subject.is_viewer?).to be true
+      expect(subject.is_viewer).to be subject.is_viewer?
+    end
     it 'should be true if the group is a viewer group' do
       allow(subject).to receive(:groups).and_return(['workgroup:sdr:viewer-role'])
-      expect(subject.is_viewer).to be_truthy
+      expect(subject.is_viewer).to be true
     end
-    it 'should be true if the group is a deprecated viewer group' do
+    it 'should be false if the group is a deprecated viewer group' do
       allow(subject).to receive(:groups).and_return(['workgroup:dlss:dor-viewer'])
-      expect(subject.is_viewer).to be_truthy
+      expect(subject.is_viewer).to be false
     end
-    it 'should be false otherwise' do
+    it 'should be false for a blank group' do
       allow(subject).to receive(:groups).and_return([])
-      expect(subject.is_viewer).to be_falsey
-      expect(subject.is_viewer?).to be_falsey
+      expect(subject.is_viewer).to be false
+      allow(subject).to receive(:groups).and_return(nil)
+      expect(subject.is_viewer).to be false
+    end
+    it 'should be false with an inadequate group membership' do
+      allow(subject).to receive(:groups).and_return(['workgroup:dlss:not-viewer'])
+      expect(subject.is_viewer).to be false
+    end
+    it 'should be false for ADMIN_GROUPS' do
+      allow(subject).to receive(:groups).and_return(User::ADMIN_GROUPS)
+      expect(subject.is_viewer).to be false
+    end
+    it 'should be false for MANAGER_GROUPS' do
+      allow(subject).to receive(:groups).and_return(User::MANAGER_GROUPS)
+      expect(subject.is_viewer).to be false
+    end
+    it 'should be true for VIEWER_GROUPS' do
+      allow(subject).to receive(:groups).and_return(User::VIEWER_GROUPS)
+      expect(subject.is_viewer).to be true
+    end
+  end
+
+  describe 'KNOWN_ROLES' do
+    it 'contains roles defined in Dor::Governable'
+  end
+
+  describe 'solr_role_allowed' do
+    let(:solr_doc) do
+      {
+        'roleA' => ['dlss:groupA', 'dlss:groupB'],
+        'roleB' => ['dlss:groupA', 'dlss:groupC']
+      }
+    end
+    before :each do
+      allow(subject).to receive(:groups).and_return(['dlss:groupA'])
+    end
+    it 'returns true when DOR solr document has a role with values that include a user group' do
+      expect(subject.solr_role_allowed?(solr_doc, 'roleA')).to be true
+    end
+    it 'returns false when DOR solr document has a role with values that do not include a user group' do
+      allow(subject).to receive(:groups).and_return(['dlss:groupX'])
+      expect(subject.solr_role_allowed?(solr_doc, 'roleA')).to be false
+    end
+    it 'returns false when DOR solr document has no matching roles' do
+      expect(subject.solr_role_allowed?(solr_doc, 'roleX')).to be false
+    end
+    it 'returns false when DOR solr document is empty' do
+      expect(subject.solr_role_allowed?({}, 'roleA')).to be false
+    end
+    it 'returns false when user belongs to no groups' do
+      allow(subject).to receive(:groups).and_return([])
+      expect(subject.solr_role_allowed?(solr_doc, 'roleA')).to be false
     end
   end
 
   describe 'roles' do
-    before(:each) do
-      @answer = {}
-      @doc = {
-        'apo_role_dor-administrator_ssim' => ['workgroup:dlss:groupA', 'workgroup:dlss:groupB'],
-        'apo_role_sdr-administrator_ssim' => ['workgroup:dlss:groupA', 'workgroup:dlss:groupB'],
-        'apo_role_dor-apo-manager_ssim'   => ['workgroup:dlss:groupC', 'workgroup:dlss:groupD'],
-        'apo_role_dor-viewer_ssim'        => ['workgroup:dlss:groupE', 'workgroup:dlss:groupF'],
-        'apo_role_sdr-viewer_ssim'        => ['workgroup:dlss:groupE', 'workgroup:dlss:groupF'],
-        'apo_role_person_dor-viewer_ssim' => ['sunetid:tcramer'],
-        'apo_role_person_sdr-viewer_ssim' => ['sunetid:tcramer'],
-        'apo_role_group_manager_ssim'     => ['workgroup:dlss:groupR']
+    # The exact DRUID is not important in these specs, because
+    # the Dor::SearchService is mocked to return solr_doc.
+    let(:druid) { 'druid:ab123cd4567' }
+    let(:answer) do
+      {
+        'response' => { 'docs' => [solr_doc] }
       }
-      @answer['response'] = { 'docs' => [@doc] }
-      allow(Dor::SearchService).to receive(:query).and_return(@answer)
-      @user = User.find_or_create_by_webauth(double('webauth', :login => 'asdf'))
     end
-    it 'should build a set of roles' do
-      expect(@user).to receive(:groups).and_return(['workgroup:dlss:groupF', 'workgroup:dlss:groupA'])
-      expect(@user.roles('pid')).to eq(['dor-administrator', 'sdr-administrator', 'dor-viewer', 'sdr-viewer'])
+    let(:solr_doc) do
+      {
+        'apo_role_sdr-administrator_ssim' => %w(workgroup:dlss:groupA workgroup:dlss:groupB),
+        'apo_role_sdr-viewer_ssim'        => %w(workgroup:dlss:groupE workgroup:dlss:groupF),
+        'apo_role_dor-apo-manager_ssim'   => %w(workgroup:dlss:groupC workgroup:dlss:groupD),
+        'apo_role_person_sdr-viewer_ssim' => %w(sunetid:tcramer),
+        'apo_role_group_manager_ssim'     => %w(workgroup:dlss:groupR)
+      }
+    end
+    before(:each) do
+      allow(Dor::SearchService).to receive(:query).and_return(answer)
+    end
+    it 'should accept any object identifier' do
+      expect{subject.roles(druid)}.not_to raise_error
+      expect{subject.roles('anyStringOK')}.not_to raise_error
+    end
+    it 'should return an empty array for any blank object identifer' do
+      ['', nil].each do |pid|
+        expect{subject.roles(pid)}.not_to raise_error
+        expect(subject.roles(pid)).to be_empty
+      end
+    end
+    it 'should build a set of roles from groups' do
+      user_groups = %w(workgroup:dlss:groupF workgroup:dlss:groupA)
+      user_roles = %w(sdr-administrator sdr-viewer)
+      expect(subject).to receive(:groups).and_return(user_groups).at_least(:once)
+      expect(subject.roles(druid)).to eq(user_roles)
     end
     it 'should translate the old "manager" role into dor-apo-manager' do
-      expect(@user).to receive(:groups).and_return(['workgroup:dlss:groupR'])
-      expect(@user.roles('pid')).to eq(['dor-apo-manager'])
+      expect(subject).to receive(:groups).and_return(['workgroup:dlss:groupR']).at_least(:once)
+      expect(subject.roles(druid)).to eq(['dor-apo-manager'])
     end
-    it 'should work correctly if the individual is named in the apo, but isnt in any groups that matter' do
-      expect(@user).to receive(:groups).and_return(['sunetid:tcramer'])
-      expect(@user.roles('pid')).to eq(['dor-viewer', 'sdr-viewer'])
+    it 'should return an empty set of roles if the DRUID solr search fails' do
+      empty_doc = { 'response' => { 'docs' => [] } }
+      allow(Dor::SearchService).to receive(:query).and_return(empty_doc)
+      # check that the code will return immediately if solr doc is empty
+      expect(subject).not_to receive(:groups)
+      expect(subject).not_to receive(:solr_role_allowed?)
+      expect(subject.roles(druid)).to be_empty
+    end
+    it 'should work correctly if the individual is named in the apo, but is not in any groups that matter' do
+      expect(subject).to receive(:groups).and_return(['sunetid:tcramer']).at_least(:once)
+      expect(subject.roles(druid)).to eq(['sdr-viewer'])
     end
     it 'should hang onto results through the life of the user object, avoiding multiple solr searches to find the roles for the same pid multiple times' do
-      expect(@user).to receive(:groups).and_return(['testdoesnotcarewhatishere'])
+      expect(subject).to receive(:groups).and_return(['testdoesnotcarewhatishere']).at_least(:once)
       expect(Dor::SearchService).to receive(:query).once
-      @user.roles('pid')
-      @user.roles('pid')
-    end
-    it 'should return an empty array given a nil pid' do
-      expect(@user.roles(nil)).to eq([])
+      subject.roles(druid)
+      subject.roles(druid)
     end
   end
 
@@ -142,7 +267,7 @@ describe User, :type => :model do
         expect(@user.groups).to eq(expected_groups)
       end
       it 'should return the groups by impersonation' do
-        impersonated_groups = ['workgroup:dlss:impersonatedgroup1', 'workgroup:dlss:impersonatedgroup2']
+        impersonated_groups = %w(workgroup:dlss:impersonatedgroup1 workgroup:dlss:impersonatedgroup2)
         @user.set_groups_to_impersonate(impersonated_groups)
         expect(@user.groups).to eq(impersonated_groups)
       end
@@ -151,30 +276,69 @@ describe User, :type => :model do
       webauth_privgroup_str = 'sdr:administrator-role|sdr:manager-role|sdr:viewer-role'
       mock_webauth = double('webauth', :login => 'asdf', :logged_in? => true, :privgroup => webauth_privgroup_str)
       user = User.find_or_create_by_webauth(mock_webauth)
-      expect(user.is_admin  ).to be_truthy
-      expect(user.is_manager).to be_truthy
-      expect(user.is_viewer ).to be_truthy
-      user.set_groups_to_impersonate(['workgroup:sdr:not-an-administrator-role', 'workgroup:sdr:not-a-manager-role', 'workgroup:sdr:not-a-viewer-role'])
-      expect(user.is_admin  ).to be_falsey
-      expect(user.is_manager).to be_falsey
-      expect(user.is_viewer ).to be_falsey
+      expect(user.is_admin).to be true
+      expect(user.is_manager).to be true
+      expect(user.is_viewer).to be true
+      user.set_groups_to_impersonate(%w(workgroup:sdr:not-an-administrator-role workgroup:sdr:not-a-manager-role workgroup:sdr:not-a-viewer-role))
+      expect(user.is_admin).to be false
+      expect(user.is_manager).to be false
+      expect(user.is_viewer).to be false
     end
   end
+
+  describe 'set_groups_to_impersonate' do
+    def groups_to_impersonate
+      subject.instance_variable_get(:@groups_to_impersonate)
+    end
+    before :each do
+      subject.instance_variable_set(:@groups_to_impersonate, %w(a b))
+    end
+    it 'resets the role_cache' do
+      subject.instance_variable_set(:@role_cache, {a: 1})
+      subject.set_groups_to_impersonate []
+      expect(subject.instance_variable_get(:@role_cache)).to be_empty
+    end
+    it 'removes impersonation groups when given nil' do
+      subject.set_groups_to_impersonate nil
+      expect(groups_to_impersonate).to be_nil
+    end
+    it 'removes impersonation groups when given an empty String' do
+      subject.set_groups_to_impersonate ''
+      expect(groups_to_impersonate).to be_nil
+    end
+    it 'removes impersonation groups when given an empty Array' do
+      subject.set_groups_to_impersonate []
+      expect(groups_to_impersonate).to be_nil
+    end
+    it 'removes impersonation groups when given an empty Hash' do
+      subject.set_groups_to_impersonate({})
+      expect(groups_to_impersonate).to be_nil
+    end
+    it 'returns an Array<String> given a String argument' do
+      subject.set_groups_to_impersonate 'groupA'
+      expect(groups_to_impersonate).to eq ['groupA']
+    end
+    it 'returns an Array<String> argument as given' do
+      subject.set_groups_to_impersonate ['groupA']
+      expect(groups_to_impersonate).to eq ['groupA']
+    end
+  end
+
   describe '#can_view_something?' do
     it 'returns false' do
-      expect(subject.can_view_something?).to be_falsey
+      expect(subject.can_view_something?).to be false
     end
     context 'when admin' do
       it 'returns true' do
         expect(subject).to receive(:is_admin).and_return(true)
-        expect(subject.can_view_something?).to be_truthy
+        expect(subject.can_view_something?).to be true
       end
     end
     context 'when manager' do
       it 'returns true' do
         expect(subject).to receive(:is_admin).and_return(false)
         expect(subject).to receive(:is_manager).and_return(true)
-        expect(subject.can_view_something?).to be_truthy
+        expect(subject.can_view_something?).to be true
       end
     end
     context 'when viewer' do
@@ -182,7 +346,7 @@ describe User, :type => :model do
         expect(subject).to receive(:is_admin).and_return(false)
         expect(subject).to receive(:is_manager).and_return(false)
         expect(subject).to receive(:is_viewer).and_return(true)
-        expect(subject.can_view_something?).to be_truthy
+        expect(subject.can_view_something?).to be true
       end
     end
     context 'with permitted_apos' do
@@ -191,18 +355,16 @@ describe User, :type => :model do
         expect(subject).to receive(:is_manager).and_return(false)
         expect(subject).to receive(:is_viewer).and_return(false)
         expect(subject).to receive(:permitted_apos).and_return([1])
-        expect(subject.can_view_something?).to be_truthy
+        expect(subject.can_view_something?).to be true
       end
     end
   end
 
   # TODO
   describe 'permitted_apos' do
-    xit 'not implemented' do
-    end
+    it 'not implemented'
   end
   describe 'permitted_collections' do
-    xit 'not implemented' do
-    end
+    it 'not implemented'
   end
 end


### PR DESCRIPTION
Extracted from https://github.com/sul-dlss/argo/pull/532.  This is a minimal change to the Argo permissions to remove an obscure init file and put these values in the User model, where they belong.  This was discussed in slack where a consensus agreed this was a good approach.

The file removed was `config/initializers/permissions.rb` and the values were transferred to
`app/models/user.rb`.  Apart from `lib/tasks/argo.rake`, the `User` model is the only place these values are used in the application.  All other changes are spec files that need the new `User::` namespace to use the values.

As discussed in slack and confirmed by @LynnMcRae , the `dor-*` roles are deprecated (`dor-admin`, `dor-viewer` and `dor-manager`).  Lynn confirmed that these user roles are removed from APO metadata.

This blocks #532 and it is ready for review.  @mejackreed or @jmartin-sul is likely already familiar with this code from other APO reviews.