### PR TITLE
Fix strange JS failures in workflow_service_creation_spec.rb

### DIFF
--- a/app/views/items/_add_workflow.html.erb
+++ b/app/views/items/_add_workflow.html.erb
@@ -2,7 +2,7 @@
   <div class='form-group'>
     <%= select_tag :wf, options_for_select(workflow_options, default_workflow_option), class: 'form-control' %>
   </div>
-  <button class='btn btn-primary'>
+  <button id='add_wf_button' class='btn btn-primary'>
     Add
   </button>
 <% end %>

--- a/spec/features/workflow_service_creation_spec.rb
+++ b/spec/features/workflow_service_creation_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.feature 'Workflow Service Creation' do
+feature 'Workflow Service Creation' do
   let(:current_user) do
     double(
       :webauth_user,
@@ -11,15 +11,17 @@ RSpec.feature 'Workflow Service Creation' do
       roles: []
     )
   end
-  before do
-    allow_any_instance_of(ItemsController).to receive(:current_user)
-      .and_return(current_user)
-    allow_any_instance_of(CatalogController).to receive(:current_user)
-      .and_return(current_user)
+  before :each do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(current_user)
+    @druid = 'druid:qq613vj0238' # a fixture Dor::Item record
   end
-  scenario 'redirect and display on show page' do
-    visit add_workflow_item_path 'druid:qq613vj0238'
-    click_button 'Add'
+
+  scenario 'redirect and display on show page - with JS', js: true do
+    visit add_workflow_item_path(@druid)
+    expect(page).to have_content('Add workflow')
+    expect(page).to have_button('Add')
+    find('#wf').find(:option, 'accessionWF').select_option
+    find('#add_wf_button').trigger('click')
     within '.flash_messages' do
       expect(page).to have_css '.alert.alert-info', text: 'Added accessionWF'
     end


### PR DESCRIPTION
This is pulled out of https://github.com/sul-dlss/argo/pull/532.  This arose from mysterious JS errors while running feature specs that were failing to find a UI button.  This change adds a CSS #id to the button and adds some checks in the specs.  The strange behavior was discussed with @mejackreed in slack and he may want to review this.

While working on this, discovered that the feature spec is very sensitive to the format of the `id`.  That is, it accepts `druid:qq613vj0238` but not `qq613vj0238`.  With the latter, my system raises:
```
  1) Workflow Service Creation redirect and display on show page - with JS
     Failure/Error: @object = Dor::Item.find params[:id]
     
     Rubydora::FedoraInvalidRequest:
       See logger for details
     # ./app/controllers/items_controller.rb:716:in `create_obj'
```
This sensitivity (failure) is the motivation for more consistent parsing of the `id`, which is in the PR at
https://github.com/sul-dlss/argo/pull/555
