### PR TITLE
add support for externalFile data in the Contents section of the show page

### DIFF
--- a/app/views/catalog/_show_sections/_default_contents.html.erb
+++ b/app/views/catalog/_show_sections/_default_contents.html.erb
@@ -54,6 +54,7 @@
                              <%= ['publish','shelve','preserve'].reject { |a| file[a] != 'yes' }.join('/') %>)
                           </li>
                         <% end %>
+                        <%= render partial: 'catalog/_show_sections/default_contents_external_file', locals: { resource: child } -%>
                       </ul>
                     </li>
                   <% end %>
@@ -72,7 +73,7 @@
                      <%= ['publish','shelve','preserve'].reject { |a| file[a] != 'yes' }.join('/') %>)
                   </li>
                 <% end %>
-                
+                <%= render partial: 'catalog/_show_sections/default_contents_external_file', locals: { resource: resource } -%>
               </ul>
             </li>
           <% end %>

--- a/app/views/catalog/_show_sections/_default_contents_external_file.html.erb
+++ b/app/views/catalog/_show_sections/_default_contents_external_file.html.erb
@@ -1,0 +1,10 @@
+<% resource.xpath('externalFile').each do |external_file| %>
+  <li class="external-file">
+    <span class="label">
+      External File
+    </span>
+    <%= external_file['fileId'] -%>
+    (from item '<%= link_to external_file['objectId'], catalog_path(external_file['objectId']) unless external_file['objectId'].blank? -%>',
+     resource '<%= external_file['resourceId'] -%>')
+  </li>
+<% end %>

--- a/spec/views/catalog/_show_sections/_default_contents_external_file.html.erb_spec.rb
+++ b/spec/views/catalog/_show_sections/_default_contents_external_file.html.erb_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+RSpec.describe 'catalog/_show_sections/default_contents_external_file.html.erb', type: :view do
+  it 'is silent if no resources' do
+    render :partial => subject, locals: { resource: Nokogiri::XML('') }
+    expect(rendered).to eq('')
+  end
+  it 'is silent if only file resources' do
+    render :partial => subject, locals: { resource: Nokogiri::XML('<file/><file/>') }
+    expect(rendered).to eq('')
+  end
+  it 'shows an external file' do
+    render :partial => subject, locals: { resource: Nokogiri::XML('
+      <externalFile fileId="2542A.jp2" objectId="druid:cg767mn6478" resourceId="cg767mn6478_1" mimetype="image/jp2"/>') }
+    expect(rendered).to have_css('li.external-file span.label', text: 'External File')
+    expect(rendered).to have_css('li.external-file', text: '2542A.jp2')
+    expect(rendered).to have_css('li.external-file', text: 'from item \'druid:cg767mn6478\'')
+    expect(rendered).to have_link('druid:cg767mn6478', href: '/catalog/druid:cg767mn6478')
+    expect(rendered).to have_css('li.external-file', text: 'resource \'cg767mn6478_1\'')
+  end
+  it 'shows an external file even if it has bad data' do
+    render :partial => subject, locals: { resource: Nokogiri::XML('<externalFile fileId="2542A.jp2"/>') }
+    expect(rendered).to have_css('li.external-file span.label', text: 'External File')
+    expect(rendered).to have_css('li.external-file', text: '2542A.jp2')
+    expect(rendered).to have_css('li.external-file', text: 'from item \'\'')
+    expect(rendered).to have_css('li.external-file', text: 'resource \'\'')
+  end
+  it 'shows multiple external files' do
+    render :partial => subject, locals: { resource: Nokogiri::XML('<resource>
+      <externalFile fileId="2542A.jp2" objectId="druid:cg767mn6478" resourceId="cg767mn6478_1" mimetype="image/jp2"/>
+      <externalFile fileId="2542B.jp2" objectId="druid:cg767mn6479" resourceId="cg767mn6479_1" mimetype="image/jp2"/>
+      </resource>').children }
+    expect(rendered).to have_css('li[1].external-file span.label', text: 'External File')
+    expect(rendered).to have_css('li[1].external-file', text: '2542A.jp2')
+    expect(rendered).to have_css('li[1].external-file', text: 'from item \'druid:cg767mn6478\'')
+    expect(rendered).to have_link('druid:cg767mn6478', href: '/catalog/druid:cg767mn6478')
+    expect(rendered).to have_css('li[1].external-file', text: 'resource \'cg767mn6478_1\'')
+    expect(rendered).to have_css('li[2].external-file span.label', text: 'External File')
+    expect(rendered).to have_css('li[2].external-file', text: '2542B.jp2')
+    expect(rendered).to have_css('li[2].external-file', text: 'from item \'druid:cg767mn6479\'')
+    expect(rendered).to have_link('druid:cg767mn6479', href: '/catalog/druid:cg767mn6479')
+    expect(rendered).to have_css('li[2].external-file', text: 'resource \'cg767mn6479_1\'')
+  end
+end


### PR DESCRIPTION
This PR fixes #485. Since `catalog/_show_sections/_default_contents` is so messy and I wanted to keep the new functionality DRY, I implemented this as a partial `catalog/_show_sections/_default_contents_external_file`. I was able to add unit tests for this partial.

![screen shot 2016-02-22 at 3 47 47 pm](https://cloud.githubusercontent.com/assets/1861171/13236804/abe44a02-d97b-11e5-90a8-410090723f7c.png)

The above screenshot was generated using the following `contentMetadata` for a test object on my laptop

```xml
<contentMetadata type="image" objectId="rn653dy9317">
  <resource type="image" sequence="106" id="rn653dy9317_106">
    <label>Image 106</label>
    <file mimetype="image/jp2" publish="yes" shelve="yes" format="JPEG2000" preserve="yes" size="3305991" id="M1090_S15_B01_F07_0106.jp2">
      <imageData width="5102" height="3426"/>
      <attr name="representation">uncropped</attr>
      <checksum type="sha1">fd28e74b3139b04a0e5c5c3d3263598f629f8967</checksum>
      <checksum type="md5">244cbb3960407f59ac77a916870e0502</checksum>
    </file>
    <file mimetype="image/tiff" publish="no" shelve="no" format="TIFF" preserve="yes" size="52467428" id="M1090_S15_B01_F07_0106.tif">
      <imageData width="5102" height="3426"/>
      <attr name="representation">uncropped</attr>
      <checksum type="sha1">cf336c4f714b180a09bbfefde159d689e1d517bd</checksum>
      <checksum type="md5">56978088366e66f87d4d5a531f2fea04</checksum>
    </file>
  </resource>
  <resource type="image" sequence="107" id="rn653dy9317_107">
    <label>This is a verrrrrrrrryyyyyyyyyyyyy loooooooooonnnnnnnnnnnnnnggggggggggggg label</label>
    <externalFile fileId="abc123.jp2" objectId="aa111bb2222" resourceId="aa111bb2222_01"/>
    <externalFile fileId="def123.jp2" objectId="aa111bb2222" resourceId="aa111bb2222_02"/>
  </resource>
</contentMetadata>
```