### PR TITLE
Remove unused dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gem 'bootstrap-sass'
 gem 'coderay'
 gem 'coffee-rails'
 gem 'config'
-gem 'daemons'
 gem 'delayed_job'
 gem 'delayed_job_active_record'
 gem 'equivalent-xml', '>= 0.6.0'   # For ignoring_attr_values() with arguments
@@ -13,15 +12,12 @@ gem 'jqgrid-jquery-rails'
 gem 'jquery-rails'
 gem 'jquery-ui-rails'
 gem 'jquery-validation-rails'
-gem 'kaminari'
-gem 'kgio'
 gem 'mysql2', '~> 0.3.2'    # Temporary fix for mysql2/rails incompatibility, see https://github.com/brianmario/mysql2/issues/675
 gem 'net-sftp'
 gem 'newrelic_rpm'
 gem 'nokogiri', '~> 1.6'
 gem 'prawn', '~> 1'
 gem 'prawn-table'
-gem 'progressbar'
 gem 'rack-webauth', :git => 'https://github.com/nilclass/rack-webauth.git'
 gem 'rails', '~> 4.0' # specifying because we expect a major vers upgrade to break things
 gem 'rake'
@@ -35,7 +31,6 @@ gem 'squash_rails', '=1.3.3', :require => 'squash/rails'  # TODO: upgrading to 1
 gem 'squash_ruby',  :require => 'squash/ruby'
 gem 'therubyracer', '~> 0.11'
 gem 'uglifier', '>= 1.0.3'
-gem 'unicode'
 
 # Stanford/Hydra related gems
 gem 'about_page'
@@ -50,8 +45,6 @@ gem 'moab-versioning'
 gem 'mods_display'
 gem 'responders', '~> 2.0'
 gem 'rsolr'
-gem 'rsolr-client-cert', '~> 0.5.2'
-gem 'solrizer'
 gem 'stanford-mods'
 gem 'sul_styles', '~> 0.3.0' # later versions require ruby 2.1 or higher
 
@@ -59,7 +52,6 @@ group :test, :development do
   gem 'http_logger'
   gem 'rspec-rails', '~> 3'
   gem 'capybara'
-  gem 'rack-test', :require => 'rack/test'
   gem 'simplecov', :require => false
   gem 'pry-byebug'
   gem 'pry-doc'

--- a/Gemfile
+++ b/Gemfile
@@ -70,8 +70,8 @@ group :development do
 end
 
 group :deployment do
-  gem 'capistrano', '=3.2.1' # pinned because inadvertent capistrano upgrades tend to cause deployment issues.
-  gem 'capistrano-rails', '=1.1.5' # pinned because otherwise deployment fails with:  NoMethodError: undefined method `verbosity' for "/usr/bin/env deploy:migrating\n":String
+  gem 'capistrano', '= 3.4.0' # pinned because inadvertent capistrano upgrades tend to cause deployment issues.
+  gem 'capistrano-rails'
   gem 'capistrano-passenger'
   gem 'dlss-capistrano', '~> 3.1'
   gem 'capistrano3-delayed-job', '~> 1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,6 @@ gem 'about_page'
 gem 'active-fedora'
 gem 'blacklight', '~> 5.9.0' # TODO: BL >= 5.10.x has new deprecation warnings vs <= 5.9.x, will investigate and unpin after current upgrade stuff has settled
 gem 'blacklight-hierarchy'
-gem 'blacklight-marc'
 gem 'dor-services', '~> 5.3', '>= 5.3.4'
 gem 'is_it_working-cbeer'
 gem 'jettywrapper'

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem 'mods_display'
 gem 'responders', '~> 2.0'
 gem 'rsolr'
 gem 'stanford-mods'
-gem 'sul_styles', '~> 0.3.0' # later versions require ruby 2.1 or higher
+gem 'sul_styles', '~> 0.3'
 
 group :test, :development do
   gem 'http_logger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,10 +75,6 @@ GEM
     blacklight-hierarchy (0.1.1)
       blacklight (~> 5, < 6)
       rails (~> 4.1)
-    blacklight-marc (5.5.0)
-      blacklight (~> 5.8)
-      marc (>= 0.4.3, < 1.1)
-      rails
     bootstrap-sass (3.3.6)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
@@ -262,9 +258,6 @@ GEM
       validatable
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    marc (1.0.0)
-      scrub_rb (>= 1.0.1, < 2)
-      unf
     mediashelf-loggable (0.4.10)
     method_source (0.8.2)
     mime-types (1.25.1)
@@ -447,7 +440,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    scrub_rb (1.0.1)
     simplecov (0.11.2)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -525,7 +517,6 @@ DEPENDENCIES
   barby
   blacklight (~> 5.9.0)
   blacklight-hierarchy
-  blacklight-marc
   bootstrap-sass
   capistrano (= 3.2.1)
   capistrano-passenger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
       bundler (~> 1.2)
       thor (~> 0.18)
     byebug (8.2.2)
-    capistrano (3.2.1)
+    capistrano (3.4.0)
       i18n
       rake (>= 10.0.0)
       sshkit (~> 1.3)
@@ -97,12 +97,12 @@ GEM
       capistrano (~> 3.0)
     capistrano-passenger (0.2.0)
       capistrano (~> 3.0)
-    capistrano-rails (1.1.5)
+    capistrano-rails (1.1.6)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
     capistrano-releaseboard (0.0.1)
       faraday
-    capistrano3-delayed-job (1.5.0)
+    capistrano3-delayed-job (1.6.0)
       capistrano (>= 3.0.0)
     capybara (2.6.2)
       addressable
@@ -518,9 +518,9 @@ DEPENDENCIES
   blacklight (~> 5.9.0)
   blacklight-hierarchy
   bootstrap-sass
-  capistrano (= 3.2.1)
+  capistrano (= 3.4.0)
   capistrano-passenger
-  capistrano-rails (= 1.1.5)
+  capistrano-rails
   capistrano3-delayed-job (~> 1.0)
   capybara
   capybara_discoball

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,9 +59,8 @@ GEM
     addressable (2.4.0)
     arel (6.0.3)
     ast (2.2.0)
-    autoprefixer-rails (6.3.3)
+    autoprefixer-rails (6.3.3.1)
       execjs
-      json
     bagit (0.3.2)
       docopt (~> 0.5.0)
       validatable (~> 1.6)
@@ -121,7 +120,7 @@ GEM
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
     cliver (0.3.2)
-    coderay (1.1.0)
+    coderay (1.1.1)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.1.x)
@@ -134,9 +133,8 @@ GEM
       activesupport (>= 3.0)
       deep_merge (~> 1.0.0)
     confstruct (0.2.7)
-    coveralls (0.8.10)
+    coveralls (0.8.11)
       json (~> 1.8)
-      rest-client (>= 1.6.8, < 2)
       simplecov (~> 0.11.0)
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
@@ -252,7 +250,6 @@ GEM
     kaminari (0.16.3)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
-    kgio (2.10.0)
     libv8 (3.16.14.13)
     link_header (0.0.8)
     logger (1.2.8)
@@ -398,14 +395,11 @@ GEM
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     retries (0.0.5)
-    roo (2.3.1)
+    roo (2.3.2)
       nokogiri (~> 1)
       rubyzip (~> 1.1, < 2.0.0)
     rsolr (1.0.13)
       builder (>= 2.1.2)
-    rsolr-client-cert (0.5.2)
-      rest-client
-      rsolr
     rsolr-ext (1.0.3)
       rsolr (>= 1.0.2)
     rspec-core (3.4.3)
@@ -445,7 +439,7 @@ GEM
       mime-types
       nokogiri
       rest-client
-    rubyzip (1.1.7)
+    rubyzip (1.2.0)
     sass (3.4.21)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -509,7 +503,6 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
-    unicode (0.4.4.2)
     unicode-display_width (0.3.1)
     uuidtools (2.1.5)
     validatable (1.6.7)
@@ -544,7 +537,6 @@ DEPENDENCIES
   coffee-rails
   config
   coveralls
-  daemons
   database_cleaner
   delayed_job
   delayed_job_active_record
@@ -559,8 +551,6 @@ DEPENDENCIES
   jquery-rails
   jquery-ui-rails
   jquery-validation-rails
-  kaminari
-  kgio
   moab-versioning
   mods_display
   mysql2 (~> 0.3.2)
@@ -570,12 +560,10 @@ DEPENDENCIES
   poltergeist
   prawn (~> 1)
   prawn-table
-  progressbar
   pry-byebug
   pry-doc
   pry-rails
   pry-remote
-  rack-test
   rack-webauth!
   rails (~> 4.0)
   rake
@@ -583,14 +571,12 @@ DEPENDENCIES
   rest-client
   retries
   rsolr
-  rsolr-client-cert (~> 0.5.2)
   rspec-rails (~> 3)
   rubocop
   ruby-graphviz
   ruby-prof
   sass-rails
   simplecov
-  solrizer
   sprockets (~> 3.4)
   sqlite3
   squash_rails (= 1.3.3)
@@ -599,7 +585,6 @@ DEPENDENCIES
   sul_styles (~> 0.3.0)
   therubyracer (~> 0.11)
   uglifier (>= 1.0.3)
-  unicode
   wfs_rails (~> 0.0.2)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -473,7 +473,7 @@ GEM
       activesupport
       mods (~> 2.0.2)
     stomp (1.3.4)
-    sul_styles (0.3.0)
+    sul_styles (0.6.0)
       rails (~> 4.1)
     systemu (2.6.5)
     term-ansicolor (1.3.2)
@@ -573,7 +573,7 @@ DEPENDENCIES
   squash_rails (= 1.3.3)
   squash_ruby
   stanford-mods
-  sul_styles (~> 0.3.0)
+  sul_styles (~> 0.3)
   therubyracer (~> 0.11)
   uglifier (>= 1.0.3)
   wfs_rails (~> 0.0.2)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,7 +1,5 @@
 require 'blacklight/catalog'
 class CatalogController < ApplicationController
-  include Blacklight::Marc::Catalog
-
   include BlacklightSolrExtensions
   include Blacklight::Catalog
   include Argo::AccessControlsEnforcement

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -12,13 +12,6 @@ class SolrDocument
 
   # self.unique_key = 'id'
 
-  # The following shows how to setup this blacklight document to display marc documents
-  extension_parameters[:marc_source_field] = :marc_display
-  extension_parameters[:marc_format_type ] = :marcxml
-  use_extension(Blacklight::Solr::Document::Marc) do |document|
-    document.key?(:marc_display)
-  end
-
   # Email uses the semantic field mappings below to generate the body of an email.
   SolrDocument.use_extension(Blacklight::Solr::Document::Email)
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,4 +1,4 @@
-lock '3.2.1'
+lock '3.4.0'
 
 set :application, 'argo'
 set :repo_url, 'https://github.com/sul-dlss/argo.git'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,6 @@ Argo::Application.routes.draw do
     end
   end
 
-  Blacklight::Marc.add_routes(self)
   Blacklight.add_routes(self, :except => [:catalog])
   # Catalog stuff.
   match 'view/opensearch', :to => 'catalog#opensearch', :via => [:get, :post]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,6 +43,10 @@ def instantiate_fixture(druid, klass = ActiveFedora::Base)
   item_from_foxml(File.read(fname), klass)
 end
 
+# Checks for pending migrations before tests are run.
+# If you are not using ActiveRecord, you can remove this line.
+ActiveRecord::Migration.maintain_test_schema!
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
- `solrizer` and `kaminari` are transitive dependencies and don't need to be explicitly declared
- `kgio` was introduced in https://github.com/sul-dlss/argo/commit/c18bd49d4c8e8a548d458a78fa4bf308617eb329, but wasn't removed when `dalli` was.
- `progressbar` was supporting the `reindex_all` rake task, which has since been rewritten without the progress bar.
- `unicode` was introduced when upgrading to blacklight 4 (https://github.com/sul-dlss/argo/commit/924a3a8092af917216df61b770f43a39282eb98e) but we don't seem to be using it
- `rsolr-client-cert` isn't needed with our Solr Cloud setup.
- `daemons` was added at the same time as delayed job, but seems unused (https://github.com/sul-dlss/argo/commit/a7d1a094543ed0b54887baf45e40ecf111dbe6bc)
