### PR TITLE
Create User#can_admin?, User#can_manage? and User#can_view?

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -135,4 +135,96 @@ class User < ActiveRecord::Base
   def can_view_something?
     is_admin || is_manager || is_viewer || permitted_apos.length > 0
   end
+
+  # Notes on definitions for known roles in dor-services:
+  #
+  # At present, there are a few methods that all do the same thing;
+  # see all the `can_manage_*` methods in Dor::Governable, i.e.
+  # https://github.com/sul-dlss/dor-services/blob/develop/lib/dor/models/governable.rb
+  #
+  # The upshot of this is that it is not yet clear how Argo should query a Dor
+  # object about management rights. That is, it is not clear how granular the
+  # management privilege should be. The consensus from discussions is to use a
+  # default query for `dor_object.can_manage_item?` (without recourse to
+  # `dor_object.can_manage_content?` etc.)
+  #
+  # When more granular permissions are required, these methods can adapt
+  # because the `permission` parameter can be changed as required.
+
+  # Authorize object administration permissions using Argo user roles.
+  # This includes User#is_admin, it excludes User#is_manager;
+  # otherwise permissions are determined by the object.
+  #
+  # @param dor_object [Dor::Base] Accepts any Dor::Governable object
+  # @param permission [String] dor_object.can_manage_{permission}?
+  #                            The default is dor_object.can_manage_item?
+  # @return [Boolean]
+  def can_admin?(dor_object, permission = 'item')
+    # Any administrator can manage any object.
+    return true if is_admin
+    # Check user roles permitted to manage the object.
+    permission_method = "can_manage_#{permission}?"
+    request_object_permission(dor_object, permission_method)
+  end
+
+  # Authorize object management permissions using Argo user roles.
+  # This includes User#is_admin and User#is_manager;
+  # otherwise permissions are determined by the object.
+  #
+  # @param dor_object [Dor::Base] Accepts any Dor::Governable object
+  # @param permission [String] dor_object.can_manage_{permission}?
+  #                            The default is dor_object.can_manage_item?
+  # @return [Boolean]
+  def can_manage?(dor_object, permission = 'item')
+    # Any administrator or manager can manage any object.
+    return true if is_admin || is_manager
+    # Check user roles permitted to manage the object.
+    permission_method = "can_manage_#{permission}?"
+    request_object_permission(dor_object, permission_method)
+  end
+
+  # Authorize object view permissions using Argo user roles.
+  # This includes User#is_admin, User#is_manager, and User#is_viewer;
+  # otherwise permissions are determined by the object.
+  #
+  # @param dor_object [Dor::Base] Accepts any Dor::Governable object
+  # @param permission [String] dor_object.can_view_{permission}?
+  #                            The default is dor_object.can_view_metadata?
+  # @return [Boolean]
+  def can_view?(dor_object, permission = 'metadata')
+    # Any administrator, manager or viewer can view any object.
+    return true if is_admin || is_manager || is_viewer
+    # Check user roles permitted to view the object.
+    permission_method = "can_view_#{permission}?"
+    request_object_permission(dor_object, permission_method)
+  end
+
+  private
+
+  # Authorize object permissions using Argo user roles.
+  # First check permissions on the governing APO of the object.
+  # If that fails and the object is an APO, let it authorize permission.
+  #
+  # @param dor_object [Dor::Base] Accepts any Dor::Governable object
+  # @param permission [String] dor_object.send(permission)
+  # @return [Boolean]
+  def request_object_permission(dor_object, permission)
+    # Check that we can request a specific permission.  Note that this could
+    # be more specific by checking that the `permission` method is defined in
+    # Dor::Governable from dor-services, but that level of detail in this check
+    # could break the flexibility of this method and dor-services designs.
+    unless dor_object.respond_to? permission
+      raise ArgumentError.new("DOR object doesn't respond to: #{permission}")
+    end
+    # The authorization is first requested using the governing APO.
+    apo = dor_object.admin_policy_object
+    if apo
+      return true if dor_object.send(permission, roles(apo.pid))
+    end
+    # Failing that, if the object is an APO, it can grant permission.
+    if dor_object.is_a? Dor::AdminPolicyObject
+      return true if dor_object.send(permission, roles(dor_object.pid))
+    end
+    false
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -360,6 +360,351 @@ describe User, :type => :model do
     end
   end
 
+  describe '#can_admin?' do
+    before :each do
+      expect(subject).not_to receive(:is_manager)
+      expect(subject).not_to receive(:is_viewer)
+    end
+
+    shared_examples 'Argo grants permission to manage object' do
+      it 'permits admin' do
+        expect(subject).to receive(:is_admin).once.and_return(true)
+        expect(subject.can_admin?(item)).to be true
+      end
+      it 'denies manager' do
+        expect(subject).to receive(:is_admin).once.and_return(false)
+        expect(subject.can_admin?(item)).to be false
+      end
+    end
+
+    context 'checks object permissions' do
+      let(:druid) { 'druid:hv992ry2431' }
+      let(:item) { instantiate_fixture(druid, Dor::AdminPolicyObject) }
+      context 'when user has no Argo permissions' do
+        before :each do
+          expect(subject).to receive(:is_admin).once.and_return(false)
+        end
+        it 'using default "can_manage_item?"' do
+          expect(item).to receive(:can_manage_item?).at_least(:once)
+          subject.can_admin?(item)
+        end
+        it 'using custom "can_manage_content?"' do
+          expect(item).to receive(:can_manage_content?).at_least(:once)
+          subject.can_admin?(item, 'content')
+        end
+        it 'raises ArgumentError for invalid permissions' do
+          expect{subject.can_admin?(item, 'WTF')}.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    context 'DOR object is an APO with a governing APO' do
+      let(:druid) { 'druid:hv992ry2431' }
+      let(:item) { instantiate_fixture(druid, Dor::AdminPolicyObject) }
+      let(:apo) { item.admin_policy_object }
+      it_behaves_like 'Argo grants permission to manage object'
+      context 'when user has no Argo permissions' do
+        before :each do
+          expect(subject).to receive(:is_admin).once.and_return(false)
+        end
+        it 'allows user with authorized role in governing APO' do
+          # This checks the governing APO and grants permission.
+          role = 'sdr-administrator'
+          expect(subject).to receive(:roles).with(apo.pid).once.and_return([role])
+          expect(subject).not_to receive(:roles).with(item.pid)
+          expect(item).to receive(:can_manage_item?).with([role]).once.and_return(true)
+          expect(subject.can_admin?(item)).to be true
+        end
+        it 'allows user with authorized role in item APO' do
+          # This checks the governing APO and does not grant permission;
+          # it then checks the item APO and grants permission.
+          apo_role = 'not-administrator'
+          item_role = 'sdr-administrator'
+          expect(subject).to receive(:roles).with(apo.pid).once.and_return([apo_role])
+          expect(subject).to receive(:roles).with(item.pid).once.and_return([item_role])
+          expect(item).to receive(:can_manage_item?).with([apo_role]).once.and_return(false)
+          expect(item).to receive(:can_manage_item?).with([item_role]).once.and_return(true)
+          expect(subject.can_admin?(item)).to be true
+        end
+        it 'forbids user without authorized role in any APO' do
+          # This checks the governing APO and does not grant permission;
+          # it then checks the item APO and does not grant permission.
+          role = 'sdr-viewer'
+          expect(subject).to receive(:roles).with(apo.pid).once.and_return([role])
+          expect(subject).to receive(:roles).with(item.pid).once.and_return([role])
+          expect(item).to receive(:can_manage_item?).with([role]).twice.and_return(false)
+          expect(subject.can_admin?(item)).to be false
+        end
+      end
+    end
+
+    context 'DOR object is an APO without a governing APO' do
+      let(:druid) { 'druid:hv992ry2431' }
+      let(:item) do
+        item = instantiate_fixture(druid, Dor::AdminPolicyObject)
+        allow(item).to receive(:admin_policy_object).and_return(nil)
+        item
+      end
+      it_behaves_like 'Argo grants permission to manage object'
+      context 'when user has no Argo permissions' do
+        before :each do
+          expect(subject).to receive(:is_admin).once.and_return(false)
+        end
+        it 'allows user with authorized role' do
+          # There is no governing APO to grant permission, so
+          # it checks the item APO and grants permission.
+          role = 'sdr-administrator'
+          expect(subject).to receive(:roles).with(item.pid).once.and_return([role])
+          expect(item).to receive(:can_manage_item?).with([role]).once.and_return(true)
+          expect(subject.can_admin?(item)).to be true
+        end
+        it 'forbids user without authorized role' do
+          # There is no governing APO to grant permission, so
+          # it checks the item APO and does not grant permission.
+          role = 'sdr-viewer'
+          expect(subject).to receive(:roles).with(item.pid).once.and_return([role])
+          expect(item).to receive(:can_manage_item?).with([role]).once.and_return(false)
+          expect(subject.can_admin?(item)).to be false
+        end
+      end
+    end
+  end
+
+  describe '#can_manage?' do
+    before :each do
+      expect(subject).not_to receive(:is_viewer)
+    end
+
+    shared_examples 'Argo grants permission to manage object' do
+      it 'permits admin' do
+        expect(subject).to receive(:is_admin).once.and_return(true)
+        expect(subject).not_to receive(:is_manager)
+        expect(subject.can_manage?(item)).to be true
+      end
+      it 'permits manager' do
+        expect(subject).to receive(:is_admin).once.and_return(false)
+        expect(subject).to receive(:is_manager).once.and_return(true)
+        expect(subject.can_manage?(item)).to be true
+      end
+    end
+
+    context 'checks object permissions' do
+      let(:druid) { 'druid:hv992ry2431' }
+      let(:item) { instantiate_fixture(druid, Dor::AdminPolicyObject) }
+      context 'when user has no Argo permissions' do
+        before :each do
+          expect(subject).to receive(:is_admin).once.and_return(false)
+          expect(subject).to receive(:is_manager).once.and_return(false)
+        end
+        it 'using default "can_manage_item?"' do
+          expect(item).to receive(:can_manage_item?).at_least(:once)
+          subject.can_manage?(item)
+        end
+        it 'using custom "can_manage_content?"' do
+          expect(item).to receive(:can_manage_content?).at_least(:once)
+          subject.can_manage?(item, 'content')
+        end
+        it 'raises ArgumentError for invalid permissions' do
+          expect{subject.can_manage?(item, 'WTF')}.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    context 'DOR object is an APO with a governing APO' do
+      let(:druid) { 'druid:hv992ry2431' }
+      let(:item) { instantiate_fixture(druid, Dor::AdminPolicyObject) }
+      let(:apo) { item.admin_policy_object }
+      it_behaves_like 'Argo grants permission to manage object'
+      context 'when user has no Argo permissions' do
+        before :each do
+          expect(subject).to receive(:is_admin).once.and_return(false)
+          expect(subject).to receive(:is_manager).once.and_return(false)
+        end
+        it 'allows user with authorized role in governing APO' do
+          # This checks the governing APO and grants permission.
+          role = 'sdr-administrator'
+          expect(subject).to receive(:roles).with(apo.pid).once.and_return([role])
+          expect(subject).not_to receive(:roles).with(item.pid)
+          expect(item).to receive(:can_manage_item?).with([role]).once.and_return(true)
+          expect(subject.can_manage?(item)).to be true
+        end
+        it 'allows user with authorized role in item APO' do
+          # This checks the governing APO and does not grant permission;
+          # it then checks the item APO and grants permission.
+          apo_role = 'not-administrator'
+          item_role = 'sdr-administrator'
+          expect(subject).to receive(:roles).with(apo.pid).once.and_return([apo_role])
+          expect(subject).to receive(:roles).with(item.pid).once.and_return([item_role])
+          expect(item).to receive(:can_manage_item?).with([apo_role]).once.and_return(false)
+          expect(item).to receive(:can_manage_item?).with([item_role]).once.and_return(true)
+          expect(subject.can_manage?(item)).to be true
+        end
+        it 'forbids user without authorized role in any APO' do
+          # This checks the governing APO and does not grant permission;
+          # it then checks the item APO and does not grant permission.
+          role = 'sdr-viewer'
+          expect(subject).to receive(:roles).with(apo.pid).once.and_return([role])
+          expect(subject).to receive(:roles).with(item.pid).once.and_return([role])
+          expect(item).to receive(:can_manage_item?).with([role]).twice.and_return(false)
+          expect(subject.can_manage?(item)).to be false
+        end
+      end
+    end
+
+    context 'DOR object is an APO without a governing APO' do
+      let(:druid) { 'druid:hv992ry2431' }
+      let(:item) do
+        item = instantiate_fixture(druid, Dor::AdminPolicyObject)
+        allow(item).to receive(:admin_policy_object).and_return(nil)
+        item
+      end
+      it_behaves_like 'Argo grants permission to manage object'
+      context 'when user has no Argo permissions' do
+        before :each do
+          expect(subject).to receive(:is_admin).once.and_return(false)
+          expect(subject).to receive(:is_manager).once.and_return(false)
+        end
+        it 'allows user with authorized role' do
+          # There is no governing APO to grant permission, so
+          # it checks the item APO and grants permission.
+          role = 'sdr-administrator'
+          expect(subject).to receive(:roles).with(item.pid).once.and_return([role])
+          expect(item).to receive(:can_manage_item?).with([role]).once.and_return(true)
+          expect(subject.can_manage?(item)).to be true
+        end
+        it 'forbids user without authorized role' do
+          # There is no governing APO to grant permission, so
+          # it checks the item APO and does not grant permission.
+          role = 'sdr-viewer'
+          expect(subject).to receive(:roles).with(item.pid).once.and_return([role])
+          expect(item).to receive(:can_manage_item?).with([role]).once.and_return(false)
+          expect(subject.can_manage?(item)).to be false
+        end
+      end
+    end
+  end
+
+  describe '#can_view?' do
+    shared_examples 'Argo grants permission to view object' do
+      it 'permits admin' do
+        expect(subject).to receive(:is_admin).once.and_return(true)
+        expect(subject).not_to receive(:is_manager)
+        expect(subject).not_to receive(:is_viewer)
+        expect(subject.can_view?(item)).to be true
+      end
+      it 'permits manager' do
+        expect(subject).to receive(:is_admin).once.and_return(false)
+        expect(subject).to receive(:is_manager).once.and_return(true)
+        expect(subject).not_to receive(:is_viewer)
+        expect(subject.can_view?(item)).to be true
+      end
+      it 'permits viewer' do
+        expect(subject).to receive(:is_admin).once.and_return(false)
+        expect(subject).to receive(:is_manager).once.and_return(false)
+        expect(subject).to receive(:is_viewer).once.and_return(true)
+        expect(subject.can_view?(item)).to be true
+      end
+    end
+
+    context 'checks object permissions' do
+      let(:druid) { 'druid:hv992ry2431' }
+      let(:item) { instantiate_fixture(druid, Dor::AdminPolicyObject) }
+      context 'when user has no Argo permissions' do
+        before :each do
+          expect(subject).to receive(:is_admin).once.and_return(false)
+          expect(subject).to receive(:is_manager).once.and_return(false)
+          expect(subject).to receive(:is_viewer).once.and_return(false)
+        end
+        it 'using default "can_view_metadata?"' do
+          expect(item).to receive(:can_view_metadata?).at_least(:once)
+          subject.can_view?(item)
+        end
+        it 'using custom "can_view_content?"' do
+          expect(item).to receive(:can_view_content?).at_least(:once)
+          subject.can_view?(item, 'content')
+        end
+        it 'raises ArgumentError for invalid permissions' do
+          expect{subject.can_view?(item, 'WTF')}.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    context 'DOR object is an APO with a governing APO' do
+      let(:druid) { 'druid:hv992ry2431' }
+      let(:item) { instantiate_fixture(druid, Dor::AdminPolicyObject) }
+      let(:apo) { item.admin_policy_object }
+      it_behaves_like 'Argo grants permission to view object'
+      context 'when user has no Argo permissions' do
+        before :each do
+          expect(subject).to receive(:is_admin).once.and_return(false)
+          expect(subject).to receive(:is_manager).once.and_return(false)
+          expect(subject).to receive(:is_viewer).once.and_return(false)
+        end
+        it 'allows user with authorized role in governing APO' do
+          # This checks the governing APO and grants permission.
+          role = 'sdr-viewer'
+          expect(subject).to receive(:roles).with(apo.pid).once.and_return([role])
+          expect(subject).not_to receive(:roles).with(item.pid)
+          expect(item).to receive(:can_view_metadata?).with([role]).once.and_return(true)
+          expect(subject.can_view?(item)).to be true
+        end
+        it 'allows user with authorized role in item APO' do
+          # This checks the governing APO and does not grant permission;
+          # it then checks the item APO and grants permission.
+          apo_role = 'not-administrator'
+          item_role = 'sdr-administrator'
+          expect(subject).to receive(:roles).with(apo.pid).once.and_return([apo_role])
+          expect(subject).to receive(:roles).with(item.pid).once.and_return([item_role])
+          expect(item).to receive(:can_view_metadata?).with([apo_role]).once.and_return(false)
+          expect(item).to receive(:can_view_metadata?).with([item_role]).once.and_return(true)
+          expect(subject.can_view?(item)).to be true
+        end
+        it 'forbids user without authorized role in any APO' do
+          # This checks the governing APO and does not grant permission;
+          # it then checks the item APO and does not grant permission.
+          role = 'sdr-viewer'
+          expect(subject).to receive(:roles).with(apo.pid).once.and_return([role])
+          expect(subject).to receive(:roles).with(item.pid).once.and_return([role])
+          expect(item).to receive(:can_view_metadata?).with([role]).twice.and_return(false)
+          expect(subject.can_view?(item)).to be false
+        end
+      end
+    end
+
+    context 'DOR object is an APO without a governing APO' do
+      let(:druid) { 'druid:hv992ry2431' }
+      let(:item) do
+        item = instantiate_fixture(druid, Dor::AdminPolicyObject)
+        allow(item).to receive(:admin_policy_object).and_return(nil)
+        item
+      end
+      it_behaves_like 'Argo grants permission to view object'
+      context 'when user has no Argo permissions' do
+        before :each do
+          expect(subject).to receive(:is_admin).once.and_return(false)
+          expect(subject).to receive(:is_manager).once.and_return(false)
+          expect(subject).to receive(:is_viewer).once.and_return(false)
+        end
+        it 'allows user with authorized role' do
+          # There is no governing APO to grant permission, so
+          # it checks the item APO and grants permission.
+          role = 'sdr-administrator'
+          expect(subject).to receive(:roles).with(item.pid).once.and_return([role])
+          expect(item).to receive(:can_view_metadata?).with([role]).once.and_return(true)
+          expect(subject.can_view?(item)).to be true
+        end
+        it 'forbids user without authorized role' do
+          # There is no governing APO to grant permission, so
+          # it checks the item APO and does not grant permission.
+          role = 'sdr-viewer'
+          expect(subject).to receive(:roles).with(item.pid).once.and_return([role])
+          expect(item).to receive(:can_view_metadata?).with([role]).once.and_return(false)
+          expect(subject.can_view?(item)).to be false
+        end
+      end
+    end
+  end
+
   # TODO
   describe 'permitted_apos' do
     it 'not implemented'


### PR DESCRIPTION
This code, when applied, is a possible solution for #76.  An alternative solution is sketched in https://github.com/sul-dlss/argo/pull/596 (discussed in https://github.com/sul-dlss/argo/issues/586).

This PR is just about creating additional User methods that can be used in authorization.  The core of this PR is in the ability of the user model to check permissions on any DOR object.

This is an extract from a larger goal that was previously proposed in #532, but that work is too complex to evaluate. Smaller chunks of that work can proceed and gradually accomplish the same outcome.
