### PR TITLE
User permissions applied only to catalog controller

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -342,26 +342,18 @@ class CatalogController < ApplicationController
     sorted_info.reverse!
   end
 
-  # Determines whether or not the current user has permissions to view the current DOR object.
+  # Determines whether the current user has permission to view the DOR object.
   def valid_user?(dor_object)
-    begin
-      @apo = dor_object.admin_policy_object
-    rescue
-      return false
-    end
-
-    if @apo
-      unless @user.is_admin || @user.is_viewer || dor_object.can_view_metadata?(@user.roles(@apo.pid))
-        render :status => :forbidden, :text => 'forbidden'
-        return false
-      end
-    else
-      unless @user.is_admin || @user.is_viewer
-        render :status => :forbidden, :text => 'No APO, no access'
-        return false
-      end
-    end
-    true
+    return true if @user.can_view?(dor_object)
+    msg = if dor_object.admin_policy_object
+            'Governing APO forbids access'
+          elsif dor_object.is_a? Dor::AdminPolicyObject
+            'Item is an APO that forbids access'
+          else
+            'Item has no APO that allows access'
+          end
+    render :status => :forbidden, :text => msg
+    false
   end
 
   def get_leafdir(directory)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -135,4 +135,96 @@ class User < ActiveRecord::Base
   def can_view_something?
     is_admin || is_manager || is_viewer || permitted_apos.length > 0
   end
+
+  # Notes on definitions for known roles in dor-services:
+  #
+  # At present, there are a few methods that all do the same thing;
+  # see all the `can_manage_*` methods in Dor::Governable, i.e.
+  # https://github.com/sul-dlss/dor-services/blob/develop/lib/dor/models/governable.rb
+  #
+  # The upshot of this is that it is not yet clear how Argo should query a Dor
+  # object about management rights. That is, it is not clear how granular the
+  # management privilege should be. The consensus from discussions is to use a
+  # default query for `dor_object.can_manage_item?` (without recourse to
+  # `dor_object.can_manage_content?` etc.)
+  #
+  # When more granular permissions are required, these methods can adapt
+  # because the `permission` parameter can be changed as required.
+
+  # Authorize object administration permissions using Argo user roles.
+  # This includes User#is_admin, it excludes User#is_manager;
+  # otherwise permissions are determined by the object.
+  #
+  # @param dor_object [Dor::Base] Accepts any Dor::Governable object
+  # @param permission [String] dor_object.can_manage_{permission}?
+  #                            The default is dor_object.can_manage_item?
+  # @return [Boolean]
+  def can_admin?(dor_object, permission = 'item')
+    # Any administrator can manage any object.
+    return true if is_admin
+    # Check user roles permitted to manage the object.
+    permission_method = "can_manage_#{permission}?"
+    request_object_permission(dor_object, permission_method)
+  end
+
+  # Authorize object management permissions using Argo user roles.
+  # This includes User#is_admin and User#is_manager;
+  # otherwise permissions are determined by the object.
+  #
+  # @param dor_object [Dor::Base] Accepts any Dor::Governable object
+  # @param permission [String] dor_object.can_manage_{permission}?
+  #                            The default is dor_object.can_manage_item?
+  # @return [Boolean]
+  def can_manage?(dor_object, permission = 'item')
+    # Any administrator or manager can manage any object.
+    return true if is_admin || is_manager
+    # Check user roles permitted to manage the object.
+    permission_method = "can_manage_#{permission}?"
+    request_object_permission(dor_object, permission_method)
+  end
+
+  # Authorize object view permissions using Argo user roles.
+  # This includes User#is_admin, User#is_manager, and User#is_viewer;
+  # otherwise permissions are determined by the object.
+  #
+  # @param dor_object [Dor::Base] Accepts any Dor::Governable object
+  # @param permission [String] dor_object.can_view_{permission}?
+  #                            The default is dor_object.can_view_metadata?
+  # @return [Boolean]
+  def can_view?(dor_object, permission = 'metadata')
+    # Any administrator, manager or viewer can view any object.
+    return true if is_admin || is_manager || is_viewer
+    # Check user roles permitted to view the object.
+    permission_method = "can_view_#{permission}?"
+    request_object_permission(dor_object, permission_method)
+  end
+
+  private
+
+  # Authorize object permissions using Argo user roles.
+  # First check permissions on the governing APO of the object.
+  # If that fails and the object is an APO, let it authorize permission.
+  #
+  # @param dor_object [Dor::Base] Accepts any Dor::Governable object
+  # @param permission [String] dor_object.send(permission)
+  # @return [Boolean]
+  def request_object_permission(dor_object, permission)
+    # Check that we can request a specific permission.  Note that this could
+    # be more specific by checking that the `permission` method is defined in
+    # Dor::Governable from dor-services, but that level of detail in this check
+    # could break the flexibility of this method and dor-services designs.
+    unless dor_object.respond_to? permission
+      raise ArgumentError.new("DOR object doesn't respond to: #{permission}")
+    end
+    # The authorization is first requested using the governing APO.
+    apo = dor_object.admin_policy_object
+    if apo
+      return true if dor_object.send(permission, roles(apo.pid))
+    end
+    # Failing that, if the object is an APO, it can grant permission.
+    if dor_object.is_a? Dor::AdminPolicyObject
+      return true if dor_object.send(permission, roles(dor_object.pid))
+    end
+    false
+  end
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -2,101 +2,189 @@ require 'spec_helper'
 
 describe CatalogController, :type => :controller do
 
-  before :each do
-#   log_in_as_mock_user(subject)
-    @druid = 'rn653dy9317'  # a fixture Dor::Item record
-    @item = instantiate_fixture(@druid, Dor::Item)
-    @user = User.find_or_create_by_webauth double('WebAuth', :login => 'sunetid', :logged_in? => true, :attributes => {'DISPLAYNAME' => 'Example User'}, :privgroup => '')
-    allow(Dor).to receive(:find).with("druid:#{@druid}").and_return(@item)
-    allow(Dor::Item).to receive(:find).with("druid:#{@druid}").and_return(@item)
+  let(:item) do
+    object = instantiate_fixture('rn653dy9317', Dor::Item)
+    allow(Dor).to receive(:find).with(object.pid).and_return(object)
+    object
+  end
+  let(:apo) do
+    object = instantiate_fixture('hv992ry2431', Dor::AdminPolicyObject)
+    allow(Dor).to receive(:find).with(object.pid).and_return(object)
+    object
+  end
+  let(:current_user) do
+    webauth = double(
+      'WebAuth',
+      login: 'sunetid',
+      logged_in?: true,
+      attributes: {'DISPLAYNAME' => 'Example User'},
+      privgroup: ''
+    )
+    user = User.find_or_create_by_webauth(webauth)
+    allow(subject).to receive(:current_user).and_return(user)
+    user
   end
 
-  shared_examples 'APO-independent auth' do
-    describe 'no user' do
+  # These specs do not depend on an APO to authorize privileged roles.
+  # Argo has global privileges based on webauth groups.
+  shared_examples 'APO-independent auth for show' do
+    context 'no user' do
       it 'basic get redirects to login' do
-        expect(subject).to receive(:webauth).and_return(nil)
-        get 'show', :id => @druid
-        expect(response.code).to eq('401')  # Unauthorized without webauth, no place to redirect
+        # ApplicationController#authorize! returns :unauthorized
+        expect(subject).not_to receive(:valid_user?)
+        expect(subject).to receive(:current_user).and_return(nil)
+        get 'show', :id => item.pid
+        expect(response).to have_http_status(:unauthorized)
       end
     end
-    describe 'with user (valid_user)' do
+    context 'with valid user' do
       before :each do
-        expect(subject).to receive(:valid_user?).with(@item).and_call_original # called every time
-        allow(subject).to receive(:current_user).and_return(@user)
+        # Ensure the `current_user` is instantiated for all these examples
+        expect(current_user).to receive('can_view?').with(item).and_call_original
+        expect(subject).to receive(:valid_user?).with(item).and_call_original
       end
       it 'unauthorized_user' do
-        get 'show', :id => @druid
-        expect(response.code).to eq('403')  # two different flavors
-        # expect(response.body).to include 'No APO'
+        # CatalogController#valid_user? returns :forbidden
+        get 'show', :id => item.pid
+        expect(response).to have_http_status(:forbidden)
       end
       it 'is_admin' do
-        allow(@user).to receive(:is_admin).and_return(true)
-        get 'show', :id => @druid
-        expect(response.code).to eq('200')
+        expect(current_user).to receive(:is_admin).at_least(:once).and_return(true)
+        expect(current_user).not_to receive(:is_manager)
+        expect(current_user).not_to receive(:is_viewer)
+        get 'show', :id => item.pid
+        expect(response).to have_http_status(:ok)
+      end
+      it 'is_manager' do
+        expect(current_user).to receive(:is_admin).at_least(:once).and_return(false)
+        expect(current_user).to receive(:is_manager).at_least(:once).and_return(true)
+        expect(current_user).not_to receive(:is_viewer)
+        get 'show', :id => item.pid
+        expect(response).to have_http_status(:ok)
       end
       it 'is_viewer' do
-        allow(@user).to receive(:is_viewer).and_return(true)
-        get 'show', :id => @druid
-        expect(response.code).to eq('200')
+        expect(current_user).to receive(:is_admin).at_least(:once).and_return(false)
+        expect(current_user).to receive(:is_manager).at_least(:once).and_return(false)
+        expect(current_user).to receive(:is_viewer).at_least(:once).and_return(true)
+        get 'show', :id => item.pid
+        expect(response).to have_http_status(:ok)
       end
-      it 'impersonating nobody' do
-        @user.set_groups_to_impersonate(['some:irrelevance'])
-        get 'show', :id => @druid
-        expect(response.code).to eq('403')
-      end
-      it 'impersonating viewer' do
-        @user.set_groups_to_impersonate(['some:irrelevance', 'workgroup:sdr:viewer-role'])
-        get 'show', :id => @druid
-        expect(response.code).to eq('200')
+    end
+  end
+
+  # These specs all depend on an APO that can validate that a user
+  # is authorized for privileged roles.  These roles depend on
+  # methods and roles defined in Dor::Governable
+  shared_examples 'APO-dependent auth for show' do
+    context 'with valid user' do
+      before :each do
+        allow(current_user).to receive(:is_admin).and_return(false)
+        allow(current_user).to receive(:is_manager).and_return(false)
+        allow(current_user).to receive(:is_viewer).and_return(false)
       end
       it 'impersonating admin' do
-        @user.set_groups_to_impersonate(['some:irrelevance', 'workgroup:sdr:administrator-role'])
-        get 'show', :id => @druid
-        expect(response.code).to eq('200')
+        skip 'TODO: enable Dor::Governable#groups_which_admin_item to exclude managers'
+        # If Dor::Governable#groups_which_admin_item exists, enable this spec.
+        # roles = item.groups_which_admin_item
+        # expect(current_user).to receive(:roles).with(apo.pid).at_least(:once).and_return(roles)
+        # get 'show', :id => item.pid
+        # expect(response).to have_http_status(:ok)
+      end
+      it 'impersonating manager' do
+        roles = item.groups_which_manage_item
+        expect(current_user).to receive(:roles).with(apo.pid).at_least(:once).and_return(roles)
+        get 'show', :id => item.pid
+        expect(response).to have_http_status(:ok)
+      end
+      it 'impersonating viewer' do
+        roles = ['sdr-viewer']
+        expect(current_user).to receive(:roles).with(apo.pid).at_least(:once).and_return(roles)
+        get 'show', :id => item.pid
+        expect(response).to have_http_status(:ok)
+      end
+      it 'impersonating nobody' do
+        expect(current_user).to receive(:roles).with(apo.pid).at_least(:once).and_return([])
+        get 'show', :id => item.pid
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end
 
   describe '#show enforces permissions' do
-    describe 'without APO' do
-      before :each do
-        allow(@item).to receive(:admin_policy_object).and_return(nil)
-      end
-      describe 'impersonating user with no extra powers' do
-        it 'is forbidden since there is no APO' do
-          allow(subject).to receive(:current_user).and_return(@user)
-          get 'show', :id => @druid
-          expect(response.code).to eq('403')  # Forbidden
-          expect(response.body).to include 'No APO'
+    context 'without a governing APO' do
+      context 'item is not an APO' do
+        before :each do
+          allow(item).to receive(:admin_policy_object).and_return(nil)
+          expect(current_user).not_to receive(:roles)
         end
+        describe 'user without authorized role' do
+          it 'is forbidden since there is no APO' do
+            get 'show', :id => item.pid
+            expect(response).to have_http_status(:forbidden)
+            expect(response.body).to include 'Item has no APO that allows access'
+          end
+        end
+        it_behaves_like 'APO-independent auth for show'
+        # No user roles can be tested because there is no APO to validate them.
+        # So it cannot behave like 'APO-dependent auth'
       end
-      it_behaves_like 'APO-independent auth'
+
+      context 'item is an APO' do
+        # Override the definition of `item` so it's an APO without a governing
+        # APO.  It must be `item` for the shared examples used in this context.
+        # So this let(:item) effectively assigns `item = apo`.
+        # In the shared examples, the `user.roles` should receive the `apo.pid`
+        # only because the `item == apo`; so there is no point in these specs
+        # expecting `current_user.roles(item.pid)`
+        # instead of `current_user.roles(apo.pid)`
+        # although they could (and they must if `item != apo`).
+        let(:item) do
+          allow(apo).to receive(:admin_policy_object).and_return(nil)
+          apo
+        end
+        describe 'impersonating user with no extra powers' do
+          it 'is forbidden since there is no role in this APO' do
+            expect(item).to be_instance_of Dor::AdminPolicyObject
+            expect(current_user).to receive(:roles).with(item.pid).at_least(:once).and_return([])
+            get 'show', :id => item.pid
+            expect(response).to have_http_status(:forbidden)
+            expect(response.body).to include 'Item is an APO that forbids access'
+          end
+        end
+        # These shared examples all use the `item` defined in the most
+        # recent `let(:item)`, so that will be the apo, as noted above.
+        it_behaves_like 'APO-independent auth for show'
+        it_behaves_like 'APO-dependent auth for show'
+      end
     end
 
-    describe 'with APO' do
+    context 'with a governing APO' do
       before :each do
-        @apo_druid = 'druid:hv992ry2431'
-        @apo = instantiate_fixture('hv992ry2431', Dor::AdminPolicyObject)
-        allow(@item).to receive(:admin_policy_object).and_return(@apo)
-        allow(@user).to receive(:roles).with(@apo_druid).and_return([])
+        # Ensure the APO for `item` is an instantiated APO fixture, which
+        # is defined in the overall context at the top of this file.
+        allow(item).to receive(:admin_policy_object).and_return(apo)
       end
+
       describe 'impersonating_user with no extra powers' do
         it 'is forbidden if roles do not match' do
-          allow(subject).to receive(:current_user).and_return(@user)
-          get 'show', :id => @druid
-          expect(response.code).to eq('403')  # Forbidden
-          expect(response.body).to include 'forbidden'
+          allow(current_user).to receive(:roles).with(apo.pid).and_return([])
+          get 'show', :id => item.pid
+          expect(response).to have_http_status(:forbidden)
+          expect(response.body).to include 'APO forbids access'
         end
+
         it 'succeeds if roles match' do
-          allow(@user).to receive(:roles).with(@apo_druid).and_return(['dor-viewer'])
-          allow(subject).to receive(:current_user).and_return(@user)
-          get 'show', :id => @druid
+          roles = ['sdr-viewer']
+          allow(current_user).to receive(:roles).with(apo.pid).and_return(roles)
+          get 'show', :id => item.pid
           expect(response.code).to eq('200')
         end
       end
-      it_behaves_like 'APO-independent auth'
+      it_behaves_like 'APO-independent auth for show'
+      it_behaves_like 'APO-dependent auth for show'
     end
   end
+
   describe 'blacklight config' do
     let(:config) { controller.blacklight_config }
     it 'should have the date facets' do
@@ -129,13 +217,22 @@ describe CatalogController, :type => :controller do
       expect(config.http_method).to eq :post
     end
   end
+
   describe 'error handling' do
-    let(:druid) { 'druid:zz999zz9999' }
+    before :each do
+      allow(subject).to receive(:current_user).and_return(admin_user)
+    end
     it 'should 404 on missing item' do
-      expect(subject).to receive(:current_user).and_return(double('WebAuth', is_admin: true)).twice
-      expect(Dor).to receive(:find).with(druid).and_raise(ActiveFedora::ObjectNotFoundError)
-      get 'show', :id => druid
+      pid = 'druid:zz999zz9999'
+      expect(Dor).to receive(:find).with(pid).and_raise(ActiveFedora::ObjectNotFoundError)
+      get 'show', :id => pid
       expect(response).to have_http_status(:not_found)
+    end
+    it 'should add a "druid:" prefix for an ID without it' do
+      pid = item.pid.sub('druid:', '')
+      expect(Dor).to receive(:find).with("druid:#{pid}").and_call_original
+      get 'show', :id => pid
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -360,6 +360,351 @@ describe User, :type => :model do
     end
   end
 
+  describe '#can_admin?' do
+    before :each do
+      expect(subject).not_to receive(:is_manager)
+      expect(subject).not_to receive(:is_viewer)
+    end
+
+    shared_examples 'Argo grants permission to manage object' do
+      it 'permits admin' do
+        expect(subject).to receive(:is_admin).once.and_return(true)
+        expect(subject.can_admin?(item)).to be true
+      end
+      it 'denies manager' do
+        expect(subject).to receive(:is_admin).once.and_return(false)
+        expect(subject.can_admin?(item)).to be false
+      end
+    end
+
+    context 'checks object permissions' do
+      let(:druid) { 'druid:hv992ry2431' }
+      let(:item) { instantiate_fixture(druid, Dor::AdminPolicyObject) }
+      context 'when user has no Argo permissions' do
+        before :each do
+          expect(subject).to receive(:is_admin).once.and_return(false)
+        end
+        it 'using default "can_manage_item?"' do
+          expect(item).to receive(:can_manage_item?).at_least(:once)
+          subject.can_admin?(item)
+        end
+        it 'using custom "can_manage_content?"' do
+          expect(item).to receive(:can_manage_content?).at_least(:once)
+          subject.can_admin?(item, 'content')
+        end
+        it 'raises ArgumentError for invalid permissions' do
+          expect{subject.can_admin?(item, 'WTF')}.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    context 'DOR object is an APO with a governing APO' do
+      let(:druid) { 'druid:hv992ry2431' }
+      let(:item) { instantiate_fixture(druid, Dor::AdminPolicyObject) }
+      let(:apo) { item.admin_policy_object }
+      it_behaves_like 'Argo grants permission to manage object'
+      context 'when user has no Argo permissions' do
+        before :each do
+          expect(subject).to receive(:is_admin).once.and_return(false)
+        end
+        it 'allows user with authorized role in governing APO' do
+          # This checks the governing APO and grants permission.
+          role = 'sdr-administrator'
+          expect(subject).to receive(:roles).with(apo.pid).once.and_return([role])
+          expect(subject).not_to receive(:roles).with(item.pid)
+          expect(item).to receive(:can_manage_item?).with([role]).once.and_return(true)
+          expect(subject.can_admin?(item)).to be true
+        end
+        it 'allows user with authorized role in item APO' do
+          # This checks the governing APO and does not grant permission;
+          # it then checks the item APO and grants permission.
+          apo_role = 'not-administrator'
+          item_role = 'sdr-administrator'
+          expect(subject).to receive(:roles).with(apo.pid).once.and_return([apo_role])
+          expect(subject).to receive(:roles).with(item.pid).once.and_return([item_role])
+          expect(item).to receive(:can_manage_item?).with([apo_role]).once.and_return(false)
+          expect(item).to receive(:can_manage_item?).with([item_role]).once.and_return(true)
+          expect(subject.can_admin?(item)).to be true
+        end
+        it 'forbids user without authorized role in any APO' do
+          # This checks the governing APO and does not grant permission;
+          # it then checks the item APO and does not grant permission.
+          role = 'sdr-viewer'
+          expect(subject).to receive(:roles).with(apo.pid).once.and_return([role])
+          expect(subject).to receive(:roles).with(item.pid).once.and_return([role])
+          expect(item).to receive(:can_manage_item?).with([role]).twice.and_return(false)
+          expect(subject.can_admin?(item)).to be false
+        end
+      end
+    end
+
+    context 'DOR object is an APO without a governing APO' do
+      let(:druid) { 'druid:hv992ry2431' }
+      let(:item) do
+        item = instantiate_fixture(druid, Dor::AdminPolicyObject)
+        allow(item).to receive(:admin_policy_object).and_return(nil)
+        item
+      end
+      it_behaves_like 'Argo grants permission to manage object'
+      context 'when user has no Argo permissions' do
+        before :each do
+          expect(subject).to receive(:is_admin).once.and_return(false)
+        end
+        it 'allows user with authorized role' do
+          # There is no governing APO to grant permission, so
+          # it checks the item APO and grants permission.
+          role = 'sdr-administrator'
+          expect(subject).to receive(:roles).with(item.pid).once.and_return([role])
+          expect(item).to receive(:can_manage_item?).with([role]).once.and_return(true)
+          expect(subject.can_admin?(item)).to be true
+        end
+        it 'forbids user without authorized role' do
+          # There is no governing APO to grant permission, so
+          # it checks the item APO and does not grant permission.
+          role = 'sdr-viewer'
+          expect(subject).to receive(:roles).with(item.pid).once.and_return([role])
+          expect(item).to receive(:can_manage_item?).with([role]).once.and_return(false)
+          expect(subject.can_admin?(item)).to be false
+        end
+      end
+    end
+  end
+
+  describe '#can_manage?' do
+    before :each do
+      expect(subject).not_to receive(:is_viewer)
+    end
+
+    shared_examples 'Argo grants permission to manage object' do
+      it 'permits admin' do
+        expect(subject).to receive(:is_admin).once.and_return(true)
+        expect(subject).not_to receive(:is_manager)
+        expect(subject.can_manage?(item)).to be true
+      end
+      it 'permits manager' do
+        expect(subject).to receive(:is_admin).once.and_return(false)
+        expect(subject).to receive(:is_manager).once.and_return(true)
+        expect(subject.can_manage?(item)).to be true
+      end
+    end
+
+    context 'checks object permissions' do
+      let(:druid) { 'druid:hv992ry2431' }
+      let(:item) { instantiate_fixture(druid, Dor::AdminPolicyObject) }
+      context 'when user has no Argo permissions' do
+        before :each do
+          expect(subject).to receive(:is_admin).once.and_return(false)
+          expect(subject).to receive(:is_manager).once.and_return(false)
+        end
+        it 'using default "can_manage_item?"' do
+          expect(item).to receive(:can_manage_item?).at_least(:once)
+          subject.can_manage?(item)
+        end
+        it 'using custom "can_manage_content?"' do
+          expect(item).to receive(:can_manage_content?).at_least(:once)
+          subject.can_manage?(item, 'content')
+        end
+        it 'raises ArgumentError for invalid permissions' do
+          expect{subject.can_manage?(item, 'WTF')}.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    context 'DOR object is an APO with a governing APO' do
+      let(:druid) { 'druid:hv992ry2431' }
+      let(:item) { instantiate_fixture(druid, Dor::AdminPolicyObject) }
+      let(:apo) { item.admin_policy_object }
+      it_behaves_like 'Argo grants permission to manage object'
+      context 'when user has no Argo permissions' do
+        before :each do
+          expect(subject).to receive(:is_admin).once.and_return(false)
+          expect(subject).to receive(:is_manager).once.and_return(false)
+        end
+        it 'allows user with authorized role in governing APO' do
+          # This checks the governing APO and grants permission.
+          role = 'sdr-administrator'
+          expect(subject).to receive(:roles).with(apo.pid).once.and_return([role])
+          expect(subject).not_to receive(:roles).with(item.pid)
+          expect(item).to receive(:can_manage_item?).with([role]).once.and_return(true)
+          expect(subject.can_manage?(item)).to be true
+        end
+        it 'allows user with authorized role in item APO' do
+          # This checks the governing APO and does not grant permission;
+          # it then checks the item APO and grants permission.
+          apo_role = 'not-administrator'
+          item_role = 'sdr-administrator'
+          expect(subject).to receive(:roles).with(apo.pid).once.and_return([apo_role])
+          expect(subject).to receive(:roles).with(item.pid).once.and_return([item_role])
+          expect(item).to receive(:can_manage_item?).with([apo_role]).once.and_return(false)
+          expect(item).to receive(:can_manage_item?).with([item_role]).once.and_return(true)
+          expect(subject.can_manage?(item)).to be true
+        end
+        it 'forbids user without authorized role in any APO' do
+          # This checks the governing APO and does not grant permission;
+          # it then checks the item APO and does not grant permission.
+          role = 'sdr-viewer'
+          expect(subject).to receive(:roles).with(apo.pid).once.and_return([role])
+          expect(subject).to receive(:roles).with(item.pid).once.and_return([role])
+          expect(item).to receive(:can_manage_item?).with([role]).twice.and_return(false)
+          expect(subject.can_manage?(item)).to be false
+        end
+      end
+    end
+
+    context 'DOR object is an APO without a governing APO' do
+      let(:druid) { 'druid:hv992ry2431' }
+      let(:item) do
+        item = instantiate_fixture(druid, Dor::AdminPolicyObject)
+        allow(item).to receive(:admin_policy_object).and_return(nil)
+        item
+      end
+      it_behaves_like 'Argo grants permission to manage object'
+      context 'when user has no Argo permissions' do
+        before :each do
+          expect(subject).to receive(:is_admin).once.and_return(false)
+          expect(subject).to receive(:is_manager).once.and_return(false)
+        end
+        it 'allows user with authorized role' do
+          # There is no governing APO to grant permission, so
+          # it checks the item APO and grants permission.
+          role = 'sdr-administrator'
+          expect(subject).to receive(:roles).with(item.pid).once.and_return([role])
+          expect(item).to receive(:can_manage_item?).with([role]).once.and_return(true)
+          expect(subject.can_manage?(item)).to be true
+        end
+        it 'forbids user without authorized role' do
+          # There is no governing APO to grant permission, so
+          # it checks the item APO and does not grant permission.
+          role = 'sdr-viewer'
+          expect(subject).to receive(:roles).with(item.pid).once.and_return([role])
+          expect(item).to receive(:can_manage_item?).with([role]).once.and_return(false)
+          expect(subject.can_manage?(item)).to be false
+        end
+      end
+    end
+  end
+
+  describe '#can_view?' do
+    shared_examples 'Argo grants permission to view object' do
+      it 'permits admin' do
+        expect(subject).to receive(:is_admin).once.and_return(true)
+        expect(subject).not_to receive(:is_manager)
+        expect(subject).not_to receive(:is_viewer)
+        expect(subject.can_view?(item)).to be true
+      end
+      it 'permits manager' do
+        expect(subject).to receive(:is_admin).once.and_return(false)
+        expect(subject).to receive(:is_manager).once.and_return(true)
+        expect(subject).not_to receive(:is_viewer)
+        expect(subject.can_view?(item)).to be true
+      end
+      it 'permits viewer' do
+        expect(subject).to receive(:is_admin).once.and_return(false)
+        expect(subject).to receive(:is_manager).once.and_return(false)
+        expect(subject).to receive(:is_viewer).once.and_return(true)
+        expect(subject.can_view?(item)).to be true
+      end
+    end
+
+    context 'checks object permissions' do
+      let(:druid) { 'druid:hv992ry2431' }
+      let(:item) { instantiate_fixture(druid, Dor::AdminPolicyObject) }
+      context 'when user has no Argo permissions' do
+        before :each do
+          expect(subject).to receive(:is_admin).once.and_return(false)
+          expect(subject).to receive(:is_manager).once.and_return(false)
+          expect(subject).to receive(:is_viewer).once.and_return(false)
+        end
+        it 'using default "can_view_metadata?"' do
+          expect(item).to receive(:can_view_metadata?).at_least(:once)
+          subject.can_view?(item)
+        end
+        it 'using custom "can_view_content?"' do
+          expect(item).to receive(:can_view_content?).at_least(:once)
+          subject.can_view?(item, 'content')
+        end
+        it 'raises ArgumentError for invalid permissions' do
+          expect{subject.can_view?(item, 'WTF')}.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    context 'DOR object is an APO with a governing APO' do
+      let(:druid) { 'druid:hv992ry2431' }
+      let(:item) { instantiate_fixture(druid, Dor::AdminPolicyObject) }
+      let(:apo) { item.admin_policy_object }
+      it_behaves_like 'Argo grants permission to view object'
+      context 'when user has no Argo permissions' do
+        before :each do
+          expect(subject).to receive(:is_admin).once.and_return(false)
+          expect(subject).to receive(:is_manager).once.and_return(false)
+          expect(subject).to receive(:is_viewer).once.and_return(false)
+        end
+        it 'allows user with authorized role in governing APO' do
+          # This checks the governing APO and grants permission.
+          role = 'sdr-viewer'
+          expect(subject).to receive(:roles).with(apo.pid).once.and_return([role])
+          expect(subject).not_to receive(:roles).with(item.pid)
+          expect(item).to receive(:can_view_metadata?).with([role]).once.and_return(true)
+          expect(subject.can_view?(item)).to be true
+        end
+        it 'allows user with authorized role in item APO' do
+          # This checks the governing APO and does not grant permission;
+          # it then checks the item APO and grants permission.
+          apo_role = 'not-administrator'
+          item_role = 'sdr-administrator'
+          expect(subject).to receive(:roles).with(apo.pid).once.and_return([apo_role])
+          expect(subject).to receive(:roles).with(item.pid).once.and_return([item_role])
+          expect(item).to receive(:can_view_metadata?).with([apo_role]).once.and_return(false)
+          expect(item).to receive(:can_view_metadata?).with([item_role]).once.and_return(true)
+          expect(subject.can_view?(item)).to be true
+        end
+        it 'forbids user without authorized role in any APO' do
+          # This checks the governing APO and does not grant permission;
+          # it then checks the item APO and does not grant permission.
+          role = 'sdr-viewer'
+          expect(subject).to receive(:roles).with(apo.pid).once.and_return([role])
+          expect(subject).to receive(:roles).with(item.pid).once.and_return([role])
+          expect(item).to receive(:can_view_metadata?).with([role]).twice.and_return(false)
+          expect(subject.can_view?(item)).to be false
+        end
+      end
+    end
+
+    context 'DOR object is an APO without a governing APO' do
+      let(:druid) { 'druid:hv992ry2431' }
+      let(:item) do
+        item = instantiate_fixture(druid, Dor::AdminPolicyObject)
+        allow(item).to receive(:admin_policy_object).and_return(nil)
+        item
+      end
+      it_behaves_like 'Argo grants permission to view object'
+      context 'when user has no Argo permissions' do
+        before :each do
+          expect(subject).to receive(:is_admin).once.and_return(false)
+          expect(subject).to receive(:is_manager).once.and_return(false)
+          expect(subject).to receive(:is_viewer).once.and_return(false)
+        end
+        it 'allows user with authorized role' do
+          # There is no governing APO to grant permission, so
+          # it checks the item APO and grants permission.
+          role = 'sdr-administrator'
+          expect(subject).to receive(:roles).with(item.pid).once.and_return([role])
+          expect(item).to receive(:can_view_metadata?).with([role]).once.and_return(true)
+          expect(subject.can_view?(item)).to be true
+        end
+        it 'forbids user without authorized role' do
+          # There is no governing APO to grant permission, so
+          # it checks the item APO and does not grant permission.
+          role = 'sdr-viewer'
+          expect(subject).to receive(:roles).with(item.pid).once.and_return([role])
+          expect(item).to receive(:can_view_metadata?).with([role]).once.and_return(false)
+          expect(subject.can_view?(item)).to be false
+        end
+      end
+    end
+  end
+
   # TODO
   describe 'permitted_apos' do
     it 'not implemented'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,19 +30,6 @@ Capybara.default_max_wait_time = 10
 # Note: no such files, currently.
 Dir[Rails.root.join('spec/support/**/*.rb')].each {|f| require f}
 
-def druid_to_path(druid, flavor = 'xml')
-  fixture_mask = File.join(File.dirname(__FILE__), 'fixtures', "*_#{druid.sub(/:/, '_')}.#{flavor}")
-  other_mask   = Rails.root.join('fedora_conf', 'data', "#{druid.sub(/druid:/, '')}.#{flavor}")
-  Dir[fixture_mask].first || Dir[other_mask].first
-end
-
-def instantiate_fixture(druid, klass = ActiveFedora::Base)
-  fname = druid_to_path(druid)
-  Rails.logger.debug "instantiate_fixture(#{druid}) ==> #{fname}"
-  return nil if fname.nil?
-  item_from_foxml(File.read(fname), klass)
-end
-
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
@@ -76,8 +63,20 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 end
 
-def log_in_as_mock_user(subject)
-  allow(subject).to receive(:webauth).and_return(double(:webauth_user, :login => 'sunetid', :logged_in? => true))
+################################################################
+# Dor objects
+
+def druid_to_path(druid, flavor = 'xml')
+  fixture_mask = File.join(File.dirname(__FILE__), 'fixtures', "*_#{druid.sub(/:/, '_')}.#{flavor}")
+  other_mask   = Rails.root.join('fedora_conf', 'data', "#{druid.sub(/druid:/, '')}.#{flavor}")
+  Dir[fixture_mask].first || Dir[other_mask].first
+end
+
+def instantiate_fixture(druid, klass = ActiveFedora::Base)
+  fname = druid_to_path(druid)
+  Rails.logger.debug "instantiate_fixture(#{druid}) ==> #{fname}"
+  return nil if fname.nil?
+  item_from_foxml(File.read(fname), klass)
 end
 
 # Highly similar to https://github.com/sul-dlss/dor-services/blob/master/spec/foxml_helper.rb
@@ -112,4 +111,83 @@ def item_from_foxml(foxml, item_class = Dor::Base, other_class = ActiveFedora::O
     end
   end
   result
+end
+
+################################################################
+# Users
+
+def log_in_as_mock_user(subject)
+  user = double(
+    :webauth_user,
+    :login => 'sunetid',
+    :logged_in? => true,
+  )
+  allow(subject).to receive(:webauth).and_return(user)
+end
+
+# A User with `is_admin` privilege.  This is the ultimate privilege.
+# This user is configured to be the ApplicationController#current_user.
+# @return admin_user [User] An admin user
+def admin_user
+  webauth = double(
+    'WebAuth',
+    :login => 'sunetid',
+    :attributes => {'DISPLAYNAME' => 'Admin'}
+  )
+  admin_user = User.find_or_create_by_webauth(webauth)
+  allow(admin_user).to receive(:groups).and_return(User::ADMIN_GROUPS)
+  # admin privilege supercedes all others, no need to mock anything else.
+  allow(admin_user).to receive(:is_admin).and_return(true)
+  # Could impose additional restraints, but it's likely overkill
+  # in the spec helper methods (individual specs could do so), e.g.
+  # expect(admin_user).not_to receive(:is_manager)
+  # expect(admin_user).not_to receive(:is_viewer)
+  allow_any_instance_of(ApplicationController)
+    .to receive(:current_user)
+    .and_return(admin_user)
+  admin_user
+end
+
+# A User without `is_admin` privilege, but with `is_manager` privilege.  The
+# `is_manager` privilege will trump all lower privileges.
+# This user is configured to be the ApplicationController#current_user.
+# @return manager_user [User] A manager user
+def manager_user
+  webauth = double(
+    'WebAuth',
+    :login => 'sunetid',
+    :attributes => {'DISPLAYNAME' => 'Manager'}
+  )
+  manager_user = User.find_or_create_by_webauth(webauth)
+  allow(manager_user).to receive(:groups).and_return(User::MANAGER_GROUPS)
+  allow(manager_user).to receive(:is_admin).and_return(false)
+  allow(manager_user).to receive(:is_manager).and_return(true)
+  # Could impose additional restraints, but it's likely overkill
+  # in the spec helper methods (individual specs could do so), e.g.
+  # expect(manager_user).not_to receive(:is_viewer)
+  allow_any_instance_of(ApplicationController)
+    .to receive(:current_user)
+    .and_return(manager_user)
+  manager_user
+end
+
+# A User without `is_admin` or `is_manager` privileges, but with `is_viewer`.
+# The `is_viewer` privilege will trump all lower privileges (workgroups).
+# This user is configured to be the ApplicationController#current_user.
+# @return view_user [User] A viewer user
+def view_user
+  webauth = double(
+    'WebAuth',
+    :login => 'sunetid',
+    :attributes => {'DISPLAYNAME' => 'Viewer'}
+  )
+  view_user = User.find_or_create_by_webauth(webauth)
+  allow(view_user).to receive(:groups).and_return(User::VIEWER_GROUPS)
+  allow(view_user).to receive(:is_admin).and_return(false)
+  allow(view_user).to receive(:is_manager).and_return(false)
+  allow(view_user).to receive(:is_viewer).and_return(true)
+  allow_any_instance_of(ApplicationController)
+    .to receive(:current_user)
+    .and_return(view_user)
+  view_user
 end


### PR DESCRIPTION
This applies the enhanced user only to the catalog controller and specs for it are passing, but the app as a whole does not pass specs. This is an application of #595 

This branch is based on https://github.com/sul-dlss/argo/compare/user-permissions
