### PR TITLE
[WIP] registration controller - handle missing apo_id

### DIFF
--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -35,21 +35,25 @@ class RegistrationController < ApplicationController
   def collection_list
     truncate_limit = (params[:truncate] || 60).to_i
     collections = { '' => 'None' }
-    apo_object = Dor.find(params[:apo_id])
-    apo_object.administrativeMetadata.ng_xml.search('//registration/collection/@id').each do |node|
-      col_id = node.to_s
-      col_druid = col_id.gsub(/^druid:/, '')
-      col_title_field = SolrDocument::FIELD_TITLE
-      # grab the collection title from Solr, or fall back to DOR
-      solr_doc = Blacklight.solr.find({:q => "id:\"#{col_id}\"", :rows => 1, :fl => col_title_field}).docs.first
-      if solr_doc.present? && solr_doc[col_title_field].present?
-        collections[col_id] = "#{short_label(solr_doc[col_title_field], truncate_limit)} (#{col_druid})"
-      else
-        begin # Title not found in Solr, so check DOR
-          collection = Dor.find(col_id)
-          collections[col_id] = "#{short_label(collection.label, truncate_limit)} (#{col_druid})"
-        rescue ActiveFedora::ObjectNotFoundError
-          collections[col_id] = "Unknown Collection (#{col_druid})"
+    # This method can be called without an :apo_id when
+    # registering a new item, so it must handle this scenario.
+    unless params[:apo_id].blank?
+      apo_object = Dor.find(params[:apo_id])
+      apo_object.administrativeMetadata.ng_xml.search('//registration/collection/@id').each do |node|
+        col_id = node.to_s
+        col_druid = col_id.gsub(/^druid:/, '')
+        col_title_field = SolrDocument::FIELD_TITLE
+        # grab the collection title from Solr, or fall back to DOR
+        solr_doc = Blacklight.solr.find({:q => "id:\"#{col_id}\"", :rows => 1, :fl => col_title_field}).docs.first
+        if solr_doc.present? && solr_doc[col_title_field].present?
+          collections[col_id] = "#{short_label(solr_doc[col_title_field], truncate_limit)} (#{col_druid})"
+        else
+          begin # Title not found in Solr, so check DOR
+            collection = find_druid(col_id)
+            collections[col_id] = "#{short_label(collection.label, truncate_limit)} (#{col_druid})"
+          rescue ActiveFedora::ObjectNotFoundError
+            collections[col_id] = "Unknown Collection (#{col_druid})"
+          end
         end
       end
     end
@@ -59,44 +63,48 @@ class RegistrationController < ApplicationController
   end
 
   def rights_list
-    apo_object = Dor.find(params[:apo_id], :lightweight => true)
-    adm_xml = apo_object.defaultObjectRights.ng_xml
-
-    # FIXME: should not be in Controller
-    # figure out what the default option (if any) should be
-    default_opt = nil
-    if !adm_xml.xpath('//rightsMetadata/access[@type=\'read\']/machine/world').empty?
-      # readable by world translates to World
-      default_opt = 'world'
-    elsif !adm_xml.xpath('//rightsMetadata/access[@type=\'read\']/machine/group[text()=\'Stanford\' or text()=\'stanford\']').empty?
-      # TODO: this is stupid, should handle "stanford" regardless of the string's case, but the xpath parser doesn't support the lower-case() fn
-      # readable by stanford translates to Stanford
-      # TODO: found something indicating that xpath might support regex
-      default_opt = 'stanford'
-    elsif !adm_xml.xpath('//rightsMetadata/access[@type=\'read\']/machine/none').empty?
-      # readable by none is either Citation Only (formerly "None") or Dark
-      if !adm_xml.xpath('//rightsMetadata/access[@type=\'discover\']/machine/world').empty?
-        # discoverable by world but readable by none translates to Citation Only/none
-        default_opt = 'none'
-      elsif !adm_xml.xpath('//rightsMetadata/access[@type=\'discover\']/machine/none').empty?
-        # discoverable by none and readable by none translates to Dark
-        default_opt = 'dark'
-      end
-    end
-
-    # iterate through the default version of the rights list.  if we found a default option
-    # selection, label it in the UI text and key it as 'default' (instead of its own name).  if
-    # we didn't find a default option, we'll just return the default list of rights options with no
-    # specified selection.
     result = {}
-    Constants::DEFAULT_RIGHTS_OPTIONS.each do |val|
-      if default_opt == val[1]
-        result['default'] = "#{val[0]} (APO default)"
-      else
-        result[val[1]] = val[0]
+    # This method can be called without an :apo_id when
+    # registering a new item, so it must handle this scenario.
+    unless params[:apo_id].blank?
+      apo_object = Dor.find(params[:apo_id], :lightweight => true)
+      adm_xml = apo_object.defaultObjectRights.ng_xml
+
+      # FIXME: should not be in Controller
+      # figure out what the default option (if any) should be
+      default_opt = nil
+      if !adm_xml.xpath('//rightsMetadata/access[@type=\'read\']/machine/world').empty?
+        # readable by world translates to World
+        default_opt = 'world'
+      elsif !adm_xml.xpath('//rightsMetadata/access[@type=\'read\']/machine/group[text()=\'Stanford\' or text()=\'stanford\']').empty?
+        # TODO: this is stupid, should handle "stanford" regardless of the string's case, but the xpath parser doesn't support the lower-case() fn
+        # readable by stanford translates to Stanford
+        # TODO: found something indicating that xpath might support regex
+        default_opt = 'stanford'
+      elsif !adm_xml.xpath('//rightsMetadata/access[@type=\'read\']/machine/none').empty?
+        # readable by none is either Citation Only (formerly "None") or Dark
+        if !adm_xml.xpath('//rightsMetadata/access[@type=\'discover\']/machine/world').empty?
+          # discoverable by world but readable by none translates to Citation Only/none
+          default_opt = 'none'
+        elsif !adm_xml.xpath('//rightsMetadata/access[@type=\'discover\']/machine/none').empty?
+          # discoverable by none and readable by none translates to Dark
+          default_opt = 'dark'
+        end
+      end
+
+      # Iterate through the default version of the rights list.  if we found a
+      # default option selection, label it in the UI text and key it as
+      # 'default' (instead of its own name).  if we didn't find a default
+      # option, we'll just return the default list of rights options with no
+      # specified selection.
+      Constants::DEFAULT_RIGHTS_OPTIONS.each do |val|
+        if default_opt == val[1]
+          result['default'] = "#{val[0]} (APO default)"
+        else
+          result[val[1]] = val[0]
+        end
       end
     end
-
     respond_to do |format|
       format.any(:json, :xml) { render request.format.to_sym => result }
     end

--- a/spec/controllers/registration_controller_spec.rb
+++ b/spec/controllers/registration_controller_spec.rb
@@ -3,10 +3,11 @@ require 'spec_helper'
 describe RegistrationController, :type => :controller do
   before :each do
     @item = double(Dor::Item)
+    allow(Dor).to receive(:find).and_return(@item)
+    allow(Dor::Item).to receive(:find).and_return(@item)
     @current_user = double(:webauth_user, :login => 'sunetid', :logged_in? => true, :privgroup => ADMIN_GROUPS.first)
     allow(@current_user).to receive(:is_admin).and_return(true)
     allow(controller).to receive(:current_user).and_return(@current_user)
-    allow(Dor::Item).to receive(:find).and_return(@item)
   end
 
   describe 'rights_list' do
@@ -34,9 +35,7 @@ describe RegistrationController, :type => :controller do
       </rightsMetadata>
       XML
 
-      @item = double(Dor::Item)
       xml = Nokogiri::XML(content)
-      allow(Dor).to receive(:find).and_return(@item)
       # using content metadata, but any datastream would do
       object_rights = double(Dor::ContentMetadataDS)
       allow(object_rights).to receive(:ng_xml).and_return xml
@@ -69,9 +68,7 @@ describe RegistrationController, :type => :controller do
       </rightsMetadata>
       XML
 
-      @item = double(Dor::Item)
       xml = Nokogiri::XML(content)
-      allow(Dor).to receive(:find).and_return(@item)
       # using content metadata, but any datastream would do
       object_rights = double(Dor::ContentMetadataDS)
       allow(object_rights).to receive(:ng_xml).and_return xml
@@ -104,9 +101,7 @@ describe RegistrationController, :type => :controller do
       </rightsMetadata>
       XML
 
-      @item = double(Dor::Item)
       xml = Nokogiri::XML(content)
-      allow(Dor).to receive(:find).and_return(@item)
       # using content metadata, but any datastream would do
       object_rights = double(Dor::ContentMetadataDS)
       allow(object_rights).to receive(:ng_xml).and_return xml
@@ -139,9 +134,7 @@ describe RegistrationController, :type => :controller do
       </rightsMetadata>
       XML
 
-      @item = double(Dor::Item)
       xml = Nokogiri::XML(content)
-      allow(Dor).to receive(:find).and_return(@item)
       # using content metadata, but any datastream would do
       object_rights = double(Dor::ContentMetadataDS)
       allow(object_rights).to receive(:ng_xml).and_return xml
@@ -174,9 +167,7 @@ describe RegistrationController, :type => :controller do
       </rightsMetadata>
       XML
 
-      @item = double(Dor::Item)
       xml = Nokogiri::XML(content)
-      allow(Dor).to receive(:find).and_return(@item)
       # using content metadata, but any datastream would do
       object_rights = double(Dor::ContentMetadataDS)
       allow(object_rights).to receive(:ng_xml).and_return xml
@@ -187,9 +178,7 @@ describe RegistrationController, :type => :controller do
 
     it 'should show no default if there is no xml' do
       content = ''
-      @item = double(Dor::Item)
       xml = Nokogiri::XML(content)
-      allow(Dor).to receive(:find).and_return(@item)
       # using content metadata, but any datastream would do
       object_rights = double(Dor::ContentMetadataDS)
       allow(object_rights).to receive(:ng_xml).and_return xml
@@ -217,8 +206,18 @@ describe RegistrationController, :type => :controller do
   end
 
   describe '#collection_list' do
-    it 'should handle invalid parameters' do
-      expect { get 'collection_list' }.to raise_error(ArgumentError)
+    it 'should handle a missing "apo_id" parameter' do
+      # The RegistrationController#collection_list can be called without
+      # an :apo_id parameter when registering a new item, see
+      # spec/features/item_registration_spec.rb
+      # So, it's not simple to enforce say ActionController::BadRequest for
+      # a missing parameter.  The method must accept a missing parameter.
+      # In this first call with a missing parameter, it doesn't specify a
+      # known format (:json, :xml), so it fails to respond.
+      expect { get 'collection_list' }.to raise_error(ActionController::UnknownFormat)
+      # When a known format is given, it's OK.
+      expect { get 'collection_list', format: :json }.not_to raise_error
+      expect { get 'collection_list', format: :xml }.not_to raise_error
     end
 
     it 'should handle a bogus APO' do


### PR DESCRIPTION
While working on APO authorization, it seemed that creating a new APO could call the action without an `apo_id`.