### PR TITLE
Add User#is_webauth_admin? to distinguish between original and impersonated groups

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -1,6 +1,6 @@
 class AuthController < ApplicationController
   before_action(except: [:forget_impersonated_groups]) do
-    render :status => :forbidden, :text => 'forbidden' unless current_user && current_user.is_admin?
+    render :status => :forbidden, :text => 'forbidden' unless current_user && current_user.is_webauth_admin?
   end
 
   def remember_impersonated_groups

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -98,7 +98,11 @@ class User < ActiveRecord::Base
 
   def groups
     return @groups_to_impersonate unless @groups_to_impersonate.blank?
-    @groups ||= begin
+    webauth_groups
+  end
+
+  def webauth_groups
+    @webauth_groups ||= begin
       perm_keys = ["sunetid:#{login}"]
       return perm_keys unless webauth && webauth.privgroup.present?
       perm_keys + webauth.privgroup.split(/\|/).map {|g| "workgroup:#{g}"}
@@ -108,6 +112,12 @@ class User < ActiveRecord::Base
   # @return [Boolean] is the user a repository wide administrator
   def is_admin?
     !(groups & ADMIN_GROUPS).blank?
+  end
+
+  # @return [Boolean] is the user a repository wide administrator without
+  #     taking into account impersonation.
+  def is_webauth_admin?
+    !(webauth_groups & ADMIN_GROUPS).blank?
   end
 
   # @return [Boolean] is the user a repository wide manager

--- a/spec/controllers/auth_controller_spec.rb
+++ b/spec/controllers/auth_controller_spec.rb
@@ -5,7 +5,7 @@ describe AuthController, :type => :controller do
   describe 'test impersonation' do
     context 'as an admin' do
       before :each do
-        log_in_as_mock_user(subject, is_admin?: true)
+        log_in_as_mock_user(subject, is_webauth_admin?: true)
       end
 
       it 'should be able to remember and forget impersonated groups' do
@@ -20,7 +20,7 @@ describe AuthController, :type => :controller do
 
     context 'as an ordinary user' do
       before :each do
-        log_in_as_mock_user(subject, is_admin?: false)
+        log_in_as_mock_user(subject, is_webauth_admin?: false)
       end
 
       it 'should be able to remember and forget impersonated groups' do


### PR DESCRIPTION
I'd be very interested in naming `is_webauth_admin?` something better, either now or in the future.