### PR TITLE
Updates Argo to latest 5.x version of Blacklight (5.18.0)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'uglifier', '>= 1.0.3'
 # Stanford/Hydra related gems
 gem 'about_page'
 gem 'active-fedora'
-gem 'blacklight', '~> 5.11.3' # More deprecation warnings from 5.11.3 to 5.16
+gem 'blacklight', '~> 5.18'
 gem 'blacklight-hierarchy'
 gem 'dor-services', '~> 5.4', '>= 5.4.2'
 gem 'is_it_working-cbeer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,10 +65,10 @@ GEM
       docopt (~> 0.5.0)
       validatable (~> 1.6)
     barby (0.6.2)
-    blacklight (5.11.3)
+    blacklight (5.18.0)
       bootstrap-sass (~> 3.2)
       deprecation
-      kaminari (~> 0.13)
+      kaminari (>= 0.15)
       nokogiri (~> 1.6)
       rails (>= 3.2.6, < 5)
       rsolr (~> 1.0.11)
@@ -451,7 +451,7 @@ GEM
     sprockets (3.5.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.0.1)
+    sprockets-rails (3.0.3)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
@@ -513,7 +513,7 @@ DEPENDENCIES
   about_page
   active-fedora
   barby
-  blacklight (~> 5.11.3)
+  blacklight (~> 5.18)
   blacklight-hierarchy
   bootstrap-sass
   capistrano (= 3.4.0)

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -22,8 +22,7 @@ class ReportController < CatalogController
     # params[:sort] = "#{params.delete(:sidx)} #{params.delete(:sord)}" if params[:sidx].present?
     rows_per_page = params[:rows] ? params.delete(:rows).to_i : 10
     params[:per_page] = rows_per_page * [params.delete(:npage).to_i, 1].max
-
-    @report = Report.new(params)
+    @report = Report.new(params, current_user: current_user)
 
     respond_to do |format|
       format.json do
@@ -44,7 +43,7 @@ class ReportController < CatalogController
   def pids
     # params[:per_page]=100
     # params[:rows]=100
-    ids = Report.new(params, ['druid']).pids params
+    ids = Report.new(params, ['druid'], current_user: current_user).pids params
     respond_to do |format|
       format.json do
         render :json => {
@@ -60,7 +59,7 @@ class ReportController < CatalogController
     response.headers['Content-Type'] = 'application/octet-stream'
     response.headers['Content-Disposition'] = 'attachment; filename=report.csv'
     response.headers['Last-Modified'] = Time.now.utc.rfc2822 # HTTP requires GMT date/time
-    self.response_body = Report.new(params, fields).to_csv
+    self.response_body = Report.new(params, fields, current_user: current_user).to_csv
   end
 
   # an ajax call to reset workflow states for objects
@@ -101,7 +100,7 @@ class ReportController < CatalogController
   ##
   # @return [Array]
   def pids_from_report(params)
-    Report.new(params, ['druids']).pids params
+    Report.new(params, ['druids'], current_user: current_user).pids params
   end
 
   ##

--- a/app/helpers/argo_helper.rb
+++ b/app/helpers/argo_helper.rb
@@ -186,7 +186,7 @@ module ArgoHelper
   end
 
   def render_index_info(document)
-    "indexed by DOR Services v#{@document.get(Dor::INDEX_VERSION_FIELD)}"
+    "indexed by DOR Services v#{@document.first(Dor::INDEX_VERSION_FIELD)}"
   end
 
   def render_searchworks_link(document, link_text = 'Searchworks', opts = {:target => '_blank'})
@@ -215,8 +215,8 @@ module ArgoHelper
   end
 
   def render_datastream_link(document)
-    return unless document_has?(@document, 'objectType_ssim') && @document.get('objectType_ssim') == 'adminPolicy'
-    link_to 'MODS bulk loads', bulk_jobs_index_path(@document.get('id')), :id => 'bulk-button', :class => 'button btn btn-primary'
+    return unless @document.admin_policy?
+    link_to 'MODS bulk loads', bulk_jobs_index_path(@document), :id => 'bulk-button', :class => 'button btn btn-primary'
   end
 
 end

--- a/app/models/concerns/object_type_concern.rb
+++ b/app/models/concerns/object_type_concern.rb
@@ -1,0 +1,16 @@
+module ObjectTypeConcern
+  extend Blacklight::Solr::Document
+
+  FIELD_OBJECT_TYPE = :objectType_ssim
+
+  ##
+  # Eventhough this is a multivalued Solr field, it should actually be treated
+  # as a single valued field.
+  def object_type
+    first(FIELD_OBJECT_TYPE)
+  end
+
+  def admin_policy?
+    object_type == 'adminPolicy'
+  end
+end

--- a/app/models/null_user.rb
+++ b/app/models/null_user.rb
@@ -1,0 +1,19 @@
+class NullUser
+  # rubocop:disable Style/PredicateName
+  def is_admin?
+    false
+  end
+
+  def is_manager?
+    false
+  end
+
+  def is_viewer?
+    false
+  end
+  # rubocop:enable Style/PredicateName
+
+  def permitted_apos
+    []
+  end
+end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -9,7 +9,7 @@ class Report
     include ValueHelper
   end
 
-  attr_reader :response, :document_list, :num_found, :params
+  attr_reader :response, :document_list, :num_found, :params, :current_user
 
   @blacklight_config = blacklight_config.deep_copy if @blacklight_config.nil?
 
@@ -161,7 +161,8 @@ class Report
     }
   end
 
-  def initialize(params = {}, fields = nil)
+  def initialize(params = {}, fields = nil, current_user: NullUser.new)
+    @current_user = current_user
     if fields.nil?
       @fields = self.class.blacklight_config.report_fields
     else

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -9,6 +9,7 @@ class SolrDocument
   include DocumentDateConcern
   include PreservationSizeConcern
   include EmbargoConcern
+  include ObjectTypeConcern
 
   # self.unique_key = 'id'
 

--- a/app/views/catalog/_bulk_index_table.html.erb
+++ b/app/views/catalog/_bulk_index_table.html.erb
@@ -1,7 +1,7 @@
 <div id="bulk-upload-table">
     <table class="table table-hover">
 	<tr>
-	    <th>When</th><th>Who</th><th>File Name</th><th>Note</th><th>Status <%= link_to bulk_status_help_path(@document.get('id')), :data => { ajax_modal: 'trigger', ajax_modal_title: 'Status Information' } do %><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span><% end %></th><th>Druids</th><th>Success</th><th/><th/>
+	    <th>When</th><th>Who</th><th>File Name</th><th>Note</th><th>Status <%= link_to bulk_status_help_path, :data => { ajax_modal: 'trigger', ajax_modal_title: 'Status Information' } do %><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span><% end %></th><th>Druids</th><th>Success</th><th/><th/>
 	</tr>
 	<% @bulk_jobs.each do |job| %>
 	<tr>

--- a/app/views/catalog/_show_workflows.html.erb
+++ b/app/views/catalog/_show_workflows.html.erb
@@ -9,7 +9,7 @@
         status = workflows[wf]
     -%>
       <tr>
-        <td><%= link_to wf, workflow_view_item_path(document.get('id'), wf, :repo => status[:repo]), :title => wf, :data => { ajax_modal: 'trigger' } %></td>
+        <td><%= link_to wf, workflow_view_item_path(document.id, wf, :repo => status[:repo]), :title => wf, :data => { ajax_modal: 'trigger' } %></td>
         <td>
           <%=status[:status] %>
           <% if status[:errors] > 0 -%>

--- a/spec/models/concerns/object_type_concern_spec.rb
+++ b/spec/models/concerns/object_type_concern_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+RSpec.describe ObjectTypeConcern do
+  let(:document) { SolrDocument.new(document_attributes) }
+  describe '#object_type' do
+    context 'when field present' do
+      let(:document_attributes) do
+        { SolrDocument::FIELD_OBJECT_TYPE => ['item', 'other stuff'] }
+      end
+      it 'returns the first object type' do
+        expect(document.object_type).to eq 'item'
+      end
+    end
+    context 'when field not present' do
+      let(:document_attributes) { { } }
+      it 'returns nil' do
+        expect(document.object_type).to be_nil
+      end
+    end
+  end
+  describe '#admin_policy?' do
+    context 'when object type is an adminPolicy' do
+      let(:document_attributes) do
+        { SolrDocument::FIELD_OBJECT_TYPE => ['adminPolicy'] }
+      end
+      it 'checks and returns true' do
+        expect(document.admin_policy?).to be true
+      end
+    end
+    context 'when object type is not an adminPolicy' do
+      let(:document_attributes) do
+        { SolrDocument::FIELD_OBJECT_TYPE => ['item'] }
+      end
+      it 'checks and returns false' do
+        expect(document.admin_policy?).to be false
+      end
+    end
+    context 'when object type is missing' do
+      let(:document_attributes) { { } }
+      it 'checks and returns false' do
+        expect(document.admin_policy?).to be false
+      end
+    end
+  end
+end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -3,7 +3,9 @@ require 'spec_helper'
 describe Report, :type => :model do
   context 'csv' do
     before :each do
-      @csv = subject.to_csv
+      @csv = described_class.new(
+        current_user: mock_user(is_admin?: true)
+      ).to_csv
     end
 
     it 'should generate data in valid CSV format' do


### PR DESCRIPTION
This PR updates Argo to the latest Blacklight 5.x branch 5.18. It does continue use of the SolrDocument mixins for convenience methods. This pulls some of that logic out of the view.