### PR TITLE
Allow a non-admin to forget an impersonation group

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -1,5 +1,5 @@
 class AuthController < ApplicationController
-  before_action do
+  before_action(except: [:forget_impersonated_groups]) do
     render :status => :forbidden, :text => 'forbidden' unless current_user && current_user.is_admin?
   end
 

--- a/spec/controllers/auth_controller_spec.rb
+++ b/spec/controllers/auth_controller_spec.rb
@@ -27,6 +27,9 @@ describe AuthController, :type => :controller do
         impersonated_groups_str = 'workgroup:dlss:impersonatedgroup1,workgroup:dlss:impersonatedgroup2'
         post :remember_impersonated_groups, {:groups => impersonated_groups_str}
         expect(session[:groups]).to be_blank
+
+        post :forget_impersonated_groups
+        expect(response.status).to_not eq 403
       end
     end
   end


### PR DESCRIPTION
Fixes a regression in the `AuthController` where a non-admin could not forget an impersonation.