### PR TITLE
lower default delayed_job worker count

### DIFF
--- a/config/deploy/prod-a.rb
+++ b/config/deploy/prod-a.rb
@@ -5,4 +5,4 @@ set :rails_env, 'production'
 
 set :deploy_to, '/opt/app/lyberadmin/argo'
 
-set :delayed_job_workers, 16
+set :delayed_job_workers, 12

--- a/config/deploy/prod-b.rb
+++ b/config/deploy/prod-b.rb
@@ -8,4 +8,4 @@ set :rails_env, 'production'
 
 set :deploy_to, '/opt/app/lyberadmin/argo'
 
-set :delayed_job_workers, 16
+set :delayed_job_workers, 12

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -3,4 +3,4 @@ server 'argo-prod.stanford.edu', user: 'lyberadmin', roles: %w(web db app)
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'
 
-set :delayed_job_workers, 16
+set :delayed_job_workers, 12

--- a/config/deploy/stage-a.rb
+++ b/config/deploy/stage-a.rb
@@ -6,4 +6,4 @@ set :bundle_without, %w(test development).join(' ')
 
 set :deploy_to, '/opt/app/lyberadmin/argo'
 
-set :delayed_job_workers, 10
+set :delayed_job_workers, 4

--- a/config/deploy/stage-b.rb
+++ b/config/deploy/stage-b.rb
@@ -6,4 +6,4 @@ set :bundle_without, %w(test development).join(' ')
 
 set :deploy_to, '/opt/app/lyberadmin/argo'
 
-set :delayed_job_workers, 10
+set :delayed_job_workers, 4


### PR DESCRIPTION
* use same number of workers as CPUs on prod (12/12)
* use half the number of workers as CPUs on stage (4/8)