### PR TITLE
Add embargo_update to authorized before_action group.

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,6 +9,7 @@ class ItemsController < ApplicationController
   before_action :forbid_modify, :only => [
     :add_collection, :set_collection, :remove_collection,
     :datastream_update,
+    :embargo_update,
     :mods,
     :open_version, :close_version,
     :update_resource,
@@ -226,10 +227,6 @@ class ItemsController < ApplicationController
   end
 
   def embargo_update
-    unless current_user.is_admin?
-      render :status => :forbidden, :text => 'forbidden'
-      return
-    end
     fail ArgumentError, 'Missing embargo_date parameter' unless params[:embargo_date].present?
     @object.update_embargo(DateTime.parse(params[:embargo_date]).utc)
     @object.datastreams['events'].add_event('Embargo', current_user.to_s , 'Embargo date modified')

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -71,8 +71,11 @@ describe ItemsController, :type => :controller do
   end
   describe 'embargo_update' do
     it 'should 403 if you are not an admin' do
-      allow(@current_user).to receive(:is_admin?).and_return(false)
-      post 'embargo_update', :id => @pid, :date => '12/19/2013'
+      expect(@current_user).to receive(:is_admin?).and_return(false)
+      expect(@item).to receive(:can_manage_content?).and_return(false)
+      expect(subject).not_to receive(:save_and_reindex)
+      expect(subject).not_to receive(:flush_index)
+      post :embargo_update, :id => @pid, :embargo_date => '2100-01-01'
       expect(response).to have_http_status(:forbidden)
     end
     it 'should call Dor::Item.update_embargo' do
@@ -81,7 +84,7 @@ describe ItemsController, :type => :controller do
       expect(controller).to receive(:save_and_reindex)
       expect(controller).to receive(:flush_index).and_call_original
       expect(Dor::SearchService.solr).to receive(:commit) # from flush_index internals
-      post :embargo_update, :id => @pid, :embargo_date => '2100-01-01T00:00:00Z'
+      post :embargo_update, :id => @pid, :embargo_date => '2100-01-01'
       expect(response).to have_http_status(:found) # redirect to catalog page
     end
     it 'should require a date' do


### PR DESCRIPTION
When the action is not authorized, the after_action groups will
not do anything.  In it's current form, the action requires
authorization, but when it fails it still triggers after_actions
that run save_and_reindex needlessly.

This should fix #622 