### PR TITLE
Silence deprecation in configuration

### DIFF
--- a/config/environments/dor_development.rb
+++ b/config/environments/dor_development.rb
@@ -9,7 +9,7 @@ Dor.configure do
     url Settings.FEDORA_URL
   end
 
-  solrizer do
+  solr do
     url Settings.SOLRIZER_URL
   end
 

--- a/config/environments/dor_production.rb
+++ b/config/environments/dor_production.rb
@@ -9,7 +9,7 @@ Dor.configure do
     url Settings.FEDORA_URL
   end
 
-  solrizer do
+  solr do
     url Settings.SOLRIZER_URL
   end
 

--- a/config/environments/dor_staging.rb
+++ b/config/environments/dor_staging.rb
@@ -9,7 +9,7 @@ Dor.configure do
     url Settings.FEDORA_URL
   end
 
-  solrizer do
+  solr do
     url Settings.SOLRIZER_URL
   end
 

--- a/config/environments/dor_test.rb
+++ b/config/environments/dor_test.rb
@@ -3,7 +3,7 @@ Dor.configure do
     url Settings.FEDORA_URL
   end
 
-  solrizer do
+  solr do
     url Settings.SOLRIZER_URL
   end
 


### PR DESCRIPTION
was, for example:
```
DEPRECATION WARNING: Dor::Config -- solrizer configuration is deprecated. Please use solr instead.
(called from <top (required)> at /home/travis/build/sul-dlss/argo/config/environments/dor_test.rb:1)
```

Similar edit will be required in our deployed shared_configs.