### PR TITLE
Fixes an issue where prepare bulk update can not be done by adding ca…

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -54,7 +54,7 @@ class ItemsController < ApplicationController
 
   # open a new version if needed. 400 if the item is in a state that doesnt allow opening a version.
   def prepare
-    if can_open_version? @object.pid
+    if DorObjectWorkflowStatus.new(@object.pid).can_open_version?
       begin
         vers_md_upd_info = {
           :significance => params[:severity],

--- a/app/helpers/dor_object_helper.rb
+++ b/app/helpers/dor_object_helper.rb
@@ -96,16 +96,6 @@ module DorObjectHelper
     Sdr::Client.current_version(object.pid)
   end
 
-  ##
-  # @deprecated Please use non-blocking requests rather than blocking helpers.
-  # See WorkflowServiceController#openable for JSON API to this logic
-  def can_open_version?(pid)
-    return false unless Dor::Config.workflow.client.get_lifecycle('dor', pid, 'accessioned')
-    return false if Dor::Config.workflow.client.get_active_lifecycle('dor', pid, 'submitted')
-    return false if Dor::Config.workflow.client.get_active_lifecycle('dor', pid, 'opened')
-    true
-  end
-
   def render_qfacet_value(facet_solr_field, item, options = {})
     params = add_facet_params(facet_solr_field, item.qvalue)
     Rails.cache.fetch('route_for' + params.to_s, :expires_in => 1.hour) do

--- a/app/jobs/modsulator_job.rb
+++ b/app/jobs/modsulator_job.rb
@@ -97,7 +97,7 @@ class ModsulatorJob < ActiveJob::Base
         # If the object is currently in the opened version state, then go ahead, otherwise (unless the status is "Registered")
         # open a new version first, but do not close it
         if dor_object.status_info[:status_code] != 9 && dor_object.status_info[:status_code] != 1
-          unless can_open_version?(dor_object.id)
+          unless DorObjectWorkflowStatus.new(dor_object.pid).can_open_version?
             log.puts("argo.bulk_metadata.bulk_log_unable_to_version #{current_druid}")  # totally unexpected
             next
           end

--- a/app/models/dor_object_workflow_status.rb
+++ b/app/models/dor_object_workflow_status.rb
@@ -1,0 +1,24 @@
+class DorObjectWorkflowStatus
+  attr_reader :pid
+
+  ##
+  # @param [String] pid in format "druid:abc123def4567"
+  def initialize(pid)
+    @pid = pid
+  end
+
+  ##
+  # @return [Boolean]
+  def can_open_version?
+    return false unless workflow.get_lifecycle('dor', pid, 'accessioned')
+    return false if workflow.get_active_lifecycle('dor', pid, 'submitted')
+    return false if workflow.get_active_lifecycle('dor', pid, 'opened')
+    true
+  end
+
+  private
+
+  def workflow
+    Dor::Config.workflow.client
+  end
+end

--- a/spec/models/dor_object_workflow_status_spec.rb
+++ b/spec/models/dor_object_workflow_status_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+RSpec.describe DorObjectWorkflowStatus do
+  subject { described_class.new(pid) }
+  let(:pid) { 'druid:abc123def4567' }
+  describe '#can_open_version?' do
+    context 'when not accessioned' do
+      before do
+        expect(Dor::Config.workflow.client)
+          .to receive(:get_lifecycle).with('dor', pid, 'accessioned')
+          .and_return(false)
+      end
+      it { expect(subject.can_open_version?).to eq false }
+    end
+    context 'when accessioned and submitted' do
+      before do
+        expect(Dor::Config.workflow.client)
+          .to receive(:get_lifecycle).with('dor', pid, 'accessioned')
+          .and_return(true)
+        expect(Dor::Config.workflow.client)
+          .to receive(:get_active_lifecycle).with('dor', pid, 'submitted')
+          .and_return(true)
+      end
+      it { expect(subject.can_open_version?).to eq false }
+    end
+    context 'when accessioned, not submitted, and opened' do
+      before do
+        expect(Dor::Config.workflow.client)
+          .to receive(:get_lifecycle).with('dor', pid, 'accessioned')
+          .and_return(true)
+        expect(Dor::Config.workflow.client)
+          .to receive(:get_active_lifecycle).with('dor', pid, 'submitted')
+          .and_return(false)
+        expect(Dor::Config.workflow.client)
+          .to receive(:get_active_lifecycle).with('dor', pid, 'opened')
+          .and_return(true)
+      end
+      it { expect(subject.can_open_version?).to eq false }
+    end
+    context 'when accessioned, not submitted, and not opened' do
+      before do
+        expect(Dor::Config.workflow.client)
+          .to receive(:get_lifecycle).with('dor', pid, 'accessioned')
+          .and_return(true)
+        expect(Dor::Config.workflow.client)
+          .to receive(:get_active_lifecycle).with('dor', pid, 'submitted')
+          .and_return(false)
+        expect(Dor::Config.workflow.client)
+          .to receive(:get_active_lifecycle).with('dor', pid, 'opened')
+          .and_return(false)
+      end
+      it { expect(subject.can_open_version?).to eq true }
+    end
+  end
+end


### PR DESCRIPTION
…n_open_version? inside a new class DorObjectWorkflowStatus

This will need to be merged with logic in:

 - argo/app/controllers/workflow_service_controller.rb

Error originally came in when the `DorObjectHelper` mixin was removed in 670c010797a0b23ef24b9a7f8676b6d82021718c. This logic should never be in a helper in the first place.