### PR TITLE
add the Registration datetime to the report columns and fix download

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -54,7 +54,7 @@ class ReportController < CatalogController
   end
 
   def download
-    fields = params['fields'] ? params.delete('fields').split(/\s*,\s*/) : nil
+    fields = params['fields'].present? ? params.delete('fields').split(/\s*,\s*/) : nil
     params[:per_page] = 10
     response.headers['Content-Type'] = 'application/octet-stream'
     response.headers['Content-Disposition'] = 'attachment; filename=report.csv'

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -17,30 +17,30 @@ class Report
 
     config.report_fields = [
       {
-        :label => 'Druid', :field => 'druid',
+        :field => :druid, :label => 'Druid',
         :proc => lambda { |doc| doc['id'].split(/:/).last },
         :sort => true, :default => true, :width => 100
       },
       {
-        :field => 'purl', :label => 'Purl',
+        :field => :purl, :label => 'Purl',
         :proc => lambda { |doc| File.join(Settings.PURL_URL, doc['id'].split(/:/).last) },
-        :solr_fields => ['id'],
+        :solr_fields => %w(id),
         :sort => false, :default => false, :width => 100
       },
       {
-        :field => 'title', :label => 'Title',
+        :field => :title, :label => 'Title',
         :proc => lambda { |doc| retrieve_terms(doc)[:title] },
         :solr_fields => %w(public_dc_title_tesim dc_title_tesim obj_label_ssim),
         :sort => false, :default => false, :width => 100
       },
       {
-        :field => 'citation', :label => 'Citation',
+        :field => :citation, :label => 'Citation',
         :proc => lambda { |doc| render_citation(doc) },
         :solr_fields => %w(public_dc_creator_tesim dc_creator_tesim public_dc_title_tesim dc_title_tesim obj_label_ssim originInfo_place_placeTerm_tesim public_dc_publisher_tesim originInfo_publisher_tesim public_dc_date_tesim),
         :sort => false, :default => true, :width => 100
       },
       {
-        :field => 'source_id_ssim', :label => 'Source Id',
+        :field => :source_id_ssim, :label => 'Source Id',
         :sort => false, :default => true, :width => 100
       },
       {
@@ -63,23 +63,28 @@ class Report
         :sort => false, :default => false, :width => 100
       },
       {
-        :field => 'project_tag_ssim', :label => 'Project',
+        :field => :project_tag_ssim, :label => 'Project',
         :sort => true, :default => false, :width => 100
       },
       {
-        :field => 'registered_by_tag_ssim', :label => 'Registered By',
+        :field => :registered_by_tag_ssim, :label => 'Registered By',
         :sort => true, :default => false, :width => 100
       },
       {
-        :field => 'tag_ssim', :label => 'Tags',
+        :field => :registered_earliest_dttsi, :label => 'Registered',
+        :proc => lambda { |doc| render_datetime(doc[:registered_earliest_dttsi])},
         :sort => true, :default => false, :width => 100
       },
       {
-        :field => 'objectType_ssim', :label => 'Object Type',
+        :field => :tag_ssim, :label => 'Tags',
         :sort => true, :default => false, :width => 100
       },
       {
-        :field => 'content_type_ssim', :label => 'Content Type',
+        :field => :objectType_ssim, :label => 'Object Type',
+        :sort => true, :default => false, :width => 100
+      },
+      {
+        :field => :content_type_ssim, :label => 'Content Type',
         :sort => true, :default => false, :width => 100
       },
       {
@@ -87,51 +92,48 @@ class Report
         :sort => true, :default => false, :width => 100
       },
       {
-        :field => 'barcode_id_ssim', :label => 'Barcode',
+        :field => :barcode_id_ssim, :label => 'Barcode',
         :sort => true, :default => false, :width => 100
       },
       {
-        :field => 'status_ssi', :label => 'Status',
+        :field => :status_ssi, :label => 'Status',
         :sort => false, :default => true, :width => 100
       },
       {
-        :field => 'accessioned_dttsim', :label => 'Accession. Datetime',
-        :proc => lambda { |doc| render_datetime(doc['accessioned_dttsim'])},
-        :solr_fields => ['accessioned_dttsim'],
+        :field => :accessioned_dttsim, :label => 'Accession. Datetime',
+        :proc => lambda { |doc| render_datetime(doc[:accessioned_dttsim])},
         :sort => true, :default => false, :width => 100
       },
       {
-        :field => 'published_dttsim', :label => 'Pub. Date',
-        :proc => lambda { |doc| render_datetime(doc['published_dttsim'])},
-        :solr_fields => ['published_dttsim'],
+        :field => :published_dttsim, :label => 'Pub. Date',
+        :proc => lambda { |doc| render_datetime(doc[:published_dttsim])},
         :sort => true, :default => true, :width => 100
       },
       {
-        :field => 'workflow_status_ssim', :label => 'Errors',
-        :proc => lambda { |doc| doc['workflow_status_ssim'].first.split('|')[2] },
-        :solr_fields => ['workflow_status_ssim'],
+        :field => :workflow_status_ssim, :label => 'Errors',
+        :proc => lambda { |doc| doc[:workflow_status_ssim].first.split('|')[2] },
         :sort => true, :default => false, :width => 100
       },
       {
-        :field => 'file_count', :label => 'Files',
-        :proc => lambda { |doc| doc['content_file_count_itsi'] },
-        :solr_fields => ['content_file_count_itsi'],
+        :field => :file_count, :label => 'Files',
+        :proc => lambda { |doc| doc[:content_file_count_itsi] },
+        :solr_fields => %w(content_file_count_itsi),
         :sort => false, :default => true, :width => 50
       },
       {
-        :field => 'shelved_file_count', :label => 'Shelved Files',
-        :proc => lambda {|doc| doc['shelved_content_file_count_itsi'] },
-        :solr_fields => ['shelved_content_file_count_itsi'],
+        :field => :shelved_file_count, :label => 'Shelved Files',
+        :proc => lambda {|doc| doc[:shelved_content_file_count_itsi] },
+        :solr_fields => %w(shelved_content_file_count_itsi),
         :sort => false, :default => true, :width => 50
       },
       {
-        :field => 'resource_count', :label => 'Resources',
-        :proc => lambda {|doc| doc['resource_count_itsi'] },
-        :solr_fields => ['resource_count_itsi'],
+        :field => :resource_count, :label => 'Resources',
+        :proc => lambda {|doc| doc[:resource_count_itsi] },
+        :solr_fields => %w(resource_count_itsi),
         :sort => false, :default => true, :width => 50
       },
       {
-        :field => 'preserved_size', :label => 'Preservation Size',
+        :field => :preserved_size, :label => 'Preservation Size',
         :proc => lambda { |doc| doc.preservation_size },
         :solr_fields => [SolrDocument::FIELD_PRESERVATION_SIZE],
         :sort => false, :default => true, :width => 50
@@ -161,12 +163,13 @@ class Report
     }
   end
 
+  # @param [Array<String>] fields
   def initialize(params = {}, fields = nil, current_user: NullUser.new)
     @current_user = current_user
     if fields.nil?
       @fields = self.class.blacklight_config.report_fields
     else
-      @fields = self.class.blacklight_config.report_fields.select { |f| fields.nil? || fields.include?(f[:field]) }
+      @fields = self.class.blacklight_config.report_fields.select { |f| fields.include?(f[:field].to_s) }
       @fields.sort! { |a, b| fields.index(a[:field]) <=> fields.index(b[:field]) }
     end
     @params = params
@@ -210,6 +213,9 @@ class Report
 
   protected
 
+  # @param [Array<SolrDocument>] docs
+  # @param [Array<Hash>] fields
+  # @return [Array<Hash>]
   def docs_to_records(docs, fields = blacklight_config.report_fields)
     result = []
     docs.each_with_index do |doc, index|

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -61,10 +61,15 @@ describe ReportController, :type => :controller do
   end
   describe 'download' do
     it 'should download valid CSV data' do
-      get :download
-      expect(response.status).to eq(200)
+      get :download, fields: ' '
+      expect(response).to have_http_status(:ok)
       expect(response.header['Content-Disposition']).to eq('attachment; filename=report.csv')
       expect { CSV.parse(response.body) }.not_to raise_error
+    end
+    it 'should download valid CSV data for specific fields' do
+      get :download, fields: 'druid,purl,source_id_ssim,tag_ssim'
+      expect(response).to have_http_status(:ok)
+      expect(response.body.strip).to eq('"Druid","Purl","Source Id","Tags"')
     end
   end
   describe 'config' do

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -50,5 +50,42 @@ describe Report, :type => :model do
       expect(config.report_fields.length).to eq(25)
       expect(config.report_fields.all? { |f| f[:field].is_a? Symbol }).to be_truthy # all :field keys are symbols
     end
+    it 'should have all the mandatory, default report fields' do
+      [
+        :druid,
+        :purl,
+        :citation,
+        :source_id_ssim,
+        SolrDocument::FIELD_APO_TITLE,
+        :status_ssi,
+        :published_dttsim,
+        :file_count,
+        :shelved_file_count,
+        :resource_count,
+        :preserved_size
+      ].each do |k|
+        expect(config.report_fields.any? { |f| f[:field] == k}).to be_truthy
+      end
+    end
+    it 'should have all the mandatory, non-default report fields' do
+      [
+        :title,
+        SolrDocument::FIELD_APO_ID,
+        SolrDocument::FIELD_COLLECTION_ID,
+        SolrDocument::FIELD_COLLECTION_TITLE,
+        :project_tag_ssim,
+        :registered_by_tag_ssim,
+        :registered_earliest_dttsi,
+        :tag_ssim,
+        :objectType_ssim,
+        :content_type_ssim,
+        SolrDocument::FIELD_CATKEY_ID,
+        :barcode_id_ssim,
+        :accessioned_dttsim,
+        :workflow_status_ssim
+      ].each do |k|
+        expect(config.report_fields.any? { |f| f[:field] == k}).to be_truthy
+      end
+    end
   end
 end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -16,7 +16,7 @@ describe Report, :type => :model do
       rows = CSV.parse(@csv)
       expect(rows.is_a?(Array)).to be_truthy
       expect(rows.length).to be > 1    # at least headers + data
-      expect(rows[0].length).to eq(24) # default headers
+      expect(rows[0].length).to eq(25) # default headers
     end
 
     it 'should force double quotes for all fields' do
@@ -25,12 +25,12 @@ describe Report, :type => :model do
 
     it 'should handle a title with double quotes in it' do
       row = CSV.parse(@csv).find { |row| row[0] == 'hj185vb7593' }
-      expect(row[2]).to eq('Slides, IA 11, Geodesic Domes, Double Skin "Growth" House, N.C. State, 1953')
+      expect(row[2]).to eq('Slides, IA 11, Geodesic Domes, Double Skin "Growth" House, N.C. State, 1953') # 2 == title field
     end
 
     it 'should handle a multivalued fields' do
       row = CSV.parse(@csv).find { |row| row[0] == 'xb482bw3979' }
-      expect(row[11].split('; ').length).to eq(2)
+      expect(row[12].split('; ').length).to eq(2) # 12 == tag field
     end
   end
   describe 'blacklight config' do
@@ -45,6 +45,10 @@ describe Report, :type => :model do
       expect(keys).to include 'object_modified_date', SolrDocument::FIELD_LAST_MODIFIED_DATE.to_s
       expect(keys).to include 'version_opened_date', SolrDocument::FIELD_LAST_OPENED_DATE.to_s
       expect(keys).to include 'embargo_release_date', SolrDocument::FIELD_EMBARGO_RELEASE_DATE.to_s
+    end
+    it 'should have report fields' do
+      expect(config.report_fields.length).to eq(25)
+      expect(config.report_fields.all? { |f| f[:field].is_a? Symbol }).to be_truthy # all :field keys are symbols
     end
   end
 end


### PR DESCRIPTION
This PR fixes #648 and #627 by adding a registration datetime to the available reporting columns, and fixing the report field `:field` parameters such that they are all symbols and downstream expects them as such. The latter fixes the download functionality.