### PR TITLE
only activate Purge button if object is in registered state

### DIFF
--- a/app/helpers/argo_helper.rb
+++ b/app/helpers/argo_helper.rb
@@ -118,7 +118,7 @@ module ArgoHelper
         label: 'Purge',
         new_page: true,
         confirm: 'This object will be permanently purged from DOR. This action cannot be undone. Are you sure?',
-        check_url: workflow_service_submitted_path(pid)
+        check_url: !registered_only?(doc)
       }
 
       buttons << {:url => '/items/' + pid + '/source_id_ui', :label => 'Change source id'}
@@ -191,4 +191,9 @@ module ArgoHelper
     link_to 'MODS bulk loads', bulk_jobs_index_path(@document), :id => 'bulk-button', :class => 'button btn btn-primary'
   end
 
+  protected
+
+  def registered_only?(document)
+    ['Registered', 'Unknown Status'].include?(document['processing_status_text_ssi'])
+  end
 end

--- a/spec/features/enable_buttons_spec.rb
+++ b/spec/features/enable_buttons_spec.rb
@@ -18,7 +18,6 @@ feature 'Enable buttons' do
     expect(page).to have_css 'a.disabled', text: 'Close Version'
     expect(page).to have_css 'a.disabled', text: 'Open for modification'
     expect(page).to have_css 'a.disabled', text: 'Republish'
-    expect(page).to have_css 'a.disabled', text: 'Purge'
   end
   scenario 'buttons are enabled if their services return true', js: true do
     allow_any_instance_of(WorkflowServiceController).to receive(:check_if_can_close_version).and_return(true)
@@ -26,6 +25,5 @@ feature 'Enable buttons' do
     expect(page).to_not have_css 'a.disabled', text: 'Close Version'
     expect(page).to_not have_css 'a.disabled', text: 'Open for modification'
     expect(page).to_not have_css 'a.disabled', text: 'Republish'
-    expect(page).to_not have_css 'a.disabled', text: 'Purge'
   end
 end

--- a/spec/helpers/argo_helper_spec.rb
+++ b/spec/helpers/argo_helper_spec.rb
@@ -111,4 +111,13 @@ describe ArgoHelper, :type => :helper do
       expect(helper.method(:render_facet_value).owner).to eq(Blacklight::FacetsHelperBehavior)
     end
   end
+  describe 'purge button' do
+    it 'is enabled for registered only item' do
+      expect(helper.registered_only?({ 'processing_status_text_ssi' => 'Registered'})).to be_truthy
+      expect(helper.registered_only?({ 'processing_status_text_ssi' => 'Unknown Status'})).to be_truthy
+    end
+    it 'is disabled for items beyond registered only' do
+      expect(helper.registered_only?({ 'processing_status_text_ssi' => 'In accessioning'})).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes #634 by changing the disabled/enabled check on the Purge button to use the processing status facet value.