### PR TITLE
fix bulk operations on search results

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -15,11 +15,7 @@ class ReportController < CatalogController
   end
 
   def data
-    # if !params[:sidx] || params[:sidx] == 'druid'
-    #  params[:sidx] = 'id'
-    # end
     params[:sord] ||= 'asc'
-    # params[:sort] = "#{params.delete(:sidx)} #{params.delete(:sord)}" if params[:sidx].present?
     rows_per_page = params[:rows] ? params.delete(:rows).to_i : 10
     params[:per_page] = rows_per_page * [params.delete(:npage).to_i, 1].max
     @report = Report.new(params, current_user: current_user)
@@ -41,13 +37,13 @@ class ReportController < CatalogController
   end
 
   def pids
-    # params[:per_page]=100
-    # params[:rows]=100
-    ids = Report.new(params, ['druid'], current_user: current_user).pids params
     respond_to do |format|
       format.json do
         render :json => {
-          :druids => ids
+          :druids => Report.new(params, current_user: current_user).pids(
+            source_id: params[:source_id].present?,
+            tags: params[:tags].present?
+          )
         }
       end
     end
@@ -99,7 +95,10 @@ class ReportController < CatalogController
   ##
   # @return [Array]
   def pids_from_report(params)
-    Report.new(params, ['druids'], current_user: current_user).pids params
+    Report.new(params, ['druids'], current_user: current_user).pids(
+      source_id: params[:source_id].present?,
+      tags: params[:tags].present?
+    )
   end
 
   ##

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -61,10 +61,13 @@ class ReportController < CatalogController
   # an ajax call to reset workflow states for objects
   def reset
     render nothing: true, status: 501 unless request.xhr?
+    fail ArgumentError, 'Missing reset_workflow' unless params[:reset_workflow].present?
+    fail ArgumentError, 'Missing reset_step' unless params[:reset_step].present?
+
     @workflow = params[:reset_workflow]
     @step = params[:reset_step]
-    @ids  = pids_from_report(params)
-    @repo = repo_from_workflow(params[:reset_workflow])
+    @repo = repo_from_workflow(@workflow)
+    @ids  = Report.new(params, current_user: current_user).pids
     @ids.each do |pid|
       Dor::Config.workflow.client.update_workflow_status(
         @repo,
@@ -91,15 +94,6 @@ class ReportController < CatalogController
   end
 
   private
-
-  ##
-  # @return [Array]
-  def pids_from_report(params)
-    Report.new(params, ['druids'], current_user: current_user).pids(
-      source_id: params[:source_id].present?,
-      tags: params[:tags].present?
-    )
-  end
 
   ##
   # @return [String, nil]

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -170,41 +170,41 @@ class Report
       @fields = self.class.blacklight_config.report_fields
     else
       @fields = self.class.blacklight_config.report_fields.select { |f| fields.include?(f[:field].to_s) }
-      @fields.sort! { |a, b| fields.index(a[:field]) <=> fields.index(b[:field]) }
+      @fields.sort! { |a, b| fields.index(a[:field].to_s) <=> fields.index(b[:field].to_s) }
     end
     @params = params
     @params[:page] ||= 1
 
-    (@response, @document_list) = search_results(params, search_params_logic)
+    (@response, @document_list) = search_results(@params, search_params_logic)
     @num_found = @response['response']['numFound'].to_i
   end
 
-  def pids(params)
-    @params[:page] = 1
+  def pids(opts = {})
+    params[:page] = 1
     params[:per_page] = 100
     (@response, @document_list) = search_results(params, search_params_logic)
-    toret = []
+    pids = []
     while @document_list.length > 0
       report_data.each do |rec|
-        if params[:source_id]
-          toret << rec[:druid].to_s + "\t" + rec[:source_id_ssim].to_s
-        elsif params[:tags]
+        if opts[:source_id].present?
+          pids << rec[:druid] + "\t" + rec[:source_id_ssim]
+        elsif opts[:tags].present?
           tags = ''
           unless rec[:tag_ssim].nil?
             rec[:tag_ssim].split(';').each do |tag|
-              tags += "\t" + tag.to_s
+              tags += "\t" + tag
             end
           end
-          toret << rec[:druid] + tags
+          pids << rec[:druid] + tags
         else
-          toret << rec[:druid]
+          pids << rec[:druid]
         end
       end
-      @params[:page] += 1
+      params[:page] += 1
       (@response, @document_list) = search_results(params, search_params_logic)
     end
 
-    toret
+    pids
   end
 
   def report_data
@@ -215,16 +215,16 @@ class Report
 
   # @param [Array<SolrDocument>] docs
   # @param [Array<Hash>] fields
-  # @return [Array<Hash>]
+  # @return [Array<Hash(Symbol => String)>]
   def docs_to_records(docs, fields = blacklight_config.report_fields)
     result = []
     docs.each_with_index do |doc, index|
       row = Hash[fields.collect do |spec|
-        val = spec.key?(:proc) ? spec[:proc].call(doc) : doc[spec[:field]] rescue nil
+        val = spec.key?(:proc) ? spec[:proc].call(doc) : doc[spec[:field].to_s] rescue nil
         val = val.join('; ') if val.is_a?(Array)
-        [spec[:field], val]
+        [spec[:field].to_sym, val.to_s]
       end]
-      row['id'] = index + 1
+      row[:id] = index + 1
       result << row
     end
     result

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -187,17 +187,17 @@ class Report
     while @document_list.length > 0
       report_data.each do |rec|
         if params[:source_id]
-          toret << rec['druid'].to_s + "\t" + rec['source_id_ssim'].to_s
+          toret << rec[:druid].to_s + "\t" + rec[:source_id_ssim].to_s
         elsif params[:tags]
           tags = ''
-          unless rec['tag_ssim'].nil?
-            rec['tag_ssim'].split(';').each do |tag|
+          unless rec[:tag_ssim].nil?
+            rec[:tag_ssim].split(';').each do |tag|
               tags += "\t" + tag.to_s
             end
           end
-          toret << rec['druid'] + tags
+          toret << rec[:druid] + tags
         else
-          toret << rec['druid']
+          toret << rec[:druid]
         end
       end
       @params[:page] += 1

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -21,6 +21,13 @@ describe ReportController, :type => :controller do
       expect{ JSON.parse(response.body) }.not_to raise_error()
     end
   end
+  describe ':pids' do
+    it 'should return json' do
+      get :pids, :format => :json
+      pids = JSON.parse(response.body)['druids']
+      expect(pids.is_a?(Array)).to be_truthy
+    end
+  end
   describe 'bulk' do
     it 'should render the correct template' do
       get :bulk

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -45,34 +45,31 @@ describe ReportController, :type => :controller do
     end
   end
   describe 'POST reset' do
+    let(:repo) { 'dor' }
     let(:workflow) { 'accessionWF' }
     let(:step) { 'descriptive-metadata' }
-    let(:ids) { [1, 2, 3, 4, 5] }
-    it 'sets instance variable and calls update workflow service' do
-      expect(controller).to receive(:pids_from_report).and_return(ids)
+    it 'requires parameters' do
+      expect { xhr :post, :reset }.to raise_error(ArgumentError)
+      expect { xhr :post, :reset, reset_workflow: workflow }.to raise_error(ArgumentError)
+      expect { xhr :post, :reset, reset_step: step }.to raise_error(ArgumentError)
+    end
+    it 'sets instance variables and calls update workflow service' do
       expect(controller).to receive(:repo_from_workflow)
-        .and_return('dor')
-      ids.each do |id|
-        expect(Dor::Config.workflow.client).to receive(:update_workflow_status)
-          .with('dor', "druid:#{id}", workflow, step, 'waiting')
-      end
-      xhr :post, :reset, reset_workflow: workflow, reset_step: step
+        .and_return(repo)
+      expect(Dor::Config.workflow.client).to receive(:update_workflow_status)
+        .with(repo, 'druid:xb482bw3979', workflow, step, 'waiting')
+      xhr :post, :reset, reset_workflow: workflow, reset_step: step, q: 'Cephalopods' # has single match
       expect(assigns(:workflow)).to eq workflow
       expect(assigns(:step)).to eq step
-      expect(assigns(:ids)).to eq ids
-      expect(response).to have_http_status(:ok)
-    end
-    it 'gets the correct pids from a new Report' do
-      expect(Report).to receive(:new).and_return(double('report', pids: []))
-      xhr :post, :reset, reset_workflow: workflow, reset_step: step
+      expect(assigns(:ids)).to eq(%w(xb482bw3979))
+      expect(assigns(:repo)).to eq(repo)
       expect(response).to have_http_status(:ok)
     end
     it 'gets repo from the WorkflowObject' do
-      expect(controller).to receive(:pids_from_report).and_return([])
       expect(Dor::WorkflowObject).to receive(:find_by_name)
-        .and_return double(definition: double(repo: 'dor'))
-      xhr :post, :reset, reset_workflow: workflow, reset_step: step
-      expect(assigns(:repo)).to eq 'dor'
+        .and_return double(definition: double(repo: repo)) # mocks dor-services call
+      xhr :post, :reset, reset_workflow: workflow, reset_step: step, q: 'NoMatchesForThisString'
+      expect(assigns(:repo)).to eq repo
       expect(response).to have_http_status(:ok)
     end
   end

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -2,35 +2,45 @@ require 'spec_helper'
 
 describe ReportController, :type => :controller do
   before :each do
-    log_in_as_mock_user(subject)
-    allow_any_instance_of(User).to receive(:groups).and_return(['sdr:administrator-role'])
+    @current_user = mock_user(is_admin?: true, can_view_something?: true)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).
+      and_return(@current_user)
   end
   describe ':workflow_grid' do
     it 'should work' do
       get :workflow_grid
+      expect(response).to have_http_status(:ok)
       expect(response).to render_template('workflow_grid')
     end
   end
   describe ':data' do
     it 'should return json' do
       get :data, :format => :json, :rows => 5
-      expect{ JSON.parse(response.body) }.not_to raise_error()
+      expect(response).to have_http_status(:ok)
+      data = JSON.parse(response.body)
+      expect(data['rows'].length).to eq(5)
     end
     it 'should default to 10 rows per page, rather than defaulting to 0 and generating an exception when the number of pages is infinity when no row count is passed in' do
       get :data, :format => :json
-      expect{ JSON.parse(response.body) }.not_to raise_error()
+      expect(response).to have_http_status(:ok)
+      data = JSON.parse(response.body)
+      expect(data['rows'].length).to eq(10)
     end
   end
   describe ':pids' do
     it 'should return json' do
       get :pids, :format => :json
+      expect(response).to have_http_status(:ok)
       pids = JSON.parse(response.body)['druids']
       expect(pids.is_a?(Array)).to be_truthy
+      expect(pids.length > 1).to be_truthy
+      expect(pids.first).to eq('br481xz7820')
     end
   end
   describe 'bulk' do
     it 'should render the correct template' do
       get :bulk
+      expect(response).to have_http_status(:ok)
       expect(response).to render_template('bulk')
     end
   end
@@ -50,12 +60,12 @@ describe ReportController, :type => :controller do
       expect(assigns(:workflow)).to eq workflow
       expect(assigns(:step)).to eq step
       expect(assigns(:ids)).to eq ids
-      expect(response.status).to eq 200
+      expect(response).to have_http_status(:ok)
     end
     it 'gets the correct pids from a new Report' do
       expect(Report).to receive(:new).and_return(double('report', pids: []))
       xhr :post, :reset, reset_workflow: workflow, reset_step: step
-      expect(response.status).to eq 200
+      expect(response).to have_http_status(:ok)
     end
     it 'gets repo from the WorkflowObject' do
       expect(controller).to receive(:pids_from_report).and_return([])
@@ -63,7 +73,7 @@ describe ReportController, :type => :controller do
         .and_return double(definition: double(repo: 'dor'))
       xhr :post, :reset, reset_workflow: workflow, reset_step: step
       expect(assigns(:repo)).to eq 'dor'
-      expect(response.status).to eq 200
+      expect(response).to have_http_status(:ok)
     end
   end
   describe 'download' do
@@ -71,12 +81,18 @@ describe ReportController, :type => :controller do
       get :download, fields: ' '
       expect(response).to have_http_status(:ok)
       expect(response.header['Content-Disposition']).to eq('attachment; filename=report.csv')
-      expect { CSV.parse(response.body) }.not_to raise_error
+      data = CSV.parse(response.body)
+      expect(data.first.length).to eq(25)
+      expect(data.length > 1).to be_truthy
+      expect(data[1].first).to eq('br481xz7820') # first data row starts with pid
     end
     it 'should download valid CSV data for specific fields' do
       get :download, fields: 'druid,purl,source_id_ssim,tag_ssim'
       expect(response).to have_http_status(:ok)
-      expect(response.body.strip).to eq('"Druid","Purl","Source Id","Tags"')
+      data = CSV.parse(response.body)
+      expect(data.first).to eq(%w(Druid Purl Source\ Id Tags))
+      expect(data.length > 1).to be_truthy
+      expect(data[1].first).to eq('br481xz7820') # first data row starts with pid
     end
   end
   describe 'config' do

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -88,4 +88,24 @@ describe Report, :type => :model do
       end
     end
   end
+  describe '#pids' do
+    it 'should return unqualified druids by default' do
+      expect(described_class.new(
+        { q: 'report' }, %w(druid),
+        current_user: mock_user(is_admin?: true)
+      ).pids).to eq(%w(fg464dn8891 pb873ty1662 qq613vj0238))
+    end
+    it 'should return druids and source ids' do
+      expect(described_class.new(
+        { q: 'report' }, %w(druid source_id_ssim),
+        current_user: mock_user(is_admin?: true)
+      ).pids(source_id: true)).to include "qq613vj0238\tsul:36105011952764"
+    end
+    it 'should return druids and tags' do
+      expect(described_class.new(
+        { q: 'report' }, %w(druid tag_ssim),
+        current_user: mock_user(is_admin?: true)
+      ).pids(tags: true)).to include "fg464dn8891\tRegistered By : llam813\t Remediated By : 4.6.6.2"
+    end
+  end
 end


### PR DESCRIPTION
`Report#pids` should expect search result fields to be keyed on symbols, not strings.

looks like a minor regression as a result of:  https://github.com/sul-dlss/argo/commit/4b158da1293edccfee8d3ddb8578c1ac55f0c5f5  (a quick test where i reverted that commit fixed the issue, but i doubt reverting the commit is actually the right fix)

i assume report field configs were changed from using strings to symbols for some reason, so i'm guessing the right thing to do here is to fix the `pids` method?

this is deployed to stage, and seems to fix the problem with getting a list of druids from search results for bulk update (but it replaces the branch with the dor-services upgrade that fixes a couple indexing things, so indexing on argo-stage is back to being like argo-prod).

leaving this marked as WIP, because it'd be nice to write a test, but i'm not really sure what to do there.  i'm inclined to have `search_results` return fake data in the expected format, but i'm not sure how to mock the call to it.