### PR TITLE
enable_buttons_spec feature had a typo

### DIFF
--- a/spec/features/enable_buttons_spec.rb
+++ b/spec/features/enable_buttons_spec.rb
@@ -21,7 +21,7 @@ feature 'Enable buttons' do
   end
   scenario 'buttons are enabled if their services return true', js: true do
     allow_any_instance_of(WorkflowServiceController).to receive(:check_if_can_close_version).and_return(true)
-    allow_any_instance_of(WorkflowServiceController).to receive(:check_if_can_open_verison).and_return(true)
+    allow_any_instance_of(WorkflowServiceController).to receive(:check_if_can_open_version).and_return(true)
     expect(page).to_not have_css 'a.disabled', text: 'Close Version'
     expect(page).to_not have_css 'a.disabled', text: 'Open for modification'
     expect(page).to_not have_css 'a.disabled', text: 'Republish'


### PR DESCRIPTION
Given that this test works with a typo, it's not clear to me if the test is doing its job.  Is it supposed to have a line  

```ruby
visit catalog_path 'druid:hj185vb7593'
```
after the allow statements?