### PR TITLE
Extend maximum runtime for Delayed Job to a much larger value.

### DIFF
--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,7 +1,7 @@
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.sleep_delay = 60
 Delayed::Worker.max_attempts = 3
-Delayed::Worker.max_run_time = 30.minutes
+Delayed::Worker.max_run_time = 48.hours
 Delayed::Worker.read_ahead = 10
 Delayed::Worker.default_queue_name = 'default'
 Delayed::Worker.delay_jobs = !Rails.env.test?


### PR DESCRIPTION
30 minutes is not enough time for e.g. descriptive metadata download jobs to complete when thousands of objects are selected. Let's bump the max runtime.