### PR TITLE
apo indexing fix

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -670,7 +670,11 @@ class ItemsController < ApplicationController
   # Filters
   def create_obj
     raise 'missing druid' unless params[:id]
-    @object = Dor::Item.find params[:id]
+    create_obj_and_apo params[:id]
+  end
+
+  def create_obj_and_apo(obj_pid)
+    @object = Dor.find obj_pid
     @apo = @object.admin_policy_object
     @apo = ( @apo ? @apo.pid : '' )
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -647,7 +647,7 @@ class ItemsController < ApplicationController
 
     # We need to sync up the workflows datastream with workflow service (using #find)
     # and then force a committed Solr update before redirection.
-    reindex Dor::Item.find(params[:id])
+    reindex Dor.find(params[:id])
     msg = "Added #{wf_name}"
 
     if params[:bulk]

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -388,7 +388,6 @@ describe ItemsController, :type => :controller do
     it 'should initialize the new workflow' do
       expect(@item).to receive(:create_workflow)
       expect(@wf).to receive(:[]).with('accessionWF').and_return(nil)
-      allow(Dor::Item).to receive(:find).with(@pid).and_return(@item)
       expect(controller).to receive(:flush_index)
       post 'add_workflow', :id => @pid, :wf => 'accessionWF'
     end

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -16,7 +16,7 @@ describe ItemsController, :type => :controller do
     allow(@current_user).to receive(:is_manager?).and_return(false)
     allow(@current_user).to receive(:roles).and_return([])
     allow_any_instance_of(ItemsController).to receive(:current_user).and_return(@current_user)
-    allow(Dor::Item).to receive(:find).with(@pid).and_return(@item)
+    allow(Dor).to receive(:find).with(@pid).and_return(@item)
     idmd = double()
     apo  = double()
     wf   = double()
@@ -388,6 +388,7 @@ describe ItemsController, :type => :controller do
     it 'should initialize the new workflow' do
       expect(@item).to receive(:create_workflow)
       expect(@wf).to receive(:[]).with('accessionWF').and_return(nil)
+      allow(Dor::Item).to receive(:find).with(@pid).and_return(@item)
       expect(controller).to receive(:flush_index)
       post 'add_workflow', :id => @pid, :wf => 'accessionWF'
     end
@@ -409,7 +410,7 @@ describe ItemsController, :type => :controller do
       expect(response).to have_http_status(:ok)
     end
     it 'should 404 on missing item' do
-      expect(Dor::Item).to receive(:find).with(@pid).and_raise(ActiveFedora::ObjectNotFoundError)
+      expect(Dor).to receive(:find).with(@pid).and_raise(ActiveFedora::ObjectNotFoundError)
       get :workflow_view, id: @pid, wf_name: 'accessionWF', repo: 'dor', format: :html
       expect(response).to have_http_status(:not_found)
     end
@@ -450,6 +451,14 @@ describe ItemsController, :type => :controller do
       expect(response).to have_http_status(:ok)
       expect(assigns(:available_in_workspace)).to be_falsey
       expect(assigns(:available_in_workspace_error)).to match(/Net::SSH::AuthenticationFailed/)
+    end
+  end
+  describe '#create_obj_and_apo' do
+    it 'loads an object of the appropriate type' do
+      expect(Dor).to receive(:find).with('druid:zt570tx3016').and_call_original
+      allow(Dor).to receive(:find).with('druid:hv992ry2431')
+      subject.send(:create_obj_and_apo, 'druid:zt570tx3016')
+      expect(subject.instance_variable_get(:@object).to_solr).to include({'active_fedora_model_ssi' => 'Dor::AdminPolicyObject'})
     end
   end
 end

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -453,11 +453,19 @@ describe ItemsController, :type => :controller do
     end
   end
   describe '#create_obj_and_apo' do
-    it 'loads an object of the appropriate type' do
-      expect(Dor).to receive(:find).with('druid:zt570tx3016').and_call_original
-      allow(Dor).to receive(:find).with('druid:hv992ry2431')
+    it 'loads an APO object so that it has the appropriate model type (according to the solr doc)' do
+      expect(Dor).to receive(:find).with('druid:zt570tx3016').and_call_original # override the earlier Dor.find expectation
+      allow(Dor).to receive(:find).with('druid:hv992ry2431') # create_obj_and_apo will try to lookup the APO's APO
       subject.send(:create_obj_and_apo, 'druid:zt570tx3016')
-      expect(subject.instance_variable_get(:@object).to_solr).to include({'active_fedora_model_ssi' => 'Dor::AdminPolicyObject'})
+      expect(subject.instance_variable_get(:@object).to_solr).to include({'active_fedora_model_ssi' => 'Dor::AdminPolicyObject',
+                                                                          'has_model_ssim' => 'info:fedora/afmodel:Dor_AdminPolicyObject'})
+    end
+    it 'loads an Item object so that it has the appropriate model type (according to the solr doc)' do
+      expect(Dor).to receive(:find).with('druid:hj185vb7593').and_call_original # override the earlier Dor.find expectation
+      allow(Dor).to receive(:find).with('druid:ww057vk7675') # create_obj_and_apo will try to lookup the Item's APO
+      subject.send(:create_obj_and_apo, 'druid:hj185vb7593')
+      expect(subject.instance_variable_get(:@object).to_solr).to include({'active_fedora_model_ssi' => 'Dor::Item',
+                                                                          'has_model_ssim' => 'info:fedora/afmodel:Dor_Item'})
     end
   end
 end


### PR DESCRIPTION
fixed #725 by loading the object using `Dor.find` instead of `Dor::Item.find`

Bug was when you edited a datastream directly in argo, upon saving, the object would always be indexed in Solr as an item.  Now, it's actually indexed as its object type.

paired w/ @ndushay, who got us to add some `puts` statements and find an items_controller indexing bug much more quickly than if i'd kept being perplexed about why dor-indexing-app didn't seem to be getting indexing messages (but i'm still perplexed about that, and will file an investigation ticket for it).