### PR TITLE
Save metadata in bulk downloaded zip files with the .xml extension.

### DIFF
--- a/app/jobs/descmetadata_download_job.rb
+++ b/app/jobs/descmetadata_download_job.rb
@@ -86,7 +86,7 @@ class DescmetadataDownloadJob < GenericJob
   end
 
   def write_to_zip(value, entry_name, zip_file)
-    zip_file.get_output_stream(entry_name) { |f| f.puts(value) }
+    zip_file.get_output_stream("#{entry_name}.xml") { |f| f.puts(value) }
   end
 
   # Write initial job information to the log file.

--- a/spec/jobs/descmetadata_download_job_spec.rb
+++ b/spec/jobs/descmetadata_download_job_spec.rb
@@ -56,7 +56,7 @@ describe DescmetadataDownloadJob, type: :job do
       druid = 'druid:123'
       output_file = double('zip_output_file')
       string_value = 'descMetadata.xml'
-      expect(zip).to receive(:get_output_stream).with(druid).and_yield(output_file)
+      expect(zip).to receive(:get_output_stream).with("#{druid}.xml").and_yield(output_file)
       expect(output_file).to receive(:puts).with(string_value)
       @download_job.write_to_zip(string_value, druid, zip)
     end


### PR DESCRIPTION
Fixes #756 