### PR TITLE
fix population of item registration apo select box

### DIFF
--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -3,15 +3,19 @@ module RegistrationHelper
   # permission_keys will likely be a list of workgroups to which a user belongs plus
   # the user's sunetid, to determine which APOs grant the user registration permissions.
   def apo_list(*permission_keys)
-    q = 'objectType_ssim:adminPolicy AND !tag_ssim:"Project : Hydrus"'
+    return [] if permission_keys.blank?
+
+    q = ''
     unless permission_keys.empty?
-      q += '(' + permission_keys.flatten.map { |key| %(apo_register_permissions_ssim:"#{key}") }.join(' OR ') + ')'
+      q += permission_keys.flatten.map { |key| %(apo_register_permissions_ssim:"#{key}") }.join(' OR ')
     end
 
     result = Dor::SearchService.query(
       q,
+      :defType => 'lucene',
       :rows => 99999,
-      :fl => 'id,tag_ssim,dc_title_tesim'
+      :fl => 'id,tag_ssim,dc_title_tesim',
+      :fq => ['objectType_ssim:adminPolicy', '!tag_ssim:"Project : Hydrus"']
     ).docs
 
     result.sort! do |a, b|

--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -5,10 +5,7 @@ module RegistrationHelper
   def apo_list(permission_keys)
     return [] if permission_keys.blank?
 
-    q = ''
-    unless permission_keys.empty?
-      q += permission_keys.flatten.map { |key| %(apo_register_permissions_ssim:"#{key}") }.join(' OR ')
-    end
+    q = permission_keys.map { |key| %(apo_register_permissions_ssim:"#{key}") }.join(' OR ')
 
     result = Dor::SearchService.query(
       q,

--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -2,7 +2,7 @@ module RegistrationHelper
 
   # permission_keys will likely be a list of workgroups to which a user belongs plus
   # the user's sunetid, to determine which APOs grant the user registration permissions.
-  def apo_list(*permission_keys)
+  def apo_list(permission_keys)
     return [] if permission_keys.blank?
 
     q = ''

--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -1,11 +1,19 @@
 module RegistrationHelper
 
+  # permission_keys will likely be a list of workgroups to which a user belongs plus
+  # the user's sunetid, to determine which APOs grant the user registration permissions.
   def apo_list(*permission_keys)
     q = 'objectType_ssim:adminPolicy AND !tag_ssim:"Project : Hydrus"'
     unless permission_keys.empty?
       q += '(' + permission_keys.flatten.map { |key| %(apo_register_permissions_ssim:"#{key}") }.join(' OR ') + ')'
     end
-    result = Dor::SearchService.query(q, :rows => 99999, :fl => 'id,tag_ssim,dc_title_tesim').docs
+
+    result = Dor::SearchService.query(
+      q,
+      :rows => 99999,
+      :fl => 'id,tag_ssim,dc_title_tesim'
+    ).docs
+
     result.sort! do |a, b|
       Array(a['tag_ssim']).include?('AdminPolicy : default') ? -1 : a['dc_title_tesim'].to_s <=> b['dc_title_tesim'].to_s
     end

--- a/app/views/items/register.html.erb
+++ b/app/views/items/register.html.erb
@@ -8,7 +8,7 @@
 <% end %>
 <div id='properties' class="ui-widget" style="display: none">
         <div class="property-item"><label for="object_type">Type of Object</label><%= select_tag :object_type, options_for_select(valid_object_types), :'data-rcparam' => 'objectType' %></div>
-        <div class="property-item"><label for='apo_id'>Admin Policy</label><%= select_tag :apo_id, options_for_select(apo_list(*(@perm_keys))), :'data-rcparam' => 'apoId' %></div>
+        <div class="property-item"><label for='apo_id'>Admin Policy</label><%= select_tag :apo_id, options_for_select(apo_list(@perm_keys)), :'data-rcparam' => 'apoId' %></div>
         <div class="property-item"><label for='collection'>Collection</label><%= select_tag :collection, '', :'data-rcparam' => 'collection' %></div>
 
         <div class="property-item"><label for="rights">Rights</label><%= select_tag :rights, options_for_select(Constants::DEFAULT_RIGHTS_OPTIONS), :'data-tagname' => 'Process : Rights' %></div>

--- a/spec/helpers/registration_helper_spec.rb
+++ b/spec/helpers/registration_helper_spec.rb
@@ -1,7 +1,32 @@
 require 'spec_helper'
 
 describe RegistrationHelper do
-  it 'tests nothing' do
-    skip
+  describe '#apo_list' do
+    let(:perm_keys) { ['sunetid:user', 'workgroup:dlss:mock-group1', 'workgroup:dlss:mock-group2'] }
+
+    it 'runs the appropriate query for the given permission keys' do
+      q = 'objectType_ssim:adminPolicy AND !tag_ssim:"Project : Hydrus"'
+      q += '(' + perm_keys.map { |key| %(apo_register_permissions_ssim:"#{key}") }.join(' OR ') + ')'
+
+      expect(Dor::SearchService).to receive(:query).with(
+        q,
+        rows: 99999,
+        fl: 'id,tag_ssim,dc_title_tesim'
+      ).and_return(double(docs: []))
+
+      apo_list(*perm_keys)
+    end
+
+    it 'sorts the results and formats them correctly' do
+      result_rows = [
+        {'id' => 1, 'tag_ssim' => 'prefix : suffix', 'dc_title_tesim' => 'z'},
+        {'id' => 2, 'tag_ssim' => 'AdminPolicy : default', 'dc_title_tesim' => 'y'},
+        {'id' => 3, 'tag_ssim' => 'prefix : suffix2', 'dc_title_tesim' => 'x'}
+      ]
+      expect(Dor::SearchService).to receive(:query).and_return(double(docs: result_rows))
+
+      apos = apo_list(*perm_keys)
+      expect(apos).to eq [['y', '2'], ['x', '3'], ['z', '1']]
+    end
   end
 end

--- a/spec/helpers/registration_helper_spec.rb
+++ b/spec/helpers/registration_helper_spec.rb
@@ -15,7 +15,7 @@ describe RegistrationHelper do
         fq: ['objectType_ssim:adminPolicy', '!tag_ssim:"Project : Hydrus"']
       ).and_return(double(docs: []))
 
-      apo_list(*perm_keys)
+      apo_list(perm_keys)
     end
 
     it 'sorts the results and formats them correctly' do
@@ -26,13 +26,13 @@ describe RegistrationHelper do
       ]
       expect(Dor::SearchService).to receive(:query).and_return(double(docs: result_rows))
 
-      apos = apo_list(*perm_keys)
+      apos = apo_list(perm_keys)
       expect(apos).to eq [['y', '2'], ['x', '3'], ['z', '1']]
     end
   end
 
   it 'returns nothing when permission_keys is empty' do
     expect(Dor::SearchService).to_not receive(:query)
-    expect(apo_list(*[])).to eq []
+    expect(apo_list([])).to eq []
   end
 end


### PR DESCRIPTION
also, cleaned up the code and wrote tests.

deployed to stage.  appears to be working, but would be good to get someone who knows their way around item registration better to take a look.  @LynnMcRae or @blalbrit?

for the reviewers, i tried to break things into logical commits, and to do something similar to PR #760.

also, FWIW, the solr query requests now look something like this, according to the logs:
```
https://[host]/argo_stage/select?wt=ruby&q=apo_register_permissions_ssim:"sunetid:apanopte"+OR+apo_register_permissions_ssim:"workgroup:sdr:administrator-role"+OR+apo_register_permissions_ssim:"workgroup:dlss:lyberteam"+OR+apo_register_permissions_ssim:"workgroup:dlss:developers"&fq=objectType_ssim:adminPolicy&fq=!tag_ssim:"Project+:+Hydrus"&rows=99999&fl=id,tag_ssim,dc_title_tesim&start=0
```

closes #766