### PR TITLE
items_helper_spec: fix failing schema validation spec

### DIFF
--- a/spec/helpers/items_helper_spec.rb
+++ b/spec/helpers/items_helper_spec.rb
@@ -39,7 +39,12 @@ describe ItemsHelper, :type => :helper do
       doc = Nokogiri.XML(mods_xml) do |config|
         config.default_xml.noblanks
       end
-      expect(schema_validate(doc).length).to eq(6)
+      # the expected length is the number of error statements from validation
+      # here's what the array looks like:
+      # ["Element '{http://www.loc.gov/mods/v3}titleInfo', attribute 'type': [facet 'enumeration'] The value 'main' is not an element of the set {'abbreviated', 'translated', 'alternative', 'uniform'}.",
+      # "Element '{http://www.loc.gov/mods/v3}titleInfo', attribute 'type': 'main' is not a valid value of the atomic type '{http://www.loc.gov/mods/v3}titleInfoTypeAttributeDefinition'.",
+      # "Element '{http://www.loc.gov/mods/v3}typeOfResource': This element is not expected."]
+      expect(schema_validate(doc).length).to eq(3)
     end
   end
 end


### PR DESCRIPTION
@jmartin-sul   This is a better fix for the problem than #775

Closes #774