### PR TITLE
fix newrelic config so that agent can be fully enabled/disabled

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -18,8 +18,8 @@ common: &default_settings
   # Relic.  For more details, see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/renaming-applications
   app_name: <%= Settings.NEWRELIC.APP_NAME %>
 
-  # To disable the agent regardless of other settings, uncomment the following:
-  # agent_enabled: false
+  # To disable the agent regardless of other settings, set the following to false:
+  agent_enabled: <%= Settings.NEWRELIC.ENABLED %>
 
   # Logging level for log/newrelic_agent.log
   log_level: info


### PR DESCRIPTION
previously, `Settings.NEWRELIC.ENABLED` actually only controlled whether profiling info was sent to the collector for dev instances.

`Settings.NEWRELIC.ENABLED` should control whether the agent is enabled and collecting info at all (regardless of rails env), not just whether it reports to the collector in dev.