### PR TITLE
Fixes tag links on show page.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -48,7 +48,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'identifier_tesim',                label: 'IDs',               helper_method: :value_for_identifier_tesim
     config.add_show_field 'originInfo_date_created_tesim',   label: 'Created'
     config.add_show_field 'preserved_size_dbtsi',            label: 'Preservation Size', helper_method: :preserved_size_human
-    config.add_show_field 'tag_ssim',                        label: 'Tags',              helper_method: :value_for_tag_ssim
+    config.add_show_field 'tag_ssim',                        label: 'Tags',              link_to_search: true
     config.add_show_field 'released_to_ssim',                label: 'Released to'
     config.add_show_field 'status_ssi',                      label: 'Status'
     config.add_show_field 'wf_error_ssim',                   label: 'Error',             helper_method: :value_for_wf_error

--- a/app/helpers/value_helper.rb
+++ b/app/helpers/value_helper.rb
@@ -73,12 +73,4 @@ module ValueHelper
     val = args[:document][args[:field]]
     Array(val).reject { |v| v == args[:document]['id'] }.sort.uniq.join(', ')
   end
-
-  def value_for_tag_ssim(args)
-    val = args[:document][args[:field]]
-    tags = Array(val).uniq.collect do |v|
-      link_to v, add_facet_params_and_redirect('tag_ssim', v)
-    end
-    tags.join('<br/>').html_safe
-  end
 end


### PR DESCRIPTION
Closes #802 

Not sure if the comma separated is ok, but gives us the default blacklight (which is less code to maintain untested)

## Before
![screen shot 2016-10-07 at 9 34 00 am](https://cloud.githubusercontent.com/assets/1656824/19191850/239b8dc2-8c72-11e6-94b5-4b5692dc246c.png)

## After
![screen shot 2016-10-07 at 9 34 16 am](https://cloud.githubusercontent.com/assets/1656824/19191861/285286ae-8c72-11e6-813e-98000d90b48c.png)
