### PR TITLE
Deployment improvements

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -32,3 +32,4 @@ require 'whenever/capistrano'
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }
 
 require 'capistrano/honeybadger'
+require 'capistrano/shared_configs'

--- a/Capfile
+++ b/Capfile
@@ -22,14 +22,13 @@ require 'capistrano/deploy'
 # require 'capistrano/rails/migrations'
 
 require 'capistrano/bundler'
-require 'capistrano/rails'
-require 'capistrano/passenger'
-require 'dlss/capistrano'
 require 'capistrano/delayed_job'
+require 'capistrano/honeybadger'
+require 'capistrano/passenger'
+require 'capistrano/rails'
+require 'capistrano/shared_configs'
+require 'dlss/capistrano'
 require 'whenever/capistrano'
 
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }
-
-require 'capistrano/honeybadger'
-require 'capistrano/shared_configs'

--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,7 @@ group :deployment do
   gem 'capistrano', '= 3.6.0' # pinned because inadvertent capistrano upgrades tend to cause deployment issues.
   gem 'capistrano-rails'
   gem 'capistrano-passenger'
+  gem 'capistrano-shared_configs'
   gem 'dlss-capistrano', '~> 3.1'
   gem 'capistrano3-delayed-job', '~> 1.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,7 @@ GEM
       capistrano-bundler (~> 1.1)
     capistrano-releaseboard (0.0.1)
       faraday
+    capistrano-shared_configs (0.1.1)
     capistrano3-delayed-job (1.7.2)
       capistrano (~> 3.0, >= 3.0.0)
     capybara (2.8.0)
@@ -557,6 +558,7 @@ DEPENDENCIES
   capistrano (= 3.6.0)
   capistrano-passenger
   capistrano-rails
+  capistrano-shared_configs
   capistrano3-delayed-job (~> 1.0)
   capybara
   capybara_discoball

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -75,3 +75,6 @@ namespace :deploy do
     end
   end
 end
+
+# honeybadger_env otherwise defaults to rails_env
+set :honeybadger_env, fetch(:stage)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -78,3 +78,6 @@ end
 
 # honeybadger_env otherwise defaults to rails_env
 set :honeybadger_env, fetch(:stage)
+
+# update shared_configs before restarting app
+before 'deploy:restart', 'shared_configs:update'

--- a/config/deploy/prod-a.rb
+++ b/config/deploy/prod-a.rb
@@ -1,9 +1,0 @@
-server 'argo-prod-a.stanford.edu', user: 'lyberadmin', roles: %w(web db app)
-
-Capistrano::OneTimeKey.generate_one_time_key!
-set :rails_env, 'production'
-
-set :deploy_to, '/opt/app/lyberadmin/argo'
-set :bundle_without, %w(deployment development test).join(' ')
-
-set :delayed_job_workers, 12

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,3 +1,4 @@
+server 'argo-prod-a.stanford.edu', user: 'lyberadmin', roles: %w(web db app)
 server 'argo-prod-b.stanford.edu', user: 'lyberadmin', roles: %w(web db app)
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/stage-b.rb
+++ b/config/deploy/stage-b.rb
@@ -1,9 +1,0 @@
-server 'argo-stage-b.stanford.edu', user: 'lyberadmin', roles: %w(web db app)
-
-Capistrano::OneTimeKey.generate_one_time_key!
-set :rails_env, 'staging'
-set :bundle_without, %w(deployment test development).join(' ')
-
-set :deploy_to, '/opt/app/lyberadmin/argo'
-
-set :delayed_job_workers, 4

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,4 +1,5 @@
 server 'argo-stage-a.stanford.edu', user: 'lyberadmin', roles: %w(web db app)
+server 'argo-stage-b.stanford.edu', user: 'lyberadmin', roles: %w(web db app)
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'staging'


### PR DESCRIPTION
* set honeybadger environment to cap deloyment "stage" (i.e. `dev`, `stage`, `prod`) instead of defaulting to the rails env
* auto-update the instance's shared_configs upon deployment
* consolidate the deployment of stage and prod to a single config/command for each instance, instead of one for each node in the load balanced environment
* minor Capfile `require` cleanup

test deployments to stage and dev with this branch were successful. 