### PR TITLE
Adds base functionality for Profiling

### DIFF
--- a/app/assets/stylesheets/argo/profile.scss
+++ b/app/assets/stylesheets/argo/profile.scss
@@ -1,0 +1,3 @@
+.table-fixed-layout {
+  table-layout: fixed;
+}

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -1,0 +1,4 @@
+##
+# Used for the profile view but just inherits from CatalogController
+class ProfileController < CatalogController
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,7 +20,8 @@ module ApplicationHelper
     [
       ViewSwitcher.new(:catalog, :catalog_index_url),
       ViewSwitcher.new(:report, :report_url),
-      ViewSwitcher.new(:workflow_grid, :report_workflow_grid_url)
+      ViewSwitcher.new(:workflow_grid, :report_workflow_grid_url),
+      ViewSwitcher.new(:profile, :profile_index_url)
     ]
   end
 
@@ -46,6 +47,12 @@ module ApplicationHelper
   # @return [Boolean]
   def workflow_grid_view?(params)
     params['controller'] == 'report' && params['action'] == 'workflow_grid'
+  end
+
+  ##
+  # @return [Boolean]
+  def profile_view?(params)
+    params['controller'] == 'profile' && params['action'] == 'index'
   end
 
   ##

--- a/app/helpers/profile_helper.rb
+++ b/app/helpers/profile_helper.rb
@@ -1,0 +1,10 @@
+module ProfileHelper
+  include Blacklight::CatalogHelperBehavior
+  ##
+  # Kind of a hacky override, but better than overriding additional partials
+  # Don't show pagination for ProfileController requests
+  def show_pagination?(*)
+    return false if params['controller'] == 'profile'
+    super
+  end
+end

--- a/app/models/argo/profile_queries.rb
+++ b/app/models/argo/profile_queries.rb
@@ -1,0 +1,20 @@
+module Argo
+  ##
+  # Part of the Blacklight SearchBuilder, but only used for ProfileController to
+  # add additional parameters to the Solr request.
+  module ProfileQueries
+    extend ActiveSupport::Concern
+
+    def add_profile_queries(solr_parameters)
+      return solr_parameters unless blacklight_params['controller'] == 'profile'
+      solr_parameters['facet.field'] ||= []
+      solr_parameters['facet.field'] << SolrDocument::FIELD_APO_TITLE.to_s
+      solr_parameters['facet.field'] << SolrDocument::SolrDocument::FIELD_COLLECTION_TITLE.to_s
+      solr_parameters['stats'] = true
+      solr_parameters['stats.field'] ||= []
+      # Use this paradigm to compute needed statistics
+      # solr_parameters['stats.field'] << 'published_dttsim'
+      solr_parameters
+    end
+  end
+end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -2,13 +2,15 @@ class SearchBuilder < Blacklight::Solr::SearchBuilder
   include Argo::AccessControlsEnforcement
   include Argo::CustomSearch
   include Argo::DateFieldQueries
+  include Argo::ProfileQueries
 
-  self.default_processor_chain += [:add_access_controls_to_solr_params, :pids_only, :add_date_field_queries]
+  self.default_processor_chain += [:add_access_controls_to_solr_params, :pids_only, :add_date_field_queries, :add_profile_queries]
 
   def initialize(processor_chain, scope)
     super(processor_chain, scope)
     @processor_chain += [:add_access_controls_to_solr_params] unless @processor_chain.include?(:add_access_controls_to_solr_params)
     @processor_chain += [:pids_only] unless @processor_chain.include?(:pids_only)
     @processor_chain += [:add_date_field_queries] unless @processor_chain.include?(:add_date_field_queries)
+    @processor_chain += [:add_profile_queries] unless @processor_chain.include?(:add_profile_queries)
   end
 end

--- a/app/presenters/profile_presenter.rb
+++ b/app/presenters/profile_presenter.rb
@@ -1,0 +1,30 @@
+##
+# Used in the Profile view to provide convenience to the
+# Blacklight::Solr::Response for easy view magic
+class ProfilePresenter
+  delegate :aggregations, to: :response
+
+  attr_reader :response
+
+  ##
+  # @param [Blacklight::Solr::Response] response
+  def initialize(response)
+    @response = response
+  end
+
+  def apo_titles
+    aggregations[SolrDocument::FIELD_APO_TITLE.to_s].items
+  end
+
+  def collection_titles
+    aggregations[SolrDocument::FIELD_COLLECTION_TITLE.to_s].items
+  end
+
+  def rights_descriptions
+    aggregations['rights_descriptions_ssim'].items
+  end
+
+  def content_type
+    aggregations['content_type_ssim'].items
+  end
+end

--- a/app/views/profile/_document_list.html.erb
+++ b/app/views/profile/_document_list.html.erb
@@ -1,0 +1,31 @@
+<% @presenter = ProfilePresenter.new(@response) %>
+
+<h3>Profile</h3>
+
+<div id="admin-policies">
+  <h4>Admin Policies</h4>
+  <table class='table table-fixed-layout'>
+    <%= render partial: 'table_row',  collection: @presenter.apo_titles, as: :item %>
+  </table>
+</div>
+
+<div id="collection">
+  <h4>Collection</h4>
+  <table class='table table-fixed-layout'>
+    <%= render partial: 'table_row',  collection: @presenter.collection_titles, as: :item %>
+  </table>
+</div>
+
+<div id='rights'>
+  <h4>Rights</h4>
+  <table class='table table-fixed-layout'>
+    <%= render partial: 'table_row',  collection: @presenter.rights_descriptions, as: :item %>
+  </table>
+</div>
+
+<div id='contents'>
+  <h4>Contents</h4>
+  <table class='table table-fixed-layout'>
+    <%= render partial: 'table_row',  collection: @presenter.content_type, as: :item %>
+  </table>
+</div>

--- a/app/views/profile/_search_header.html.erb
+++ b/app/views/profile/_search_header.html.erb
@@ -1,0 +1,2 @@
+<%= render 'constraints' %>
+<%= render 'catalog/report_view_toggle' %>

--- a/app/views/profile/_table_row.html.erb
+++ b/app/views/profile/_table_row.html.erb
@@ -1,0 +1,8 @@
+<tr>
+  <td>
+    <%= item.value %>
+  </td>
+  <td>
+    <%= item.hits %>
+  </td>
+</tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Argo::Application.routes.draw do
   end
 
   Blacklight.add_routes(self, :except => [:catalog])
+  resources :profile, only: [:index]
+
   # Catalog stuff.
   match 'view/opensearch', :to => 'catalog#opensearch', :via => [:get, :post]
   match 'view/citation',   :to => 'catalog#citation',   :via => [:get, :post]

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe ProfileController do
+  it 'is a subclass of CatalogController' do
+    expect(described_class.superclass).to eq CatalogController
+  end
+end

--- a/spec/features/profile_spec.rb
+++ b/spec/features/profile_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe 'Profile' do
+  let(:current_user) do
+    mock_user(is_admin?: true)
+  end
+  before do
+    expect_any_instance_of(ProfileController).to receive(:current_user)
+      .at_least(1).times.and_return(current_user)
+  end
+  describe 'Admin Policies' do
+    it 'lists admin policies and counts' do
+      visit profile_index_path f: { objectType_ssim: ['item'] }
+      within '#admin-policies' do
+        expect(page).to have_css 'h4', text: 'Admin Policies'
+        expect(page).to have_css 'td:nth-child(1)', text: 'Stanford University Libraries - Special Collections'
+        expect(page).to have_css 'td:nth-child(2)', text: '4'
+      end
+    end
+  end
+  describe 'Collection' do
+    it 'lists collections and counts' do
+      visit profile_index_path f: { objectType_ssim: ['item'] }
+      within '#collection' do
+        expect(page).to have_css 'h4', text: 'Collection'
+        expect(page).to have_css 'td:nth-child(1)', text: 'druid:pb873ty1662'
+        expect(page).to have_css 'td:nth-child(2)', text: '1'
+      end
+    end
+  end
+  describe 'Rights' do
+    it 'lists rights and counts' do
+      visit profile_index_path f: { objectType_ssim: ['item'] }
+      within '#rights' do
+        expect(page).to have_css 'h4', text: 'Rights'
+        expect(page).to have_css 'td:nth-child(1)', text: 'dark'
+        expect(page).to have_css 'td:nth-child(2)', text: '2'
+      end
+    end
+  end
+  describe 'Contents' do
+    it 'lists content type and counts' do
+      visit profile_index_path f: { objectType_ssim: ['item'] }
+      within '#contents' do
+        expect(page).to have_css 'h4', text: 'Contents'
+        expect(page).to have_css 'td:nth-child(1)', text: 'image'
+        expect(page).to have_css 'td:nth-child(2)', text: '3'
+      end
+    end
+  end
+end

--- a/spec/helpers/profile_helper_spec.rb
+++ b/spec/helpers/profile_helper_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe ProfileHelper, type: :helper do
+  describe '#show_pagination?' do
+    context 'when using ProfileController' do
+      it 'returns false' do
+        allow(helper).to receive_messages(params: { 'controller' => 'profile'})
+        expect(helper.show_pagination?).to eq false
+      end
+    end
+  end
+end

--- a/spec/models/profile_queries_spec.rb
+++ b/spec/models/profile_queries_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+class TestClass
+  include Argo::ProfileQueries
+end
+
+describe Argo::ProfileQueries do
+  subject { TestClass.new }
+  # let(:blacklight_params) { { controller: 'profile' } }
+  before do
+    allow(subject).to receive(:blacklight_params).and_return(blacklight_params)
+  end
+  context 'in ProfileController' do
+    let(:blacklight_params) { { 'controller' => 'profile' } }
+    it 'adds in required facet fields' do
+      catalog_config = CatalogController.blacklight_config.deep_copy
+      solr_parameters = subject.add_profile_queries(catalog_config)
+      facet_fields = solr_parameters.facet_fields.map{ |f| f[0] } + solr_parameters['facet.field']
+      required_fields = [SolrDocument::FIELD_APO_TITLE.to_s, SolrDocument::SolrDocument::FIELD_COLLECTION_TITLE.to_s, 'rights_descriptions_ssim', 'content_type_ssim']
+      expect(facet_fields).to include(*required_fields)
+    end
+    it 'adds in requred stats fields' do
+      catalog_config = CatalogController.blacklight_config.deep_copy
+      solr_parameters = subject.add_profile_queries(catalog_config)
+      expect(solr_parameters['stats']).to be true
+    end
+  end
+  context 'in another Controller' do
+    let(:blacklight_params) { { 'controller' => 'catalog' } }
+    it 'does not modify solr_params' do
+      expect(subject.add_profile_queries(CatalogController.blacklight_config.deep_copy)).to eq CatalogController.blacklight_config.deep_copy
+    end
+  end
+end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -44,5 +44,16 @@ RSpec.describe SearchBuilder do
       expect(subject.processor_chain
         .count { |x| x == :add_date_field_queries }).to eq 1
     end
+    it 'contains add_profile_queries once' do
+      expect(subject.processor_chain)
+        .to include :add_profile_queries
+      expect(subject.processor_chain
+        .count { |x| x == :add_profile_queries }).to eq 1
+      new_search = described_class.new(subject.processor_chain, context)
+      expect(new_search.processor_chain)
+        .to include :add_profile_queries
+      expect(subject.processor_chain
+        .count { |x| x == :add_profile_queries }).to eq 1
+    end
   end
 end


### PR DESCRIPTION
This PR adds the base functionality for creating our Results Profile (formerly "Collection Profile").

<img width="1273" alt="screen shot 2016-10-14 at 3 17 59 pm" src="https://cloud.githubusercontent.com/assets/1656824/19399838/6fd653ca-9221-11e6-95c7-42d4eef4565b.png">

The idea here is that the rest of the functionality can be built off of this. Lays down the base work for #204 

Closes #836 

Partially addresses #838 