### PR TITLE
update release tag capitalization to new standard

### DIFF
--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -10,6 +10,6 @@ module Constants
   CONTENT_TYPES = %w(image book file manuscript map media).freeze
   RESOURCE_TYPES = %w(image page file audio video).freeze
   RELEASE_TARGETS = [
-    %w(SearchWorks SearchWorks)
+    %w(Searchworks Searchworks)
   ].freeze
 end

--- a/spec/views/bulk_actions/_form.html.erb_spec.rb
+++ b/spec/views/bulk_actions/_form.html.erb_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'bulk_actions/_form.html.erb' do
       expect(rendered).to have_css 'input[type="radio"][value="true"][checked="checked"][name="bulk_action[manage_release][tag]"]'
       expect(rendered).to have_css 'input[type="radio"][value="false"][name="bulk_action[manage_release][tag]"]'
       expect(rendered).to have_css 'select[name="bulk_action[manage_release][to]"]'
-      expect(rendered).to have_css 'option[value="SearchWorks"]'
+      expect(rendered).to have_css 'option[value="Searchworks"]'
       expect(rendered).to have_css 'input[value="self"][type="hidden"][name="bulk_action[manage_release][what]"]', visible: false
       expect(rendered).to have_css 'input[value="esnowden"][type="hidden"][name="bulk_action[manage_release][who]"]', visible: false
     end


### PR DESCRIPTION
Closes #849 

![screen shot 2016-10-25 at 5 20 07 pm](https://cloud.githubusercontent.com/assets/1656824/19704825/55b8d4e0-9ad7-11e6-8b89-c5508fd16fa4.png)
