### PR TITLE
config/deploy.rb: descriptions for .htaccess gen and eye restart/config tasks

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -43,6 +43,7 @@ namespace :deploy do
   # in argo's git repo, and so a fresh copy (without the generated .htaccess file)
   # will get written with each deployment.  the .htaccess file with the correct
   # list of workgroups is required for argo's permissions checking mechanism to function.
+  desc 're-generate .htaccess from the current APOs (so workgroup-based perm checks function)'
   after :restart, :initialize_htaccess do
     on roles(:web), in: :groups, limit: 3, wait: 10 do
       # Here we can do anything such as:
@@ -58,6 +59,7 @@ namespace :deploy do
   # eye may not be installed system-wide.  load the delayed_job_workers.eye config,
   # which should monitor workers for memory consumption (restarting them individually
   # if and when they exceed the configured threshold).
+  desc "stop/start eye, config for monitoring the deployment's delayed_job workers"
   after :restart, :load_eye_dj_config do
     on roles(:app) do
       within release_path do


### PR DESCRIPTION
so tasks show up in `cap -T` output

suggested by @eefahy after she tried to find a task for the eye restart but didn't see anything about when running `cap -T`