### PR TITLE
SolrDocument#collection_titles should return an empty array for objects without collections

### DIFF
--- a/app/models/concerns/collection_concern.rb
+++ b/app/models/concerns/collection_concern.rb
@@ -22,13 +22,13 @@ module CollectionConcern
   # Access a SolrDocument's *first* Collection title
   # @return [String, nil]
   def collection_title
-    collection_titles.first if collection_titles
+    collection_titles.first
   end
 
   ##
   # Access a SolrDocument's Collection(s) title
   # @return [Array<String>, nil]
   def collection_titles
-    fetch(FIELD_COLLECTION_TITLE, nil)
+    fetch(FIELD_COLLECTION_TITLE, [])
   end
 end

--- a/spec/models/concerns/collection_concern_spec.rb
+++ b/spec/models/concerns/collection_concern_spec.rb
@@ -20,7 +20,7 @@ describe CollectionConcern do
         expect(document.collection_id).to be_nil
         expect(document.collection_ids).to be_nil
         expect(document.collection_title).to be_nil
-        expect(document.collection_titles).to be_nil
+        expect(document.collection_titles).to eq []
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/argo/issues/879