### PR TITLE
Use proper MODS for descMetadata for workflow objects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,7 @@ gem 'about_page'
 gem 'active-fedora', '~> 8.2'
 gem 'blacklight', '~> 6.0'
 gem 'blacklight-hierarchy'
-gem 'dor-services', '>= 5.14.0', '< 6'
+gem 'dor-services', '>= 5.17.0', '< 6'
 gem 'moab-versioning'
 gem 'mods_display'
 gem 'okcomputer' # monitors application and its dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    active-fedora (8.2.1)
+    active-fedora (8.2.2)
       active-triples (~> 0.4.0)
       activesupport (>= 3.0.0)
       deprecation
@@ -205,7 +205,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dor-rights-auth (1.3.0)
       nokogiri
-    dor-services (5.15.1)
+    dor-services (5.17.0)
       active-fedora (>= 6.0, < 9.a)
       activesupport (>= 3.2.18)
       confstruct (~> 0.2.7)
@@ -223,7 +223,7 @@ GEM
       rdf (~> 1.1, >= 1.1.7)
       rest-client (>= 1.7, < 3)
       retries
-      rsolr-ext (~> 1.0.3)
+      rsolr (>= 1.0.3, < 3)
       ruby-cache (~> 0.3.0)
       ruby-graphviz
       rubydora (~> 1.6, >= 1.6.5)
@@ -522,8 +522,6 @@ GEM
       rubyzip (~> 1.1, < 2.0.0)
     rsolr (1.1.2)
       builder (>= 2.1.2)
-    rsolr-ext (1.0.3)
-      rsolr (>= 1.0.2)
     rspec-core (3.5.4)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
@@ -551,7 +549,7 @@ GEM
     ruby-graphviz (1.2.2)
     ruby-prof (0.16.2)
     ruby-progressbar (1.8.1)
-    rubydora (1.9.0)
+    rubydora (1.9.1)
       activemodel
       activesupport
       deprecation
@@ -699,7 +697,7 @@ DEPENDENCIES
   delayed_job
   delayed_job_active_record
   dlss-capistrano (~> 3.1)
-  dor-services (>= 5.14.0, < 6)
+  dor-services (>= 5.17.0, < 6)
   ebnf (= 1.0.0)
   equivalent-xml (>= 0.6.0)
   eye

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dor-rights-auth (1.3.0)
       nokogiri
-    dor-services (5.17.0)
+    dor-services (5.17.1)
       active-fedora (>= 6.0, < 9.a)
       activesupport (>= 3.2.18)
       confstruct (~> 0.2.7)
@@ -246,11 +246,11 @@ GEM
       nokogiri (>= 1.4.3)
     erubis (2.7.0)
     execjs (2.7.0)
-    eye (0.8.1)
+    eye (0.9.1)
       celluloid (~> 0.17.3)
       celluloid-io (~> 0.17.0)
       sigar (~> 0.7.3)
-      state_machine
+      state_machines
       thor
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
@@ -270,7 +270,7 @@ GEM
       tilt
     hashdiff (0.3.0)
     hitimes (1.2.4)
-    honeybadger (2.7.0)
+    honeybadger (2.7.1)
     hooks (0.4.1)
       uber (~> 0.0.14)
     htmlentities (4.3.4)
@@ -612,7 +612,7 @@ GEM
     stanford-mods (2.3.1)
       activesupport
       mods (~> 2.0, >= 2.0.2)
-    state_machine (1.2.0)
+    state_machines (0.4.0)
     stomp (1.4.3)
     sul_styles (0.6.1)
       rails (>= 4.1, < 6)

--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -13,7 +13,7 @@ class RegistrationController < ApplicationController
   end
 
   def workflow_list
-    docs = Dor::SearchService.query(%(id:"#{params[:apo_id]}")).docs
+    docs = Dor::SearchService.query(%(id:"#{params[:apo_id]}"))['response']['docs']
     result = docs.collect { |doc| doc['registration_workflow_id_ssim'] }.compact
     apo_object = Dor.find(params[:apo_id], :lightweight => true)
     adm_xml = apo_object.administrativeMetadata.ng_xml
@@ -43,7 +43,7 @@ class RegistrationController < ApplicationController
         q: "id:\"#{col_id}\"",
         rows: 1,
         fl: col_title_field
-      }).docs.first
+      })['response']['docs'].first
       if solr_doc.present? && solr_doc[col_title_field].present?
         collections[col_id] = "#{short_label(solr_doc[col_title_field], truncate_limit)} (#{col_druid})"
       else

--- a/app/helpers/apo_helper.rb
+++ b/app/helpers/apo_helper.rb
@@ -32,7 +32,7 @@ module ApoHelper
 
   def workflow_options
     q = 'objectType_ssim:workflow '
-    result = Dor::SearchService.query(q, :rows => 99999, :fl => 'id,tag_ssim,dc_title_tesim').docs
+    result = Dor::SearchService.query(q, :rows => 99999, :fl => 'id,tag_ssim,dc_title_tesim')['response']['docs']
     result.sort! do |a, b|
       a['dc_title_tesim'].to_s <=> b['dc_title_tesim'].to_s
     end
@@ -47,7 +47,7 @@ module ApoHelper
 
   def agreement_options
     q = 'objectType_ssim:agreement '
-    result = Dor::SearchService.query(q, :rows => 99999, :fl => 'id,tag_ssim,dc_title_tesim').docs
+    result = Dor::SearchService.query(q, :rows => 99999, :fl => 'id,tag_ssim,dc_title_tesim')['response']['docs']
     result.sort! do |a, b|
       a['dc_title_tesim'].to_s <=> b['dc_title_tesim'].to_s
     end

--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -13,7 +13,7 @@ module RegistrationHelper
       :rows => 99999,
       :fl => 'id,tag_ssim,dc_title_tesim',
       :fq => ['objectType_ssim:adminPolicy', '!tag_ssim:"Project : Hydrus"']
-    ).docs
+    )['response']['docs']
 
     result.sort! do |a, b|
       Array(a['tag_ssim']).include?('AdminPolicy : default') ? -1 : a['dc_title_tesim'].to_s <=> b['dc_title_tesim'].to_s

--- a/app/models/concerns/permitted_queries.rb
+++ b/app/models/concerns/permitted_queries.rb
@@ -62,7 +62,7 @@ class PermittedQueries
       rows: 1000,
       fl: 'id,tag_ssim,dc_title_tesim',
       fq: ['objectType_ssim:collection', '!project_tag_ssim:Hydrus']
-    ).docs
+    )['response']['docs']
 
     result.sort! do |a, b|
       a['dc_title_tesim'].to_s <=> b['dc_title_tesim'].to_s

--- a/app/models/track_sheet.rb
+++ b/app/models/track_sheet.rb
@@ -104,13 +104,13 @@ class TrackSheet
     table_data.push(['Date Printed:', Time.now.strftime('%c')])
     table_data
   end
-  
+
   # @param [String] druid unqualified DRUID identifier
   # @return [Hash] doc from Solr or to_solr
   # @note To the extent we use Solr input filters or copyField(s), the Solr version will differ from the to_solr hash.
   # @note That difference shouldn't be important for the few known fields we use here.
   def find_or_create_in_solr_by_id(druid)
-    doc = Dor::SearchService.query(%(id:"druid:#{druid}"), :rows => 1).docs.first
+    doc = Dor::SearchService.query(%(id:"druid:#{druid}"), :rows => 1)['response']['docs'].first
     return doc unless doc.nil?
     obj = Dor.load_instance "druid:#{druid}"
     solr_doc = obj.to_solr

--- a/fedora_conf/data/fy957df3135.xml
+++ b/fedora_conf/data/fy957df3135.xml
@@ -243,9 +243,13 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
 </foxml:datastreamVersion>
 </foxml:datastream>
 <foxml:datastream ID="descMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
-<foxml:datastreamVersion ID="descMetadata.0" LABEL="Descriptive Metadata" CREATED="2011-10-26T23:24:04.134Z" MIMETYPE="text/xml" SIZE="13">
+<foxml:datastreamVersion ID="descMetadata.0" LABEL="Descriptive Metadata" CREATED="2011-10-26T23:24:04.134Z" MIMETYPE="text/xml" SIZE="289">
 <foxml:xmlContent>
-<xml></xml>
+  <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd">
+    <titleInfo>
+      <title>digitizationWF</title>
+    </titleInfo>
+  </mods>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
 </foxml:datastream>

--- a/fedora_conf/data/tm388wy6148.xml
+++ b/fedora_conf/data/tm388wy6148.xml
@@ -392,9 +392,13 @@
 </foxml:datastreamVersion>
 </foxml:datastream>
 <foxml:datastream ID="descMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
-<foxml:datastreamVersion ID="descMetadata.0" LABEL="Descriptive Metadata" CREATED="2011-10-26T23:23:58.254Z" MIMETYPE="text/xml" SIZE="13">
+<foxml:datastreamVersion ID="descMetadata.0" LABEL="Descriptive Metadata" CREATED="2011-10-26T23:23:58.254Z" MIMETYPE="text/xml" SIZE="286">
 <foxml:xmlContent>
-<xml/>
+  <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd">
+    <titleInfo>
+      <title>accessionWF</title>
+    </titleInfo>
+  </mods>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
 </foxml:datastream>

--- a/lib/pid_gatherer.rb
+++ b/lib/pid_gatherer.rb
@@ -49,8 +49,8 @@ module Argo
         start = 0
         solr_pids = []
         resp = Dor::SearchService.query(q, :sort => 'id asc', :rows => 1000, :start => start, :fl => ['id'])
-        while resp.docs.length > 0
-          solr_pids += resp.docs.map { |doc| doc['id'] }
+        while resp['response']['docs'].length > 0
+          solr_pids += resp['response']['docs'].map { |doc| doc['id'] }
           start += 1000
           resp = Dor::SearchService.query(q, :sort => 'id asc', :rows => 1000, :start => start, :fl => ['id'])
         end

--- a/spec/helpers/registration_helper_spec.rb
+++ b/spec/helpers/registration_helper_spec.rb
@@ -13,7 +13,7 @@ describe RegistrationHelper do
         rows: 99999,
         fl: 'id,tag_ssim,dc_title_tesim',
         fq: ['objectType_ssim:adminPolicy', '!tag_ssim:"Project : Hydrus"']
-      ).and_return(double(docs: []))
+      ).and_return({ 'response' => { 'docs' => [] } })
 
       apo_list(perm_keys)
     end
@@ -24,7 +24,7 @@ describe RegistrationHelper do
         {'id' => 2, 'tag_ssim' => 'AdminPolicy : default', 'dc_title_tesim' => 'y'},
         {'id' => 3, 'tag_ssim' => 'prefix : suffix2', 'dc_title_tesim' => 'x'}
       ]
-      expect(Dor::SearchService).to receive(:query).and_return(double(docs: result_rows))
+      expect(Dor::SearchService).to receive(:query).and_return({ 'response' => { 'docs' => result_rows }})
 
       apos = apo_list(perm_keys)
       expect(apos).to eq [['y', '2'], ['x', '3'], ['z', '1']]


### PR DESCRIPTION
This fixes fixture data that causes `to_solr` being called on Workflow objects in dor-services 5.17 to fail.

```
Undefined namespace prefix: /oai_dc:dc/*[count(text()) = 0]
```

This PR also updates to dor-services 5.17.x where these fixtures break.

TODO: 
- [x] Fix this line too https://github.com/sul-dlss/argo/blob/master/lib/tasks/argo.rake#L12