### PR TITLE
Use RSolr-provided escaping for workgroup values

### DIFF
--- a/app/models/concerns/permitted_queries.rb
+++ b/app/models/concerns/permitted_queries.rb
@@ -20,7 +20,7 @@ class PermittedQueries
   # Also queries Solr based on groups
   # @return [Array[String]] list of DRUIDs from APOs that this User can view
   def permitted_apos
-    query = groups.map { |g| g.gsub(':', '\:') }.join(' OR ')
+    query = groups.map { |g| RSolr.solr_escape(g) }.join(' OR ')
 
     q = ''
     if is_admin

--- a/spec/models/concerns/permitted_queries_spec.rb
+++ b/spec/models/concerns/permitted_queries_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe PermittedQueries do
         expect(user.permitted_apos).to be_an Array
       end
     end
+
+    context 'personal workgroups' do
+      it 'does not raise an RSolr syntax error' do
+        user.set_groups_to_impersonate ['~sunetid:somegroup']
+        expect{user.permitted_apos}.to_not raise_error
+        expect(user.permitted_apos).to be_an Array
+      end
+    end
   end
   describe '#permitted_collections' do
     let(:user) { User.find_or_create_by_remoteuser 'test_user' }


### PR DESCRIPTION
Fixes #846 