### PR TITLE
Use upstream logic for validating source ids

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -412,22 +412,9 @@ class ItemsController < ApplicationController
     end
   end
 
-  # TODO: this should be a method in dor-services, invoked within set_source_id
-  def self.normalize_source_id(new_source_id)
-    src_id_arr = new_source_id.split(':').map(&:strip)
-    raise 'new source_id must be of the form "source:value"' if src_id_arr.length != 2
-    src_id_arr.join(':')
-  end
-
   def source_id
-    new_id = ItemsController.normalize_source_id(params[:new_id])
-    @object.source_id = new_id
-    # TODO: the content= and content_will_change! calls belong in dor-services,
-    # for this method and other similar methods. can then clean up
-    # allow(idmd).to receive(:"ng_xml") (and "content_will_change!") in tests.
-    # getting rid of "Metadata\.content\s*=\s*"
-    @object.identityMetadata.content = @object.identityMetadata.ng_xml.to_xml
-    @object.identityMetadata.content_will_change!
+    @object.source_id = params[:new_id]
+
     respond_to do |format|
       if params[:bulk]
         format.html { render :status => :ok, :plain => 'Updated source id.' }


### PR DESCRIPTION
Upstream does:

```ruby
   parts = value.split(':').map(&:strip)
    # parts = value.split(/:/, 2).map(&:strip) # if we needed to allow colons in values or bunched colon separators
    raise ArgumentError, "Source ID must follow the format 'namespace:value', not '#{value}'" unless
      parts.length == 2 && parts[0].present? && parts[1].present?
```