### PR TITLE
Improve home page performance

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -63,10 +63,10 @@ class CatalogController < ApplicationController
     config.add_facet_field 'content_type_ssim',               label: 'Content Type',        limit: 10
     config.add_facet_field 'rights_descriptions_ssim',        label: 'Access Rights',       limit: 1000, sort: 'index', home: false
     config.add_facet_field 'use_license_machine_ssi',         label: 'License',             limit: 10, home: false
-    config.add_facet_field 'nonhydrus_collection_title_ssim', label: 'Collection',          limit: 9999, sort: 'index'
-    config.add_facet_field 'hydrus_collection_title_ssim',    label: 'Hydrus Collection',   limit: 9999, sort: 'index', home: false
-    config.add_facet_field 'nonhydrus_apo_title_ssim',        label: 'Admin Policy',        limit: 9999, sort: 'index'
-    config.add_facet_field 'hydrus_apo_title_ssim',           label: 'Hydrus Admin Policy', limit: 9999, sort: 'index', home: false
+    config.add_facet_field 'nonhydrus_collection_title_ssim', label: 'Collection',          limit: 10, more_limit: 9999, sort: 'index'
+    config.add_facet_field 'hydrus_collection_title_ssim',    label: 'Hydrus Collection',   limit: 10, more_limit: 9999, sort: 'index', home: false
+    config.add_facet_field 'nonhydrus_apo_title_ssim',        label: 'Admin Policy',        limit: 10, more_limit: 9999, sort: 'index'
+    config.add_facet_field 'hydrus_apo_title_ssim',           label: 'Hydrus Admin Policy', limit: 10, more_limit: 9999, sort: 'index', home: false
     config.add_facet_field 'current_version_isi',             label: 'Version',             limit: 10, home: false
     config.add_facet_field 'processing_status_text_ssi',      label: 'Processing Status',   limit: 10, home: false
     config.add_facet_field 'released_to_ssim',                label: 'Released To',         limit: 10

--- a/app/controllers/concerns/date_facet_configurations.rb
+++ b/app/controllers/concerns/date_facet_configurations.rb
@@ -9,56 +9,56 @@ module DateFacetConfigurations
       # TODO: update blacklight_range_limit to work w/ dates and use it.  Or something similarly powerful.
       #      Per-query user-paramatized facet endpoints w/ auto-scaling granularity is the point.
       #      See solr facet ranges (start/end/gap), NOT facet range queries (fq), as here.
-      config.add_facet_field 'registered_date', :label => 'Registered', :query => {
+      config.add_facet_field 'registered_date', :home => false, :label => 'Registered', :query => {
         :days_7  => { :label => 'within 7 days',  :fq => "#{SolrDocument::FIELD_REGISTERED_DATE}:[NOW/DAY-7DAYS TO *]"},
         :days_30 => { :label => 'within 30 days', :fq => "#{SolrDocument::FIELD_REGISTERED_DATE}:[NOW/DAY-30DAYS TO *]"}
       }, partial: 'catalog/show_date_choice', raw_facet_field: SolrDocument::FIELD_REGISTERED_DATE
-      config.add_facet_field SolrDocument::FIELD_REGISTERED_DATE, label: 'Registered', show: false
+      config.add_facet_field SolrDocument::FIELD_REGISTERED_DATE, label: 'Registered', show: false, home: false
 
-      config.add_facet_field 'accessioned_latest_date', :label => 'Last Accessioned', :query => {
+      config.add_facet_field 'accessioned_latest_date', :home => false, :label => 'Last Accessioned', :query => {
         :days_7  => { :label => 'within 7 days',  :fq => "#{SolrDocument::FIELD_LAST_ACCESSIONED_DATE}:[NOW/DAY-7DAYS TO *]"},
         :days_30 => { :label => 'within 30 days', :fq => "#{SolrDocument::FIELD_LAST_ACCESSIONED_DATE}:[NOW/DAY-30DAYS TO *]"}
       }, partial: 'catalog/show_date_choice', raw_facet_field: SolrDocument::FIELD_LAST_ACCESSIONED_DATE
-      config.add_facet_field SolrDocument::FIELD_LAST_ACCESSIONED_DATE, label: 'Last Accessioned', show: false
+      config.add_facet_field SolrDocument::FIELD_LAST_ACCESSIONED_DATE, label: 'Last Accessioned', show: false, home: false
 
-      config.add_facet_field 'published_latest_date', :label => 'Last Published', :query => {
+      config.add_facet_field 'published_latest_date', :home => false, :label => 'Last Published', :query => {
         :days_7  => { :label => 'within 7 days',  :fq => "#{SolrDocument::FIELD_LAST_PUBLISHED_DATE}:[NOW/DAY-7DAYS TO *]"},
         :days_30 => { :label => 'within 30 days', :fq => "#{SolrDocument::FIELD_LAST_PUBLISHED_DATE}:[NOW/DAY-30DAYS TO *]"}
       }, partial: 'catalog/show_date_choice', raw_facet_field: SolrDocument::FIELD_LAST_PUBLISHED_DATE
-      config.add_facet_field SolrDocument::FIELD_LAST_PUBLISHED_DATE, label: 'Last Published', show: false
+      config.add_facet_field SolrDocument::FIELD_LAST_PUBLISHED_DATE, label: 'Last Published', show: false, home: false
 
-      config.add_facet_field 'submitted_latest_date', :label => 'Last Submitted', :query => {
+      config.add_facet_field 'submitted_latest_date', :home => false, :label => 'Last Submitted', :query => {
         :days_7  => { :label => 'within 7 days',  :fq => "#{SolrDocument::FIELD_LAST_SUBMITTED_DATE}:[NOW/DAY-7DAYS TO *]"},
         :days_30 => { :label => 'within 30 days', :fq => "#{SolrDocument::FIELD_LAST_SUBMITTED_DATE}:[NOW/DAY-30DAYS TO *]"}
       }, partial: 'catalog/show_date_choice', raw_facet_field: SolrDocument::FIELD_LAST_SUBMITTED_DATE
-      config.add_facet_field SolrDocument::FIELD_LAST_SUBMITTED_DATE, label: 'Last Submitted', show: false
+      config.add_facet_field SolrDocument::FIELD_LAST_SUBMITTED_DATE, label: 'Last Submitted', show: false, home: false
 
-      config.add_facet_field 'deposited_date', :label => 'Last Ingested', :query => {
+      config.add_facet_field 'deposited_date', :home => false, :label => 'Last Ingested', :query => {
         :days_1  => { :label => 'today',          :fq => "#{SolrDocument::FIELD_LAST_DEPOSITED_DATE}:[NOW/DAY TO *]"},
         :days_7  => { :label => 'within 7 days',  :fq => "#{SolrDocument::FIELD_LAST_DEPOSITED_DATE}:[NOW/DAY-7DAYS TO *]"},
         :days_30 => { :label => 'within 30 days', :fq => "#{SolrDocument::FIELD_LAST_DEPOSITED_DATE}:[NOW/DAY-30DAYS TO *]"}
       }, partial: 'catalog/show_date_choice', raw_facet_field: SolrDocument::FIELD_LAST_DEPOSITED_DATE
-      config.add_facet_field SolrDocument::FIELD_LAST_DEPOSITED_DATE, label: 'Last Ingested', show: false
+      config.add_facet_field SolrDocument::FIELD_LAST_DEPOSITED_DATE, label: 'Last Ingested', show: false, home: false
 
-      config.add_facet_field 'object_modified_date', :label => 'Last Modified', :query => {
+      config.add_facet_field 'object_modified_date', :home => false, :label => 'Last Modified', :query => {
         :days_7  => { :label => 'within 7 days',  :fq => "#{SolrDocument::FIELD_LAST_MODIFIED_DATE}:[NOW/DAY-7DAYS TO *]"},
         :days_30 => { :label => 'within 30 days', :fq => "#{SolrDocument::FIELD_LAST_MODIFIED_DATE}:[NOW/DAY-30DAYS TO *]"}
       }, partial: 'catalog/show_date_choice', raw_facet_field: SolrDocument::FIELD_LAST_MODIFIED_DATE
-      config.add_facet_field SolrDocument::FIELD_LAST_MODIFIED_DATE, label: 'Last Modified', show: false
+      config.add_facet_field SolrDocument::FIELD_LAST_MODIFIED_DATE, label: 'Last Modified', show: false, home: false
 
-      config.add_facet_field 'version_opened_date', :label => 'Last Opened', :query => {
+      config.add_facet_field 'version_opened_date', :home => false, :label => 'Last Opened', :query => {
         :all     => { :label => 'All',               :fq => "#{SolrDocument::FIELD_LAST_OPENED_DATE}:*"},
         :days_7  => { :label => 'more than 7 days',  :fq => "#{SolrDocument::FIELD_LAST_OPENED_DATE}:[* TO NOW/DAY-7DAYS]"},
         :days_30 => { :label => 'more than 30 days', :fq => "#{SolrDocument::FIELD_LAST_OPENED_DATE}:[* TO NOW/DAY-30DAYS]"}
       }, partial: 'catalog/show_date_choice', raw_facet_field: SolrDocument::FIELD_LAST_OPENED_DATE
-      config.add_facet_field SolrDocument::FIELD_LAST_OPENED_DATE, label: 'Last Opened', show: false
+      config.add_facet_field SolrDocument::FIELD_LAST_OPENED_DATE, label: 'Last Opened', show: false, home: false
 
-      config.add_facet_field 'embargo_release_date', :label => 'Embargo Release Date', :query => {
+      config.add_facet_field 'embargo_release_date', :home => false, :label => 'Embargo Release Date', :query => {
         :days_7  => { :label => 'up to 7 days',  :fq => "#{SolrDocument::FIELD_EMBARGO_RELEASE_DATE}:[NOW TO NOW/DAY+7DAYS]"},
         :days_30 => { :label => 'up to 30 days', :fq => "#{SolrDocument::FIELD_EMBARGO_RELEASE_DATE}:[NOW TO NOW/DAY+30DAYS]"},
         :all     => { :label => 'All',           :fq => "#{SolrDocument::FIELD_EMBARGO_RELEASE_DATE}:*"}
       }, partial: 'catalog/show_date_choice', raw_facet_field: SolrDocument::FIELD_EMBARGO_RELEASE_DATE
-      config.add_facet_field SolrDocument::FIELD_EMBARGO_RELEASE_DATE, label: 'Embargo Release Date', show: false
+      config.add_facet_field SolrDocument::FIELD_EMBARGO_RELEASE_DATE, label: 'Embargo Release Date', show: false, home: false
     end
   end
 end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -5,5 +5,36 @@ class SearchBuilder < Blacklight::SearchBuilder
   include Argo::DateFieldQueries
   include Argo::ProfileQueries
 
-  self.default_processor_chain += [:add_access_controls_to_solr_params, :pids_only, :add_date_field_queries, :add_profile_queries]
+  self.default_processor_chain += [
+    :add_access_controls_to_solr_params,
+    :pids_only,
+    :add_date_field_queries,
+    :add_profile_queries
+  ]
+
+  # customize facet paging behavior to allow a separately configurable limit for
+  # the full list of facets
+  def add_facet_paging_to_solr(solr_params)
+    return unless facet.present?
+
+    super
+
+    facet_config = blacklight_config.facet_fields[facet]
+
+    if facet_config.more_limit
+      limit = if scope.respond_to?(:facet_list_limit)
+                scope.facet_list_limit.to_s.to_i
+              elsif solr_params['facet.limit']
+                solr_params['facet.limit'].to_i
+              else
+                facet_config[:more_limit]
+              end
+
+      page = blacklight_params.fetch(request_keys[:page], 1).to_i
+      offset = (page - 1) * limit
+
+      solr_params[:"f.#{facet}.facet.limit"] = limit + 1
+      solr_params[:"f.#{facet}.facet.offset"] = offset
+    end
+  end
 end

--- a/app/views/catalog/_search_sidebar.html.erb
+++ b/app/views/catalog/_search_sidebar.html.erb
@@ -1,0 +1,5 @@
+<%= render 'facets' %>
+
+<% unless has_search_parameters? || params[:all]  %>
+  <%= link_to "Show more facets", root_path(all: true), class: 'btn btn-primary' %>
+<% end %>

--- a/spec/features/date_range_form_spec.rb
+++ b/spec/features/date_range_form_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Date range form', js: true do
     @current_user = mock_user(is_admin?: true, can_view_something?: true)
     allow_any_instance_of(ApplicationController).to receive(:current_user).
       and_return(@current_user)
-    visit root_path
+    visit root_path(all: true)
     find('[data-target="#facet-object_modified_date"]').click
   end
   let(:tomorrow) { (Time.current + 1.day).strftime('%m/%d/%Y') }

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe 'Home page' do
+  let(:current_user) do
+    mock_user(is_admin?: true)
+  end
+  before :each do
+    allow_any_instance_of(CatalogController).to receive(:current_user).
+      and_return(current_user)
+  end
+
+  describe 'facets' do
+    it 'displays an abbreviated facet list' do
+      visit root_path
+
+      expect(page).to have_selector '.facet-field-heading', text: 'Collection'
+      expect(page).not_to have_selector '.facet-field-heading', text: 'Version'
+    end
+
+    it 'has a click-through to the full facet list' do
+      visit root_path
+
+      click_link 'Show more facets'
+
+      expect(page).to have_selector '.facet-field-heading', text: 'Collection'
+      expect(page).to have_selector '.facet-field-heading', text: 'Version'
+    end
+  end
+end

--- a/spec/integration/item_displays_spec.rb
+++ b/spec/integration/item_displays_spec.rb
@@ -25,7 +25,7 @@ describe 'mods_view', :type => :request do
       expect(page).to have_content('Limit your search')
     end
     it 'should have the expected search facets', js: true do
-      search_facets = ['Object Type', 'Content Type', 'Admin Policy', 'Version']
+      search_facets = ['Object Type', 'Content Type', 'Admin Policy']
       visit root_path
       search_facets.each do |facet|
         expect(page).to have_content(facet)

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -55,4 +55,18 @@ RSpec.describe SearchBuilder do
         .count { |x| x == :add_profile_queries }).to eq 1
     end
   end
+
+  describe '#add_facet_paging_to_solr' do
+    let(:facet) { 'nonhydrus_collection_title_ssim' }
+    subject { search_builder.with(user_params).facet(facet) }
+
+    it 'uses the :more_limit configuration to independently change the "more" size' do
+      solr_params = {}
+
+      subject.add_facet_paging_to_solr(solr_params)
+
+      expect(solr_params).to include :"f.#{facet}.facet.limit" => 10000,
+                                     :"f.#{facet}.facet.offset" => 0
+    end
+  end
 end


### PR DESCRIPTION
These changes significantly improve Argo home page performance (from 20+ seconds to <10s).

Limiting facets:

<img width="386" alt="screen shot 2017-01-19 at 9 54 50 am" src="https://cloud.githubusercontent.com/assets/111218/22118708/afc909d4-de2d-11e6-88da-9bddda4ee03f.png">
<img width="382" alt="screen shot 2017-01-19 at 9 56 07 am" src="https://cloud.githubusercontent.com/assets/111218/22118709/afcbeaf0-de2d-11e6-91cd-a25a34752fc0.png">

Full value list after clicking "More >>"

<img width="972" alt="screen shot 2017-01-19 at 9 57 12 am" src="https://cloud.githubusercontent.com/assets/111218/22118721/b855431a-de2d-11e6-9913-b33fa2f26cc6.png">

