### PR TITLE
upgrade to latest dor-services to get new rights type codes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,7 @@ gem 'about_page'
 gem 'active-fedora', '~> 8.2'
 gem 'blacklight', '~> 6.0'
 gem 'blacklight-hierarchy'
-gem 'dor-services', '>= 5.17.0', '< 6'
+gem 'dor-services', '>= 5.21.4', '< 6'
 gem 'moab-versioning'
 gem 'mods_display'
 gem 'okcomputer' # monitors application and its dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    active-fedora (8.3.0)
+    active-fedora (8.4.0)
       active-triples (~> 0.4.0)
       activesupport (>= 3.0.0)
       deprecation
@@ -42,7 +42,7 @@ GEM
       om (~> 3.1)
       rdf-rdfxml (~> 1.1)
       rsolr (>= 1.0.11, < 3)
-      rubydora (~> 1.8)
+      rubydora (>= 1.8.0, < 3)
     active-triples (0.4.0)
       activemodel (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -205,7 +205,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dor-rights-auth (1.3.0)
       nokogiri
-    dor-services (5.21.1)
+    dor-services (5.21.4)
       active-fedora (>= 6.0, < 9.a)
       activesupport (>= 3.2.18)
       confstruct (~> 0.2.7)
@@ -277,7 +277,7 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     http_logger (0.5.1)
-    i18n (0.7.0)
+    i18n (0.8.0)
     iso-639 (0.2.8)
     jbuilder (2.6.1)
       activesupport (>= 3.0.0, < 5.1)
@@ -558,7 +558,7 @@ GEM
       mime-types
       nokogiri
       rest-client
-    rubyzip (1.2.0)
+    rubyzip (1.2.1)
     safe_yaml (1.0.4)
     sass (3.4.23)
     sass-rails (5.0.6)
@@ -609,7 +609,7 @@ GEM
     sshkit (1.11.5)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    stanford-mods (2.3.1)
+    stanford-mods (2.4.0)
       activesupport
       mods (~> 2.0, >= 2.0.2)
     state_machines (0.4.0)
@@ -625,7 +625,7 @@ GEM
       ref
     thor (0.19.4)
     thread_safe (0.3.5)
-    tilt (2.0.5)
+    tilt (2.0.6)
     timers (4.1.2)
       hitimes
     tins (1.6.0)
@@ -697,7 +697,7 @@ DEPENDENCIES
   delayed_job
   delayed_job_active_record
   dlss-capistrano (~> 3.1)
-  dor-services (>= 5.17.0, < 6)
+  dor-services (>= 5.21.4, < 6)
   ebnf (= 1.0.0)
   equivalent-xml (>= 0.6.0)
   eye
@@ -761,4 +761,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.13.6
+   1.13.7


### PR DESCRIPTION
the Gemfile edit wasn't strictly necessary for the upgrade itself (could've just done `bundle update`), but i think we do actually want this latest version of dor-services to be the minimum allowable version of dor-services, so it seemed like the right thing to do semantically.

closes #934 