### PR TITLE
Set APO (single object and bulk)

### DIFF
--- a/app/controllers/bulk_actions_controller.rb
+++ b/app/controllers/bulk_actions_controller.rb
@@ -50,7 +50,8 @@ class BulkActionsController < ApplicationController
       :action_type,
       :description,
       :pids,
-      manage_release: [:tag, :what, :who, :to]
+      manage_release: [:tag, :what, :who, :to],
+      set_governing_apo: [:new_apo_id]
     ).merge(webauth: { privgroup: webauth.privgroup, login: webauth.login })
   end
 end

--- a/app/helpers/argo_helper.rb
+++ b/app/helpers/argo_helper.rb
@@ -76,6 +76,17 @@ module ArgoHelper
         label: 'Reindex',
         new_page: true
       }
+
+      # note that the backend will also check can?(:manage_governing_apo, object, new_apo_id), but
+      # we can't do that here, since we don't yet know what APO the user might move the object to.
+      # so it's possible that the user will get this button even if there are no other APOs they're
+      # allowed to move the object to.
+      buttons << {
+        url: set_governing_apo_ui_item_path(id: pid),
+        label: 'Set governing APO',
+        check_url: !object.allows_modification?
+      }
+
       buttons << {:url => add_workflow_item_path(id: pid), :label => 'Add workflow'}
 
       buttons << {

--- a/app/jobs/set_governing_apo_job.rb
+++ b/app/jobs/set_governing_apo_job.rb
@@ -1,0 +1,60 @@
+##
+# job to move an object to a new governing APO
+class SetGoverningApoJob < GenericJob
+  queue_as :set_governing_apo
+
+  attr_reader :pids, :new_apo_id, :webauth
+
+  def perform(bulk_action_id, params)
+    @new_apo_id = params[:set_governing_apo]['new_apo_id']
+    @webauth = OpenStruct.new params[:webauth]
+    @pids = params[:pids]
+
+    File.open(bulk_action.log_name, 'w') do |log|
+      log.puts("#{Time.current} Starting SetGoverningApoJob for BulkAction #{bulk_action_id}")
+      update_druid_count
+
+      pids.each do |current_druid|
+        log.puts("#{Time.current} SetGoverningApoJob: Starting update for #{current_druid} (bulk_action.id=#{bulk_action_id})")
+        set_governing_apo_and_index_safely(current_druid, log)
+        log.puts("#{Time.current} SetGoverningApoJob: Finished update for #{current_druid} (bulk_action.id=#{bulk_action_id})")
+      end
+
+      Dor::SearchService.solr.commit
+      log.puts("#{Time.current} Finished SetGoverningApoJob for BulkAction #{bulk_action_id}")
+    end
+  end
+
+  private
+
+  def set_governing_apo_and_index_safely(current_druid, log)
+    current_obj = Dor.find(current_druid)
+
+    check_can_set_governing_apo!(current_obj)
+
+    current_obj.admin_policy_object = Dor.find(new_apo_id)
+    current_obj.identityMetadata.adminPolicy = nil if current_obj.identityMetadata.adminPolicy # no longer supported, erase if present as a bit of remediation
+    current_obj.save
+    Dor::SearchService.solr.add current_obj.to_solr
+
+    log.puts("#{Time.current} SetGoverningApoJob: Successfully updated #{current_druid} (bulk_action.id=#{bulk_action.id})")
+    bulk_action.increment(:druid_count_success).save
+  rescue => e
+    log.puts("#{Time.current} SetGoverningApoJob: Unexpected error for #{current_druid} (bulk_action.id=#{bulk_action.id}): #{e}")
+    bulk_action.increment(:druid_count_fail).save
+  end
+
+  def check_can_set_governing_apo!(obj)
+    raise "#{obj.pid} is not open for modification" unless obj.allows_modification?
+    raise "user not authorized to move #{obj.pid} to #{new_apo_id}" unless ability.can?(:manage_governing_apo, obj, new_apo_id)
+  end
+
+  def ability
+    @ability ||= Ability.new(User.find_or_create_by_webauth(webauth))
+  end
+
+  def update_druid_count
+    bulk_action.update(druid_count_total: pids.length)
+    bulk_action.save
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -22,7 +22,7 @@ class Ability
     can :manage, :all if user.is_admin?
     cannot :impersonate, User unless user.is_webauth_admin?
 
-    can [:manage_item, :manage_content, :manage_desc_metadata, :view_content, :view_metadata], ActiveFedora::Base if user.is_manager?
+    can [:manage_item, :manage_content, :manage_desc_metadata, :manage_governing_apo, :view_content, :view_metadata], ActiveFedora::Base if user.is_manager?
     can :create, Dor::AdminPolicyObject if user.is_manager?
 
     can [:view_metadata, :view_content], ActiveFedora::Base if user.is_viewer?
@@ -55,6 +55,11 @@ class Ability
       if dor_item.admin_policy_object
         dor_item.can_manage_desc_metadata? user.roles(dor_item.admin_policy_object.pid)
       end
+    end
+
+    can :manage_governing_apo, ActiveFedora::Base do |dor_item, new_apo_id|
+      # user must have management privileges on both the target APO and the APO currently governing the item
+      dor_item.can_manage_item?(user.roles(new_apo_id)) && can?(:manage_item, dor_item)
     end
 
     can :view_content, Dor::AdminPolicyObject do |dor_item|

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -13,6 +13,11 @@
 #   check to the APO's own ID for Dor::AdminPolicyObject types in addition to the checks for ActiveFedora::Base types (e.g. the
 #   "can :manage_item, Dor::AdminPolicyObject" and "can :manage_item, ActiveFedora::Base" definitions, with the latter being checked
 #   first).  see https://github.com/sul-dlss/argo/issues/76
+#
+# note about confusing dor-services method declarations:
+#  * the can_manage_*? and can_view_*? method calls (e.g. dor_item.can_manage_item? or dor_item.can_view_metadata?) don't
+#  actually do anything with the state of the object that receives the message.  they could all be static methods in Dor::Governable,
+#  since  they just check the intersection of the given roles with the appropriate static list of known roles.
 class Ability
   include CanCan::Ability
 

--- a/app/models/bulk_action.rb
+++ b/app/models/bulk_action.rb
@@ -1,6 +1,6 @@
 class BulkAction < ActiveRecord::Base
   belongs_to :user
-  validates :action_type, inclusion: { in: %w(GenericJob DescmetadataDownloadJob ReleaseObjectJob) }
+  validates :action_type, inclusion: { in: %w(GenericJob DescmetadataDownloadJob ReleaseObjectJob SetGoverningApoJob) }
   after_create do
     create_output_directory
     create_log_file
@@ -9,7 +9,7 @@ class BulkAction < ActiveRecord::Base
   before_destroy :remove_output_directory
 
   # A virtual attribute used for job creation but not persisted
-  attr_accessor :pids, :manage_release, :webauth
+  attr_accessor :pids, :manage_release, :set_governing_apo, :webauth
 
   def file(filename)
     File.join(output_directory, filename)
@@ -48,6 +48,7 @@ class BulkAction < ActiveRecord::Base
       pids: pids.split,
       output_directory: output_directory,
       manage_release: manage_release,
+      set_governing_apo: set_governing_apo,
       webauth: webauth
     }
   end

--- a/app/views/bulk_actions/_form.html.erb
+++ b/app/views/bulk_actions/_form.html.erb
@@ -27,6 +27,10 @@
         <%= f.radio_button(:action_type, 'ReleaseObjectJob', autocomplete: 'off') %>
         Manage release
       </label>
+      <label href='#set_governing_apo_custom_options' data-toggle='tab' class='btn btn-default'>
+        <%= f.radio_button(:action_type, 'SetGoverningApoJob', autocomplete: 'off') %>
+        Update governing APO
+      </label>
     </div>
 
     <div class='tab-content'>
@@ -40,6 +44,12 @@
           Adds release tags to individual objects.
         </span>
         <%= render 'bulk_actions/forms/manage_release_form',  f: f %>
+      </div>
+      <div role='tabpanel' class= 'tab-pane' id='set_governing_apo_custom_options'>
+        <span class='help-block'>
+          Moves the object to a new governing APO.
+        </span>
+        <%= render 'bulk_actions/forms/set_governing_apo_form', f: f %>
       </div>
     </div>
   </div>

--- a/app/views/bulk_actions/forms/_set_governing_apo_form.html.erb
+++ b/app/views/bulk_actions/forms/_set_governing_apo_form.html.erb
@@ -1,0 +1,12 @@
+<div>
+  <%= f.fields_for :set_governing_apo do |set_governing_apo_fields| %>
+    <div class='form-group'>
+      <div class='text'>
+        <label for='bulk_action_set_governing_apo_new_apo_id' class='control-label'>
+          New governing APO
+        </label>
+        <%= set_governing_apo_fields.select(:new_apo_id, apo_list(current_user.groups)) %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/items/_set_governing_apo_ui.html.erb
+++ b/app/views/items/_set_governing_apo_ui.html.erb
@@ -1,0 +1,8 @@
+<%= form_tag set_governing_apo_item_path(id: @object.pid) do %>
+  <div class='form-group'>
+    <%= select_tag(:new_apo_id, options_for_select(apo_list(current_user.groups), @object.admin_policy_object.try(:pid))) %>
+  </div>
+  <button class='btn btn-primary'>
+    Update
+  </button>
+<% end %>

--- a/app/views/items/set_governing_apo_ui.html.erb
+++ b/app/views/items/set_governing_apo_ui.html.erb
@@ -1,0 +1,4 @@
+<div class='container'>
+  <h1>Set governing APO</h1>
+  <%= render partial: 'set_governing_apo_ui' %>
+</div>

--- a/app/views/items/set_governing_apo_ui.js.erb
+++ b/app/views/items/set_governing_apo_ui.js.erb
@@ -1,0 +1,7 @@
+<div class='modal-header'>
+  <button type='button' class='ajax-modal-close close' data-dismiss='modal' aria-hidden='true'>×</button>
+  <h3 class="modal-title">Set governing APO</h3>
+</div>
+<div class='modal-body'>
+  <%= render partial: 'set_governing_apo_ui' %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,6 +128,8 @@ Argo::Application.routes.draw do
       get  'rights'
       post 'prepare'
       post 'set_rights'
+      get 'set_governing_apo_ui'
+      post 'set_governing_apo'
       get  'preserved_file', :action => :get_preserved_file
       post :release_hold
       match :add_workflow, :action => :add_workflow, :as => 'add_workflow', :via => [:get, :post]

--- a/spec/features/bulk_set_governing_apo_spec.rb
+++ b/spec/features/bulk_set_governing_apo_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.feature 'Bulk Update of Governing APO' do
+  let(:current_user) { create(:user) }
+  before(:each) do
+    expect(current_user).to receive(:to_s).at_least(:once).and_return('name')
+    # Needed because we are accessing multiple instances of BulkActionsController
+    allow_any_instance_of(BulkActionsController).to receive(:current_user).and_return(current_user)
+    allow_any_instance_of(RegistrationHelper).to receive(:apo_list).and_return(['APO 1', 'APO 2', 'APO 3'])
+  end
+  scenario 'Creates a new job' do
+    visit new_bulk_action_path
+    choose 'bulk_action_action_type_setgoverningapojob'
+    select 'APO 2'
+    fill_in 'pids', with: 'druid:br481xz7820'
+    click_button 'Submit'
+    expect(page).to have_css 'h1', text: 'Bulk Actions'
+    within 'table.table' do
+      expect(page).to have_css 'td', text: 'SetGoverningApoJob'
+      expect(page).to have_css 'td', text: 'Scheduled Action'
+    end
+  end
+end

--- a/spec/features/collection_manage_release_spec.rb
+++ b/spec/features/collection_manage_release_spec.rb
@@ -4,8 +4,8 @@ RSpec.feature 'Collection manage release' do
   let(:current_user) { create(:user, sunetid: 'esnowden') }
   before(:each) do
     obj = double(
-      'collection',
-      admin_policy_object: false,
+      Dor::Collection,
+      admin_policy_object: nil,
       datastreams: {},
       can_manage_item?: true,
       catkey: nil,

--- a/spec/features/collection_manage_release_spec.rb
+++ b/spec/features/collection_manage_release_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature 'Collection manage release' do
       Dor::Collection,
       admin_policy_object: nil,
       datastreams: {},
+      allows_modification?: true,
       can_manage_item?: true,
       catkey: nil,
       identityMetadata: double(ng_xml: Nokogiri::XML(''))

--- a/spec/features/enable_buttons_spec.rb
+++ b/spec/features/enable_buttons_spec.rb
@@ -6,6 +6,7 @@ feature 'Enable buttons' do
     @obj = double(
       Dor::Item,
       admin_policy_object: nil,
+      allows_modification?: true,
       datastreams: {},
       can_manage_item?: true,
       catkey: nil,

--- a/spec/features/enable_buttons_spec.rb
+++ b/spec/features/enable_buttons_spec.rb
@@ -4,8 +4,8 @@ feature 'Enable buttons' do
   before do
     @current_user = mock_user(is_admin?: true)
     @obj = double(
-      'item',
-      admin_policy_object: false,
+      Dor::Item,
+      admin_policy_object: nil,
       datastreams: {},
       can_manage_item?: true,
       catkey: nil,

--- a/spec/features/item_catkey_change_spec.rb
+++ b/spec/features/item_catkey_change_spec.rb
@@ -21,15 +21,25 @@ RSpec.feature 'Item catkey change' do
   end
   feature 'when modification is allowed' do
     scenario 'changes the catkey' do
+      # things get squirrely when you have an expect_any_instance_of for a
+      # method that gets called repeatedly on different instantiations of the
+      # class.  but allow_any_instance_of works fine, so use that with a block
+      # that keeps count manually and provides a return val for invocations
+      # of Dor::Item#allows_modification?
+      allows_mod_count = 0
+      allow_any_instance_of(Dor::Item).to receive(:allows_modification?) do
+        allows_mod_count += 1
+        true
+      end
       expect_any_instance_of(CatalogController).to receive(:current_user)
         .at_least(1).times.and_return(current_user)
-      expect_any_instance_of(Dor::Item)
-        .to receive(:allows_modification?).and_return(true)
+
       visit catkey_ui_item_path 'druid:kv840rx2720'
       fill_in 'new_catkey', with: '12345'
       click_button 'Update'
       expect(page).to have_css '.alert.alert-info', text: 'Catkey for ' \
         'druid:kv840rx2720 has been updated!'
+      expect(allows_mod_count).to be > 1
     end
   end
 end

--- a/spec/features/item_manage_release_spec.rb
+++ b/spec/features/item_manage_release_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature 'Item manage release' do
     obj = double(
       Dor::Item,
       admin_policy_object: nil,
+      allows_modification?: true,
       datastreams: {},
       can_manage_item?: true,
       catkey: nil,

--- a/spec/features/item_manage_release_spec.rb
+++ b/spec/features/item_manage_release_spec.rb
@@ -4,8 +4,8 @@ RSpec.feature 'Item manage release' do
   let(:current_user) { create(:user, sunetid: 'esnowden') }
   before(:each) do
     obj = double(
-      'item',
-      admin_policy_object: false,
+      Dor::Item,
+      admin_policy_object: nil,
       datastreams: {},
       can_manage_item?: true,
       catkey: nil,

--- a/spec/features/item_source_id_change_spec.rb
+++ b/spec/features/item_source_id_change_spec.rb
@@ -21,15 +21,25 @@ RSpec.feature 'Item source id change' do
   end
   feature 'when modification is allowed' do
     scenario 'changes the source id' do
+      # things get squirrely when you have an expect_any_instance_of for a
+      # method that gets called repeatedly on different instantiations of the
+      # class.  but allow_any_instance_of works fine, so use that with a block
+      # that keeps count manually and provides a return val for invocations
+      # of Dor::Item#allows_modification?
+      allows_mod_count = 0
+      allow_any_instance_of(Dor::Item).to receive(:allows_modification?) do
+        allows_mod_count += 1
+        true
+      end
       expect_any_instance_of(CatalogController).to receive(:current_user)
         .at_least(1).times.and_return(current_user)
-      expect_any_instance_of(Dor::Item)
-        .to receive(:allows_modification?).and_return(true)
+
       visit source_id_ui_item_path 'druid:kv840rx2720'
       fill_in 'new_id', with: 'sulair:newSource'
       click_button 'Update'
       expect(page).to have_css '.alert.alert-info', text: 'Source Id for ' \
         'druid:kv840rx2720 has been updated!'
+      expect(allows_mod_count).to be > 1
     end
   end
 end

--- a/spec/features/set_governing_apo_spec.rb
+++ b/spec/features/set_governing_apo_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+RSpec.feature 'Set governing APO' do
+  let(:groups) { ['workgroup:dlss:dor-admin', 'workgroup:dlss:developers'] }
+  let(:current_user) { mock_user(is_admin?: true, groups: groups) }
+  let(:new_apo) { double(Dor::AdminPolicyObject, pid: 'druid:ww057vk7675') }
+  let(:obj) do
+    double(
+      Dor::Item,
+      pid: 'druid:kv840rx2720',
+      admin_policy_object: new_apo,
+      datastreams: {},
+      identityMetadata: double(Dor::IdentityMetadataDS, adminPolicy: nil),
+      can_manage_item?: true
+    )
+  end
+
+  before do
+    allow(Dor).to receive(:find).with(obj.pid).and_return(obj)
+    allow(Dor).to receive(:find).with(new_apo.pid).and_return(new_apo)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(current_user)
+  end
+
+  scenario 'modification not currently allowed' do
+    allow(obj).to receive(:allows_modification?).and_return(false)
+    visit set_governing_apo_ui_item_path 'druid:kv840rx2720'
+    select 'Stanford University Libraries - Special Collections', from: 'new_apo_id', match: :first
+    click_button 'Update'
+    expect(page.status_code).to eq 403
+    expect(page).to have_css 'body', text: 'Object cannot be modified in its current state.'
+  end
+
+  scenario 'modification not currently allowed, user not allowed to move object to new APO' do
+    allow(obj).to receive(:allows_modification?).and_return(false)
+    allow_any_instance_of(ItemsController).to receive(:authorize!).with(:manage_governing_apo, obj, new_apo.pid).and_raise(CanCan::AccessDenied)
+    visit set_governing_apo_ui_item_path 'druid:kv840rx2720'
+    select 'Stanford University Libraries - Special Collections', from: 'new_apo_id', match: :first
+    click_button 'Update'
+    expect(page.status_code).to eq 403
+    expect(page).to have_css 'body', text: 'forbidden'
+  end
+
+  scenario 'modification allowed, user not allowed to move object to new APO' do
+    allow(obj).to receive(:allows_modification?).and_return(true)
+
+    visit solr_document_path 'druid:kv840rx2720'
+    click_link 'Set governing APO'
+
+    allow_any_instance_of(ItemsController).to receive(:authorize!).with(:manage_governing_apo, obj, new_apo.pid).and_raise(CanCan::AccessDenied)
+    select 'Stanford University Libraries - Special Collections', from: 'new_apo_id', match: :first
+
+    expect(obj).not_to receive(:admin_policy_object=)
+    expect(obj).not_to receive(:save)
+    expect(obj).not_to receive(:to_solr)
+    expect(Dor::SearchService.solr).not_to receive(:add)
+    click_button 'Update'
+    expect(page.status_code).to eq 403
+    expect(page).to have_css 'body', text: 'forbidden'
+  end
+
+  scenario 'modification allowed, user allowed to move object to new APO' do
+    allow(obj).to receive(:allows_modification?).and_return(true)
+
+    visit solr_document_path 'druid:kv840rx2720'
+    click_link 'Set governing APO'
+
+    allow_any_instance_of(ItemsController).to receive(:authorize!).with(:manage_governing_apo, obj, new_apo.pid)
+    select 'Stanford University Libraries - Special Collections', from: 'new_apo_id', match: :first
+
+    expect(obj).to receive(:admin_policy_object=).with(new_apo)
+    expect(obj).to receive(:save)
+    expect(obj).to receive(:to_solr).and_return({})
+    expect(Dor::SearchService.solr).to receive(:add).with({})
+    click_button 'Update'
+    expect(page).to have_css 'body', text: 'Governing APO updated!'
+  end
+end

--- a/spec/helpers/argo_helper_spec.rb
+++ b/spec/helpers/argo_helper_spec.rb
@@ -12,6 +12,7 @@ describe ArgoHelper, :type => :helper do
       allow(controller).to receive(:current_user).and_return(@usr)
       allow(helper).to receive(:current_user).and_return(@usr)
       allow(@object).to receive(:can_manage_item?).and_return(true)
+      allow(@object).to receive(:allows_modification?).and_return(true)
       allow(@object).to receive(:pid).and_return(@item_id)
       desc_md = double(Dor::DescMetadataDS)
       @id_md  = double(Dor::IdentityMetadataDS)
@@ -33,6 +34,11 @@ describe ArgoHelper, :type => :helper do
             label: 'Reindex',
             url: "/dor/reindex/#{@item_id}",
             new_page: true
+          },
+          {
+            label: 'Set governing APO',
+            url: "/items/#{@item_id}/set_governing_apo_ui",
+            check_url: false
           },
           {
             label: 'Add workflow',

--- a/spec/jobs/set_governing_apo_job_spec.rb
+++ b/spec/jobs/set_governing_apo_job_spec.rb
@@ -1,0 +1,148 @@
+require 'spec_helper'
+
+describe SetGoverningApoJob do
+  let(:bulk_action_no_process_callback) do
+    bulk_action = build(
+      :bulk_action,
+      action_type: 'SetGoverningApoJob'
+    )
+    expect(bulk_action).to receive(:process_bulk_action_type)
+    bulk_action.save
+    bulk_action
+  end
+
+  let(:new_apo_id) { 'druid:aa111bb2222' }
+  let(:webauth) { { 'privgroup' => 'dorstuff', 'login' => 'someuser' } }
+
+  before do
+    allow(subject).to receive(:bulk_action).and_return(bulk_action_no_process_callback)
+  end
+
+  describe '#perform' do
+    let(:pids) { ['druid:bb111cc2222', 'druid:cc111dd2222', 'druid:dd111ee2222'] }
+    let(:params) do
+      {
+        pids: pids,
+        set_governing_apo: { 'new_apo_id' => new_apo_id },
+        webauth: webauth
+      }
+    end
+
+    context 'in a happy world' do
+      it 'updates the total druid count, attempts to update the APO for each druid, and commits to solr' do
+        pids.each do |pid|
+          expect(subject).to receive(:set_governing_apo_and_index_safely).with(pid, instance_of(File))
+        end
+        expect(Dor::SearchService.solr).to receive(:commit)
+        subject.perform(bulk_action_no_process_callback.id, params)
+        expect(bulk_action_no_process_callback.druid_count_total).to eq pids.length
+      end
+
+      it 'logs info about progress' do
+        allow(subject).to receive(:set_governing_apo_and_index_safely)
+        allow(Dor::SearchService.solr).to receive(:commit)
+
+        buffer = StringIO.new
+        expect(File).to receive(:open).with(bulk_action_no_process_callback.log_name, 'w').and_yield(buffer)
+
+        subject.perform(bulk_action_no_process_callback.id, params)
+
+        bulk_action_id = bulk_action_no_process_callback.id
+        expect(buffer.string).to include "Starting SetGoverningApoJob for BulkAction #{bulk_action_id}"
+        pids.each do |pid|
+          expect(buffer.string).to include "SetGoverningApoJob: Starting update for #{pid} (bulk_action.id=#{bulk_action_id})"
+          expect(buffer.string).to include "SetGoverningApoJob: Finished update for #{pid} (bulk_action.id=#{bulk_action_id})"
+        end
+        expect(buffer.string).to include "Finished SetGoverningApoJob for BulkAction #{bulk_action_id}"
+      end
+
+      # it might be cleaner to break the testing here into smaller cases for #set_governing_apo_and_index_safely,
+      # assuming one is inclined to test private methods, but it also seemed reasonable to do a slightly more end-to-end
+      # test of #perform, to prove that common failure cases for individual objects wouldn't fail the whole run.
+      it 'increments the failure and success counts, keeps running even if an individual update fails, and logs status of each update' do
+        buffer = StringIO.new
+        expect(File).to receive(:open).with(bulk_action_no_process_callback.log_name, 'w').and_yield(buffer)
+
+        item1 = double(Dor::Item)
+        item3 = double(Dor::Item)
+        apo = double(Dor::AdminPolicyObject)
+
+        expect(Dor).to receive(:find).with(pids[0]).and_return(item1)
+        expect(subject).to receive(:check_can_set_governing_apo!).with(item1)
+        expect(Dor).to receive(:find).with(pids[1]).and_raise(ActiveFedora::ObjectNotFoundError)
+        expect(Dor).to receive(:find).with(pids[2]).and_return(item3)
+        expect(subject).to receive(:check_can_set_governing_apo!).with(item3).and_raise('user not allowed to move to target apo')
+
+        expect(Dor).to receive(:find).with(new_apo_id).and_return(apo)
+        idmd = double(Dor::IdentityMetadataDS, adminPolicy: double(Dor::AdminPolicyObject))
+        expect(item1).to receive(:admin_policy_object=).with(apo)
+        expect(item1).to receive(:identityMetadata).and_return(idmd).exactly(:twice)
+        expect(idmd).to receive(:adminPolicy=).with(nil)
+        expect(item1).to receive(:save)
+        expect(item1).to receive(:to_solr).and_return(field: 'value')
+        expect(Dor::SearchService.solr).to receive(:add).with(field: 'value').exactly(:once)
+
+        expect(item3).not_to receive(:admin_policy_object=)
+        expect(item3).not_to receive(:identityMetadata)
+        expect(item3).not_to receive(:save)
+
+        expect(Dor::SearchService.solr).to receive(:commit)
+
+        subject.perform(bulk_action_no_process_callback.id, params)
+        expect(bulk_action_no_process_callback.druid_count_success).to eq 1
+        expect(bulk_action_no_process_callback.druid_count_fail).to eq 2
+
+        bulk_action_id = bulk_action_no_process_callback.id
+        expect(buffer.string).to include "SetGoverningApoJob: Successfully updated #{pids[0]} (bulk_action.id=#{bulk_action_id})"
+        expect(buffer.string).to include "SetGoverningApoJob: Unexpected error for #{pids[1]} (bulk_action.id=#{bulk_action_id}): ActiveFedora::ObjectNotFoundError"
+        expect(buffer.string).to include "SetGoverningApoJob: Unexpected error for #{pids[2]} (bulk_action.id=#{bulk_action_id}): user not allowed to move to target apo"
+      end
+    end
+  end
+
+  describe '#check_can_set_governing_apo!' do
+    let(:pid) { '123' }
+    let(:obj) { double(Dor::Collection, pid: pid) }
+    let(:ability) { double(Ability) }
+
+    before do
+      subject.instance_variable_set(:@new_apo_id, new_apo_id)
+      subject.instance_variable_set(:@ability, ability)
+    end
+
+    it "gets an object that allows modification, that the user can't manage" do
+      allow(obj).to receive(:allows_modification?).and_return(true)
+      allow(ability).to receive(:can?).with(:manage_governing_apo, obj, new_apo_id).and_return(false)
+      expect { subject.send(:check_can_set_governing_apo!, obj) }.to raise_error("user not authorized to move #{pid} to #{new_apo_id}")
+    end
+    it "gets an object that doesn't allow modification, that the user can manage" do
+      allow(obj).to receive(:allows_modification?).and_return(false)
+      allow(ability).to receive(:can?).with(:manage_governing_apo, obj, new_apo_id).and_return(true)
+      expect { subject.send(:check_can_set_governing_apo!, obj) }.to raise_error("#{pid} is not open for modification")
+    end
+    it "gets an object that doesn't allow modification, that the user can't manage" do
+      allow(obj).to receive(:allows_modification?).and_return(false)
+      allow(ability).to receive(:can?).with(:manage_governing_apo, obj, new_apo_id).and_return(false)
+      expect { subject.send(:check_can_set_governing_apo!, obj) }.to raise_error("#{pid} is not open for modification")
+    end
+    it 'gets an object that allows modification, that the user can manage' do
+      allow(obj).to receive(:allows_modification?).and_return(true)
+      allow(ability).to receive(:can?).with(:manage_governing_apo, obj, new_apo_id).and_return(true)
+      expect { subject.send(:check_can_set_governing_apo!, obj) }.not_to raise_error
+    end
+  end
+
+  describe '#ability' do
+    before { subject.instance_variable_set(:@webauth, webauth) }
+
+    it 'caches the result' do
+      user = double(User)
+      expect(User).to receive(:find_or_create_by_webauth).with(webauth).and_return(user).exactly(:once)
+      ability = double(Ability)
+      expect(Ability).to receive(:new).with(user).and_return(ability).exactly(:once)
+
+      expect(subject.send(:ability)).to be(ability)
+      expect(subject.send(:ability)).to be(ability)
+    end
+  end
+end

--- a/spec/models/bulk_action_spec.rb
+++ b/spec/models/bulk_action_spec.rb
@@ -57,13 +57,13 @@ RSpec.describe BulkAction do
     expect(GenericJob).to receive(:perform_later)
       .with(
         @bulk_action.id,
-        {
+        hash_including(
           pids: %w(a b c),
           output_directory: Settings.BULK_METADATA.DIRECTORY +
             "#{@bulk_action.action_type}_#{@bulk_action.id}",
           manage_release: {},
           webauth: {}
-        }
+        )
       )
     @bulk_action.run_callbacks(:create) { true }
   end

--- a/spec/views/bulk_actions/_form.html.erb_spec.rb
+++ b/spec/views/bulk_actions/_form.html.erb_spec.rb
@@ -4,15 +4,22 @@ RSpec.describe 'bulk_actions/_form.html.erb' do
   before do
     @bulk_action = assign(:bulk_actions, create(:bulk_action))
     allow(view).to receive(:current_user).and_return(double(sunetid: 'esnowden'))
-  end
-  it 'form by default has action_type selected' do
+
     render
+  end
+
+  it 'form by default has action_type selected' do
     expect(rendered)
       .to have_css 'input[type="radio"][value="DescmetadataDownloadJob"][checked="checked"]'
   end
+  describe 'common form fields' do
+    it 'has proper form input values' do
+      expect(rendered).to have_css 'textarea[name="bulk_action[pids]"]'
+      expect(rendered).to have_css 'textarea[name="bulk_action[description]"]'
+    end
+  end
   describe 'Release Object Job form' do
     it 'has proper form input values' do
-      render
       expect(rendered).to have_css 'input[type="radio"][value="ReleaseObjectJob"]'
       expect(rendered).to have_css 'input[type="radio"][value="true"][checked="checked"][name="bulk_action[manage_release][tag]"]'
       expect(rendered).to have_css 'input[type="radio"][value="false"][name="bulk_action[manage_release][tag]"]'

--- a/spec/views/bulk_actions/_form.html.erb_spec.rb
+++ b/spec/views/bulk_actions/_form.html.erb_spec.rb
@@ -1,9 +1,13 @@
 require 'spec_helper'
 
 RSpec.describe 'bulk_actions/_form.html.erb' do
+  let(:user_groups) { ['dlss-developers', 'top-secret-clearance'] }
+  let(:apo_list) { [['APO 1', 'druid:123'], ['APO 2', 'druid:234']] }
+
   before do
     @bulk_action = assign(:bulk_actions, create(:bulk_action))
-    allow(view).to receive(:current_user).and_return(double(sunetid: 'esnowden'))
+    allow(view).to receive(:current_user).and_return(double(sunetid: 'esnowden', groups: user_groups))
+    allow(view).to receive(:apo_list).with(user_groups).and_return(apo_list)
 
     render
   end
@@ -12,12 +16,14 @@ RSpec.describe 'bulk_actions/_form.html.erb' do
     expect(rendered)
       .to have_css 'input[type="radio"][value="DescmetadataDownloadJob"][checked="checked"]'
   end
+
   describe 'common form fields' do
     it 'has proper form input values' do
       expect(rendered).to have_css 'textarea[name="bulk_action[pids]"]'
       expect(rendered).to have_css 'textarea[name="bulk_action[description]"]'
     end
   end
+
   describe 'Release Object Job form' do
     it 'has proper form input values' do
       expect(rendered).to have_css 'input[type="radio"][value="ReleaseObjectJob"]'
@@ -27,6 +33,13 @@ RSpec.describe 'bulk_actions/_form.html.erb' do
       expect(rendered).to have_css 'option[value="Searchworks"]'
       expect(rendered).to have_css 'input[value="self"][type="hidden"][name="bulk_action[manage_release][what]"]', visible: false
       expect(rendered).to have_css 'input[value="esnowden"][type="hidden"][name="bulk_action[manage_release][who]"]', visible: false
+    end
+  end
+
+  describe 'Update governing APO Job form' do
+    it 'has proper form input values' do
+      expect(rendered).to have_css 'input[type="radio"][value="SetGoverningApoJob"]'
+      expect(rendered).to have_css 'select[name="bulk_action[set_governing_apo][new_apo_id]"] option[value="druid:234"]'
     end
   end
 end

--- a/spec/views/items/_set_governing_apo_ui.html.erb_spec.rb
+++ b/spec/views/items/_set_governing_apo_ui.html.erb_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.describe 'items/_set_governing_apo_ui.html.erb' do
+  let(:object) { double(Dor::Item, pid: 'druid:987', admin_policy_object: cur_apo) }
+  let(:groups) { ['dlss-developers'] }
+  let(:current_user) { double(User, groups: groups) }
+  let(:apo_list) { [['APO 1', 'druid:123'], ['APO 2', 'druid:234']] }
+
+  before(:each) do
+    assign(:object, object)
+    allow(view).to receive(:current_user).and_return(current_user)
+    allow(view).to receive(:apo_list).with(groups).and_return(apo_list)
+    render
+  end
+
+  context 'current APO is not nil' do
+    let(:cur_apo) { double(Dor::AdminPolicyObject, pid: 'druid:123') }
+    it 'renders the partial content' do
+      expect(rendered).to have_css 'select[name="new_apo_id"] option[value="druid:123"][selected="selected"]'
+      expect(rendered).to have_css 'select[name="new_apo_id"] option[value="druid:234"]'
+      expect(rendered).to have_css 'button.btn-primary', text: 'Update'
+      expect(rendered).to have_css 'form[action="/items/druid:987/set_governing_apo"]'
+    end
+  end
+
+  context 'current APO is nil' do
+    let(:cur_apo) { nil }
+    it 'renders the partial content' do
+      expect(rendered).not_to have_css 'select[name="new_apo_id"] option[selected="selected"]'
+      expect(rendered).to have_css 'select[name="new_apo_id"] option[value="druid:123"]'
+      expect(rendered).to have_css 'select[name="new_apo_id"] option[value="druid:234"]'
+      expect(rendered).to have_css 'button.btn-primary', text: 'Update'
+      expect(rendered).to have_css 'form[action="/items/druid:987/set_governing_apo"]'
+    end
+  end
+end

--- a/spec/views/items/set_governing_apo_ui.html.erb_spec.rb
+++ b/spec/views/items/set_governing_apo_ui.html.erb_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec.describe 'items/set_governing_apo_ui.html.erb' do
+  it 'renders the HTML template' do
+    stub_template 'items/_set_governing_apo_ui.html.erb' => 'stubbed_set_governing_apo_ui'
+    render
+    expect(rendered).to have_css '.container h1', text: 'Set governing APO'
+    expect(rendered).to have_css '.container', text: 'stubbed_set_governing_apo_ui'
+  end
+end

--- a/spec/views/items/set_governing_apo_ui.js.erb_spec.rb
+++ b/spec/views/items/set_governing_apo_ui.js.erb_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe 'items/set_governing_apo_ui.js.erb' do
+  it 'renders the JS template' do
+    stub_template 'items/_set_governing_apo_ui.html.erb' => 'stubbed_set_governing_apo_ui'
+    render
+    expect(rendered)
+      .to have_css '.modal-header h3.modal-title', text: 'Set governing APO'
+    expect(rendered).to have_css '.modal-body', text: 'stubbed_set_governing_apo_ui'
+  end
+end


### PR DESCRIPTION
this is getting pretty close to done, so here's a WIP PR, since it's easier to comment on that than on a branch by itself.

here's what's left to do, AFAIK at the moment:
* [x] feature spec for the individual object update case (partially done on my laptop, but not yet pushed up)
* [x] items_controller_spec.rb additions
* [x] ability_spec additions.rb
* [x] manual testing on stage

here are some questions i have for what's done so far:
* the APO update (not including saving or reindexing) consists of the following two lines:
```ruby
@object.admin_policy_object = Dor.find(params[:new_apo_id])
@object.identityMetadata.adminPolicy = nil if @object.identityMetadata.adminPolicy # no longer supported, erase if present as a bit of remediation
```
seems like that should be broken out into a common helper method.  or maybe placed in dor-services as a helper method?  it's only two repeated lines, but it seems like it'd be good to centralize them.  then, if other things wanted to update APO, they'd be doing it correctly via common code.
* the permissions checking is done three different ways in three different places:  items_controller does it in its usual style, using `before_action` filters.  the job does the check in a single conditional statement called from the method that does the update.  the button rendering (necessarily) does a slightly more relaxed check in a nested conditional where the button is added to the list of buttons to render (it can't check that the user has permission to move the object to the target APO, because there's no way to know what APO the user might want to move the object to at button render time).
* there's some repetition between the edit forms used for the bulk job and the individual obj edit, but this is actually the repetition i'm least concerned about.  the form is pretty simple, and i'm not sure it'd be less complex or more maintainable to abstract it to something shared.

closes #957