### PR TITLE
fix refresh descMetadata UI

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -26,10 +26,14 @@ class ItemsController < ApplicationController
     :embargo_update,
     :embargo_form
   ]
+  before_action :authorize_manage_desc_metadata!, :only => [
+    :refresh_metadata
+  ]
   before_action :enforce_versioning, :only => [
     :add_collection, :set_collection, :remove_collection,
     :source_id, :set_source_id,
     :catkey,
+    :refresh_metadata,
     :set_content_type,
     :set_rights,
     :tags,
@@ -709,6 +713,10 @@ class ItemsController < ApplicationController
 
   def authorize_manage_item!
     authorize! :manage_item, @object
+  end
+
+  def authorize_manage_desc_metadata!
+    authorize! :manage_desc_metadata, @object
   end
 
   def enforce_versioning

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -537,9 +537,21 @@ class ItemsController < ApplicationController
   end
 
   def refresh_metadata
+    if @object.catkey.blank?
+      render status: :forbidden, plain: 'object must have catkey to refresh descMetadata'
+      return
+    end
+
     @object.build_datastream('descMetadata', true)
     @object.descMetadata.content = @object.descMetadata.ng_xml.to_s
-    render :status => :ok, :plain => 'Refreshed.'
+
+    respond_to do |format|
+      if params[:bulk]
+        format.html {render status: :ok, plain: 'Refreshed.'}
+      else
+        format.any { redirect_to solr_document_path(params[:id]), notice: "Metadata for #{@object.pid} successfully refreshed from catkey:#{@object.catkey}" }
+      end
+    end
   end
 
   def scrubbed_content_ng_utf8(content)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -43,6 +43,7 @@ class ItemsController < ApplicationController
     :tags, :tags_bulk,
     :source_id,
     :catkey,
+    :refresh_metadata,
     :set_rights,
     :set_content_type
   ]
@@ -538,7 +539,6 @@ class ItemsController < ApplicationController
   def refresh_metadata
     @object.build_datastream('descMetadata', true)
     @object.descMetadata.content = @object.descMetadata.ng_xml.to_s
-    @object.descMetadata.save
     render :status => :ok, :plain => 'Refreshed.'
   end
 


### PR DESCRIPTION
previously, the controller just showed a plaintext success method, as it had only been invokable from the old bulk actions page.

this updates it to keep the same behavior for bulk actions, but for single object update, it now redirects back to the object detail page with a flash message indicating success.  it also guards against invocation on objects without catkeys.

also, tests for all the aforementioned behavior.

and a bit of refactoring to have the standard `after_action` handle saving the updated object, instead of doing it explicitly in the updating controller method.

<img width="1510" alt="screen shot 2017-03-22 at 10 09 15 pm" src="https://cloud.githubusercontent.com/assets/7741604/24233039/a0f0e4a4-0f4c-11e7-9b02-f2c7aa77b712.png">
