### PR TITLE
argo helper polish

### DIFF
--- a/app/helpers/argo_helper.rb
+++ b/app/helpers/argo_helper.rb
@@ -131,16 +131,18 @@ module ArgoHelper
         buttons << {url: refresh_metadata_item_path(id: pid), label: 'Refresh descMetadata', new_page: true, disabled: !object.allows_modification?}
       end
       buttons << { url: manage_release_solr_document_path(pid), label: 'Manage release' }
-    end
-    if doc.key?('embargo_status_ssim')
-      embargo_data = doc['embargo_status_ssim']
-      text = embargo_data.split.first
-      # date=embargo_data.split.last
-      if text != 'released'
-        # TODO: add a date picker and button to change the embargo date for those who should be able to.
-        buttons << {:label => 'Update embargo', :url => embargo_form_item_path(pid)} if can?(:manage_item, object)
+
+      if doc.key?('embargo_status_ssim')
+        embargo_data = doc['embargo_status_ssim']
+        text = embargo_data.split.first
+        # date=embargo_data.split.last
+        if text != 'released'
+          # TODO: add a date picker and button to change the embargo date for those who should be able to.
+          buttons << {:label => 'Update embargo', :url => embargo_form_item_path(pid)}
+        end
       end
     end
+
     buttons
   end
 

--- a/app/helpers/argo_helper.rb
+++ b/app/helpers/argo_helper.rb
@@ -65,12 +65,12 @@ module ArgoHelper
       }
     end
 
-    # if this is an apo and the user has permission for the apo, let them edit it.
-    if object.datastreams.include?('roleMetadata') && can?(:manage_item, object)
-      buttons << {:url => register_apo_index_path(id: pid), :label => 'Edit APO', :new_page => true}
-      buttons << {:url => register_collection_apo_path(id: pid), :label => 'Create Collection'}
-    end
     if can?(:manage_item, object)
+      if object.is_a? Dor::AdminPolicyObject
+        buttons << {:url => register_apo_index_path(id: pid), :label => 'Edit APO', :new_page => true}
+        buttons << {:url => register_collection_apo_path(id: pid), :label => 'Create Collection'}
+      end
+
       buttons << {
         url: dor_reindex_path(pid: pid),
         label: 'Reindex',

--- a/app/helpers/argo_helper.rb
+++ b/app/helpers/argo_helper.rb
@@ -42,6 +42,17 @@ module ArgoHelper
   # Ideally this method should not make calls to external services to determine
   # what buttons should be rendered. These external requests are blocking and
   # will not allow the page to load until all requests are finished.
+  #
+  # Instead, use the `check_url` field to specify an endpoint for what'd be a blocking request
+  # to determine whether the button should be enabled.  The button will start out disabled,
+  # and will be enabled (or not) depending on the response from the call out to `check_url`.
+  #
+  # If you can determine whether the button should be disabled based on information that's
+  # already available, without making a blocking request, you can use the `disabled` field
+  # to just permanantly disable the button without calling out to a `check_url`.  Note that
+  # you should not need to use both fields, since use of `check_url` disables the button at
+  # first anyway.
+  #
   # @param [SolrDocument] doc
   # @return [Array]
   def render_buttons(doc, object = nil)
@@ -84,7 +95,7 @@ module ArgoHelper
       buttons << {
         url: set_governing_apo_ui_item_path(id: pid),
         label: 'Set governing APO',
-        check_url: !object.allows_modification?
+        disabled: !object.allows_modification?
       }
 
       buttons << {:url => add_workflow_item_path(id: pid), :label => 'Add workflow'}
@@ -101,7 +112,7 @@ module ArgoHelper
         label: 'Purge',
         new_page: true,
         confirm: 'This object will be permanently purged from DOR. This action cannot be undone. Are you sure?',
-        check_url: !registered_only?(doc)
+        disabled: !registered_only?(doc)
       }
 
       buttons << {:url => source_id_ui_item_path(id: pid), :label => 'Change source id'}

--- a/app/helpers/argo_helper.rb
+++ b/app/helpers/argo_helper.rb
@@ -62,7 +62,7 @@ module ArgoHelper
     apo_pid = doc.apo_pid
 
     buttons = []
-    if pid
+    if can?(:manage_content, object)
       buttons << {
         url: close_version_ui_item_path(pid),
         label: 'Close Version',

--- a/app/helpers/argo_helper.rb
+++ b/app/helpers/argo_helper.rb
@@ -128,7 +128,7 @@ module ArgoHelper
         buttons << {:url => rights_item_path(id: pid), :label => 'Set rights'}
       end
       if object.datastreams.include?('identityMetadata') && object.identityMetadata.otherId('catkey').present? # indicates there's a symphony record
-        buttons << {url: refresh_metadata_item_path(id: pid), label: 'Refresh descMetadata', new_page: true}
+        buttons << {url: refresh_metadata_item_path(id: pid), label: 'Refresh descMetadata', new_page: true, disabled: !object.allows_modification?}
       end
       buttons << { url: manage_release_solr_document_path(pid), label: 'Manage release' }
     end

--- a/app/views/items/_button_link_list.html.erb
+++ b/app/views/items/_button_link_list.html.erb
@@ -12,6 +12,6 @@
         button_data[:check_url] = button[:check_url]
       end
     %>
-    <%= link_to button[:label], button[:url], class: "btn button btn-primary #{'disabled' if button[:check_url]}", data: button_data %>
+    <%= link_to button[:label], button[:url], class: "btn button btn-primary #{'disabled' if button[:check_url] || button[:disabled]}", data: button_data %>
   <%end%>
 </div>

--- a/spec/helpers/argo_helper_spec.rb
+++ b/spec/helpers/argo_helper_spec.rb
@@ -48,7 +48,7 @@ describe ArgoHelper, :type => :helper do
           {
             label: 'Set governing APO',
             url: "/items/#{@item_id}/set_governing_apo_ui",
-            check_url: false
+            disabled: false
           },
           {
             label: 'Add workflow',
@@ -65,7 +65,7 @@ describe ArgoHelper, :type => :helper do
             url: "/items/#{@item_id}/purge",
             new_page: true,
             confirm: 'This object will be permanently purged from DOR. This action cannot be undone. Are you sure?',
-            check_url: true
+            disabled: true
           },
           {
             label: 'Change source id',
@@ -178,7 +178,7 @@ describe ArgoHelper, :type => :helper do
           {
             label: 'Set governing APO',
             url: "/items/#{view_apo_id}/set_governing_apo_ui",
-            check_url: false
+            disabled: false
           },
           {
             label: 'Add workflow',
@@ -195,7 +195,7 @@ describe ArgoHelper, :type => :helper do
             url: "/items/#{view_apo_id}/purge",
             new_page: true,
             confirm: 'This object will be permanently purged from DOR. This action cannot be undone. Are you sure?',
-            check_url: true
+            disabled: true
           },
           {
             label: 'Change source id',

--- a/spec/helpers/argo_helper_spec.rb
+++ b/spec/helpers/argo_helper_spec.rb
@@ -1,34 +1,33 @@
 require 'spec_helper'
 describe ArgoHelper, :type => :helper do
-  describe 'render_buttons' do
+  describe '#render_buttons' do
     before :each do
       @item_id = 'druid:kv840rx2720'
-      @apo_id = 'druid:hv992ry2431'
+      @governing_apo_id = 'druid:hv992ry2431'
       @object = instantiate_fixture(@item_id, Dor::Item)
-      @doc = SolrDocument.new({'id' => @item_id, SolrDocument::FIELD_APO_ID => [@apo_id]})
+      @doc = SolrDocument.new({'id' => @item_id, SolrDocument::FIELD_APO_ID => [@governing_apo_id]})
       @usr = mock_user(is_admin?: true)
       allow(Dor::Config.workflow.client).to receive(:get_active_lifecycle).and_return(true)
       allow(Dor::Config.workflow.client).to receive(:get_lifecycle).and_return(true)
       allow(controller).to receive(:current_user).and_return(@usr)
       allow(helper).to receive(:current_user).and_return(@usr)
-      allow(@object).to receive(:can_manage_item?).and_return(true)
       allow(@object).to receive(:allows_modification?).and_return(true)
       allow(@object).to receive(:pid).and_return(@item_id)
       desc_md = double(Dor::DescMetadataDS)
-      @id_md  = double(Dor::IdentityMetadataDS)
-      apo     = double()
+      @id_md = double(Dor::IdentityMetadataDS)
+      governing_apo = double(Dor::AdminPolicyObject)
       allow(desc_md).to receive(:new?).and_return(true)
       allow(@id_md).to receive(:otherId).with('catkey').and_return([])
       allow(@id_md).to receive(:ng_xml).and_return(Nokogiri::XML('<identityMetadata><identityMetadata>'))
-      allow(apo).to receive(:pid).and_return(@apo_id)
+      allow(governing_apo).to receive(:pid).and_return(@governing_apo_id)
       # nil datastreams don't need content for these tests, they just need to be present
       datastreams = { 'contentMetadata' => nil, 'rightsMetadata' => nil, 'descMetadata' => desc_md, 'identityMetadata' => @id_md }
       allow(@object).to receive(:datastreams).and_return(datastreams)
-      allow(@object).to receive(:admin_policy_object).and_return(apo)
+      allow(@object).to receive(:admin_policy_object).and_return(governing_apo)
       allow(Dor).to receive(:find).with(@item_id).and_return(@object)
       allow(helper).to receive(:registered_only?).with(@doc).and_return(false)
     end
-    describe 'visibility with new descMetadata' do
+    context 'a Dor::Item the user can manage, with the usual data streams, and no catkey or embargo info' do
       let(:default_buttons) do
         [
           {
@@ -103,14 +102,16 @@ describe ArgoHelper, :type => :helper do
         default_buttons.each do |button|
           expect(buttons).to include(button)
         end
+        expect(buttons.length).to eq default_buttons.length
       end
-      it 'should generate a the same button set for a non admin' do
+      it 'should generate the same button set for a non Dor-wide admin with APO specific mgmt privileges' do
         allow(@usr).to receive(:is_admin?).and_return(false)
         allow(@object).to receive(:can_manage_item?).and_return(true)
         buttons = helper.render_buttons(@doc)
         default_buttons.each do |button|
           expect(buttons).to include(button)
         end
+        expect(buttons.length).to eq default_buttons.length
       end
       it 'should include the embargo update button if the user is an admin and the object is embargoed' do
         @doc = SolrDocument.new(@doc.to_h.merge('embargo_status_ssim' => ['2012-10-19T00:00:00Z']))
@@ -122,15 +123,18 @@ describe ArgoHelper, :type => :helper do
         }).each do |button|
           expect(buttons).to include(button)
         end
+        expect(buttons.length).to eq default_buttons.length
       end
       it 'should not generate errors given an object that has no associated APO' do
+        allow(@usr).to receive(:is_admin?).and_return(false)
         allow(@doc).to receive(:apo_pid).and_return(nil)
+        allow(@object).to receive(:admin_policy_object).and_return(nil)
         allow(@usr).to receive(:roles).with(nil).and_return([])
         buttons = helper.render_buttons(@doc)
         expect(buttons).not_to be_nil
         expect(buttons.length).to be > 0
       end
-      it 'should give the refresh descMetadata button for items with catkey' do
+      it 'should include the refresh descMetadata button for items with catkey' do
         allow(@id_md).to receive(:otherId).with('catkey').and_return(['1234567'])
         buttons = helper.render_buttons(@doc)
         default_buttons.push({
@@ -140,23 +144,87 @@ describe ArgoHelper, :type => :helper do
         }).each do |button|
           expect(buttons).to include(button)
         end
+        expect(buttons.length).to eq default_buttons.length
       end
-      it 'should not render the edit collections or manage catkey buttons for an apo' do
-        @object = instantiate_fixture('zt570tx3016', Dor::AdminPolicyObject)
-        allow(Dor).to receive(:find).with(@item_id).and_return(@object)
-        buttons = helper.render_buttons(@doc)
+    end
+    context 'a Dor::AdminPolicyObject the user can manage' do
+      let(:view_apo_id) { 'druid:zt570tx3016' }
+      let(:default_buttons) do
         [
           {
-            label: 'Manage catkey',
-            url: "/items/#{@item_id}/catkey_ui"
+            label: 'Close Version',
+            url: "/items/#{view_apo_id}/close_version_ui",
+            check_url: "/workflow_service/#{view_apo_id}/closeable"
           },
           {
-            label: 'Edit collections',
-            url: "/items/#{@item_id}/collection_ui"
+            label: 'Open for modification',
+            url: "/items/#{view_apo_id}/open_version_ui",
+            check_url: "/workflow_service/#{view_apo_id}/openable"
+          },
+          {
+            label: 'Edit APO',
+            url: "/apo/register?id=#{URI.encode_www_form_component(view_apo_id)}",
+            new_page: true
+          },
+          {
+            label: 'Create Collection',
+            url: "/apo/#{view_apo_id}/register_collection"
+          },
+          {
+            label: 'Reindex',
+            url: "/dor/reindex/#{view_apo_id}",
+            new_page: true
+          },
+          {
+            label: 'Set governing APO',
+            url: "/items/#{view_apo_id}/set_governing_apo_ui",
+            check_url: false
+          },
+          {
+            label: 'Add workflow',
+            url: "/items/#{view_apo_id}/add_workflow"
+          },
+          {
+            label: 'Republish',
+            url: "/dor/republish/#{view_apo_id}",
+            check_url: "/workflow_service/#{view_apo_id}/published",
+            new_page: true
+          },
+          {
+            label: 'Purge',
+            url: "/items/#{view_apo_id}/purge",
+            new_page: true,
+            confirm: 'This object will be permanently purged from DOR. This action cannot be undone. Are you sure?',
+            check_url: true
+          },
+          {
+            label: 'Change source id',
+            url: "/items/#{view_apo_id}/source_id_ui"
+          },
+          {
+            label: 'Edit tags',
+            url: "/items/#{view_apo_id}/tags_ui"
+          },
+          {
+            label: 'Set rights',
+            url: "/items/#{view_apo_id}/rights"
+          },
+          {
+            label: 'Manage release',
+            url: "/view/#{view_apo_id}/manage_release"
           }
-        ].each do |removed_button|
-          expect(buttons).to_not include(removed_button)
+        ]
+      end
+      it 'renders the appropriate default buttons for an apo' do
+        @object = instantiate_fixture(view_apo_id, Dor::AdminPolicyObject)
+        @doc = SolrDocument.new({'id' => view_apo_id, SolrDocument::FIELD_APO_ID => [@governing_apo_id]})
+        allow(Dor).to receive(:find).with(view_apo_id).and_return(@object)
+        allow(helper).to receive(:registered_only?).with(@doc).and_return(false)
+        buttons = helper.render_buttons(@doc)
+        default_buttons.each do |button|
+          expect(buttons).to include(button)
         end
+        expect(buttons.length).to eq default_buttons.length
       end
     end
   end
@@ -166,13 +234,13 @@ describe ArgoHelper, :type => :helper do
       expect(helper.method(:render_facet_value).owner).to eq(Blacklight::FacetsHelperBehavior)
     end
   end
-  describe 'purge button' do
-    it 'is enabled for registered only item' do
-      expect(helper.registered_only?({ 'processing_status_text_ssi' => 'Registered'})).to be_truthy
-      expect(helper.registered_only?({ 'processing_status_text_ssi' => 'Unknown Status'})).to be_truthy
+  describe '#registered_only?' do
+    it 'returns true for registered only item' do
+      expect(helper.registered_only?({ 'processing_status_text_ssi' => 'Registered' })).to eq true
+      expect(helper.registered_only?({ 'processing_status_text_ssi' => 'Unknown Status' })).to eq true
     end
-    it 'is disabled for items beyond registered only' do
-      expect(helper.registered_only?({ 'processing_status_text_ssi' => 'In accessioning'})).to be_falsey
+    it 'returns false for items beyond registered only' do
+      expect(helper.registered_only?({ 'processing_status_text_ssi' => 'In accessioning' })).to eq false
     end
   end
 end

--- a/spec/helpers/argo_helper_spec.rb
+++ b/spec/helpers/argo_helper_spec.rb
@@ -107,6 +107,7 @@ describe ArgoHelper, :type => :helper do
       it 'should generate the same button set for a non Dor-wide admin with APO specific mgmt privileges' do
         allow(@usr).to receive(:is_admin?).and_return(false)
         allow(@object).to receive(:can_manage_item?).and_return(true)
+        allow(@object).to receive(:can_manage_content?).and_return(true)
         buttons = helper.render_buttons(@doc)
         default_buttons.each do |button|
           expect(buttons).to include(button)
@@ -125,14 +126,14 @@ describe ArgoHelper, :type => :helper do
         end
         expect(buttons.length).to eq default_buttons.length
       end
-      it 'should not generate errors given an object that has no associated APO' do
+      it "should not generate errors given an object that has no associated APO and a user that can't manage the object" do
         allow(@usr).to receive(:is_admin?).and_return(false)
         allow(@doc).to receive(:apo_pid).and_return(nil)
         allow(@object).to receive(:admin_policy_object).and_return(nil)
         allow(@usr).to receive(:roles).with(nil).and_return([])
         buttons = helper.render_buttons(@doc)
         expect(buttons).not_to be_nil
-        expect(buttons.length).to be > 0
+        expect(buttons.length).to eq 0
       end
       it 'should include the refresh descMetadata button for items with catkey' do
         allow(@id_md).to receive(:otherId).with('catkey').and_return(['1234567'])

--- a/spec/helpers/argo_helper_spec.rb
+++ b/spec/helpers/argo_helper_spec.rb
@@ -140,7 +140,8 @@ describe ArgoHelper, :type => :helper do
         default_buttons.push({
           label: 'Refresh descMetadata',
           url: "/items/#{@item_id}/refresh_metadata",
-          new_page: true
+          new_page: true,
+          disabled: false
         }).each do |button|
           expect(buttons).to include(button)
         end

--- a/spec/views/items/_button_link_list.html.erb_spec.rb
+++ b/spec/views/items/_button_link_list.html.erb_spec.rb
@@ -21,6 +21,11 @@ describe 'items/_button_link_list.html.erb' do
         label: 'Check me',
         url: 'http://www.example.com/check',
         check_url: workflow_service_closeable_path('abc:123')
+      },
+      {
+        label: 'Disable me',
+        url: 'http://www.example.com/check',
+        disabled: true
       }
     ]
   end
@@ -31,6 +36,7 @@ describe 'items/_button_link_list.html.erb' do
     expect(rendered).to have_css 'a[href="http://www.example.com/click"]', text: 'Click me'
     expect(rendered).to have_css 'a[href="http://www.example.com/confirm"][data-confirm="true"]', text: 'Confirm me'
     expect(rendered).to have_css 'a[href="http://www.example.com/ajax"][data-ajax-modal="trigger"]', text: 'Ajax me'
-    expect(rendered).to have_css 'a[href="http://www.example.com/check"][data-check-url="/workflow_service/abc:123/closeable"]', text: 'Check me'
+    expect(rendered).to have_css 'a.disabled[href="http://www.example.com/check"][data-check-url="/workflow_service/abc:123/closeable"]', text: 'Check me'
+    expect(rendered).to have_css 'a.disabled[href="http://www.example.com/check"]', text: 'Disable me'
   end
 end


### PR DESCRIPTION
* hide the "Open" and "Close" buttons when the user doesn't have permission to perform those operations (using the same cancan perm check that `ItemsController` uses to determine whether the user can actually perform the operation).
* add a `disabled` flag to the possible button configuration fields, for use instead of `check_url` when it's possible to disable a button without reaching out to another service with a network request (e.g. perm info based on the already loaded dor-services `object`).  #968
 * convert instances where `check_url` is used with readily locally available info to use the `disabled` flag instead.  #969
  * employ the `disabled` flag for "Refresh descMetadata" button rendering (disabled if obj doesn't allow modification).  #962
* fix check to show/hide "Edit APO" and "Create Collection" buttons to be based on whether the object is a `Dor::AdminPolicyObject` (as opposed to using presence of `datastreams['roleMetadata']` as a marker for object type).  #963
* take the two things that do a `can?(:manage_item, object)` check of their own, and put them inside the main `can?(:manage_item, object)` conditional to cut down on repetition.
* add tests for the "Close", "Open", and "Purge" buttons.
* clearer var names, more accurate test descriptions, more precise expectations/description for `#registered_only?` tests.
* more precise expectations on which buttons appear with different object states and privilege levels.  more accurate setup of test for no mgmt privs and no governing APO on item.
* more explicit testing for the set of buttons available on APOs.
* more accurate fixture instantiation and mocking, remove unnecessary allow statements.  #967
* misc formatting cleanup.

closes #969 
closes #968 
closes #967 
closes #963 
closes #962 