### PR TITLE
Make rake argo:install also do rake db:migrate.

### DIFF
--- a/lib/tasks/argo_testing.rake
+++ b/lib/tasks/argo_testing.rake
@@ -55,7 +55,7 @@ if ['test', 'development'].include? Rails.env
 
   namespace :argo do
     desc 'Install db, jetty (fedora/solr) and configs fresh'
-    task :install => ['argo:jetty:clean', 'argo:jetty:config'] do
+    task :install => ['argo:jetty:clean', 'argo:jetty:config', 'db:migrate'] do
       puts 'Installed Argo'
     end
 


### PR DESCRIPTION
I think it makes sense for "rake argo:install" to also run the db:migrate tasks in addition to installing Jetty. Currently you have to do this step manually, and it is not documented.