### PR TITLE
logging and status count improvements for failed job situations

### DIFF
--- a/app/jobs/descmetadata_download_job.rb
+++ b/app/jobs/descmetadata_download_job.rb
@@ -11,7 +11,6 @@ class DescmetadataDownloadJob < GenericJob
   # requires `:pids` (an Array of pids) and output_directory
   def perform(bulk_action_id, params)
     zip_filename = generate_zip_filename(params[:output_directory])
-    initialize_counters(bulk_action)
     with_bulk_action_log do |log|
       #  Fail with an error message if the calling BulkAction doesn't exist
       if bulk_action.nil?
@@ -75,14 +74,6 @@ class DescmetadataDownloadJob < GenericJob
       return nil
     end
     return dor_object
-  end
-
-  # Initialize the counters for the originating bulk action. This is necessary to avoid invalid counters
-  # in case of the job is restarted.
-  def initialize_counters(bulk_action)
-    bulk_action.update(druid_count_fail: 0)
-    bulk_action.update(druid_count_success: 0)
-    bulk_action.update(druid_count_total: 0)
   end
 
   def write_to_zip(value, entry_name, zip_file)

--- a/app/jobs/descmetadata_download_job.rb
+++ b/app/jobs/descmetadata_download_job.rb
@@ -12,7 +12,7 @@ class DescmetadataDownloadJob < GenericJob
   def perform(bulk_action_id, params)
     zip_filename = generate_zip_filename(params[:output_directory])
     initialize_counters(bulk_action)
-    File.open(bulk_action.log_name, 'w') do |log|
+    with_bulk_action_log do |log|
       #  Fail with an error message if the calling BulkAction doesn't exist
       if bulk_action.nil?
         log.puts("argo.bulk_metadata.bulk_log_bulk_action_not_found (looking for #{bulk_action_id})")

--- a/app/jobs/generic_job.rb
+++ b/app/jobs/generic_job.rb
@@ -1,5 +1,14 @@
 ##
 # A GenericJob used as a super class for Argo Bulk Jobs
+#
+# IMPORTANT NOTE: actions performed under this job framework should probably be idempotent
+# with respect to any given DOR object being operated on:
+#  "the property of certain operations in mathematics and computer science, that can be applied
+#  multiple times without changing the result beyond the initial application."
+#  - https://en.wikipedia.org/wiki/Idempotence
+#
+# because, if a job fails, it gets re-run, and if that job had been partially successful, some
+# objects in the batch might undergo the same action more than once.
 class GenericJob < ActiveJob::Base
   # A somewhat easy to understand and informative time stamp format
   TIME_FORMAT = '%Y-%m-%d %H:%M%P'.freeze
@@ -18,5 +27,17 @@ class GenericJob < ActiveJob::Base
 
   def bulk_action
     @bulk_action ||= BulkAction.find(arguments[0])
+  end
+
+  # usage:
+  # with_bulk_action_log do |log_buf|
+  #   log_buf.puts 'something happening with this bulk action'
+  #   # do some stuff
+  #   log_buf.puts 'another thing about the state of this bulk action'
+  # end
+  def with_bulk_action_log
+    File.open(bulk_action.log_name, 'a') do |log_buffer|
+      yield(log_buffer)
+    end
   end
 end

--- a/app/jobs/generic_job.rb
+++ b/app/jobs/generic_job.rb
@@ -13,6 +13,10 @@ class GenericJob < ActiveJob::Base
   # A somewhat easy to understand and informative time stamp format
   TIME_FORMAT = '%Y-%m-%d %H:%M%P'.freeze
 
+  before_perform do |_job|
+    bulk_action.reset_druid_counts
+  end
+
   around_perform do |_job, block|
     bulk_action.update_attribute(:status, 'Processing')
     block.call

--- a/app/jobs/release_object_job.rb
+++ b/app/jobs/release_object_job.rb
@@ -20,7 +20,7 @@ class ReleaseObjectJob < GenericJob
     @manage_release = params[:manage_release]
     @webauth = OpenStruct.new params[:webauth]
     @pids = params[:pids]
-    File.open(bulk_action.log_name, 'w') do |log|
+    with_bulk_action_log do |log|
       log.puts("#{Time.current} Starting ReleaseObjectJob for BulkAction #{bulk_action_id}")
       update_druid_count
 

--- a/app/jobs/set_governing_apo_job.rb
+++ b/app/jobs/set_governing_apo_job.rb
@@ -10,7 +10,7 @@ class SetGoverningApoJob < GenericJob
     @webauth = OpenStruct.new params[:webauth]
     @pids = params[:pids]
 
-    File.open(bulk_action.log_name, 'w') do |log|
+    with_bulk_action_log do |log|
       log.puts("#{Time.current} Starting SetGoverningApoJob for BulkAction #{bulk_action_id}")
       update_druid_count
 

--- a/app/models/bulk_action.rb
+++ b/app/models/bulk_action.rb
@@ -15,6 +15,12 @@ class BulkAction < ActiveRecord::Base
     File.join(output_directory, filename)
   end
 
+  def reset_druid_counts
+    update_attribute(:druid_count_success, 0)
+    update_attribute(:druid_count_fail, 0)
+    update_attribute(:druid_count_total, 0)
+  end
+
   private
 
   def prefix

--- a/spec/jobs/descmetadata_download_job_spec.rb
+++ b/spec/jobs/descmetadata_download_job_spec.rb
@@ -92,16 +92,6 @@ describe DescmetadataDownloadJob, type: :job do
     end
   end
 
-  describe 'initialize_counters' do
-    it 'sets the three bulk job counters to zero' do
-      bulk_action = double('bulk_action')
-      expect(bulk_action).to receive(:update).with(druid_count_fail: 0)
-      expect(bulk_action).to receive(:update).with(druid_count_success: 0)
-      expect(bulk_action).to receive(:update).with(druid_count_total: 0)
-      @download_job.initialize_counters(bulk_action)
-    end
-  end
-
   describe 'query_dor' do
     before :each do
       @log = double('log')

--- a/spec/jobs/generic_job_spec.rb
+++ b/spec/jobs/generic_job_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe GenericJob do
+  let(:bulk_action_no_process_callback) do
+    bulk_action = build(
+      :bulk_action,
+      action_type: 'GenericJob'
+    )
+    expect(bulk_action).to receive(:process_bulk_action_type)
+    bulk_action.save
+    bulk_action
+  end
+
+  before do
+    allow(subject).to receive(:bulk_action).and_return(bulk_action_no_process_callback)
+  end
+
+  describe '#with_bulk_action_log' do
+    it 'should open a log buffer in append mode, and pass it to the block' do
+      buffer = StringIO.new
+      expect(File).to receive(:open).with(bulk_action_no_process_callback.log_name, 'a').and_yield(buffer)
+
+      subject.with_bulk_action_log do |my_log_buf|
+        expect(my_log_buf).to eq buffer
+      end
+    end
+  end
+end

--- a/spec/jobs/generic_job_spec.rb
+++ b/spec/jobs/generic_job_spec.rb
@@ -1,5 +1,14 @@
 require 'spec_helper'
 
+class GenericTestJob < GenericJob
+  def perform(_bulk_action_id, _params)
+    bulk_action.increment(:druid_count_success)
+    bulk_action.increment(:druid_count_fail)
+    bulk_action.increment(:druid_count_total)
+    bulk_action.save
+  end
+end
+
 describe GenericJob do
   let(:bulk_action_no_process_callback) do
     bulk_action = build(
@@ -23,6 +32,22 @@ describe GenericJob do
       subject.with_bulk_action_log do |my_log_buf|
         expect(my_log_buf).to eq buffer
       end
+    end
+  end
+
+  describe 'before_perform' do
+    it 'resets the druid counts before the job gets (re-)run' do
+      allow(BulkAction).to receive(:find).with(bulk_action_no_process_callback.id).and_return(bulk_action_no_process_callback)
+
+      GenericTestJob.perform_now(bulk_action_no_process_callback.id, {})
+      expect(bulk_action_no_process_callback.druid_count_success).to eq 1
+      expect(bulk_action_no_process_callback.druid_count_fail).to eq 1
+      expect(bulk_action_no_process_callback.druid_count_total).to eq 1
+
+      GenericTestJob.perform_now(bulk_action_no_process_callback.id, {})
+      expect(bulk_action_no_process_callback.druid_count_success).to eq 1
+      expect(bulk_action_no_process_callback.druid_count_fail).to eq 1
+      expect(bulk_action_no_process_callback.druid_count_total).to eq 1
     end
   end
 end

--- a/spec/jobs/release_object_job_spec.rb
+++ b/spec/jobs/release_object_job_spec.rb
@@ -40,7 +40,7 @@ describe ReleaseObjectJob do
       it 'logs information to the logfile' do
         # Stub out the file, and send it to a string buffer instead
         buffer = StringIO.new
-        expect(File).to receive(:open).with(bulk_action_no_process_callback.log_name, 'w').and_yield(buffer)
+        expect(subject).to receive(:with_bulk_action_log).and_yield(buffer)
         subject.perform(bulk_action_no_process_callback.id, params)
         expect(buffer.string).to include 'Starting ReleaseObjectJob for BulkAction'
         pids.each do |pid|
@@ -74,7 +74,7 @@ describe ReleaseObjectJob do
       it 'logs information to the logfile' do
         # Stub out the file, and send it to a string buffer instead
         buffer = StringIO.new
-        expect(File).to receive(:open).with(bulk_action_no_process_callback.log_name, 'w').and_yield(buffer)
+        expect(subject).to receive(:with_bulk_action_log).and_yield(buffer)
         subject.perform(bulk_action_no_process_callback.id, params)
         pids.each do |pid|
           expect(buffer.string).to include "Beginning ReleaseObjectJob for #{pid}"
@@ -106,7 +106,7 @@ describe ReleaseObjectJob do
       it 'logs information to the logfile' do
         # Stub out the file, and send it to a string buffer instead
         buffer = StringIO.new
-        expect(File).to receive(:open).with(bulk_action_no_process_callback.log_name, 'w').and_yield(buffer)
+        expect(subject).to receive(:with_bulk_action_log).and_yield(buffer)
         subject.perform(bulk_action_no_process_callback.id, params)
         pids.each do |pid|
           expect(buffer.string).to include "Beginning ReleaseObjectJob for #{pid}"
@@ -128,7 +128,7 @@ describe ReleaseObjectJob do
       end
       it 'logs druid info to logfile' do
         buffer = StringIO.new
-        expect(File).to receive(:open).with(bulk_action_no_process_callback.log_name, 'w').and_yield(buffer)
+        expect(subject).to receive(:with_bulk_action_log).and_yield(buffer)
         subject.perform(bulk_action_no_process_callback.id, params)
         expect(buffer.string).to include 'Starting ReleaseObjectJob for BulkAction'
         pids.each do |pid|

--- a/spec/jobs/set_governing_apo_job_spec.rb
+++ b/spec/jobs/set_governing_apo_job_spec.rb
@@ -43,7 +43,7 @@ describe SetGoverningApoJob do
         allow(Dor::SearchService.solr).to receive(:commit)
 
         buffer = StringIO.new
-        expect(File).to receive(:open).with(bulk_action_no_process_callback.log_name, 'w').and_yield(buffer)
+        expect(subject).to receive(:with_bulk_action_log).and_yield(buffer)
 
         subject.perform(bulk_action_no_process_callback.id, params)
 
@@ -61,7 +61,7 @@ describe SetGoverningApoJob do
       # test of #perform, to prove that common failure cases for individual objects wouldn't fail the whole run.
       it 'increments the failure and success counts, keeps running even if an individual update fails, and logs status of each update' do
         buffer = StringIO.new
-        expect(File).to receive(:open).with(bulk_action_no_process_callback.log_name, 'w').and_yield(buffer)
+        expect(subject).to receive(:with_bulk_action_log).and_yield(buffer)
 
         item1 = double(Dor::Item)
         item3 = double(Dor::Item)


### PR DESCRIPTION
* append to the log file when opening it instead of truncating it, so that log info from an unsuccessful job attempt isn't lost.
* zero out the success/failure/total druid counts before performing the job, in case this isn't the first time the job is being attempted for a bulk action, so that the job is incrementing fresh counts.

closes #972