### PR TITLE
move bulk reindex from old bulk updates page to new bulk actions framework

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,66 +1,21 @@
 {
-  /*
-   * ENVIRONMENTS
-   * =================
-   */
-
-  // Define globals exposed by modern browsers.
   "browser": true,
-
-  // Define globals exposed by jQuery.
   "jquery": true,
-
-  // Define globals exposed by Node.js.
   "node": true,
-
-  // Allow ES6.
   "esnext": true,
 
-  /*
-   * ENFORCING OPTIONS
-   * =================
-   */
-
-  // Force all variable names to use either camelCase style or UPPER_CASE
-  // with underscores.
   "camelcase": true,
-
-  // Prohibit use of == and != in favor of === and !==.
   "eqeqeq": true,
-
-  // Enforce tab width of 2 spaces.
   "indent": 2,
-
-  // Prohibit use of a variable before it is defined.
   "latedef": true,
-
-  // Enforce line length to 80 characters
   "maxlen": 80,
-
-  // Require capitalized names for constructor functions.
   "newcap": true,
-
-  // Enforce use of single quotation marks for strings.
   "quotmark": "single",
-
-  // Enforce placing 'use strict' at the top function scope
   "strict": true,
-
-  // Prohibit use of explicitly undeclared variables.
   "undef": true,
-
-  // Warn when variables are defined but never used.
   "unused": true,
 
-  /*
-   * RELAXING OPTIONS
-   * =================
-   */
-
-  // Suppress warnings about == null comparisons.
   "eqnull": true,
-
-  // Custom predefined js stuff
   "predef": [
     "expect", "describe", "it", "xit", "spyOn", "fixture", "beforeEach", "afterEach", "L", "jasmine", "TestResponses"
   ]

--- a/app/assets/javascripts/bulk.js
+++ b/app/assets/javascripts/bulk.js
@@ -104,9 +104,6 @@ function fetch_druids(fun) {
 	}
 }
 
-function reindex(druids){
-	process_get(druids, reindex_url, 'Reindexed.');
-}
 function republish(druids){
 	process_get(druids, republish_url, "Republished.");
 }

--- a/app/jobs/local_indexing_job.rb
+++ b/app/jobs/local_indexing_job.rb
@@ -1,7 +1,9 @@
 ##
-# Base IndexingJob class
-class IndexingJob < ActiveJob::Base
-  queue_as :indexing
+# this job will reindex a list of DOR objects, locally performing the computation to
+# generate the solr document (talking directly to Fedora to retrieve the object, and
+# directly to Solr to update the index).
+class LocalIndexingJob < ActiveJob::Base
+  queue_as :indexing_local
 
   ##
   # Perform indexing job on a list of pids

--- a/app/jobs/remote_indexing_job.rb
+++ b/app/jobs/remote_indexing_job.rb
@@ -1,0 +1,39 @@
+##
+# job to reindex a DOR object to Solr using the dor_indexing_app endpoint
+class RemoteIndexingJob < GenericJob
+  queue_as :indexing_remote
+
+  attr_reader :pids
+
+  def perform(bulk_action_id, params)
+    @pids = params[:pids]
+
+    with_bulk_action_log do |log_buffer|
+      log_buffer.puts("#{Time.current} Starting RemoteIndexingJob for BulkAction #{bulk_action_id}")
+      update_druid_count
+
+      pids.each do |current_druid|
+        log_buffer.puts("#{Time.current} RemoteIndexingJob: Attempting to index #{current_druid} (bulk_action.id=#{bulk_action_id})")
+        reindex_druid_safely(current_druid, log_buffer)
+      end
+
+      log_buffer.puts("#{Time.current} Finished RemoteIndexingJob for BulkAction #{bulk_action_id}")
+    end
+  end
+
+  private
+
+  def reindex_druid_safely(current_druid, log_buffer)
+    Argo::Indexer.reindex_pid_remotely(current_druid)
+    log_buffer.puts("#{Time.current} RemoteIndexingJob: Successfully reindexed #{current_druid} (bulk_action.id=#{bulk_action.id})")
+    bulk_action.increment(:druid_count_success).save
+  rescue => e
+    log_buffer.puts("#{Time.current} RemoteIndexingJob: Unexpected error for #{current_druid} (bulk_action.id=#{bulk_action.id}): #{e}")
+    bulk_action.increment(:druid_count_fail).save
+  end
+
+  def update_druid_count
+    bulk_action.update(druid_count_total: pids.length)
+    bulk_action.save
+  end
+end

--- a/app/models/bulk_action.rb
+++ b/app/models/bulk_action.rb
@@ -1,6 +1,6 @@
 class BulkAction < ActiveRecord::Base
   belongs_to :user
-  validates :action_type, inclusion: { in: %w(GenericJob DescmetadataDownloadJob ReleaseObjectJob SetGoverningApoJob) }
+  validates :action_type, inclusion: { in: %w(GenericJob DescmetadataDownloadJob ReleaseObjectJob RemoteIndexingJob SetGoverningApoJob) }
   after_create do
     create_output_directory
     create_log_file

--- a/app/views/bulk_actions/_form.html.erb
+++ b/app/views/bulk_actions/_form.html.erb
@@ -31,6 +31,10 @@
         <%= f.radio_button(:action_type, 'SetGoverningApoJob', autocomplete: 'off') %>
         Update governing APO
       </label>
+      <label href='#reindex_object_options' data-toggle='tab' class='btn btn-default'>
+        <%= f.radio_button(:action_type, 'RemoteIndexingJob', autocomplete: 'off') %>
+        Reindex
+      </label>
     </div>
 
     <div class='tab-content'>
@@ -50,6 +54,11 @@
           Moves the object to a new governing APO.
         </span>
         <%= render 'bulk_actions/forms/set_governing_apo_form', f: f %>
+      </div>
+      <div role='tabpanel' class= 'tab-pane' id='reindex_object_options'>
+        <span class='help-block'>
+          Reindexes the DOR object to Solr
+        </span>
       </div>
     </div>
   </div>

--- a/app/views/report/bulk.html.erb
+++ b/app/views/report/bulk.html.erb
@@ -17,7 +17,6 @@ open_version_url='<%=url_for :controller => :items,:action => :prepare, :id => '
 close_version_url='<%=url_for :controller => :items,:action => :close_version, :id => 'druid:xxxxxxxxx', :bulk => 'true'%>'
 set_content_type_url='<%=url_for :controller => :items,:action => :set_content_type, :id => 'druid:xxxxxxxxx', :bulk => 'true'%>'
 purge_url='<%=url_for :controller => :items,:action => :purge_object, :id => 'druid:xxxxxxxxx', :bulk => 'true'%>'
-reindex_url='<%=url_for :controller => :dor,:action => :reindex, :pid => 'druid:xxxxxxxxx', :bulk => 'true'%>'
 republish_url='<%=url_for :controller => :dor,:action => :republish, :pid => 'druid:xxxxxxxxx'%>'
 release_hold_url='<%=url_for :controller => :items,:action => :release_hold, :id => 'druid:xxxxxxxxx', :bulk => true%>'
 set_rights_url='<%=url_for :controller => :items,:action => :set_rights, :id => 'druid:xxxxxxxxx', :bulk => 'true'%>'
@@ -94,9 +93,6 @@ ul li{
     </div>
     <strong>Options that do not require versioning</strong>
     <div class="row bulk-buttons-row">
-      <div class="col-sm-2">
-	<button class="bulk_button btn-block" id="reindex_show" name="reindex_show" onclick="$('#reindex').show(400)">Reindex</button>
-      </div>
       <div class="col-sm-2">
         <button class="bulk_button btn-block" id="republish_show" name="republish_show" onclick="$('#republish').show(400)">Republish</button>
       </div>
@@ -235,10 +231,6 @@ ul li{
 <div class="bulk_operation" id="release_hold" name="release_hold">
   <h1>Release to SDR-Ingest</h1>
   <span class="bulk_button" id="release_hold" name="release_hold" onclick="fetch_druids(release_hold);$('#release_hold').hide(400);">Release object</span>
-</div>
-<div class="bulk_operation" id="reindex" name="reindex">
-  <h1>Reindex items</h1>
-  <span class="bulk_button" id="reindex_button" name="reindex_button" onclick="fetch_druids(reindex);$('#reindex').hide(400);">Update DOR/Argo index for object</span>
 </div>
 <div class="bulk_operation" id="republish" name="republish">
   <h1>Republish items</h1>

--- a/lib/bulk_reindexer.rb
+++ b/lib/bulk_reindexer.rb
@@ -14,13 +14,13 @@ module Argo
     end
 
     ##
-    # Batch up and enqueue IndexingJobs.  pid_list is broken into batches of BATCH_SIZE, and
+    # Batch up and enqueue LocalIndexingJobs.  pid_list is broken into batches of BATCH_SIZE, and
     #  an indexing job of the given priority is submitted for each batch.
     # @param [Array<String>] pid_list
     # @param [Integer] priority
     def queue_pid_reindexing_jobs(pid_list, priority = 1)
       pid_list.each_slice(Settings.BULK_REINDEXER.BATCH_SIZE) do |sublist|
-        IndexingJob.delay(priority: priority).perform_later(sublist)
+        LocalIndexingJob.delay(priority: priority).perform_later(sublist)
       end
     end
 

--- a/spec/controllers/dor_controller_spec.rb
+++ b/spec/controllers/dor_controller_spec.rb
@@ -24,20 +24,12 @@ describe DorController, :type => :controller do
         expect(response).to redirect_to(solr_document_path(druid))
       end
     end
-    context 'from bulk action' do
-      it 'returns success code and message on success' do
-        expect(Dor::IndexingService).to receive(:reindex_pid_remotely).with(druid)
+    context 'from bulk update' do
+      it 'returns a 403 for requests from the old bulk update mechanism' do
+        expect(Dor::IndexingService).not_to receive(:reindex_pid_remotely)
         get :reindex, params: { pid: druid, bulk: 'true' }
-        expect(response.body).to eq "Successfully updated index for #{druid}"
-        expect(response).to have_http_status(:ok)
-      end
-
-      it 'returns error code and message on failure' do
-        expect(Dor::IndexingService).to receive(:reindex_pid_remotely).with(druid).and_raise(Dor::IndexingService::ReindexError)
-        expect(Rails.logger).to receive(:error).with(/Failed to update index for #{druid}/)
-        get :reindex, params: { pid: druid, bulk: 'true' }
-        expect(response.body).to eq "Failed to update index for #{druid}"
-        expect(response).to have_http_status(:internal_server_error)
+        expect(response.body).to eq 'the old bulk update mechanism is deprecated.  please use the new bulk actions framework going forward.'
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end

--- a/spec/features/bulk_reindex_spec.rb
+++ b/spec/features/bulk_reindex_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.feature 'Bulk Reindex of DOR Objects' do
+  let(:current_user) { create(:user) }
+
+  before(:each) do
+    expect(current_user).to receive(:to_s).at_least(:once).and_return('name')
+    allow_any_instance_of(BulkActionsController).to receive(:current_user).and_return(current_user)
+  end
+
+  scenario 'Creates a new job' do
+    visit new_bulk_action_path
+    choose 'bulk_action_action_type_remoteindexingjob'
+    fill_in 'pids', with: 'druid:br481xz7820'
+    click_button 'Submit'
+    expect(page).to have_css 'h1', text: 'Bulk Actions'
+    within 'table.table' do
+      expect(page).to have_css 'td', text: 'RemoteIndexingJob'
+      expect(page).to have_css 'td', text: 'Scheduled Action'
+    end
+  end
+end

--- a/spec/features/bulk_screen_spec.rb
+++ b/spec/features/bulk_screen_spec.rb
@@ -28,7 +28,6 @@ feature 'Bulk actions view', js: true do
     expect(page).to have_button('Apply APO defaults', disabled: false)
     expect(page).to have_button('Add a workflow', disabled: false)
     expect(page).to have_button('Close versions', disabled: false)
-    expect(page).to have_button('Reindex', disabled: false)
     expect(page).to have_button('Republish', disabled: false)
     expect(page).to have_button('Tags', disabled: false)
     expect(page).to have_button('Purge', disabled: false)

--- a/spec/jobs/remote_indexing_job_spec.rb
+++ b/spec/jobs/remote_indexing_job_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+describe RemoteIndexingJob do
+  let(:bulk_action_no_process_callback) do
+    bulk_action = build(
+      :bulk_action,
+      action_type: 'RemoteIndexingJob'
+    )
+    expect(bulk_action).to receive(:process_bulk_action_type)
+    bulk_action.save
+    bulk_action
+  end
+
+  let(:log_buffer) { StringIO.new }
+
+  before do
+    allow(subject).to receive(:bulk_action).and_return(bulk_action_no_process_callback)
+    allow(subject).to receive(:with_bulk_action_log).and_yield(log_buffer)
+  end
+
+  describe '#perform' do
+    let(:pids) { ['druid:bb111cc2222', 'druid:cc111dd2222', 'druid:dd111ee2222'] }
+    let(:params) { { pids: pids } }
+
+    context 'in a happy world' do
+      it 'updates the total druid count, attempts to update the APO for each druid, and commits to solr' do
+        pids.each do |pid|
+          expect(subject).to receive(:reindex_druid_safely).with(pid, log_buffer)
+        end
+        subject.perform(bulk_action_no_process_callback.id, params)
+        expect(bulk_action_no_process_callback.druid_count_total).to eq pids.length
+      end
+
+      it 'logs info about progress' do
+        allow(subject).to receive(:reindex_druid_safely)
+        subject.perform(bulk_action_no_process_callback.id, params)
+        bulk_action_id = bulk_action_no_process_callback.id
+        expect(log_buffer.string).to include "Starting RemoteIndexingJob for BulkAction #{bulk_action_id}"
+        pids.each do |pid|
+          expect(log_buffer.string).to include "RemoteIndexingJob: Attempting to index #{pid} (bulk_action.id=#{bulk_action_id})"
+        end
+        expect(log_buffer.string).to include "Finished RemoteIndexingJob for BulkAction #{bulk_action_id}"
+      end
+
+      it 'increments the failure and success counts, keeps running even if an individual update fails, and logs status of each update' do
+        timeout_err = Dor::IndexingService::ReindexError.new('Timed out connecting to server')
+        expect(Argo::Indexer).to receive(:reindex_pid_remotely).with(pids[0])
+        expect(Argo::Indexer).to receive(:reindex_pid_remotely).with(pids[1]).and_raise(ActiveFedora::ObjectNotFoundError)
+        expect(Argo::Indexer).to receive(:reindex_pid_remotely).with(pids[2]).and_raise(timeout_err)
+
+        subject.perform(bulk_action_no_process_callback.id, params)
+        expect(bulk_action_no_process_callback.druid_count_success).to eq 1
+        expect(bulk_action_no_process_callback.druid_count_fail).to eq 2
+
+        bulk_action_id = bulk_action_no_process_callback.id
+        expect(log_buffer.string).to include "RemoteIndexingJob: Successfully reindexed #{pids[0]} (bulk_action.id=#{bulk_action_id})"
+        expect(log_buffer.string).to include "RemoteIndexingJob: Unexpected error for #{pids[1]} (bulk_action.id=#{bulk_action_id}): ActiveFedora::ObjectNotFoundError"
+        expect(log_buffer.string).to include "RemoteIndexingJob: Unexpected error for #{pids[2]} (bulk_action.id=#{bulk_action_id}): #{timeout_err}"
+      end
+    end
+  end
+
+  describe '#reindex_druid_safely' do
+    let(:pid) { '123' }
+
+    it 'logs a success and increments the success count if reindexing works' do
+      expect(Argo::Indexer).to receive(:reindex_pid_remotely).with(pid)
+
+      subject.send(:reindex_druid_safely, pid, log_buffer)
+      expect(log_buffer.string).to include "RemoteIndexingJob: Successfully reindexed #{pid} (bulk_action.id=#{bulk_action_no_process_callback.id})"
+      expect(bulk_action_no_process_callback.druid_count_success).to eq 1
+      expect(bulk_action_no_process_callback.druid_count_fail).to eq 0
+    end
+
+    it 'logs an error and increments the error count if reindexing works, but does not raise an error itself' do
+      expect(Argo::Indexer).to receive(:reindex_pid_remotely).with(pid).and_raise("didn't see that one coming")
+
+      expect { subject.send(:reindex_druid_safely, pid, log_buffer) }.not_to raise_error
+      expect(log_buffer.string).to include "RemoteIndexingJob: Unexpected error for #{pid} (bulk_action.id=#{bulk_action_no_process_callback.id}): didn't see that one coming"
+      expect(bulk_action_no_process_callback.druid_count_success).to eq 0
+      expect(bulk_action_no_process_callback.druid_count_fail).to eq 1
+    end
+  end
+end

--- a/spec/views/bulk_actions/_form.html.erb_spec.rb
+++ b/spec/views/bulk_actions/_form.html.erb_spec.rb
@@ -42,4 +42,10 @@ RSpec.describe 'bulk_actions/_form.html.erb' do
       expect(rendered).to have_css 'select[name="bulk_action[set_governing_apo][new_apo_id]"] option[value="druid:234"]'
     end
   end
+
+  describe 'Reindex Job form' do
+    it 'has proper form input values' do
+      expect(rendered).to have_css 'input[type="radio"][value="RemoteIndexingJob"]'
+    end
+  end
 end


### PR DESCRIPTION
there should now be a "Reindex" option when creating a new bulk action.  the "Reindex" command on the old bulk updates page should now be gone.

deployed to stage, did a quick test by reindexing all the workflows using the new bulk action, seemed to work fine.

closes #743
partially addresses #970