### PR TITLE
Modsulator job append

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ vendor/ruby/
 /spec/fixtures/bulk_upload/workspace
 .ruby-version
 .ruby-gemset
-
+.byebug_history

--- a/app/jobs/modsulator_job.rb
+++ b/app/jobs/modsulator_job.rb
@@ -30,7 +30,7 @@ class ModsulatorJob < ActiveJob::Base
     original_filename = generate_original_filename(uploaded_filename)
     log_filename = generate_log_filename(output_directory)
 
-    File.open(log_filename, 'w') { |log|
+    File.open(log_filename, 'a') { |log|
 
       start_log(log, user_login, original_filename, note)
       response_xml = generate_xml(filetype, uploaded_filename, original_filename, log)

--- a/spec/jobs/modsulator_job_spec.rb
+++ b/spec/jobs/modsulator_job_spec.rb
@@ -209,7 +209,7 @@ describe ModsulatorJob, type: :job do
     end
 
     it 'opens the log in append mode' do
-      FileUtils.copy_file(xlsx_path, test_spreadsheet_path)  # perform deletes upload file, so we copy fixture
+      FileUtils.copy_file(xlsx_path, test_spreadsheet_path)
       expect(File).to receive(:open).with("#{@output_directory}/#{Settings.BULK_METADATA.LOG}", 'a')
       @mj.perform(nil,
                   test_spreadsheet_path,

--- a/spec/jobs/modsulator_job_spec.rb
+++ b/spec/jobs/modsulator_job_spec.rb
@@ -207,6 +207,18 @@ describe ModsulatorJob, type: :job do
       expect(File.exist?(File.join(@output_directory, Settings.BULK_METADATA.LOG))).to be_truthy
       expect(File.exist? test_spreadsheet_path).to be_falsey
     end
+
+    it 'opens the log in append mode' do
+      FileUtils.copy_file(xlsx_path, test_spreadsheet_path)  # perform deletes upload file, so we copy fixture
+      expect(File).to receive(:open).with("#{@output_directory}/#{Settings.BULK_METADATA.LOG}", 'a')
+      @mj.perform(nil,
+                  test_spreadsheet_path,
+                  @output_directory,
+                  'random_user',
+                  'xlsx',
+                  'true',
+                  'anote')
+    end
   end
 
   describe 'generate_xml' do


### PR DESCRIPTION
This PR changes the spreadsheet bulk upload to open log files in append mode. This should make it easier to debug production problems when jobs are restarted.