### PR TITLE
Add content_file_mimetypes_ssim as a facet field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -61,6 +61,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'exploded_tag_ssim',               label: 'Tag',                 limit: 9999, partial: 'blacklight/hierarchy/facet_hierarchy'
     config.add_facet_field 'objectType_ssim',                 label: 'Object Type',         limit: 10
     config.add_facet_field 'content_type_ssim',               label: 'Content Type',        limit: 10
+    config.add_facet_field 'content_file_mimetypes_ssim',     label: 'MIME Types',          limit: 10, home: false
     config.add_facet_field 'rights_descriptions_ssim',        label: 'Access Rights',       limit: 1000, sort: 'index', home: false
     config.add_facet_field 'use_license_machine_ssi',         label: 'License',             limit: 10, home: false
     config.add_facet_field 'nonhydrus_collection_title_ssim', label: 'Collection',          limit: 10, more_limit: 9999, sort: 'index'


### PR DESCRIPTION
We should wait to merge / deploy until we've fully reindexed Argo with this new field.