### PR TITLE
When adding a new catkey, strip whitespace from beginning and end.

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -439,7 +439,7 @@ class ItemsController < ApplicationController
   end
 
   def catkey
-    @object.catkey = params[:new_catkey]
+    @object.catkey = params[:new_catkey].strip
 
     respond_to do |format|
       if params[:bulk]

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -163,10 +163,10 @@ describe ItemsController, :type => :controller do
       post 'catkey', params: { :id => @pid, :new_catkey => '12345' }
       expect(response.code).to eq('403')
     end
-    it 'should update the catkey' do
+    it 'should update the catkey, trimming whitespace' do
       expect(@item).to receive(:catkey=).with('12345')
       expect(Dor::SearchService.solr).to receive(:add)
-      post 'catkey', params: { :id => @pid, :new_catkey => '12345' }
+      post 'catkey', params: { :id => @pid, :new_catkey => '   12345 ' }
     end
   end
   describe 'tags' do


### PR DESCRIPTION
Fixes #981 