### PR TITLE
Resolve dependency error for rubyzip in prod

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,7 @@ gem 'erubis' # implicit dependency required by rdf-rdfa/haml, no longer provided
 gem 'retries'
 gem 'ruby-graphviz'
 gem 'ruby-prof'
+gem 'rubyzip'
 gem 'whenever', require: false
 
 # Stanford/Hydra related gems

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -768,6 +768,7 @@ DEPENDENCIES
   rubocop
   ruby-graphviz
   ruby-prof
+  rubyzip
   sass-rails (~> 5.0)
   simplecov
   spring

--- a/app/jobs/descmetadata_download_job.rb
+++ b/app/jobs/descmetadata_download_job.rb
@@ -1,13 +1,13 @@
+require 'zip'
+
 class DescmetadataDownloadJob < GenericJob
   queue_as :default
 
   MAX_TRIES = 3
   SLEEP_SECONDS = 3
 
-  ##
-  # @param [Integer] bulk_action_id   ActiveRecord identifier of the BulkAction
-  # object that originated this job.
-  # @param [Hash] params Custom params for this job. DescmetadataDownloadJob
+  # @param [Integer] bulk_action_id ActiveRecord identifier of the BulkAction object that originated this job.
+  # @param [Hash] params Custom params for this job
   # requires `:pids` (an Array of pids) and output_directory
   def perform(bulk_action_id, params)
     zip_filename = generate_zip_filename(params[:output_directory])
@@ -21,11 +21,10 @@ class DescmetadataDownloadJob < GenericJob
 
         bulk_action.update(druid_count_total: params[:pids].length)
         bulk_action.save
-        Zip::File.open(zip_filename, Zip::File::CREATE) do |zip_file|
+        ::Zip::File.open(zip_filename, Zip::File::CREATE) do |zip_file|
           params[:pids].each do |current_druid|
             begin
               dor_object = query_dor(current_druid, log)
-
               if dor_object.nil?
                 bulk_action.increment(:druid_count_fail).save
                 next


### PR DESCRIPTION
See: https://app.honeybadger.io/projects/49894/faults/37153380#notice-trace

`zip` was previously available by chance as a sub-dependency of `roo`, but `roo` recently was removed, thankfully. Tests continued to pass because `jettywrapper` also included `rubyzip`, but `jettywrapper` is intentionally not included in prod.