### PR TITLE
Remove webapp context from the jobs

### DIFF
--- a/app/controllers/bulk_actions_controller.rb
+++ b/app/controllers/bulk_actions_controller.rb
@@ -16,8 +16,7 @@ class BulkActionsController < ApplicationController
 
   # POST /bulk_actions
   def create
-    @bulk_action = BulkAction.new(bulk_action_params)
-    @bulk_action.user = current_user
+    @bulk_action = BulkAction.new(bulk_action_params.merge(user: current_user))
 
     if @bulk_action.save
       redirect_to action: :index, notice: 'Bulk action was successfully created.'
@@ -52,6 +51,6 @@ class BulkActionsController < ApplicationController
       :pids,
       manage_release: [:tag, :what, :who, :to],
       set_governing_apo: [:new_apo_id]
-    ).merge(webauth: { privgroup: webauth.privgroup, login: webauth.login })
+    )
   end
 end

--- a/app/jobs/release_object_job.rb
+++ b/app/jobs/release_object_job.rb
@@ -3,7 +3,7 @@
 class ReleaseObjectJob < GenericJob
   queue_as :release_object
 
-  attr_reader :manage_release, :pids, :webauth
+  attr_reader :manage_release, :pids
   ##
   # This is a shameless green approach to a job that calls release from dor
   # services app and then kicks off release WF.
@@ -15,10 +15,8 @@ class ReleaseObjectJob < GenericJob
   # @option manage_release [String] :who required username of releaser
   # @option manage_release [String] :what required type of release (self, collection)
   # @option manage_release [String] :tag required (true, false)
-  # @option webauth [Hash] required for permissions check
   def perform(bulk_action_id, params)
     @manage_release = params[:manage_release]
-    @webauth = OpenStruct.new params[:webauth]
     @pids = params[:pids]
     with_bulk_action_log do |log|
       log.puts("#{Time.current} Starting ReleaseObjectJob for BulkAction #{bulk_action_id}")
@@ -71,7 +69,7 @@ class ReleaseObjectJob < GenericJob
   private
 
   def ability
-    @ability ||= Ability.new(User.find_or_create_by_webauth(webauth))
+    @ability ||= Ability.new(bulk_action.user)
   end
 
   def params_to_body(params)

--- a/app/jobs/set_governing_apo_job.rb
+++ b/app/jobs/set_governing_apo_job.rb
@@ -3,11 +3,10 @@
 class SetGoverningApoJob < GenericJob
   queue_as :set_governing_apo
 
-  attr_reader :pids, :new_apo_id, :webauth
+  attr_reader :pids, :new_apo_id
 
   def perform(bulk_action_id, params)
     @new_apo_id = params[:set_governing_apo]['new_apo_id']
-    @webauth = OpenStruct.new params[:webauth]
     @pids = params[:pids]
 
     with_bulk_action_log do |log|
@@ -50,7 +49,7 @@ class SetGoverningApoJob < GenericJob
   end
 
   def ability
-    @ability ||= Ability.new(User.find_or_create_by_webauth(webauth))
+    @ability ||= Ability.new(bulk_action.user)
   end
 
   def update_druid_count

--- a/app/models/bulk_action.rb
+++ b/app/models/bulk_action.rb
@@ -9,7 +9,7 @@ class BulkAction < ActiveRecord::Base
   before_destroy :remove_output_directory
 
   # A virtual attribute used for job creation but not persisted
-  attr_accessor :pids, :manage_release, :set_governing_apo, :webauth
+  attr_accessor :pids, :manage_release, :set_governing_apo
 
   def file(filename)
     File.join(output_directory, filename)
@@ -54,8 +54,7 @@ class BulkAction < ActiveRecord::Base
       pids: pids.split,
       output_directory: output_directory,
       manage_release: manage_release,
-      set_governing_apo: set_governing_apo,
-      webauth: webauth
+      set_governing_apo: set_governing_apo
     }
   end
 

--- a/spec/jobs/set_governing_apo_job_spec.rb
+++ b/spec/jobs/set_governing_apo_job_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe SetGoverningApoJob do
+RSpec.describe SetGoverningApoJob do
   let(:bulk_action_no_process_callback) do
     bulk_action = build(
       :bulk_action,
@@ -133,13 +133,9 @@ describe SetGoverningApoJob do
   end
 
   describe '#ability' do
-    before { subject.instance_variable_set(:@webauth, webauth) }
-
     it 'caches the result' do
-      user = double(User)
-      expect(User).to receive(:find_or_create_by_webauth).with(webauth).and_return(user).exactly(:once)
       ability = double(Ability)
-      expect(Ability).to receive(:new).with(user).and_return(ability).exactly(:once)
+      expect(Ability).to receive(:new).with(bulk_action_no_process_callback.user).and_return(ability).exactly(:once)
 
       expect(subject.send(:ability)).to be(ability)
       expect(subject.send(:ability)).to be(ability)


### PR DESCRIPTION
Jobs should not need to be aware of webauth, and since the `BulkAction` already has a user, there is no need for this.