### PR TITLE
Update to the latest patch version of solr

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -1,5 +1,5 @@
 port: 8984
-version: 6.6.0
+version: 6.6.5
 mirror_url: http://lib-solr-mirror.princeton.edu/dist/
 collection:
   dir: solr_conf/conf/


### PR DESCRIPTION
www.us.apache.org only hosts the last point release for the last three
minor releases.

See https://github.com/cbeer/solr_wrapper/pull/119