### PR TITLE
Pass the name of the facet rather than a hash

### DIFF
--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -91,11 +91,10 @@ class RegistrationController < ApplicationController
 
   def autocomplete
     facet_field = params[:field]
-    facet_fields = { fields: [facet_field] }
     response = Dor::SearchService.query(
       '*:*',
       rows: 0,
-      'facet.field': facet_fields,
+      'facet.field': facet_field,
       'facet.prefix': params[:term].titlecase,
       'facet.mincount': 1,
       'facet.limit': 15,


### PR DESCRIPTION
I believe this error was introduced when we moved away from rsolr-ext.
The current code is passing:
```
"facet.field":"{:fields=>[\"project_tag_ssim\"]}",
```

and Solr retuns a 400 bad request, because that's not the name of a
field.