### PR TITLE
Static attributes will be removed in FactoryBot 5.0

### DIFF
--- a/spec/factories/bulk_action.rb
+++ b/spec/factories/bulk_action.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :bulk_action do
-    action_type 'GenericJob'
+    action_type { 'GenericJob' }
     association :user
-    pids ''
+    pids { '' }
   end
 end


### PR DESCRIPTION
This avoids a deprecation warning in FactoryBot