### PR TITLE
Remove the diagram generation.

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -196,15 +196,6 @@ class ItemsController < ApplicationController
     respond_to do |format|
       format.html { render 'workflow_view', layout: !request.xhr? }
       format.xml  { render xml: @workflow.ng_xml.to_xml }
-      format.any(:png, :svg, :jpeg) do
-        graph = @workflow.graph
-        fail ActionController::RoutingError.new('Not Found') if graph.nil?
-        send_data(
-          graph.output(request.format.to_sym => String),
-          type: request.format.to_s,
-          disposition: 'inline'
-        )
-      end
     end
   end
 

--- a/app/views/items/_workflow_view.html.erb
+++ b/app/views/items/_workflow_view.html.erb
@@ -3,7 +3,6 @@
 <% else %>
   <span class="section-head-link">
     View:
-    <%= link_to 'Diagram', workflow_view_item_path(@object.pid, @workflow_id, :format => 'svg', :repo => params[:repo]), :title => @workflow_id, :data => { ajax_modal: 'trigger' } %> |
     <%= link_to 'XML', workflow_view_item_path(@object.pid, @workflow_id, :raw => 'true', :repo => params[:repo]), :title => @workflow_id, :data => { ajax_modal: 'trigger' } %>
   </span>
   <%= @object.pid %>


### PR DESCRIPTION
It was discussed at the patch party Nov 2018 that this feature is little used and requires a dependency on GraphViz.  By removing this feature, we can remove the graphviz dependency from dor-services.