### PR TITLE
Add bootsnap to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,8 +22,8 @@ gem 'jbuilder', '~> 2.5'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
-# Use Capistrano for deployment
-# gem 'capistrano-rails', group: :development
+# Reduces boot times through caching; required in config/boot.rb
+gem 'bootsnap', '>= 1.1.0', require: false
 
 group :development, :test do
  # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,8 @@ GEM
       blacklight (~> 6.0)
       jquery-rails
       rails (>= 4.1, < 6)
+    bootsnap (1.3.2)
+      msgpack (~> 1.0)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
@@ -398,6 +400,7 @@ GEM
     mods_display (0.6.0)
       i18n
       stanford-mods (~> 2.1)
+    msgpack (1.2.4)
     multi_json (1.13.1)
     multipart-post (2.0.0)
     mysql2 (0.4.10)
@@ -715,6 +718,7 @@ DEPENDENCIES
   barby
   blacklight (~> 6.0)
   blacklight-hierarchy
+  bootsnap (>= 1.1.0)
   bootstrap-sass
   byebug
   cancancan

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup' # Speed up boot time by caching expensive operations.


### PR DESCRIPTION
Bootsnap precomputes load path resolution and caches ruby ISeq
and YAML parsing/compilation, reducing application boot time by
approximately 50%