### PR TITLE
Use metadata object labels instead of fedora object label in edit collection dialog

### DIFF
--- a/app/helpers/value_helper.rb
+++ b/app/helpers/value_helper.rb
@@ -2,6 +2,15 @@
 
 module ValueHelper
   # Renderers
+
+  # Given a fedora object, fetch the preferred object title from MODs, if not found, notify Honeybadger and return Fedora label
+  # @return [String] object title, as pulled from descMetadata
+  def object_title(obj)
+    return obj.descMetadata.title_info.first.strip if obj.descMetadata.title_info.first.present?
+    Honeybadger.notify("No title found in descMetadata for collection #{obj.pid}")
+    obj.label
+  end
+
   def label_for_druid(druid)
     druid = druid.to_s.split(/\//).last # strip "info:fedora/"
     Rails.cache.fetch("label_for_#{druid}", expires_in: 1.hour) do

--- a/app/views/items/_collection_ui.html.erb
+++ b/app/views/items/_collection_ui.html.erb
@@ -6,7 +6,7 @@
     <ul class='list-group'>
       <% @object.collections.each do |col| %>
         <li class='list-group-item'>
-          <%= col.label %>
+          <%= object_title(col) %>
           <%= link_to url_for(:controller => :items, :action => :remove_collection, :id => @object.pid, :collection => col.pid) do %>
             <span class='glyphicon glyphicon-remove text-danger'></span>
           <% end %>

--- a/fedora_conf/data/pb873ty1662.xml
+++ b/fedora_conf/data/pb873ty1662.xml
@@ -4,7 +4,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
 <foxml:objectProperties>
 <foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
-<foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="Annual report of the State Corporation Commission showing the condition of the incorporated state banks and other institutions operating in Virginia at the close of business"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="Fedora Object Label for this collection"/>
 <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE="argo.stanford.edu"/>
 <foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="2014-07-31T22:56:35.559Z"/>
 <foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE="2014-07-31T23:01:45.441Z"/>

--- a/spec/controllers/registration_controller_spec.rb
+++ b/spec/controllers/registration_controller_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe RegistrationController, type: :controller do
       expect(data).to eq(
         '' => 'None',
         'druid:zy123xw4567' => 'A collection that sorts to the top (zy123xw4567)',
-        'druid:pb873ty1662' => 'Annual report of the State Corporation Commission showing... (pb873ty1662)',
+        'druid:pb873ty1662' => 'Fedora Object Label for this collection (pb873ty1662)',
         'druid:ab098cd7654' => 'Ze last collection in ze list (ab098cd7654)'
       )
     end
@@ -277,7 +277,7 @@ RSpec.describe RegistrationController, type: :controller do
 
       get 'collection_list', params: { apo_id: 'druid:fg464dn8891', format: :json }
       data = JSON.parse(response.body)
-      expect(data['druid:pb873ty1662']).to start_with 'Annual report of the State Corporation Commission'
+      expect(data['druid:pb873ty1662']).to eq 'Fedora Object Label for this collection (pb873ty1662)'
       expect(data['druid:gg191kg3953']).to be nil
       expect(data.length).to eq(2)
     end

--- a/spec/views/items/_collection_ui.html.erb_spec.rb
+++ b/spec/views/items/_collection_ui.html.erb_spec.rb
@@ -13,11 +13,13 @@ RSpec.describe 'items/_collection_ui.html.erb' do
     mock_user(permitted_collections: ['Catz are our legacy'])
   end
   it 'renders the partial content' do
+    allow(collection).to receive_message_chain(:descMetadata, :title_info).and_return(['But catz are nice too', 'A different node that will not show'])
     assign(:object, object)
     expect(view).to receive(:current_user).and_return(current_user)
     render
     expect(rendered).to have_css '.panel .panel-heading h3.panel-title', text: 'Remove existing collections'
-    expect(rendered).to have_css '.panel-body .list-group li.list-group-item', text: 'Dogs are better than catz'
+    expect(rendered).to have_css '.panel-body .list-group li.list-group-item', text: 'But catz are nice too' # the descMetadata title_info should display
+    expect(rendered).to_not have_css '.panel-body .list-group li.list-group-item', text: 'Dogs are better than catz' # the fedora label should *not* be there
     expect(rendered).to have_css '.panel-body .list-group li.list-group-item a span.glyphicon.glyphicon-remove.text-danger'
     expect(rendered).to have_css '.panel .panel-heading h3.panel-title', text: 'Add a collection'
     expect(rendered).to have_css '.panel-body form .form-group select.form-control option', text: 'Catz are our legacy'


### PR DESCRIPTION
add a helper for pulling the title out of metadata instead of just using the fedora label; use in edit collection modal

fixes #1006