### PR TITLE
 Remove active workflows when object is purged

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ email: false
 before_install:
   - docker pull suldlss/workflow-server:latest
   - docker run -d -p 127.0.0.1:3001:3000 suldlss/workflow-server:latest
-  - docker run -d -p 8984:8983 -v $PWD/solr_conf/conf/:/myconfig solr:7 solr-create -c argo -d /myconfig
+  # - docker run -d -p 8984:8983 -v $PWD/solr_conf/conf/:/myconfig solr:7 solr-create -c argo -d /myconfig
   - docker run -d -p 8983:8080 suldlss/fcrepo:no-messaging-latest
   - docker ps -a
   - google-chrome-stable --headless --disable-gpu --no-sandbox --remote-debugging-port=9222 http://localhost &

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ email: false
 before_install:
   - docker pull suldlss/workflow-server:latest
   - docker run -d -p 127.0.0.1:3001:3000 suldlss/workflow-server:latest
-  # - docker run -d -p 8984:8983 -v $PWD/solr_conf/conf/:/myconfig solr:7 solr-create -c argo -d /myconfig
+  - docker run -d -p 8984:8983 -v $PWD/solr_conf/conf/:/myconfig solr:7 solr-create -c argo -d /myconfig
   - docker run -d -p 8983:8080 suldlss/fcrepo:no-messaging-latest
   - docker ps -a
   - google-chrome-stable --headless --disable-gpu --no-sandbox --remote-debugging-port=9222 http://localhost &
@@ -30,6 +30,7 @@ after_script:
 
 env:
   global:
-  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up bundle install
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up bundle install
+    - RAILS_ENV=test # needed to load data
 
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ email: false
 before_install:
   - docker pull suldlss/workflow-server:latest
   - docker run -d -p 127.0.0.1:3001:3000 suldlss/workflow-server:latest
-  - docker run -d -p 8984:8983 -v $PWD/solr_conf/conf/:/myconfig solr:7 solr-create -c argo-test -d /myconfig
+  - docker run -d -p 8984:8983 -v $PWD/solr_conf/conf/:/myconfig solr:7 solr-create -c argo -d /myconfig
   - docker run -d -p 8983:8080 suldlss/fcrepo:no-messaging-latest
   - docker ps -a
   - google-chrome-stable --headless --disable-gpu --no-sandbox --remote-debugging-port=9222 http://localhost &

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Argo is the administrative interface to the Stanford Digital Repository.
 ### System Requirements
 
 1. Install Docker
-
 2. Install Ruby 2.5.3
 
 ### Check Out the Code
@@ -21,17 +20,6 @@ Argo is the administrative interface to the Stanford Digital Repository.
 git clone https://github.com/sul-dlss/argo.git
 cd argo
 ```
-
-### Configure the local environment and settings
-
-Settings configuration is managed using the [config](https://github.com/railsconfig/config) gem. Developers should create (or obtain in one of the argo branches in the `shared_configs` repo) the `config/settings/development.local.yml` file to set local development variables correctly.
-
-You will also need to create or acquire the following certificate files (per environment):
-
- - `config/certs/argo-client.crt`  # should match the value specified by `Settings.SSL.CERT_FILE`
- - `config/certs/argo-client.key`  # should match the value specified by `Settings.SSL.KEY_FILE`
-
-For vanilla Stanford laptop installations, the cert files and the local settings file should be available from a private DLSS repository.  You can clone this and create symlinks to the checked out config files (instead of having copies of those files in place).  That way, you can easily pull changes to the vanilla configs as defaults are changed, and you can submit such changes back upstream, in place on your instance.  An Argo developer or DevOps person should be able to point you to the private config repo and explain how to use it.
 
 ### Run bundler to install the Gem dependencies
 
@@ -52,7 +40,7 @@ rake argo:install
 ## Run the servers
 
 ```
-docker-compose up
+docker-compose up -d
 ```
 
 If you want to use the rails console use:
@@ -77,7 +65,7 @@ docker-compose run --rm web rake argo:repo:load
 
 ### Run the tests
 
-To run the test suite (which runs against the `test` Fedora repo/Solr collection), invoke `rspec` from the Argo app root
+To run the test suite, invoke `rspec` from the Argo app root
 ```bash
 rspec
 ```
@@ -90,7 +78,6 @@ The continuous integration build can be run by:
 ```bash
 RAILS_ENV=test bundle exec rake ci
 ```
-
 
 ### Delete records
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -492,6 +492,7 @@ class ItemsController < ApplicationController
     end
 
     @object.delete
+    Dor::CleanupService.remove_active_workflows(@object.pid)
     Dor::SearchService.solr.delete_by_id(params[:id])
     Dor::SearchService.solr.commit
 

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -4,7 +4,7 @@ PROFILER:
 # URLs
 DOR_INDEXING_URL: 'http://localhost:4000/dor'
 FEDORA_URL: 'http://fedoraAdmin:fedoraAdmin@localhost:8983/fedora'
-SOLRIZER_URL: 'http://localhost:8984/solr/argo-test'
+SOLRIZER_URL: 'http://localhost:8984/solr/argo'
 
 # Webauth
 WEBAUTH:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -3,4 +3,4 @@ BULK_METADATA:
 
 # URLs
 FEDORA_URL:   'http://fedoraAdmin:fedoraAdmin@localhost:8983/fedora'
-SOLRIZER_URL: 'http://localhost:8984/solr/argo-test'
+SOLRIZER_URL: 'http://localhost:8984/solr/argo'


### PR DESCRIPTION
Fixes #1020

In so doing:

* Stop stubbing the item pid with a bogus pid—this appears to add nothing other than a needless stub
* Use argo core for testing—this allows developers run the test suite with the given docker-compose configuration, simplifying setup