### PR TITLE
Use dor-services-app to register new objects

### DIFF
--- a/app/controllers/dor/objects_controller.rb
+++ b/app/controllers/dor/objects_controller.rb
@@ -8,7 +8,7 @@ class Dor::ObjectsController < ApplicationController
     if params[:collection] && params[:collection].length == 0
       params.delete :collection
     end
-    response = Dor::RegistrationService.create_from_request(params)
+    response = DorServices::Client.register(params: params)
     pid = response[:pid]
 
     #

--- a/app/forms/apo_form.rb
+++ b/app/forms/apo_form.rb
@@ -7,6 +7,7 @@ class ApoForm < BaseForm
   DEFAULT_MANAGER_WORKGROUPS = %w(developer service-manager metadata-staff).freeze
 
   attr_reader :default_collection_pid
+
   # @param [HashWithIndifferentAccess] params the parameters from the form
   # @return [Boolean] true if the parameters are valid
   def validate(params)
@@ -198,7 +199,7 @@ class ApoForm < BaseForm
 
   # @return [Dor::AdminPolicyObject] registers the APO
   def register_model
-    response = Dor::RegistrationService.create_from_request(register_params)
+    response = DorServices::Client.register(params: register_params)
     # Once it's been created we populate it with its metadata
     Dor.find(response[:pid])
   end

--- a/app/forms/collection_form.rb
+++ b/app/forms/collection_form.rb
@@ -16,7 +16,7 @@ class CollectionForm < BaseForm
 
   # Copies the values to the model and saves and indexes
   def save
-    register_model
+    @model ||= register_model
     sync
     model.save
     model.update_index
@@ -37,9 +37,9 @@ class CollectionForm < BaseForm
 
   # @return [Dor::Collection] registers the Collection
   def register_model
-    response = Dor::RegistrationService.create_from_request(register_params)
+    response = DorServices::Client.register(params: register_params)
     # Once it's been created we populate it with its metadata
-    @model = Dor.find(response[:pid])
+    Dor.find(response[:pid])
   end
 
   # @return [Hash] the parameters used to register an apo. Must be called after `validate`

--- a/app/services/dor_services/client.rb
+++ b/app/services/dor_services/client.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module DorServices
+  class Client
+    attr_reader :params
+
+    def self.register(params:)
+      new(params: params).register
+    end
+
+    def initialize(params:)
+      @params = params
+    end
+
+    def register
+      resp = connection.post do |req|
+        req.url 'v1/objects'
+        req.headers['Content-Type'] = 'application/json'
+        req.body = params.to_json
+      end
+      JSON.parse(resp.body).with_indifferent_access
+    end
+
+    private
+
+    def connection
+      @connection ||= Faraday.new(Settings.DOR_SERVICES_URL)
+    end
+  end
+end

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe CollectionsController do
     end
     it 'creates a collection via catkey' do
       catkey = '1234567'
-      expect(Dor::RegistrationService).to receive(:create_from_request) do |params|
-        expect(params).to match a_hash_including(
+      expect(DorServices::Client).to receive(:register) do |params|
+        expect(params[:params]).to match a_hash_including(
           label: ':auto',
           object_type: 'collection',
           admin_policy: apo.pid,
@@ -59,8 +59,8 @@ RSpec.describe CollectionsController do
       expect(mock_desc_md_ds).to receive(:content=)
       expect(mock_desc_md_ds).to receive(:save)
 
-      expect(Dor::RegistrationService).to receive(:create_from_request) do |params|
-        expect(params).to match a_hash_including(
+      expect(DorServices::Client).to receive(:register) do |params|
+        expect(params[:params]).to match a_hash_including(
           label: title,
           object_type: 'collection',
           admin_policy: apo.pid,
@@ -81,8 +81,8 @@ RSpec.describe CollectionsController do
     it 'adds the collection to the apo default collection list' do
       title = 'collection title'
       abstract = 'this is the abstract'
-      expect(Dor::RegistrationService).to receive(:create_from_request) do |params|
-        expect(params).to match a_hash_including(
+      expect(DorServices::Client).to receive(:register) do |params|
+        expect(params[:params]).to match a_hash_including(
           label: title,
           object_type: 'collection',
           admin_policy: apo.pid,

--- a/spec/controllers/dor/objects_controller_spec.rb
+++ b/spec/controllers/dor/objects_controller_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Dor::ObjectsController, type: :controller do
   let(:dor_registration) { { pid: 'abc' } }
   describe '#create' do
     it 'does something' do
-      expect(Dor::RegistrationService)
-        .to receive(:create_from_request)
+      expect(DorServices::Client)
+        .to receive(:register)
         .and_return(dor_registration)
       expect(Dor::IndexingService)
         .to receive(:reindex_pid_list)

--- a/spec/forms/apo_form_spec.rb
+++ b/spec/forms/apo_form_spec.rb
@@ -272,8 +272,8 @@ RSpec.describe ApoForm do
       it 'hits the registration service to register both an APO and a collection' do
         # verify that an APO is registered
         expect(apo).to receive(:add_roleplayer).exactly(4).times
-        expect(Dor::RegistrationService).to receive(:create_from_request) do |args|
-          expect(args).to match a_hash_including(
+        expect(DorServices::Client).to receive(:register) do |args|
+          expect(args[:params]).to match a_hash_including(
             label: 'New APO Title',
             object_type: 'adminPolicy',
             admin_policy: 'druid:hv992ry2431', # Uber-APO
@@ -286,8 +286,8 @@ RSpec.describe ApoForm do
 
         # verify that the collection is also created
         expect(apo).to receive(:add_default_collection).with(collection.pid)
-        expect(Dor::RegistrationService).to receive(:create_from_request) do |params|
-          expect(params).to match a_hash_including(
+        expect(DorServices::Client).to receive(:register) do |args|
+          expect(args[:params]).to match a_hash_including(
             label: 'col title',
             object_type: 'collection',
             admin_policy: apo.pid,

--- a/spec/forms/collection_form_spec.rb
+++ b/spec/forms/collection_form_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe CollectionForm do
     expect(mock_desc_md_ds).to receive(:content=)
     expect(mock_desc_md_ds).to receive(:save)
 
-    expect(Dor::RegistrationService).to receive(:create_from_request) do |p|
-      expect(p).to match a_hash_including(
+    expect(DorServices::Client).to receive(:register) do |p|
+      expect(p[:params]).to match a_hash_including(
         label: title,
         object_type: 'collection',
         admin_policy: apo.pid,

--- a/spec/integration/apo_spec.rb
+++ b/spec/integration/apo_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe 'apo', type: :request, js: true do
   let(:user) { create(:user) }
   let(:new_apo_druid) { 'druid:zy987wv6543' }
   let(:new_collection_druid) { 'druid:zy333wv6543' }
+  let(:new_apo) { Dor::AdminPolicyObject.new(pid: new_apo_druid) }
+  let(:new_collection) { Dor::Collection.new(pid: new_collection_druid) }
 
   after do
     Dor::AdminPolicyObject.find(new_apo_druid).destroy # clean up after ourselves
@@ -13,13 +15,13 @@ RSpec.describe 'apo', type: :request, js: true do
   end
 
   before do
-    allow(Dor::SuriService).to receive(:mint_id).and_return(new_apo_druid, new_collection_druid)
+    allow_any_instance_of(ApoForm).to receive(:register_model).and_return(new_apo)
+    allow_any_instance_of(CollectionForm).to receive(:register_model).and_return(new_collection)
     allow(ApoController).to receive(:update_index).with(any_args)
     sign_in user, groups: ['sdr:administrator-role']
   end
 
   it 'creates and edits an apo' do
-    expect(Dor::Config.workflow.client).to receive(:create_workflow).twice
     # go to the registration form and fill it in
     visit new_apo_path
     fill_in 'Title', with: 'APO Title'
@@ -35,6 +37,7 @@ RSpec.describe 'apo', type: :request, js: true do
 
     page.select('MODS', from: 'desc_md')
     page.select('Attribution Share Alike 3.0 Unported', from: 'use_license')
+
     choose 'Create a Collection'
     fill_in 'Collection Title', with: 'New Testing Collection'
     click_button 'Register APO'
@@ -48,7 +51,12 @@ RSpec.describe 'apo', type: :request, js: true do
     expect(page).to have_selector('.permissionName', text: 'someone')
     expect(find_field('desc_md').value).to eq('MODS')
     expect(find_field('use_license').value).to eq('by-sa')
-    expect(page).to have_link('New Testing Collection')
+    # TODO: This was removed when we switched from using
+    #       Dor::RegistrationService to dor-services-application. It tests a
+    #       side-effect of the registration service that is no longer
+    #       straightforward to test from within Argo.
+    #
+    # expect(page).to have_link('New Testing Collection')
 
     # Now change them
     fill_in 'Group name', with: 'dpg-staff'

--- a/spec/services/dor_services/client_spec.rb
+++ b/spec/services/dor_services/client_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DorServices::Client do
+  subject(:client) { described_class.new(params: params) }
+
+  let(:params) { { foo: 'bar' } }
+
+  describe '.register' do
+    it 'calls #register on a new instance' do
+      expect_any_instance_of(described_class).to receive(:register)
+      described_class.register(params: params)
+    end
+  end
+
+  describe '#new' do
+    it 'has a params attr' do
+      expect(client.params).to eq params
+    end
+  end
+
+  describe '#register' do
+    before do
+      allow(client).to receive(:connection).and_return(fake_connection)
+    end
+
+    let(:fake_connection) { double }
+    let(:fake_request) do
+      double(url: nil, headers: fake_headers, 'body=' => nil)
+    end
+    let(:fake_headers) { {} }
+    let(:fake_body) { double(body: '{"pid":"druid:123"}') }
+
+    it 'posts params as json' do
+      expect(fake_connection).to receive(:post).and_yield(fake_request).and_return(fake_body)
+      expect(fake_request).to receive(:url).with('v1/objects')
+      expect(fake_request).to receive(:headers).and_return(fake_headers)
+      expect(fake_request).to receive(:body=).with('{"foo":"bar"}')
+      expect(fake_headers).to receive(:[]=).with('Content-Type', 'application/json')
+      expect(client.register[:pid]).to eq('druid:123')
+    end
+  end
+end


### PR DESCRIPTION
Do this instead of using `Dor::RegistrationService` within the `dor-services` gem, which creates a service seam and reduces the reach and impact of `dor-services`.

Note that this makes a small change to an integration spec that used to test two side-effects of `Dor::RegistrationService` that are no longer as easy to test with the new service boundary. We may want to revisit this integration spec if we want the additional assurance this test affords us, say, if dor-services-app is dockerized and added as a dependency of the dev/test environments for Argo.

Fixes #1212