### PR TITLE
bulk remove all collections if none is selected

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -115,8 +115,12 @@ class ItemsController < ApplicationController
 
   def set_collection
     @object.collections.each { |collection| @object.remove_collection(collection.pid) } # first remove any existing collections
-    @object.add_collection(params[:collection]) # now add the collection
-    response_message = 'Collection successfully set.'
+    if params[:collection].present?
+      @object.add_collection(params[:collection]) # collection provided, so add it
+      response_message = 'Collection successfully set.'
+    else
+      response_message = 'Collection(s) successfully removed.' # no collection selected from drop-down, so don't bother adding a new one
+    end
     respond_to do |format|
       if params[:bulk]
         format.html { render status: :ok, plain: response_message }
@@ -127,8 +131,12 @@ class ItemsController < ApplicationController
   end
 
   def add_collection
-    @object.add_collection(params[:collection])
-    response_message = 'Collection added successfully'
+    if params[:collection].present?
+      @object.add_collection(params[:collection])
+      response_message = 'Collection added successfully'
+    else
+      response_message = 'No collection selected'
+    end
     respond_to do |format|
       if params[:bulk]
         format.html { render status: :ok, plain: response_message }

--- a/app/views/report/bulk.html.erb
+++ b/app/views/report/bulk.html.erb
@@ -140,7 +140,7 @@ ul li{
 </div>
 <div class="bulk_operation" id="set_collection" name="set_collection">
   <h1>Add/Set a collection for these objects</h1>
-  <p>This will add the selected collection if the object doesn't already have one, or replace any existing collection(s) for an object with the single selected collection.</p>
+  <p>This will add the selected collection if the object doesn't already have one, or replace any existing collection(s) for an object with the single selected collection.  If you select "None" for the collection, all collection associations will be removed, and no new associations will be added.</p>
   <%=select_tag :set_collection_select, options_for_select(current_user.permitted_collections)%>
   <span class="bulk_button" onclick="fetch_druids(set_collection);$('#set_collection').hide(400);">Set Collection</span><br/>
 </div>

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -419,6 +419,10 @@ RSpec.describe ItemsController, type: :controller do
         expect(@item).to receive(:add_collection).with('druid:1234')
         post 'add_collection', params: { id: @pid, collection: 'druid:1234' }
       end
+      it 'does not add a collection if no param supplied' do
+        expect(@item).not_to receive(:add_collection).with('druid:1234')
+        post 'add_collection', params: { id: @pid, collection: '' }
+      end
     end
 
     context "when they don't have manage_content access" do
@@ -442,6 +446,15 @@ RSpec.describe ItemsController, type: :controller do
         allow(@item).to receive(:collections).and_return([])
         expect(@item).to receive(:add_collection).with(@collection_druid)
         post 'set_collection', params: { id: @pid, collection: @collection_druid, bulk: true }
+        expect(response.code).to eq('200')
+      end
+
+      it 'remove a collection if a new one is not selected' do
+        removed_collection_pid1 = 'druid:oo00ooo0001'
+        allow(@item).to receive(:collections).and_return([Dor::Collection.new(pid: removed_collection_pid1)])
+        expect(@item).to receive(:remove_collection).with(removed_collection_pid1)
+        expect(@item).not_to receive(:add_collection)
+        post 'set_collection', params: { id: @pid, collection: '', bulk: true }
         expect(response.code).to eq('200')
       end
 

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -419,9 +419,11 @@ RSpec.describe ItemsController, type: :controller do
         expect(@item).to receive(:add_collection).with('druid:1234')
         post 'add_collection', params: { id: @pid, collection: 'druid:1234' }
       end
-      it 'does not add a collection if no param supplied' do
-        expect(@item).not_to receive(:add_collection).with('druid:1234')
-        post 'add_collection', params: { id: @pid, collection: '' }
+      context 'when no collection parameter is supplied' do
+        it 'does not add a collection' do
+          expect(@item).not_to receive(:add_collection).with('druid:1234')
+          post 'add_collection', params: { id: @pid, collection: '' }
+        end
       end
     end
 
@@ -449,13 +451,15 @@ RSpec.describe ItemsController, type: :controller do
         expect(response.code).to eq('200')
       end
 
-      it 'remove a collection if a new one is not selected' do
-        removed_collection_pid1 = 'druid:oo00ooo0001'
-        allow(@item).to receive(:collections).and_return([Dor::Collection.new(pid: removed_collection_pid1)])
-        expect(@item).to receive(:remove_collection).with(removed_collection_pid1)
-        expect(@item).not_to receive(:add_collection)
-        post 'set_collection', params: { id: @pid, collection: '', bulk: true }
-        expect(response.code).to eq('200')
+      context 'when a new collection is not selected' do
+        it 'removes the collection only without adding a new one' do
+          removed_collection_pid1 = 'druid:oo00ooo0001'
+          allow(@item).to receive(:collections).and_return([Dor::Collection.new(pid: removed_collection_pid1)])
+          expect(@item).to receive(:remove_collection).with(removed_collection_pid1)
+          expect(@item).not_to receive(:add_collection)
+          post 'set_collection', params: { id: @pid, collection: '', bulk: true }
+          expect(response.code).to eq('200')
+        end
       end
 
       it 'removes existing collections first if there are already one or more, then adds new collection' do


### PR DESCRIPTION
fixes #926 

see latest comments, where the desire is that if the user selects "None" for the collection when bulk setting the collection, it should be removed from items without setting a new one (this actually already happens, but the user gets an error message when a collection with no druid is attempted to be added each time)