### PR TITLE
create collection modal should not render layout from an ajax call

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -5,6 +5,9 @@ class CollectionsController < ApplicationController
   def new
     @apo = Dor.find params[:apo_id]
     authorize! :manage_item, @apo
+    respond_to do |format|
+      format.html { render layout: !request.xhr? }
+    end
   end
 
   def create

--- a/app/views/collections/new.html.erb
+++ b/app/views/collections/new.html.erb
@@ -59,8 +59,10 @@
       <%= button_tag 'register', id: 'register', class: 'btn btn-default' do 'Register Collection' end %>
     </div>
     <% end %>
-    <div class="form-group">
-      <%= button_to 'Cancel', solr_document_path(@apo.pid), method: :get, class: 'btn btn-default' %>
-    </div>
+    <% if !request.xhr? %>
+      <div class="form-group">
+        <%= button_to 'Cancel', solr_document_path(@apo.pid), method: :get, class: 'btn btn-default' %>
+      </div>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
* creating a collection makes an ajax call which should not render the layout (else you get JS classes when all of the JS tries to load again)
* also hide the cancel button from an ajax call to be consistent with other modals, since you already have a close modal button and the cancel would have forced a full page reload