### PR TITLE
Use the dor-services-client to get preserved files.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,7 @@ gem 'active-fedora', '~> 8.2'
 gem 'blacklight', '~> 6.0'
 gem 'blacklight-hierarchy'
 gem 'dor-services', '~> 6.0', '>= 6.0.1'
-gem 'dor-services-client', '~> 0.4'
+gem 'dor-services-client', '~> 0.5'
 gem 'moab-versioning'
 gem 'mods_display'
 gem 'okcomputer' # monitors application and its dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,9 +231,10 @@ GEM
       stanford-mods-normalizer (~> 0.1)
       systemu (~> 2.6)
       uuidtools (~> 2.1.4)
-    dor-services-client (0.4.0)
+    dor-services-client (0.5.0)
       activesupport (>= 4.2, < 6)
       faraday (~> 0.15)
+      nokogiri (~> 1.8)
     dor-workflow-service (2.3.0)
       activesupport (>= 3.2.1, < 6)
       confstruct (>= 0.2.7, < 2)
@@ -729,7 +730,7 @@ DEPENDENCIES
   devise-remote-user (~> 1.0)
   dlss-capistrano (~> 3.1)
   dor-services (~> 6.0, >= 6.0.1)
-  dor-services-client (~> 0.4)
+  dor-services-client (~> 0.5)
   equivalent-xml (>= 0.6.0)
   eye
   factory_bot_rails

--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -25,7 +25,7 @@ class FilesController < ApplicationController
 
   def preserved
     authorize! :view_content, @object
-    file_content = Sdr::Client.get_preserved_file_content(@object.pid, filename, params[:version].to_i)
+    file_content = Dor::Services::Client.preserved_content(object: @object.pid, filename: filename, version: params[:version].to_i)
     response.headers['Content-Type'] = 'application/octet-stream'
     response.headers['Content-Disposition'] = "attachment; filename=#{filename}"
     response.headers['Last-Modified'] = Time.now.utc.rfc2822 # HTTP requires GMT date/time

--- a/app/helpers/dor_object_helper.rb
+++ b/app/helpers/dor_object_helper.rb
@@ -89,7 +89,7 @@ module DorObjectHelper
   end
 
   def last_accessioned_version(pid)
-    Sdr::Client.current_version(pid)
+    Dor::Services::Client.current_version(object: pid)
   end
 
   def render_qfacet_value(facet_solr_field, item, options = {})

--- a/spec/controllers/files_controller_spec.rb
+++ b/spec/controllers/files_controller_spec.rb
@@ -50,7 +50,9 @@ RSpec.describe FilesController, type: :controller do
 
       before do
         allow(controller).to receive(:authorize!).and_return(true)
-        allow(Sdr::Client).to receive(:get_preserved_file_content).with(pid, mock_file_name, mock_version).and_return(mock_content)
+        allow(Dor::Services::Client).to receive(:preserved_content)
+          .with(object: pid, filename: mock_file_name, version: mock_version)
+          .and_return(mock_content)
       end
 
       it 'returns a response with the preserved file content as the body and the right headers' do

--- a/spec/jobs/release_object_job_spec.rb
+++ b/spec/jobs/release_object_job_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe ReleaseObjectJob do
         subject.perform(bulk_action_no_process_callback.id, params)
         pids.each do |pid|
           expect(buffer.string).to include "Beginning ReleaseObjectJob for #{pid}"
-          expect(buffer.string).to include 'Release tag failed POST Dor::Services::Client::Error : 500 ()'
+          expect(buffer.string).to include 'Release tag failed POST Dor::Services::Client::UnexpectedResponse : 500 ()'
         end
         expect(buffer.string).to include 'Adding release tag for SEARCHWORKS'
         expect(buffer.string).not_to include 'Release tag added successfully'
@@ -118,7 +118,7 @@ RSpec.describe ReleaseObjectJob do
         subject.perform(bulk_action_no_process_callback.id, params)
         pids.each do |pid|
           expect(buffer.string).to include "Beginning ReleaseObjectJob for #{pid}"
-          expect(buffer.string).to include 'Workflow creation failed POST Dor::Services::Client::Error : 500 ()'
+          expect(buffer.string).to include 'Workflow creation failed POST Dor::Services::Client::UnexpectedResponse : 500 ()'
         end
         expect(buffer.string).to include 'Adding release tag for SEARCHWORKS'
         expect(buffer.string).to include 'Release tag added successfully'


### PR DESCRIPTION
The Item#get_preserved_file method is deprecated.  This is actually going to hit
dor-services-app which will proxy the content from sdr-services-app.