### PR TITLE
Refactor to avoid checking for a newer file

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -548,8 +548,7 @@ class ItemsController < ApplicationController
       return
     end
 
-    @object.build_datastream('descMetadata', true)
-    @object.descMetadata.content = @object.descMetadata.ng_xml.to_s
+    @object.build_descMetadata_datastream(@object.descMetadata)
 
     respond_to do |format|
       if params[:bulk]

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -608,8 +608,7 @@ RSpec.describe ItemsController, type: :controller do
 
         context 'user has permission and object is editable' do
           before do
-            expect(@item).to receive(:build_datastream).with('descMetadata', true)
-            expect(descmd).to receive(:content=).with(descmd.ng_xml.to_s)
+            expect(@item).to receive(:build_descMetadata_datastream).with(descmd)
             expect(controller).to receive(:save_and_reindex)
           end
 
@@ -627,8 +626,7 @@ RSpec.describe ItemsController, type: :controller do
 
         context "object doesn't allow modification or user doesn't have permission to edit desc metadata" do
           before do
-            expect(@item).not_to receive(:build_datastream)
-            expect(descmd).not_to receive(:content=)
+            expect(@item).not_to receive(:build_descMetadata_datastream)
             expect(controller).not_to receive(:save_and_reindex)
           end
 


### PR DESCRIPTION
build_datastream has a bunch of logic to see if there is a descMetadata.xml file in stacks
that is newer than the datastream and only then calls build_descMetadata_datastream which is
what actually refreshes from the catalog.  This change avoids a bunch of that complexity.

Additionally, there is no need to mess around with the datastream content, becuase
build_descMetadata_datastream takes care of that.

See https://github.com/sul-dlss/dor-services/issues/428#issuecomment-449234431