### PR TITLE
Use dor-services client & API to open and close versions 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ gem 'active-fedora', '~> 8.2'
 gem 'blacklight', '~> 6.0'
 gem 'blacklight-hierarchy'
 gem 'dor-services', '~> 6.1'
-gem 'dor-services-client', '~> 0.5'
+gem 'dor-services-client', '~> 0.10'
 gem 'moab-versioning'
 gem 'mods_display'
 gem 'okcomputer' # monitors application and its dependencies

--- a/Gemfile
+++ b/Gemfile
@@ -42,9 +42,6 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-
 gem 'almond-rails'
 gem 'barby'
 gem 'bootstrap-sass'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -783,10 +783,9 @@ DEPENDENCIES
   stanford-mods
   sul_styles (~> 0.3)
   turbolinks (~> 5)
-  tzinfo-data
   uglifier (>= 1.3.0)
   web-console
   webmock
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,8 +231,9 @@ GEM
       stanford-mods-normalizer (~> 0.1)
       systemu (~> 2.6)
       uuidtools (~> 2.1.4)
-    dor-services-client (0.7.0)
+    dor-services-client (0.10.0)
       activesupport (>= 4.2, < 6)
+      deprecation
       faraday (~> 0.15)
       nokogiri (~> 1.8)
     dor-workflow-service (2.3.0)
@@ -733,7 +734,7 @@ DEPENDENCIES
   devise-remote-user (~> 1.0)
   dlss-capistrano (~> 3.1)
   dor-services (~> 6.1)
-  dor-services-client (~> 0.5)
+  dor-services-client (~> 0.10)
   equivalent-xml (>= 0.6.0)
   eye
   factory_bot_rails

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -75,7 +75,7 @@ class ItemsController < ApplicationController
           description: params[:description],
           opening_user_name: current_user.to_s
         }
-        @object.open_new_version(vers_md_upd_info: vers_md_upd_info)
+        Dor::Services::Client.open_new_version(object: @object, vers_md_upd_info: vers_md_upd_info)
       rescue Dor::Exception => e
         render status: :precondition_failed, plain: e
         return
@@ -348,7 +348,7 @@ class ItemsController < ApplicationController
       description: params[:description],
       opening_user_name: current_user.to_s
     }
-    @object.open_new_version(vers_md_upd_info: vers_md_upd_info)
+    Dor::Services::Client.open_new_version(object: @object, vers_md_upd_info: vers_md_upd_info)
     respond_to do |format|
       msg = params[:id] + ' is open for modification!'
       format.any { redirect_to solr_document_path(params[:id]), notice: msg }

--- a/app/helpers/dor_object_helper.rb
+++ b/app/helpers/dor_object_helper.rb
@@ -89,7 +89,7 @@ module DorObjectHelper
   end
 
   def last_accessioned_version(pid)
-    Dor::Services::Client.current_version(object: pid)
+    Dor::Services::Client.sdr.current_version(object: pid)
   end
 
   def render_qfacet_value(facet_solr_field, item, options = {})

--- a/app/jobs/modsulator_job.rb
+++ b/app/jobs/modsulator_job.rb
@@ -140,7 +140,7 @@ class ModsulatorJob < ActiveJob::Base
       description: "Descriptive metadata upload from #{original_filename}",
       opening_user_name: user_login
     }
-    dor_object.open_new_version(vers_md_upd_info: vers_md_upd_info)
+    Dor::Services::Client.open_new_version(object: dor_object, vers_md_upd_info: vers_md_upd_info)
   end
 
   # Returns true if the given object is accessioned, false otherwise.

--- a/app/jobs/set_governing_apo_job.rb
+++ b/app/jobs/set_governing_apo_job.rb
@@ -80,6 +80,6 @@ class SetGoverningApoJob < GenericJob
       description: 'Set new governing APO',
       opening_user_name: bulk_action.user.to_s
     }
-    object.open_new_version(vers_md_upd_info: vers_md_upd_info)
+    Dor::Services::Client.open_new_version(object: object, vers_md_upd_info: vers_md_upd_info)
   end
 end

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -142,12 +142,12 @@ RSpec.describe ItemsController, type: :controller do
       end
 
       it 'calls dor-services to open a new version' do
-        allow(@item).to receive(:open_new_version)
+        allow(Dor::Services::Client).to receive(:open_new_version)
         vers_md_upd_info = { significance: 'major', description: 'something', opening_user_name: user.to_s }
-        expect(@item).to receive(:open_new_version).with(vers_md_upd_info: vers_md_upd_info)
         expect(@item).to receive(:save)
         expect(Dor::SearchService.solr).to receive(:add)
         get 'open_version', params: { id: @pid, severity: vers_md_upd_info[:significance], description: vers_md_upd_info[:description] }
+        expect(Dor::Services::Client).to have_received(:open_new_version).with(object: @item, vers_md_upd_info: vers_md_upd_info)
       end
     end
 

--- a/spec/jobs/modsulator_job_spec.rb
+++ b/spec/jobs/modsulator_job_spec.rb
@@ -134,7 +134,8 @@ describe ModsulatorJob, type: :job do
     let(:dor_test_object) { double('dor_item') }
 
     it 'opens a new minor version with filename and username' do
-      expect(dor_test_object).to receive(:open_new_version).with(
+      expect(Dor::Services::Client).to receive(:open_new_version).with(
+        object: dor_test_object,
         vers_md_upd_info: {
           significance: 'minor',
           description: 'Descriptive metadata upload from testfile.xlsx',

--- a/spec/jobs/set_governing_apo_job_spec.rb
+++ b/spec/jobs/set_governing_apo_job_spec.rb
@@ -151,7 +151,8 @@ RSpec.describe SetGoverningApoJob do
     it 'opens a new version if the workflow status allows' do
       expect(DorObjectWorkflowStatus).to receive(:new).with(@dor_object.pid).and_return(@workflow)
       expect(@workflow).to receive(:can_open_version?).and_return(true)
-      expect(@dor_object).to receive(:open_new_version).with(
+      expect(Dor::Services::Client).to receive(:open_new_version).with(
+        object: @dor_object,
         vers_md_upd_info: {
           significance: 'minor',
           description: 'Set new governing APO',
@@ -163,13 +164,14 @@ RSpec.describe SetGoverningApoJob do
     it 'does not open a new version if rejected by the workflow status' do
       expect(DorObjectWorkflowStatus).to receive(:new).with(@dor_object.pid).and_return(@workflow)
       expect(@workflow).to receive(:can_open_version?).and_return(false)
-      expect(@dor_object).not_to receive(:open_new_version)
+      expect(Dor::Services::Client).not_to receive(:open_new_version)
       expect { subject.send(:open_new_version, @dor_object) }.to raise_error(/Unable to open new version/)
     end
     it 'fails with an exception if something goes wrong updating the version' do
       expect(DorObjectWorkflowStatus).to receive(:new).with(@dor_object.pid).and_return(@workflow)
       expect(@workflow).to receive(:can_open_version?).and_return(true)
-      expect(@dor_object).to receive(:open_new_version).with(
+      expect(Dor::Services::Client).to receive(:open_new_version).with(
+        object: @dor_object,
         vers_md_upd_info: {
           significance: 'minor',
           description: 'Set new governing APO',


### PR DESCRIPTION
Fixes #1277

This changes the way Argo opens and closes versions, using Dor::Services::Client instead of the dor-services gem. The latter path broke recently when we moved away from embedding HTTP basic credentials in strings stored in config (preferring a more explicit approach): the REST client connection used in sul-dlss/dor-services:lib/dor/utils/sdr_client.rb@master#L77, which is created in sul-dlss/dor-services:lib/dor/rest_resource_factory.rb@master#L17 depends on this. Instead of fixing the dor-services approach, use Dor::Services::Client and the dor-services-app HTTP API to open and close versions to continue our move away from the junk drawer (dor-services) approach to the API-centric approach.