### PR TITLE
search form should send get request to correct spot based on current view

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,6 +13,13 @@ module ApplicationHelper
     Settings.ROBOT_STATUS_URL
   end
 
+  def location_to_send_search_form
+    return report_path if report_view?
+    return report_workflow_grid_path if workflow_grid_view?
+    return search_profile_path if profile_view?
+    search_catalog_path
+  end
+
   ##
   # Views used in report view toggle
   # @return [Array<ViewSwitcher>]
@@ -27,32 +34,32 @@ module ApplicationHelper
 
   ##
   # @return [Boolean]
-  def bulk_update_view?(params)
-    params['controller'] == 'report' && params['action'] == 'bulk'
+  def bulk_update_view?
+    current_page?(report_bulk_path)
   end
 
   ##
   # @return [Boolean]
-  def catalog_view?(params)
-    params['controller'] == 'catalog'
+  def catalog_view?
+    current_page?(search_catalog_path)
   end
 
   ##
   # @return [Boolean]
-  def report_view?(params)
-    params['controller'] == 'report' && params['action'] == 'index'
+  def report_view?
+    current_page?(report_path)
   end
 
   ##
   # @return [Boolean]
-  def workflow_grid_view?(params)
-    params['controller'] == 'report' && params['action'] == 'workflow_grid'
+  def workflow_grid_view?
+    current_page?(report_workflow_grid_path)
   end
 
   ##
   # @return [Boolean]
-  def profile_view?(params)
-    params['controller'] == 'profile' && params['action'] == 'index'
+  def profile_view?
+    current_page?(search_profile_path)
   end
 
   ##

--- a/app/views/catalog/_report_view_toggle.html.erb
+++ b/app/views/catalog/_report_view_toggle.html.erb
@@ -5,9 +5,9 @@
       Select View
       <span class='caret'></span>
     </button>
-    <ul class='dropdown-menu <%= "dropdown-menu-right" if catalog_view?(params) %>' aria-labelledby='argo-view-dropdown'>
+    <ul class='dropdown-menu <%= "dropdown-menu-right" if catalog_view? %>' aria-labelledby='argo-view-dropdown'>
       <% views_to_switch.each do |view| %>
-        <li class=<%= 'active' if send("#{view.name}_view?", params)%>>
+        <li class=<%= 'active' if send("#{view.name}_view?")%>>
           <%= link_to t("argo.search.#{view.name}_view"), send(view.path, cleaned_params) %>
         </li>
       <% end %>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,5 +1,5 @@
 <div id="search" class="search">
-  <%= form_tag search_catalog_path, :method => :get, class: 'search-query-form clearfix navbar-form' do %>
+  <%= form_tag location_to_send_search_form, :method => :get, class: 'search-query-form clearfix navbar-form' do %>
     <h2 class="search sr-only"><%= label_tag(:q, "Search ") %></h2>
     <div class='input-group search-input-group'>
       <%= text_field_tag :q, params[:q], :class => "search_q q form-control" %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -11,48 +11,6 @@ RSpec.describe ApplicationHelper do
     end
   end
 
-  describe '#bulk_update_view?' do
-    it 'checks params' do
-      params = {}
-      expect(helper).not_to be_bulk_update_view(params)
-      params['controller'] = 'report'
-      expect(helper).not_to be_bulk_update_view(params)
-      params['action'] = 'bulk'
-      expect(helper).to be_bulk_update_view(params)
-    end
-  end
-
-  describe '#catalog_view?' do
-    it 'checks params' do
-      params = {}
-      expect(helper).not_to be_catalog_view(params)
-      params['controller'] = 'catalog'
-      expect(helper).to be_catalog_view(params)
-    end
-  end
-
-  describe '#report_view' do
-    it 'checks params' do
-      params = {}
-      expect(helper).not_to be_report_view(params)
-      params['controller'] = 'report'
-      expect(helper).not_to be_report_view(params)
-      params['action'] = 'index'
-      expect(helper).to be_report_view(params)
-    end
-  end
-
-  describe '#workflow_grid_view?' do
-    it 'checks params' do
-      params = {}
-      expect(helper).not_to be_workflow_grid_view(params)
-      params['controller'] = 'report'
-      expect(helper).not_to be_workflow_grid_view(params)
-      params['action'] = 'workflow_grid'
-      expect(helper).to be_workflow_grid_view(params)
-    end
-  end
-
   describe '#search_of_pids' do
     context 'when nil' do
       it 'returns an empty string' do


### PR DESCRIPTION
fixes #637 

- refactor current methods that detect which type of results view we are rendering (no need to pass params around everywhere)
- bootstrap off of these methods to send a new search to current view, but default to standard results view (in case we search from item detail page for example)
- remove unnecessary tests for the helper methods (that now just use standard rails methods, don't need params passed and in and thus do not need to be tested in my opinion)