### PR TITLE
Remove a special case from the workflow controller show

### DIFF
--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -11,16 +11,11 @@ class WorkflowsController < ApplicationController
   # @option params [String] `:repo` The workflow's repository. e.g., dor.
   def show
     params.require(:repo)
-    # fail ArgumentError, "Missing parameters: #{params.inspect}" unless params[:repo].present?
 
-    # Set variables for views; determine which workflow we're supposed to
-    # render and honor a special value of 'workflow'
+    # Set variables for views; determine which workflow we're supposed to render
     @workflow_id = params[:wf_name]
-    @workflow = if @workflow_id == 'workflow'
-                  @object.workflows
-                else
-                  fetch_workflow(@object, @workflow_id, params[:repo])
-                end
+    @workflow = fetch_workflow(@object, @workflow_id, params[:repo])
+
     respond_to do |format|
       format.html { render 'show', layout: !request.xhr? }
       format.xml  { render xml: @workflow.ng_xml.to_xml }


### PR DESCRIPTION
This was introduced 7 years ago here:
https://github.com/sul-dlss/argo/commit/5d671f0a3c3b0493842410495856bcb1bda03aa9#diff-956e46b33fb5307990c4e1a4b5fd86ccR125
but log analysis shows that this is no longer used.