### PR TITLE
Only show buttons for allowable state transfers

### DIFF
--- a/app/presenters/workflow_process_presenter.rb
+++ b/app/presenters/workflow_process_presenter.rb
@@ -22,6 +22,8 @@ class WorkflowProcessPresenter
   end
 
   def reset_button
+    return unless new_status
+
     # workflow update requires id, workflow, process, and status parameters
     form_tag item_workflow_path(pid, workflow_name) do
       hidden_field_tag('process', name) +
@@ -38,6 +40,6 @@ class WorkflowProcessPresenter
   delegate :pid, :workflow_name, to: :process_status
 
   def new_status
-    @new_status ||= ALLOWABLE_CHANGES.fetch(status, '')
+    @new_status ||= ALLOWABLE_CHANGES[status]
   end
 end

--- a/spec/presenters/workflow_process_presenter_spec.rb
+++ b/spec/presenters/workflow_process_presenter_spec.rb
@@ -2,10 +2,8 @@
 
 require 'spec_helper'
 
-RSpec.describe WorkflowProcessPresenter do
-  subject(:instance) { described_class.new(view: stub_view, process_status: process_status) }
-
-  let(:stub_view) { double('view') }
+RSpec.describe WorkflowProcessPresenter, type: :view do
+  subject(:instance) { described_class.new(view: view, process_status: process_status) }
 
   describe '#elapsed' do
     subject { instance.elapsed }
@@ -35,5 +33,33 @@ RSpec.describe WorkflowProcessPresenter do
     let(:process_status) { instance_double(WorkflowProcessStatus, note: 'hi') }
 
     it { is_expected.to eq 'hi' }
+  end
+
+  describe '#reset_button' do
+    subject { instance.reset_button }
+
+    before do
+      # allow(view).to receive(:item_workflow_path).and_return '/workflows/'
+    end
+
+    let(:process_status) do
+      instance_double(WorkflowProcessStatus,
+                      status: status,
+                      pid: 'druid:132',
+                      workflow_name: 'accessionWF',
+                      name: 'technical-metadata')
+    end
+
+    context "when it's not an allowable change" do
+      let(:status) { 'queued' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when it's an allowable change" do
+      let(:status) { 'waiting' }
+
+      it { is_expected.to have_button 'Set to completed' }
+    end
   end
 end


### PR DESCRIPTION
This used to exist:
https://github.com/sul-dlss/argo/blob/bbde9c406d096554d10e74122aa3019b30883890/app/helpers/workflow_helper.rb#L34

But was lost in this code refactor: https://github.com/sul-dlss/argo/commit/59a849cdc3da51bf93527f99d460a3d03a3df6bb