### PR TITLE
Don't explicitly depend on capistrano-shared_configs

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -31,7 +31,6 @@ require 'capistrano/delayed_job'
 require 'capistrano/honeybadger'
 require 'capistrano/passenger'
 require 'capistrano/rails'
-require 'capistrano/shared_configs'
 require 'dlss/capistrano'
 
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.

--- a/Gemfile
+++ b/Gemfile
@@ -114,10 +114,8 @@ group :test do
 end
 
 group :deployment do
-  gem 'capistrano', '~> 3.6'
   gem 'capistrano-passenger'
   gem 'capistrano-rails'
-  gem 'capistrano-shared_configs'
   gem 'capistrano3-delayed-job', '~> 1.0'
   gem 'dlss-capistrano', '~> 3.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -642,10 +642,8 @@ DEPENDENCIES
   bootstrap-sass
   byebug
   cancancan
-  capistrano (~> 3.6)
   capistrano-passenger
   capistrano-rails
-  capistrano-shared_configs
   capistrano3-delayed-job (~> 1.0)
   capybara
   chromedriver-helper


### PR DESCRIPTION
It's already required by dlss-capistrano