### PR TITLE
Add a database for the workflow service to the docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ vendor/ruby/
 .ruby-version
 .ruby-gemset
 .byebug_history
+
+# The docker volume for the workflow database
+postgres-data

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ before_install:
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
-  - docker-compose up -d solr fcrepo dor-services-app suri workflow
+  # Start everything except app
+  - docker-compose up -d db solr fcrepo dor-services-app suri workflow
   - docker-compose ps
   - google-chrome-stable --headless --disable-gpu --no-sandbox --remote-debugging-port=9222 http://localhost &
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,8 +50,30 @@ services:
     image: suldlss/suri-rails:latest
     ports:
       - 3002:3000
+  db:
+    image: postgres
+     # No ports shared externally, so that this doesn't conflict with the postgres
+     # server that TravisCI starts up.
+     # ports:
+     #   - "5432:5432"
+    environment:
+      - POSTGRES_PASSWORD=sekret
+    volumes:
+      - ./postgres-data:/var/lib/postgresql/data
 
   workflow:
     image: suldlss/workflow-server:latest
+    environment:
+      - RAILS_LOG_TO_STDOUT=true
+      - DATABASE_NAME=workflow-server
+      - DATABASE_USERNAME=postgres
+      - DATABASE_PASSWORD=sekret
+      - DATABASE_HOSTNAME=db
+      - DATABASE_PORT=5432
+      - SECRET_KEY_BASE="${SECRET_KEY_BASE}"
+      - SETTINGS__DOR_SERVICES__URL=http://dor-services-app:3000
+      - SETTINGS__ENABLE_STOMP=false
+    depends_on:
+      - db
     ports:
       - 3001:3000


### PR DESCRIPTION
This is necessary because the workflow server image had been updated to require a database.  We also turn off the STOMP notifications.