### PR TITLE
Move reindex_pid_remotely in from dor-services

### DIFF
--- a/INDEXING.md
+++ b/INDEXING.md
@@ -13,10 +13,6 @@ To support indexing, dor-services will:
 * create a Solr document representing the object (using its `to_solr` method).
 * save the document to the Solr instance specified in the configuration, possibly committing immediately.
 
-## Argo::Indexer
-
-This is deprecated for `Dor::IndexingService` in `dor-services`.
-
 ### Reusable methods
 
 The `Argo::Indexer` class provides re-usable methods for indexing:

--- a/app/controllers/dor_controller.rb
+++ b/app/controllers/dor_controller.rb
@@ -9,9 +9,9 @@ class DorController < ApplicationController
     end
 
     begin
-      Dor::IndexingService.reindex_pid_remotely params[:pid]
+      Argo::Indexer.reindex_pid_remotely params[:pid]
       flash[:notice] = "Successfully updated index for #{params[:pid]}"
-    rescue Dor::IndexingService::ReindexError => e
+    rescue Argo::Exceptions::ReindexError => e
       flash[:error] = "Failed to update index for #{params[:pid]}"
       Rails.logger.error "#{flash[:error]}: #{e.inspect}"
     end

--- a/app/models/argo/exceptions.rb
+++ b/app/models/argo/exceptions.rb
@@ -6,5 +6,8 @@ module Argo
     end
     class IndexQueueInvalidResponse < StandardError
     end
+
+    # Raised if there is a problem communicating with dor_indexing_app
+    class ReindexError < RuntimeError; end
   end
 end

--- a/lib/indexer.rb
+++ b/lib/indexer.rb
@@ -1,6 +1,25 @@
 # frozen_string_literal: true
 
 module Argo
-  class Indexer < Dor::IndexingService
+  class Indexer
+    # Use the dor-indexing-app service to reindex a pid
+    # @param [String] pid the druid
+    # @raise [Exceptions::ReindexError] on failure
+    def self.reindex_pid_remotely(pid)
+      pid = "druid:#{pid}" unless pid =~ /^druid:/
+      realtime = Benchmark.realtime do
+        with_retries(max_tries: 3, rescue: [RestClient::Exception, Errno::ECONNREFUSED]) do
+          RestClient.post("#{Settings.DOR_INDEXING_URL}/reindex/#{pid}", '')
+        end
+      end
+      Rails.logger.info "successfully updated index for #{pid} in #{format('%.3f', realtime)}s"
+    rescue RestClient::Exception, Errno::ECONNREFUSED => e
+      msg = "failed to reindex #{pid}: #{e}"
+      Rails.logger.error msg
+      raise Exceptions::ReindexError, msg
+    rescue StandardError => e
+      Rails.logger.error "failed to reindex #{pid}: #{e}"
+      raise
+    end
   end
 end

--- a/spec/controllers/dor_controller_spec.rb
+++ b/spec/controllers/dor_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe DorController, type: :controller do
   describe 'reindex' do
     context 'from a show page' do
       it 'redirects to show page and set flash notice on success' do
-        expect(Dor::IndexingService).to receive(:reindex_pid_remotely).with(druid)
+        expect(Argo::Indexer).to receive(:reindex_pid_remotely).with(druid)
         get :reindex, params: { pid: druid }
         expect(flash[:notice]).to eq "Successfully updated index for #{druid}"
         expect(response).to have_http_status(:found)
@@ -20,7 +20,7 @@ RSpec.describe DorController, type: :controller do
       end
 
       it 'redirects to show page and sets flash error on failure' do
-        expect(Dor::IndexingService).to receive(:reindex_pid_remotely).with(druid).and_raise(Dor::IndexingService::ReindexError)
+        expect(Argo::Indexer).to receive(:reindex_pid_remotely).with(druid).and_raise(Argo::Exceptions::ReindexError)
         expect(Rails.logger).to receive(:error).with(/Failed to update index for #{druid}/)
         get :reindex, params: { pid: druid }
         expect(flash[:error]).to eq "Failed to update index for #{druid}"
@@ -31,7 +31,7 @@ RSpec.describe DorController, type: :controller do
 
     context 'from bulk update' do
       it 'returns a 403 for requests from the old bulk update mechanism' do
-        expect(Dor::IndexingService).not_to receive(:reindex_pid_remotely)
+        expect(Argo::Indexer).not_to receive(:reindex_pid_remotely)
         get :reindex, params: { pid: druid, bulk: 'true' }
         expect(response.body).to eq 'the old bulk update mechanism is deprecated.  please use the new bulk actions framework going forward.'
         expect(response).to have_http_status(:forbidden)

--- a/spec/jobs/remote_indexing_job_spec.rb
+++ b/spec/jobs/remote_indexing_job_spec.rb
@@ -45,7 +45,7 @@ describe RemoteIndexingJob do
       end
 
       it 'increments the failure and success counts, keeps running even if an individual update fails, and logs status of each update' do
-        timeout_err = Dor::IndexingService::ReindexError.new('Timed out connecting to server')
+        timeout_err = Argo::Exceptions::ReindexError.new('Timed out connecting to server')
         expect(Argo::Indexer).to receive(:reindex_pid_remotely).with(pids[0])
         expect(Argo::Indexer).to receive(:reindex_pid_remotely).with(pids[1]).and_raise(ActiveFedora::ObjectNotFoundError)
         expect(Argo::Indexer).to receive(:reindex_pid_remotely).with(pids[2]).and_raise(timeout_err)

--- a/spec/lib/argo/indexer_spec.rb
+++ b/spec/lib/argo/indexer_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Argo::Indexer do
+  let(:mock_pid) { 'druid:aa111bb2222' }
+  let(:mock_default_logger) { double(Logger) }
+
+  describe '#reindex_pid_remotely' do
+    before do
+      allow(Rails).to receive(:logger).and_return(mock_default_logger)
+    end
+
+    it 'calls a remote service to reindex' do
+      expect(RestClient).to receive(:post).and_return(double)
+      expect(mock_default_logger).to receive(:info).with(/successfully updated index for druid:/)
+      described_class.reindex_pid_remotely(mock_pid)
+    end
+
+    it 'calls a remote service to reindex even without a druid: prefix' do
+      expect(RestClient).to receive(:post).and_return(double)
+      expect(mock_default_logger).to receive(:info).with(/successfully updated index for druid:/)
+      described_class.reindex_pid_remotely('aa111bb2222')
+    end
+
+    it 'raises a ReindexRemotelyError exception in cases of predictable failures' do
+      expect(RestClient).to receive(:post).exactly(3).and_raise(RestClient::Exception.new(double))
+      expect(mock_default_logger).to receive(:error).with(/failed to reindex/)
+      expect { described_class.reindex_pid_remotely(mock_pid) }.to raise_error(Argo::Exceptions::ReindexError)
+    end
+
+    it 'raises a ReindexRemotelyError exception in cases of remote host is down' do
+      expect(RestClient).to receive(:post).exactly(3).and_raise(Errno::ECONNREFUSED)
+      expect(mock_default_logger).to receive(:error).with(/failed to reindex/)
+      expect { described_class.reindex_pid_remotely(mock_pid) }.to raise_error(Argo::Exceptions::ReindexError)
+    end
+
+    it 'raises other exceptions in cases of unpredictable failures' do
+      expect(RestClient).to receive(:post).and_raise(RuntimeError.new)
+      expect(mock_default_logger).to receive(:error).with(/failed to reindex/)
+      expect { described_class.reindex_pid_remotely(mock_pid) }.to raise_error(RuntimeError)
+    end
+  end
+end


### PR DESCRIPTION
Argo was the only consumer of that method
Ref sul-dlss/dor-services#535