### PR TITLE
Remove unused create_minimal_mods route

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -246,34 +246,6 @@ class ItemsController < ApplicationController
     end
   end
 
-  # HELL. This makes:
-  #  ~ 3-4 remote GET requests to WFS,
-  #  ~ possibly 2 writes to WFS (each one triggers async object reindex),
-  #  ~ plus an object save (more WFS requests, Fedora write, Solr reindex)
-  def create_minimal_mods
-    unless dor_accession_error?(@object, 'descriptive-metadata') ||
-           dor_accession_error?(@object, 'publish')
-      render status: 500, plain: 'Object is not in error for descMD or publish!'
-      return
-    end
-    unless @object.descMetadata.new?
-      render status: 500, plain: 'This service cannot overwrite existing data!'
-      return
-    end
-    @object.descMetadata.content = ''
-    @object.set_desc_metadata_using_label
-    @object.save
-    if dor_accession_error?(@object, 'descriptive-metadata')
-      set_dor_accession_status(@object, 'descriptive-metadata', 'waiting')
-    end
-    if dor_accession_error?(@object, 'publish')
-      set_dor_accession_status(@object, 'publish', 'waiting')
-    end
-    respond_to do |format|
-      format.any { render plain: 'Set metadata' }
-    end
-  end
-
   def open_version
     # puts params[:description]
     vers_md_upd_info = {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,7 +117,6 @@ Argo::Application.routes.draw do
       get 'mods'
       get 'remove_duplicate_encoding'
       get 'detect_duplicate_encoding'
-      get 'create_minimal_mods'
       post 'embargo', action: :embargo_update, as: 'embargo_update'
       get 'embargo_form'
       post 'datastream',         action: :datastream_update,     as: 'datastream_update'


### PR DESCRIPTION
This was introduced https://github.com/sul-dlss/argo/commit/8e68e66c775761085496a60e6f72d7b3175f7df7
but that button has since been removed