### PR TITLE
Add spec/rails_helper.rb

### DIFF
--- a/spec/controllers/apo_controller_spec.rb
+++ b/spec/controllers/apo_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe ApoController, type: :controller do
   before do

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe ApplicationController, type: :controller do
   describe '#current_user' do

--- a/spec/controllers/auth_controller_spec.rb
+++ b/spec/controllers/auth_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe AuthController, type: :controller do
   describe 'test impersonation' do

--- a/spec/controllers/bulk_actions_controller_spec.rb
+++ b/spec/controllers/bulk_actions_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe BulkActionsController do
   let(:current_user) do

--- a/spec/controllers/bulk_jobs_controller_spec.rb
+++ b/spec/controllers/bulk_jobs_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe BulkJobsController do
   describe '#show' do

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe CatalogController, type: :controller do
   before do

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe CollectionsController do
   before do

--- a/spec/controllers/content_types_controller_spec.rb
+++ b/spec/controllers/content_types_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe ContentTypesController, type: :controller do
   before do

--- a/spec/controllers/dor/objects_controller_spec.rb
+++ b/spec/controllers/dor/objects_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe Dor::ObjectsController, type: :controller do
   before do

--- a/spec/controllers/dor_controller_spec.rb
+++ b/spec/controllers/dor_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe DorController, type: :controller do
   let(:druid) { 'druid:aa111bb2222' }

--- a/spec/controllers/files_controller_spec.rb
+++ b/spec/controllers/files_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe FilesController, type: :controller do
   let(:pid) { 'druid:oo201oo0001' }

--- a/spec/controllers/index_queue_controller_spec.rb
+++ b/spec/controllers/index_queue_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe IndexQueueController do
   describe 'GET depth' do

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe ItemsController, type: :controller do
   before do

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 describe ProfileController do
   it 'is a subclass of CatalogController' do

--- a/spec/controllers/registration_controller_spec.rb
+++ b/spec/controllers/registration_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe RegistrationController, type: :controller do
   before do

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe ReportController, type: :controller do
   before do

--- a/spec/controllers/uploads_controller_spec.rb
+++ b/spec/controllers/uploads_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe UploadsController do
   let(:user) { create(:user) }

--- a/spec/controllers/workflow_service_controller_spec.rb
+++ b/spec/controllers/workflow_service_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe WorkflowServiceController, type: :controller do
   before do

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe WorkflowsController, type: :controller do
   let(:pid) { 'druid:oo201oo0001' }

--- a/spec/features/bulk_desc_metadata_download_spec.rb
+++ b/spec/features/bulk_desc_metadata_download_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'Bulk Descriptive Metadata Download' do
   let(:current_user) { create(:user) }

--- a/spec/features/bulk_jobs_spec.rb
+++ b/spec/features/bulk_jobs_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 # Feature tests for the spreadsheet bulk uploads view.
 RSpec.describe 'Bulk jobs view', js: true do

--- a/spec/features/bulk_reindex_spec.rb
+++ b/spec/features/bulk_reindex_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'Bulk Reindex of DOR Objects' do
   let(:current_user) { create(:user) }

--- a/spec/features/bulk_release_object_spec.rb
+++ b/spec/features/bulk_release_object_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'Bulk Object Release' do
   let(:current_user) { create(:user) }

--- a/spec/features/bulk_screen_spec.rb
+++ b/spec/features/bulk_screen_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 # Feature/view tests for the (old) bulk actions view.
 RSpec.describe 'Bulk actions view', js: true do

--- a/spec/features/bulk_set_governing_apo_spec.rb
+++ b/spec/features/bulk_set_governing_apo_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'Bulk Update of Governing APO' do
   let(:current_user) { create(:user) }

--- a/spec/features/collection_manage_release_spec.rb
+++ b/spec/features/collection_manage_release_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'Collection manage release' do
   let(:current_user) { create(:user, sunetid: 'esnowden') }

--- a/spec/features/consistent_titles_spec.rb
+++ b/spec/features/consistent_titles_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'Consistent titles' do
   before do

--- a/spec/features/create_collection_spec.rb
+++ b/spec/features/create_collection_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'Add collection' do
   before do

--- a/spec/features/date_range_form_spec.rb
+++ b/spec/features/date_range_form_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'Date range form', js: true do
   let(:query_params) { {} }

--- a/spec/features/enable_buttons_spec.rb
+++ b/spec/features/enable_buttons_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'Enable buttons' do
   before do

--- a/spec/features/filter_facet_spec.rb
+++ b/spec/features/filter_facet_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'More facet view', js: true do
   before do

--- a/spec/features/full_width_spec.rb
+++ b/spec/features/full_width_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'Full width' do
   before do

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'Home page' do
   before do

--- a/spec/features/indexer_backlog_spec.rb
+++ b/spec/features/indexer_backlog_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'Indexer Backlog status', js: true do
   before do

--- a/spec/features/item_catkey_change_spec.rb
+++ b/spec/features/item_catkey_change_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'Item catkey change' do
   before do

--- a/spec/features/item_manage_release_spec.rb
+++ b/spec/features/item_manage_release_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'Item manage release' do
   let(:current_user) { create(:user, sunetid: 'esnowden') }

--- a/spec/features/item_registration_spec.rb
+++ b/spec/features/item_registration_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'Item registration page', js: true do
   let(:user) { create(:user) }

--- a/spec/features/item_source_id_change_spec.rb
+++ b/spec/features/item_source_id_change_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'Item source id change' do
   before do

--- a/spec/features/item_view_metadata_spec.rb
+++ b/spec/features/item_view_metadata_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'Item view', js: true do
   before do

--- a/spec/features/profile_spec.rb
+++ b/spec/features/profile_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'Profile' do
   before do

--- a/spec/features/release_history_spec.rb
+++ b/spec/features/release_history_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'Release history', js: true do
   before do

--- a/spec/features/report_view_spec.rb
+++ b/spec/features/report_view_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'Report view' do
   before do

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -1,7 +1,7 @@
 # coding: utf-8
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'Search results' do
   before do

--- a/spec/features/set_governing_apo_spec.rb
+++ b/spec/features/set_governing_apo_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'Set governing APO' do
   let(:groups) { ['sdr:administrator-role', 'dlss:dor-admin', 'dlss:developers'] }

--- a/spec/features/status_spec.rb
+++ b/spec/features/status_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'application and dependency monitoring' do
   it '/status checks if Rails app is running' do

--- a/spec/features/view_switcher_spec.rb
+++ b/spec/features/view_switcher_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'View switcher' do
   before do

--- a/spec/features/workflow_service_creation_spec.rb
+++ b/spec/features/workflow_service_creation_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'Workflow Service Creation' do
   let(:stub_workflow) { instance_double(Dor::Workflow::Response::Workflow, active_for?: false) }

--- a/spec/forms/apo_form_spec.rb
+++ b/spec/forms/apo_form_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe ApoForm do
   let(:instance) { described_class.new }

--- a/spec/forms/collection_form_spec.rb
+++ b/spec/forms/collection_form_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe CollectionForm do
   let(:instance) { described_class.new }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe ApplicationHelper do
   describe '#views_to_switch' do

--- a/spec/helpers/argo_helper_spec.rb
+++ b/spec/helpers/argo_helper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe ArgoHelper, type: :helper do
   describe '#render_buttons' do

--- a/spec/helpers/bulk_action_helper_spec.rb
+++ b/spec/helpers/bulk_action_helper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe BulkActionHelper do
   describe '#render_bulk_action_type' do

--- a/spec/helpers/items_helper_spec.rb
+++ b/spec/helpers/items_helper_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 describe ItemsHelper, type: :helper do
   let(:mods_xml) do
     '<mods:mods

--- a/spec/helpers/profile_helper_spec.rb
+++ b/spec/helpers/profile_helper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 describe ProfileHelper, type: :helper do
   describe '#show_pagination?' do

--- a/spec/helpers/registration_helper_spec.rb
+++ b/spec/helpers/registration_helper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 describe RegistrationHelper do
   describe '#apo_list' do

--- a/spec/helpers/spec_helper_spec.rb
+++ b/spec/helpers/spec_helper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'instantiate_fixture' do
   it 'can find fedora_conf documents by druid' do

--- a/spec/helpers/value_helper_spec.rb
+++ b/spec/helpers/value_helper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe ValueHelper do
   let(:document) { SolrDocument.new(document_attributes) }

--- a/spec/helpers/workflow_helper_spec.rb
+++ b/spec/helpers/workflow_helper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 describe WorkflowHelper, type: :helper do
   describe '#render_workflow_reset_link' do

--- a/spec/integration/apo_spec.rb
+++ b/spec/integration/apo_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'apo', type: :request, js: true do
   let(:user) { create(:user) }

--- a/spec/integration/item_displays_spec.rb
+++ b/spec/integration/item_displays_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'mods_view', type: :request do
   let(:object) { instantiate_fixture('druid_zt570tx3016', Dor::Item) }

--- a/spec/jobs/descmetadata_download_job_spec.rb
+++ b/spec/jobs/descmetadata_download_job_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 require 'fileutils'
 
 describe DescmetadataDownloadJob, type: :job do

--- a/spec/jobs/generic_job_spec.rb
+++ b/spec/jobs/generic_job_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 class GenericTestJob < GenericJob
   def perform(_bulk_action_id, _params)

--- a/spec/jobs/manage_catkey_job_spec.rb
+++ b/spec/jobs/manage_catkey_job_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe ManageCatkeyJob do
   let(:bulk_action_no_process_callback) do

--- a/spec/jobs/modsulator_job_spec.rb
+++ b/spec/jobs/modsulator_job_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 require 'fileutils'
 
 describe ModsulatorJob, type: :job do

--- a/spec/jobs/release_object_job_spec.rb
+++ b/spec/jobs/release_object_job_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe ReleaseObjectJob do
   describe '#perform' do

--- a/spec/jobs/remote_indexing_job_spec.rb
+++ b/spec/jobs/remote_indexing_job_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 describe RemoteIndexingJob do
   let(:bulk_action_no_process_callback) do

--- a/spec/jobs/set_governing_apo_job_spec.rb
+++ b/spec/jobs/set_governing_apo_job_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe SetGoverningApoJob do
   let(:bulk_action_no_process_callback) do

--- a/spec/lib/argo/indexer_spec.rb
+++ b/spec/lib/argo/indexer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe Argo::Indexer do
   let(:mock_pid) { 'druid:aa111bb2222' }

--- a/spec/lib/constants_spec.rb
+++ b/spec/lib/constants_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe Constants do
   it 'has correct CONTENT_TYPES defined' do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 require 'cancan/matchers'
 
 describe Ability do

--- a/spec/models/argo/ability_spec.rb
+++ b/spec/models/argo/ability_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe Argo::Ability do
   subject(:ability) { described_class }

--- a/spec/models/bulk_action_spec.rb
+++ b/spec/models/bulk_action_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe BulkAction do
   describe 'valid action_types' do

--- a/spec/models/concerns/apo_concern_spec.rb
+++ b/spec/models/concerns/apo_concern_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 describe ApoConcern do
   let(:document) { SolrDocument.new(document_attributes) }

--- a/spec/models/concerns/catkey_concern_spec.rb
+++ b/spec/models/concerns/catkey_concern_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 describe CatkeyConcern do
   let(:document) { SolrDocument.new(document_attributes) }

--- a/spec/models/concerns/collection_concern_spec.rb
+++ b/spec/models/concerns/collection_concern_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 describe CollectionConcern do
   let(:document) { SolrDocument.new(document_attributes) }

--- a/spec/models/concerns/document_date_concern_spec.rb
+++ b/spec/models/concerns/document_date_concern_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe DocumentDateConcern do
   let(:document) { SolrDocument.new(document_attributes) }

--- a/spec/models/concerns/druid_concern_spec.rb
+++ b/spec/models/concerns/druid_concern_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 describe DruidConcern do
   let(:document) { SolrDocument.new(document_attributes) }

--- a/spec/models/concerns/embargo_concern_spec.rb
+++ b/spec/models/concerns/embargo_concern_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe EmbargoConcern do
   let(:document) { SolrDocument.new(document_attributes) }

--- a/spec/models/concerns/object_type_concern_spec.rb
+++ b/spec/models/concerns/object_type_concern_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe ObjectTypeConcern do
   let(:document) { SolrDocument.new(document_attributes) }

--- a/spec/models/concerns/permitted_queries_spec.rb
+++ b/spec/models/concerns/permitted_queries_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe PermittedQueries do
   let(:user) { User.new(sunetid: 'test_user') }

--- a/spec/models/concerns/preservation_size_concern_spec.rb
+++ b/spec/models/concerns/preservation_size_concern_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe PreservationSizeConcern do
   let(:document) { SolrDocument.new(document_attributes) }

--- a/spec/models/concerns/title_concern_spec.rb
+++ b/spec/models/concerns/title_concern_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 describe TitleConcern do
   let(:document) { SolrDocument.new(document_attributes) }

--- a/spec/models/dor_object_workflow_status_spec.rb
+++ b/spec/models/dor_object_workflow_status_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe DorObjectWorkflowStatus do
   subject { described_class.new(pid) }

--- a/spec/models/index_queue_spec.rb
+++ b/spec/models/index_queue_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 describe IndexQueue do
   subject { described_class.new }

--- a/spec/models/release_tag_spec.rb
+++ b/spec/models/release_tag_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 describe ReleaseTag do
   describe '#initialize' do

--- a/spec/models/release_tags_spec.rb
+++ b/spec/models/release_tags_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 describe ReleaseTags do
   let(:dor_object) { instantiate_fixture('druid:qq613vj0238') }

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe Report, type: :model do
   let(:user) { instance_double(User, is_admin?: true) }

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 describe SolrDocument, type: :model do
   describe 'get_milestones' do

--- a/spec/models/track_sheet_spec.rb
+++ b/spec/models/track_sheet_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe TrackSheet do
   let(:druid) { 'xb482bw3979' }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 # General documentation about roles and permissions is on SUL Consul at
 # https://consul.stanford.edu/display/chimera/Repository+Roles+and+Permissions

--- a/spec/models/view_switcher_spec.rb
+++ b/spec/models/view_switcher_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe ViewSwitcher do
   let(:view_switcher) { described_class.new(:cool_view, :cool_view_path) }

--- a/spec/models/workflow_status_spec.rb
+++ b/spec/models/workflow_status_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe WorkflowStatus do
   subject(:workflow_status) do

--- a/spec/presenters/home_text_presenter_spec.rb
+++ b/spec/presenters/home_text_presenter_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe HomeTextPresenter do
   let(:user) do

--- a/spec/presenters/workflow_presenter_spec.rb
+++ b/spec/presenters/workflow_presenter_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe WorkflowPresenter do
   subject(:presenter) do

--- a/spec/presenters/workflow_process_presenter_spec.rb
+++ b/spec/presenters/workflow_process_presenter_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe WorkflowProcessPresenter, type: :view do
   subject(:instance) { described_class.new(view: view, process_status: process_status) }

--- a/spec/presenters/workflow_xml_presenter_spec.rb
+++ b/spec/presenters/workflow_xml_presenter_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe WorkflowXmlPresenter do
   subject(:presenter) do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,0 +1,88 @@
+# This file is copied to spec/ when you run 'rails generate rspec:install'
+require 'spec_helper'
+ENV['RAILS_ENV'] ||= 'test'
+require File.expand_path('../../config/environment', __FILE__)
+# Prevent database truncation if the environment is production
+abort("The Rails environment is running in production mode!") if Rails.env.production?
+require 'rspec/rails'
+# Add additional requires below this line. Rails is not loaded until this point!
+require 'capybara/rails'
+require 'capybara/rspec'
+require 'equivalent-xml/rspec_matchers'
+require 'webmock/rspec'
+WebMock.allow_net_connect!(net_http_connect_on_start: true)
+
+require 'simplecov'
+SimpleCov.start do
+  add_filter '/spec/'
+  add_filter '/vendor/'
+end
+
+Capybara.register_driver :selenium_chrome_headless do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w(headless disable-gpu no-sandbox window-size=1280,1696) }
+  )
+  Capybara::Selenium::Driver.new app, browser: :chrome, desired_capabilities: capabilities
+end
+
+Capybara.javascript_driver = :selenium_chrome_headless
+
+
+# Requires supporting ruby files with custom matchers and macros, etc, in
+# spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
+# run as spec files by default. This means that files in spec/support that end
+# in _spec.rb will both be required and run as specs, causing the specs to be
+# run twice. It is recommended that you do not name files matching this glob to
+# end with _spec.rb. You can configure this pattern with the --pattern
+# option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
+#
+# The following line is provided for convenience purposes. It has the downside
+# of increasing the boot-up time by auto-requiring all files in the support
+# directory. Alternatively, in the individual `*_spec.rb` files, manually
+# require only the support files necessary.
+#
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+
+# Checks for pending migrations and applies them before tests are run.
+# If you are not using ActiveRecord, you can remove these lines.
+begin
+  ActiveRecord::Migration.maintain_test_schema!
+rescue ActiveRecord::PendingMigrationError => e
+  puts e.to_s.strip
+  exit 1
+end
+RSpec.configure do |config|
+  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
+  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+
+  # If you're not using ActiveRecord, or you'd prefer not to run each of your
+  # examples within a transaction, remove the following line or assign false
+  # instead of true.
+  config.use_transactional_fixtures = true
+
+  # RSpec Rails can automatically mix in different behaviours to your tests
+  # based on their file location, for example enabling you to call `get` and
+  # `post` in specs under `spec/controllers`.
+  #
+  # You can disable this behaviour by removing the line below, and instead
+  # explicitly tag your specs with their type, e.g.:
+  #
+  #     RSpec.describe UsersController, :type => :controller do
+  #       # ...
+  #     end
+  #
+  # The different available types are documented in the features, such as in
+  # https://relishapp.com/rspec/rspec-rails/docs
+  config.infer_spec_type_from_file_location!
+
+  # Filter lines from Rails gems in backtraces.
+  config.filter_rails_from_backtrace!
+  # arbitrary gems may also be filtered via:
+  # config.filter_gems_from_backtrace("gem name")
+
+
+  config.include Capybara::DSL
+  config.include TestViewHelpers, type: :view
+  config.include SigninHelper, type: :view
+  config.include Devise::Test::ControllerHelpers, type: :controller
+end

--- a/spec/routing/catalog_spec.rb
+++ b/spec/routing/catalog_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe CatalogController do
   describe 'routing' do

--- a/spec/routing/files_spec.rb
+++ b/spec/routing/files_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'Routing to files' do
   it 'routes to #index' do

--- a/spec/routing/profile_spec.rb
+++ b/spec/routing/profile_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe ReportController do
   describe 'routing' do

--- a/spec/routing/report_routing_spec.rb
+++ b/spec/routing/report_routing_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe ReportController do
   describe 'routing' do

--- a/spec/routing/workflows_spec.rb
+++ b/spec/routing/workflows_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe WorkflowsController do
   describe 'routing' do

--- a/spec/search_builders/argo/access_controls_enforcement_spec.rb
+++ b/spec/search_builders/argo/access_controls_enforcement_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 class TestClass
   include Argo::AccessControlsEnforcement

--- a/spec/search_builders/argo/date_field_queries_spec.rb
+++ b/spec/search_builders/argo/date_field_queries_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 ##
 # Fake class for testing module

--- a/spec/search_builders/argo/profile_queries_spec.rb
+++ b/spec/search_builders/argo/profile_queries_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 class TestClass
   include Argo::ProfileQueries

--- a/spec/search_builders/search_builder_spec.rb
+++ b/spec/search_builders/search_builder_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe SearchBuilder do
   subject { search_builder.with(user_params) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,33 +1,5 @@
 # frozen_string_literal: true
 
-ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../../config/environment', __FILE__)
-require 'rspec/rails'
-require 'capybara/rails'
-require 'capybara/rspec'
-require 'equivalent-xml/rspec_matchers'
-require 'webmock/rspec'
-WebMock.allow_net_connect!(net_http_connect_on_start: true)
-
-require 'simplecov'
-SimpleCov.start do
-  add_filter '/spec/'
-  add_filter '/vendor/'
-end
-
-Capybara.register_driver :selenium_chrome_headless do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w(headless disable-gpu no-sandbox window-size=1280,1696) }
-  )
-  Capybara::Selenium::Driver.new app, browser: :chrome, desired_capabilities: capabilities
-end
-
-Capybara.javascript_driver = :selenium_chrome_headless
-
-# Requires supporting ruby files with custom matchers and macros, etc,
-# in spec/support/ and its subdirectories.
-Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
-
 def druid_to_path(druid, flavor = 'xml')
   fixture_mask = File.join(File.dirname(__FILE__), 'fixtures', "*_#{druid.sub(/:/, '_')}.#{flavor}")
   other_mask   = Rails.root.join('fedora_conf', 'data', "#{druid.sub(/druid:/, '')}.#{flavor}")
@@ -48,30 +20,8 @@ def instantiate_fixture(druid, klass = ActiveFedora::Base)
   end
 end
 
-# Checks for pending migrations before tests are run.
-# If you are not using ActiveRecord, you can remove this line.
-ActiveRecord::Migration.maintain_test_schema!
-
 RSpec.configure do |config|
   config.order = :random
-
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
-  # Run each example in an ActiveRecord transaction
-  config.use_transactional_fixtures = true
-
-  # If true, the base class of anonymous controllers will be inferred
-  # automatically. This will be the default behavior in future versions of
-  # rspec-rails.
-  config.infer_base_class_for_anonymous_controllers = false
-  config.include Capybara::DSL
-
-  config.infer_spec_type_from_file_location!
-
-  config.include TestViewHelpers, type: :view
-  config.include SigninHelper, type: :view
-  config.include Devise::Test::ControllerHelpers, type: :controller
 end
 
 # Highly similar to https://github.com/sul-dlss/dor-services/blob/master/spec/foxml_helper.rb

--- a/spec/views/_user_util_links.html.erb_spec.rb
+++ b/spec/views/_user_util_links.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 describe '_user_util_links.html.erb' do
   before do

--- a/spec/views/auth/groups.html.erb_spec.rb
+++ b/spec/views/auth/groups.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'auth/groups.html.erb' do
   before do

--- a/spec/views/bulk_actions/_form.html.erb_spec.rb
+++ b/spec/views/bulk_actions/_form.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'bulk_actions/_form.html.erb' do
   let(:user_groups) { ['dlss-developers', 'top-secret-clearance'] }

--- a/spec/views/bulk_jobs/_bulk_index_table.html.erb_spec.rb
+++ b/spec/views/bulk_jobs/_bulk_index_table.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'bulk_jobs/_bulk_index_table.html.erb' do
   let(:bulk_jobs) do

--- a/spec/views/catalog/_contents_default.html.erb_spec.rb
+++ b/spec/views/catalog/_contents_default.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'catalog/_contents_default.html.erb', type: :view do
   context 'with files' do

--- a/spec/views/catalog/_home_text.html.erb_spec.rb
+++ b/spec/views/catalog/_home_text.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'catalog/_home_text.html.erb' do
   before do

--- a/spec/views/catalog/_show_embargo_sidebar.html.erb_spec.rb
+++ b/spec/views/catalog/_show_embargo_sidebar.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'catalog/_show_embargo_sidebar.html.erb' do
   before do

--- a/spec/views/catalog/_show_external_links.html.erb_spec.rb
+++ b/spec/views/catalog/_show_external_links.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'catalog/_show_external_links.html.erb' do
   let(:document) do

--- a/spec/views/catalog/_show_releases.html.erb_spec.rb
+++ b/spec/views/catalog/_show_releases.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'catalog/_show_releases.html.erb' do
   let(:release_tags) do

--- a/spec/views/catalog/_show_sections/_default_contents_external_file.html.erb_spec.rb
+++ b/spec/views/catalog/_show_sections/_default_contents_external_file.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'catalog/_show_sections/default_contents_external_file.html.erb', type: :view do
   it 'is silent if no resources' do

--- a/spec/views/catalog/_show_sections/_file.html.erb_spec.rb
+++ b/spec/views/catalog/_show_sections/_file.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'catalog/_show_sections/file.html.erb', type: :view do
   before do

--- a/spec/views/catalog/dc.html.erb_spec.rb
+++ b/spec/views/catalog/dc.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'catalog/dc.html.erb' do
   let(:object_client) { instance_double(Dor::Services::Client::Object, metadata: metadata) }

--- a/spec/views/catalog/ds.html.erb_spec.rb
+++ b/spec/views/catalog/ds.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'catalog/ds.html.erb' do
   let(:dsid) { 'identityMetadata' }

--- a/spec/views/catalog/show.html.erb_spec.rb
+++ b/spec/views/catalog/show.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'catalog/show.html.erb' do
   let(:document) { SolrDocument.new id: 'xyz', format: 'a' }

--- a/spec/views/collections/new.html.erb_spec.rb
+++ b/spec/views/collections/new.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'collections/new.html.erb', type: :view do
   it 'renders the HTML template form' do

--- a/spec/views/content_types/_content_type.html.erb_spec.rb
+++ b/spec/views/content_types/_content_type.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'content_types/_content_type.html.erb' do
   let(:content_metadata) do

--- a/spec/views/content_types/show.html.erb_spec.rb
+++ b/spec/views/content_types/show.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'content_types/show.html.erb' do
   it 'renders the template' do

--- a/spec/views/files/index.html.erb_spec.rb
+++ b/spec/views/files/index.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'files/index.html.erb' do
   let(:contentMetadata) do

--- a/spec/views/items/_button_link_list.html.erb_spec.rb
+++ b/spec/views/items/_button_link_list.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'items/_button_link_list.html.erb' do
   let(:buttons) do

--- a/spec/views/items/_close_version_ui.html.erb_spec.rb
+++ b/spec/views/items/_close_version_ui.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'items/_close_version_ui.html.erb' do
   let(:object) { double('object', pid: 'druid:abc123') }

--- a/spec/views/items/_collection_ui.html.erb_spec.rb
+++ b/spec/views/items/_collection_ui.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'items/_collection_ui.html.erb' do
   let(:collection) do

--- a/spec/views/items/_embargo_form.html.erb_spec.rb
+++ b/spec/views/items/_embargo_form.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'items/_embargo_form.html.erb' do
   let(:current_user) { mock_user(is_admin?: true) }

--- a/spec/views/items/_open_version_ui.html.erb_spec.rb
+++ b/spec/views/items/_open_version_ui.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'items/_open_version_ui.html.erb' do
   let(:object) { double('object', pid: 'druid:abc123') }

--- a/spec/views/items/_purl_preview.html.erb_spec.rb
+++ b/spec/views/items/_purl_preview.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'items/_purl_preview.html.erb' do
   let(:mods_display) { double('mods', body: 'Cool Catz') }

--- a/spec/views/items/_rights.html.erb_spec.rb
+++ b/spec/views/items/_rights.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'items/_rights.html.erb' do
   let(:object) { double('object', pid: 'druid:abc123') }

--- a/spec/views/items/_set_governing_apo_ui.html.erb_spec.rb
+++ b/spec/views/items/_set_governing_apo_ui.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'items/_set_governing_apo_ui.html.erb' do
   let(:object) { double(Dor::Item, pid: 'druid:987', admin_policy_object: cur_apo) }

--- a/spec/views/items/_source_id_ui.html.erb_spec.rb
+++ b/spec/views/items/_source_id_ui.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'items/_source_id_ui.html.erb' do
   let(:identity_metadata) { double('idmd', sourceId: 'source id') }

--- a/spec/views/items/_tags_ui.html.erb_spec.rb
+++ b/spec/views/items/_tags_ui.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'items/_tags_ui.html.erb' do
   let(:object) do

--- a/spec/views/items/close_version_ui.html.erb_spec.rb
+++ b/spec/views/items/close_version_ui.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'items/close_version_ui.html.erb' do
   it 'renders the JS template' do

--- a/spec/views/items/collection_ui.html.erb_spec.rb
+++ b/spec/views/items/collection_ui.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'items/collection_ui.html.erb' do
   it 'renders the JS template' do

--- a/spec/views/items/embargo_form.html.erb_spec.rb
+++ b/spec/views/items/embargo_form.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'items/embargo_form.html.erb' do
   it 'renders the JS template' do

--- a/spec/views/items/file.html.erb_spec.rb
+++ b/spec/views/items/file.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'items/file.html.erb' do
   it 'renders the JS template' do

--- a/spec/views/items/open_version_ui.html.erb_spec.rb
+++ b/spec/views/items/open_version_ui.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'items/open_version_ui.html.erb' do
   it 'renders the JS template' do

--- a/spec/views/items/purl_preview.html.erb_spec.rb
+++ b/spec/views/items/purl_preview.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'items/purl_preview.html.erb' do
   let(:mods_display) { double('mods', title: ['Cool Catz']) }

--- a/spec/views/items/rights.html.erb_spec.rb
+++ b/spec/views/items/rights.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'items/rights.html.erb' do
   it 'renders the JS template' do

--- a/spec/views/items/set_governing_apo_ui.html.erb_spec.rb
+++ b/spec/views/items/set_governing_apo_ui.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'items/set_governing_apo_ui.html.erb' do
   it 'renders the JS template' do

--- a/spec/views/items/source_id_ui.html.erb_spec.rb
+++ b/spec/views/items/source_id_ui.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'items/source_id_ui.html.erb' do
   it 'renders the JS template' do

--- a/spec/views/items/tags_ui.html.erb_spec.rb
+++ b/spec/views/items/tags_ui.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'items/tags_ui.html.erb' do
   it 'renders the JS template' do

--- a/spec/views/report/workflow_grid_spec.erb_spec.rb
+++ b/spec/views/report/workflow_grid_spec.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'report/workflow_grid', type: :view do
   let(:blacklight_config) { ReportController.blacklight_config }

--- a/spec/views/uploads/new.html.erb_spec.rb
+++ b/spec/views/uploads/new.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'uploads/new.html.erb', type: :view do
   before do

--- a/spec/views/workflows/_history.html.erb_spec.rb
+++ b/spec/views/workflows/_history.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'workflows/_history.html.erb' do
   it 'renders the partial content' do

--- a/spec/views/workflows/_new.html.erb_spec.rb
+++ b/spec/views/workflows/_new.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'workflows/_new.html.erb' do
   it 'renders the partial content' do

--- a/spec/views/workflows/_show.html.erb_spec.rb
+++ b/spec/views/workflows/_show.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'workflows/_show.html.erb' do
   let(:druid) { 'druid:aa111bb2222' }

--- a/spec/views/workflows/history.html.erb_spec.rb
+++ b/spec/views/workflows/history.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'workflows/history.html.erb' do
   it 'renders the HS template' do

--- a/spec/views/workflows/new.html.erb_spec.rb
+++ b/spec/views/workflows/new.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'workflows/new.html.erb' do
   it 'renders the JS template' do

--- a/spec/views/workflows/show.html.erb_spec.rb
+++ b/spec/views/workflows/show.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe 'workflows/show.html.erb' do
   it 'renders the JS template' do


### PR DESCRIPTION
This was the default in rspec-rails 3, so it helps argo to be consistent with other
rails apps using rspec-rails