### PR TITLE
Remove useless workflow_priority parameter

### DIFF
--- a/app/forms/apo_form.rb
+++ b/app/forms/apo_form.rb
@@ -208,7 +208,6 @@ class ApoForm < BaseForm
   # @return [Hash] the parameters used to register an apo. Must be called after `validate`
   def register_params
     {
-      workflow_priority: '70',
       label: params[:title],
       object_type: 'adminPolicy',
       admin_policy: SolrDocument::UBER_APO_ID

--- a/app/forms/collection_form.rb
+++ b/app/forms/collection_form.rb
@@ -46,7 +46,6 @@ class CollectionForm < BaseForm
   # @return [Hash] the parameters used to register an apo. Must be called after `validate`
   def register_params
     reg_params = {
-      workflow_priority: '65',
       object_type: 'collection',
       admin_policy: params[:apo_pid]
     }

--- a/spec/forms/apo_form_spec.rb
+++ b/spec/forms/apo_form_spec.rb
@@ -302,8 +302,7 @@ RSpec.describe ApoForm do
           expect(args[:params]).to match a_hash_including(
             label: 'New APO Title',
             object_type: 'adminPolicy',
-            admin_policy: 'druid:hv992ry2431', # Uber-APO
-            workflow_priority: '70'
+            admin_policy: 'druid:hv992ry2431' # Uber-APO
           )
           expect(args[:metadata_source]).to be_nil # descMD is created via the form
           { pid: apo.pid }
@@ -316,8 +315,7 @@ RSpec.describe ApoForm do
           expect(args[:params]).to match a_hash_including(
             label: 'col title',
             object_type: 'collection',
-            admin_policy: apo.pid,
-            workflow_priority: '65'
+            admin_policy: apo.pid
           )
           { pid: collection.pid }
         end


### PR DESCRIPTION
This parameter was being passed to the registration service, but the registration service does not start the workflow