### PR TITLE
Use capybara :selenium_chrome_headless built-in driver definition

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,7 +6,6 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
-require 'capybara/rails'
 require 'capybara/rspec'
 require 'equivalent-xml/rspec_matchers'
 require 'webmock/rspec'
@@ -17,16 +16,6 @@ SimpleCov.start do
   add_filter '/spec/'
   add_filter '/vendor/'
 end
-
-Capybara.register_driver :selenium_chrome_headless do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w(headless disable-gpu no-sandbox window-size=1280,1696) }
-  )
-  Capybara::Selenium::Driver.new app, browser: :chrome, desired_capabilities: capabilities
-end
-
-Capybara.javascript_driver = :selenium_chrome_headless
-
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/support/selenium_webdriver.rb
+++ b/spec/support/selenium_webdriver.rb
@@ -1,0 +1,16 @@
+require 'capybara/rails'
+
+Capybara.javascript_driver = :headless_chrome
+
+Capybara.register_driver :headless_chrome do |app|
+  Capybara::Selenium::Driver.load_selenium
+  browser_options = ::Selenium::WebDriver::Chrome::Options.new.tap do |opts|
+    opts.args << '--headless'
+    opts.args << '--disable-gpu'
+    # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
+    opts.args << '--disable-site-isolation-trials'
+    opts.args << '--no-sandbox'
+    opts.args << '--window-size=1280,1696'
+  end
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
+end


### PR DESCRIPTION
Instead of trying to define our own with custom settings. Figure the one built into capybara is probably set up right.

Trying this due to recent failures around chromedriver/webdrivers in travis. In some of my other projects, they have had no problems with the recently released new version of chrome/chromedriver. I am thinking possibly because they use :selenium_chrome_headless instead of defining custom driver configuration.

Cherry-pick from https://github.com/projectblacklight/blacklight/pull/2110