### PR TITLE
Avoid an extra Fedora lookup

### DIFF
--- a/app/controllers/bulk_jobs_controller.rb
+++ b/app/controllers/bulk_jobs_controller.rb
@@ -5,9 +5,9 @@ class BulkJobsController < ApplicationController
   # Generates the index page for a given DRUID's past bulk metadata upload jobs.
   def index
     params[:apo_id] = 'druid:' + params[:apo_id] unless params[:apo_id].include? 'druid'
-    @obj = Dor.find params[:apo_id]
+    @object = Dor.find params[:apo_id]
 
-    authorize! :view_metadata, @obj
+    authorize! :view_metadata, @object
     @document = find(params[:apo_id])
     @bulk_jobs = load_bulk_jobs(params[:apo_id])
   end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -183,8 +183,8 @@ class CatalogController < ApplicationController
 
   def show
     params[:id] = 'druid:' + params[:id] unless params[:id].include? 'druid'
-    @obj = Dor.find params[:id]
-    authorize! :view_metadata, @obj
+    @object = Dor.find params[:id]
+    authorize! :view_metadata, @object
     super() # with or without an APO, if we get here, user is authorized to view
   end
 

--- a/app/helpers/argo_helper.rb
+++ b/app/helpers/argo_helper.rb
@@ -58,11 +58,10 @@ module ArgoHelper
   # first anyway.
   #
   # @param [SolrDocument] doc
+  # @param [Dor::Item] object
   # @return [Array]
-  def render_buttons(doc, object = nil)
-    pid = doc['id']
-    object ||= Dor.find(pid)
-
+  def render_buttons(doc, object)
+    pid = doc.id
     apo_pid = doc.apo_pid
 
     buttons = []

--- a/app/views/bulk_jobs/index.html.erb
+++ b/app/views/bulk_jobs/index.html.erb
@@ -1,4 +1,4 @@
-<% @page_title = "Bulk Uploads for APO #{@obj.id}" %>
+<% @page_title = "Bulk Uploads for APO #{@object.id}" %>
 <% content_for(:head) { show_presenter(@document).link_rel_alternates } -%>
 <div id="sidebar" class="col-md-3 col-sm-4">
   <%= render_document_sidebar_partial %>

--- a/app/views/catalog/_show_external_links.html.erb
+++ b/app/views/catalog/_show_external_links.html.erb
@@ -1,5 +1,3 @@
-<% document ||= @document %>
-
 <div class="show_sidebar">
   <h3 class="start-open">View in new window</h3>
   <ul class='nav nav-stacked'>
@@ -15,5 +13,5 @@
     <li><small><%= render_index_info document %></small></li>
   </ul>
   <hr>
-  <%= render(:partial => 'items/button_link_list', :locals => {:buttons => (render_buttons document, @obj)})%>
+  <%= render(:partial => 'items/button_link_list', :locals => {:buttons => (render_buttons document, object)})%>
 </div>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -16,7 +16,7 @@
   <div id="document" class="<%= render_document_class %>">
     <div id="doc_<%= @document.id.to_s.parameterize %>">
       <div class="document">
-        <%= render_document_partials @document, blacklight_config.view_config(:show).partials, object: @obj, document_counter: 0 %>
+        <%= render_document_partials @document, blacklight_config.view_config(:show).partials, object: @object, document_counter: 0 %>
       </div>
     </div>
   </div>

--- a/spec/helpers/argo_helper_spec.rb
+++ b/spec/helpers/argo_helper_spec.rb
@@ -13,31 +13,30 @@ RSpec.describe ArgoHelper, type: :helper do
                       roles: false)
     end
 
+    let(:item_id) { 'druid:kv840rx2720' }
+    let(:object) { instantiate_fixture(item_id, Dor::Item) }
+    let(:governing_apo_id) { 'druid:hv992ry2431' }
+    let(:doc) { SolrDocument.new('id' => item_id, SolrDocument::FIELD_APO_ID => [governing_apo_id]) }
+
     before do
-      @item_id = 'druid:kv840rx2720'
-      @governing_apo_id = 'druid:hv992ry2431'
-      @object = instantiate_fixture(@item_id, Dor::Item)
-      @doc = SolrDocument.new('id' => @item_id, SolrDocument::FIELD_APO_ID => [@governing_apo_id])
       allow(Dor::Config.workflow.client).to receive(:active_lifecycle).and_return(true)
       allow(Dor::Config.workflow.client).to receive(:lifecycle).and_return(true)
       allow(controller).to receive(:current_user).and_return(user)
       allow(helper).to receive(:current_user).and_return(user)
-      allow(@object).to receive(:allows_modification?).and_return(true)
-      allow(@object).to receive(:pid).and_return(@item_id)
+      allow(object).to receive(:allows_modification?).and_return(true)
+      allow(object).to receive(:pid).and_return(item_id)
       desc_md = double(Dor::DescMetadataDS)
       @id_md = double(Dor::IdentityMetadataDS)
-      governing_apo = double(Dor::AdminPolicyObject)
+      governing_apo = double(Dor::AdminPolicyObject, pid: governing_apo_id)
       allow(desc_md).to receive(:new?).and_return(true)
       allow(@id_md).to receive(:otherId).with('catkey').and_return([])
       allow(@id_md).to receive(:ng_xml).and_return(Nokogiri::XML('<identityMetadata><identityMetadata>'))
-      allow(governing_apo).to receive(:pid).and_return(@governing_apo_id)
       # nil datastreams don't need content for these tests, they just need to be present
       datastreams = { 'contentMetadata' => nil, 'rightsMetadata' => nil, 'descMetadata' => desc_md, 'identityMetadata' => @id_md }
-      allow(@object).to receive(:datastreams).and_return(datastreams)
-      allow(@object).to receive(:admin_policy_object).and_return(governing_apo)
-      allow(Dor).to receive(:find).with(@item_id).and_return(@object)
-      allow(helper).to receive(:registered_only?).with(@doc).and_return(false)
-      allow(@object).to receive(:embargoed?).and_return(false)
+      allow(object).to receive(:datastreams).and_return(datastreams)
+      allow(object).to receive(:admin_policy_object).and_return(governing_apo)
+      allow(helper).to receive(:registered_only?).with(doc).and_return(false)
+      allow(object).to receive(:embargoed?).and_return(false)
     end
 
     context 'a Dor::Item the user can manage, with the usual data streams, and no catkey or embargo info' do
@@ -45,74 +44,74 @@ RSpec.describe ArgoHelper, type: :helper do
         [
           {
             label: 'Close Version',
-            url: "/items/#{@item_id}/close_version_ui",
-            check_url: "/workflow_service/#{@item_id}/closeable"
+            url: "/items/#{item_id}/close_version_ui",
+            check_url: "/workflow_service/#{item_id}/closeable"
           },
           {
             label: 'Open for modification',
-            url: "/items/#{@item_id}/open_version_ui",
-            check_url: "/workflow_service/#{@item_id}/openable"
+            url: "/items/#{item_id}/open_version_ui",
+            check_url: "/workflow_service/#{item_id}/openable"
           },
           {
             label: 'Reindex',
-            url: "/dor/reindex/#{@item_id}",
+            url: "/dor/reindex/#{item_id}",
             new_page: true
           },
           {
             label: 'Set governing APO',
-            url: "/items/#{@item_id}/set_governing_apo_ui",
+            url: "/items/#{item_id}/set_governing_apo_ui",
             disabled: false
           },
           {
             label: 'Add workflow',
-            url: new_item_workflow_path(@item_id)
+            url: new_item_workflow_path(item_id)
           },
           {
             label: 'Republish',
-            url: "/dor/republish/#{@item_id}",
-            check_url: "/workflow_service/#{@item_id}/published",
+            url: "/dor/republish/#{item_id}",
+            check_url: "/workflow_service/#{item_id}/published",
             new_page: true
           },
           {
             label: 'Purge',
-            url: "/items/#{@item_id}/purge",
+            url: "/items/#{item_id}/purge",
             new_page: true,
             confirm: 'This object will be permanently purged from DOR. This action cannot be undone. Are you sure?',
             disabled: true
           },
           {
             label: 'Change source id',
-            url: "/items/#{@item_id}/source_id_ui"
+            url: "/items/#{item_id}/source_id_ui"
           },
           {
             label: 'Manage catkey',
-            url: "/items/#{@item_id}/catkey_ui"
+            url: "/items/#{item_id}/catkey_ui"
           },
           {
             label: 'Edit tags',
-            url: "/items/#{@item_id}/tags_ui"
+            url: "/items/#{item_id}/tags_ui"
           },
           {
             label: 'Edit collections',
-            url: "/items/#{@item_id}/collection_ui"
+            url: "/items/#{item_id}/collection_ui"
           },
           {
             label: 'Set content type',
-            url: "/items/#{@item_id}/content_type"
+            url: "/items/#{item_id}/content_type"
           },
           {
             label: 'Set rights',
-            url: "/items/#{@item_id}/rights"
+            url: "/items/#{item_id}/rights"
           },
           {
             label: 'Manage release',
-            url: "/view/#{@item_id}/manage_release"
+            url: "/view/#{item_id}/manage_release"
           }
         ]
       end
 
       it 'creates a hash with the needed button info for an admin' do
-        buttons = helper.render_buttons(@doc)
+        buttons = helper.render_buttons(doc, object)
         default_buttons.each do |button|
           expect(buttons).to include(button)
         end
@@ -122,18 +121,18 @@ RSpec.describe ArgoHelper, type: :helper do
         allow(user).to receive(:is_admin?).and_return(false)
         allow(Argo::Ability).to receive(:can_manage_item?).and_return(true)
         allow(Argo::Ability).to receive(:can_manage_content?).and_return(true)
-        buttons = helper.render_buttons(@doc)
+        buttons = helper.render_buttons(doc, object)
         default_buttons.each do |button|
           expect(buttons).to include(button)
         end
         expect(buttons.length).to eq default_buttons.length
       end
       it 'only includes the embargo update button if the user is an admin and the object is embargoed' do
-        allow(@object).to receive(:embargoed?).and_return(true)
-        buttons = helper.render_buttons(@doc)
+        allow(object).to receive(:embargoed?).and_return(true)
+        buttons = helper.render_buttons(doc, object)
         default_buttons.push(
           label: 'Update embargo',
-          url: "/items/#{@item_id}/embargo_form"
+          url: "/items/#{item_id}/embargo_form"
         ).each do |button|
           expect(buttons).to include(button)
         end
@@ -141,19 +140,19 @@ RSpec.describe ArgoHelper, type: :helper do
       end
       it "does not generate errors given an object that has no associated APO and a user that can't manage the object" do
         allow(user).to receive(:is_admin?).and_return(false)
-        allow(@doc).to receive(:apo_pid).and_return(nil)
-        allow(@object).to receive(:admin_policy_object).and_return(nil)
+        allow(doc).to receive(:apo_pid).and_return(nil)
+        allow(object).to receive(:admin_policy_object).and_return(nil)
         allow(user).to receive(:roles).with(nil).and_return([])
-        buttons = helper.render_buttons(@doc)
+        buttons = helper.render_buttons(doc, object)
         expect(buttons).not_to be_nil
         expect(buttons.length).to eq 0
       end
       it 'includes the refresh descMetadata button for items with catkey' do
         allow(@id_md).to receive(:otherId).with('catkey').and_return(['1234567'])
-        buttons = helper.render_buttons(@doc)
+        buttons = helper.render_buttons(doc, object)
         default_buttons.push(
           label: 'Refresh descMetadata',
-          url: "/items/#{@item_id}/refresh_metadata",
+          url: "/items/#{item_id}/refresh_metadata",
           new_page: true,
           disabled: false
         ).each do |button|
@@ -233,11 +232,11 @@ RSpec.describe ArgoHelper, type: :helper do
       end
 
       it 'renders the appropriate default buttons for an apo' do
-        @object = instantiate_fixture(view_apo_id, Dor::AdminPolicyObject)
-        @doc = SolrDocument.new('id' => view_apo_id, SolrDocument::FIELD_APO_ID => [@governing_apo_id])
-        allow(Dor).to receive(:find).with(view_apo_id).and_return(@object)
-        allow(helper).to receive(:registered_only?).with(@doc).and_return(false)
-        buttons = helper.render_buttons(@doc)
+        object = instantiate_fixture(view_apo_id, Dor::AdminPolicyObject)
+        doc = SolrDocument.new('id' => view_apo_id, SolrDocument::FIELD_APO_ID => [governing_apo_id])
+        allow(Dor).to receive(:find).with(view_apo_id).and_return(object)
+        allow(helper).to receive(:registered_only?).with(doc).and_return(false)
+        buttons = helper.render_buttons(doc, object)
         default_buttons.each do |button|
           expect(buttons).to include(button)
         end

--- a/spec/views/catalog/_show_external_links.html.erb_spec.rb
+++ b/spec/views/catalog/_show_external_links.html.erb_spec.rb
@@ -8,17 +8,18 @@ describe 'catalog/_show_external_links.html.erb' do
   end
   let(:current_user) { mock_user }
 
+  let(:object) { instance_double(Dor::Item) }
+
   before do
     config = Blacklight::Configuration.new
     allow(view).to receive(:blacklight_config).and_return(config)
     allow(view).to receive(:current_user).and_return(current_user)
     allow(controller).to receive(:current_user).and_return(current_user)
-    assign(:document, document)
   end
 
   it 'renders link list' do
-    expect(view).to receive(:render_buttons).and_return({})
-    render
+    expect(view).to receive(:render_buttons).with(document, object).and_return({})
+    render 'catalog/show_external_links', document: document, object: object
     expect(rendered).to have_css '.show_sidebar'
     expect(rendered).to have_css 'ul.nav.nav-stacked'
     expect(rendered).to have_css 'li', count: 6


### PR DESCRIPTION
Pass the looked up object to render_buttons().  Previously it was passing an undefined ivar