### PR TITLE
Add Earthworks as a release tag target

### DIFF
--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -12,6 +12,7 @@ module Constants
   RESOURCE_TYPES = %w(image page file audio video document 3d).freeze
 
   RELEASE_TARGETS = [
-    %w(Searchworks Searchworks)
+    %w(Searchworks Searchworks),
+    %w(Earthworks Earthworks)
   ].freeze
 end


### PR DESCRIPTION
This PR adds `Earthworks` as a target for release tags. Content will not be indexed to EarthWorks until this functionality is "turned on" by the access team.