### PR TITLE
Extract BulkActionsPersister from BulkActions

### DIFF
--- a/app/controllers/bulk_actions_controller.rb
+++ b/app/controllers/bulk_actions_controller.rb
@@ -23,7 +23,8 @@ class BulkActionsController < ApplicationController
       bulk_action_params.merge(user: current_user, groups: current_user.groups, pids: pids_with_prefix(bulk_action_params[:pids]))
     )
 
-    if @bulk_action.save
+    if BulkActionPersister.persist(@bulk_action)
+
       redirect_to action: :index, notice: 'Bulk action was successfully created.'
     else
       render :new

--- a/app/models/bulk_action.rb
+++ b/app/models/bulk_action.rb
@@ -3,11 +3,6 @@
 class BulkAction < ApplicationRecord
   belongs_to :user
   validates :action_type, inclusion: { in: %w(GenericJob DescmetadataDownloadJob ReleaseObjectJob RemoteIndexingJob SetGoverningApoJob ManageCatkeyJob) }
-  after_create do
-    create_output_directory
-    create_log_file
-    process_bulk_action_type
-  end
   before_destroy :remove_output_directory
 
   # A virtual attribute used for job creation but not persisted
@@ -24,47 +19,17 @@ class BulkAction < ApplicationRecord
     update_attribute(:druid_count_total, 0)
   end
 
+  def output_directory
+    File.join(Settings.BULK_METADATA.DIRECTORY, prefix)
+  end
+
   private
 
   def prefix
     "#{action_type}_#{id}"
   end
 
-  def output_directory
-    File.join(Settings.BULK_METADATA.DIRECTORY, prefix)
-  end
-
-  def create_log_file
-    log_filename = file(Settings.BULK_METADATA.LOG)
-    FileUtils.touch(log_filename)
-    update_attribute(:log_name, log_filename)
-  end
-
-  def create_output_directory
-    FileUtils.mkdir_p(output_directory) unless File.directory?(output_directory)
-  end
-
   def remove_output_directory
     FileUtils.rm_rf(output_directory)
-  end
-
-  ##
-  # Returns a Hash of custom params that were sent through on initialization of
-  # class, but aren't persisted and need to be passed to job.
-  # @return [Hash]
-  def job_params
-    {
-      pids: pids.split,
-      output_directory: output_directory,
-      manage_release: manage_release,
-      set_governing_apo: set_governing_apo,
-      manage_catkeys: manage_catkeys,
-      groups: groups
-    }
-  end
-
-  def process_bulk_action_type
-    action_type.constantize.perform_later(id, job_params)
-    update_attribute(:status, 'Scheduled Action')
   end
 end

--- a/app/services/bulk_action_persister.rb
+++ b/app/services/bulk_action_persister.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class BulkActionPersister
+  def self.persist(bulk_action)
+    new(bulk_action).persist
+  end
+
+  def initialize(bulk_action)
+    @bulk_action = bulk_action
+  end
+
+  def persist
+    return unless bulk_action.save
+
+    create_output_directory
+    create_log_file
+    process_bulk_action_type
+    true
+  end
+
+  private
+
+  attr_reader :bulk_action
+  delegate :id, :file, :pids, :output_directory, :manage_release, :set_governing_apo,
+           :manage_catkeys, :groups, to: :bulk_action
+
+  def create_log_file
+    log_filename = file(Settings.BULK_METADATA.LOG)
+    FileUtils.touch(log_filename)
+    bulk_action.update(log_name: log_filename)
+  end
+
+  def create_output_directory
+    FileUtils.mkdir_p(output_directory) unless File.directory?(output_directory)
+  end
+
+  def process_bulk_action_type
+    active_job_class.perform_later(id, job_params)
+    bulk_action.update(status: 'Scheduled Action')
+  end
+
+  def active_job_class
+    bulk_action.action_type.constantize
+  end
+
+  ##
+  # Returns a Hash of custom params that were sent through on initialization of
+  # class, but aren't persisted and need to be passed to job.
+  # @return [Hash]
+  def job_params
+    {
+      pids: pids.split,
+      output_directory: output_directory,
+      manage_release: manage_release,
+      set_governing_apo: set_governing_apo,
+      manage_catkeys: manage_catkeys,
+      groups: groups
+    }
+  end
+end

--- a/spec/controllers/bulk_actions_controller_spec.rb
+++ b/spec/controllers/bulk_actions_controller_spec.rb
@@ -83,8 +83,7 @@ RSpec.describe BulkActionsController do
       it 'assigns @bulk_action with catkeys passed in from form' do
         post :create, params: { bulk_action: { action_type: 'ManageCatkeyJob', pids: '', 'manage_catkeys[catkeys]' => "1234\n5678" } }
         expect(assigns(:bulk_action)).to be_an BulkAction
-        expect(assigns(:bulk_action).send(:job_params)).to be_an Hash
-        expect(assigns(:bulk_action).send(:job_params)).to include(manage_catkeys: { 'catkeys' => "1234\n5678" })
+        expect(assigns(:bulk_action).manage_catkeys).to eq('catkeys' => "1234\n5678")
       end
 
       it 'creates a new BulkAction' do
@@ -133,7 +132,8 @@ RSpec.describe BulkActionsController do
     let(:file) { bulk_action.file('test.log') }
 
     before do
-      File.new(file, 'w')
+      FileUtils.mkdir_p(bulk_action.output_directory)
+      File.open(file, 'w')
     end
 
     after do

--- a/spec/jobs/generic_job_spec.rb
+++ b/spec/jobs/generic_job_spec.rb
@@ -13,13 +13,10 @@ end
 
 RSpec.describe GenericJob do
   let(:bulk_action_no_process_callback) do
-    bulk_action = build(
+    create(
       :bulk_action,
       action_type: 'GenericJob'
     )
-    expect(bulk_action).to receive(:process_bulk_action_type)
-    bulk_action.save
-    bulk_action
   end
 
   before do

--- a/spec/models/bulk_action_spec.rb
+++ b/spec/models/bulk_action_spec.rb
@@ -17,64 +17,9 @@ RSpec.describe BulkAction do
     end
   end
 
-  describe 'triggers after_create callbacks' do
-    before do
-      @bulk_action = described_class.create(action_type: 'GenericJob', pids: '')
-    end
-
-    it '#create_output_directory' do
-      expect(@bulk_action).to receive(:create_output_directory)
-      @bulk_action.run_callbacks(:create) { true }
-    end
-    it '#create_log_file' do
-      expect(@bulk_action).to receive(:create_log_file)
-      @bulk_action.run_callbacks(:create) { true }
-    end
-    it '#process_bulk_action_type' do
-      expect(@bulk_action).to receive(:process_bulk_action_type)
-      @bulk_action.run_callbacks(:create) { true }
-    end
-  end
   ##
   # This is testing the completion of private methods
 
-  describe 'directory and file creation' do
-    before do
-      @bulk_action = described_class.create(action_type: 'GenericJob', pids: '')
-      @bulk_action.run_callbacks(:create) { true }
-    end
-
-    let(:directory) do
-      File.join(
-        Settings.BULK_METADATA.DIRECTORY,
-        "#{@bulk_action.action_type}_#{@bulk_action.id}"
-      )
-    end
-
-    it 'output_directory exists' do
-      expect(Dir.exist?(directory)).to be true
-    end
-    it 'output_file exists' do
-      expect(File.exist?(File.join(Settings.BULK_METADATA.LOG)))
-    end
-  end
-
-  it 'makes sure BulkAction job was kicked off' do
-    @bulk_action = described_class.create(
-      action_type: 'GenericJob', pids: 'a b c', manage_release: {}
-    )
-    expect(GenericJob).to receive(:perform_later)
-      .with(
-        @bulk_action.id,
-        hash_including(
-          pids: %w(a b c),
-          output_directory: Settings.BULK_METADATA.DIRECTORY +
-            "#{@bulk_action.action_type}_#{@bulk_action.id}",
-          manage_release: {}
-        )
-      )
-    @bulk_action.run_callbacks(:create) { true }
-  end
   describe 'before_destroy callbacks' do
     it 'calls #remove_output_directory' do
       @bulk_action = described_class.create(action_type: 'GenericJob', pids: '')
@@ -87,15 +32,18 @@ RSpec.describe BulkAction do
     let(:directory) do
       File.join(
         Settings.BULK_METADATA.DIRECTORY,
-        "#{@bulk_action.action_type}_#{@bulk_action.id}"
+        "#{bulk_action.action_type}_#{bulk_action.id}"
       )
+    end
+    let(:bulk_action) { described_class.create(action_type: 'GenericJob', pids: '') }
+
+    before do
+      FileUtils.mkdir_p(directory)
     end
 
     it 'cleans up output directory' do
-      @bulk_action = described_class.create(action_type: 'GenericJob', pids: '')
-      @bulk_action.run_callbacks(:create) { true }
       expect(Dir.exist?(directory)).to be true
-      @bulk_action.destroy
+      bulk_action.destroy
       expect(Dir.exist?(directory)).to be false
     end
   end

--- a/spec/services/bulk_action_persister_spec.rb
+++ b/spec/services/bulk_action_persister_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BulkActionPersister do
+  let(:bulk_action) do
+    BulkAction.create(
+      action_type: 'GenericJob',
+      pids: 'a b c',
+      manage_release: {}
+    )
+  end
+
+  it 'makes sure BulkAction job was kicked off' do
+    expect(GenericJob).to receive(:perform_later)
+      .with(
+        bulk_action.id,
+        hash_including(
+          pids: %w(a b c),
+          output_directory: Settings.BULK_METADATA.DIRECTORY +
+            "#{bulk_action.action_type}_#{bulk_action.id}",
+          manage_release: {}
+        )
+      )
+    described_class.persist(bulk_action)
+  end
+
+  describe 'all the steps are called' do
+    let(:service) { described_class.new(bulk_action) }
+
+    it '#create_output_directory' do
+      expect(service).to receive(:create_output_directory)
+      service.persist
+    end
+
+    it '#create_log_file' do
+      expect(service).to receive(:create_log_file)
+      service.persist
+    end
+
+    it '#process_bulk_action_type' do
+      expect(service).to receive(:process_bulk_action_type)
+      service.persist
+    end
+  end
+
+  describe 'directory and file creation' do
+    let(:service) { described_class.new(bulk_action) }
+
+    let(:directory) do
+      File.join(
+        Settings.BULK_METADATA.DIRECTORY,
+        "#{bulk_action.action_type}_#{bulk_action.id}"
+      )
+    end
+
+    before do
+      service.persist
+    end
+
+    it 'output_directory exists' do
+      expect(Dir).to exist(bulk_action.output_directory)
+    end
+
+    it 'output_file exists' do
+      expect(File).to exist(bulk_action.file(Settings.BULK_METADATA.LOG))
+    end
+  end
+end


### PR DESCRIPTION
Previously BulkActions had a bunch of before_create hooks.  This conflated business logic and data model into one class.  This refactoring separates the concerns into two classes which makes testing of models and behaviors easier.