### PR TITLE
Revert to sass-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rails', '~> 5.2.1'
 # Use Puma as the app server
 gem 'puma', '~> 3.7'
 # Use SCSS for stylesheets
-gem 'sassc-rails', '~> 2.1'
+gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -518,14 +518,19 @@ GEM
       rest-client
     rubyzip (1.2.3)
     safe_yaml (1.0.5)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    sass-rails (5.1.0)
+      railties (>= 5.2.0)
+      sass (~> 3.1)
+      sprockets (>= 2.8, < 4.0)
+      sprockets-rails (>= 2.0, < 4.0)
+      tilt (>= 1.1, < 3)
     sassc (2.1.0)
       ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     selenium-webdriver (3.142.3)
       childprocess (>= 0.5, < 2.0)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -676,7 +681,7 @@ DEPENDENCIES
   rubocop-rspec (~> 1.31.0)
   ruby-prof
   rubyzip
-  sassc-rails (~> 2.1)
+  sass-rails (~> 5.0)
   selenium-webdriver
   simplecov
   spring


### PR DESCRIPTION
We can't deploy sassc on our Centos 6 machines because it has glibc 2.12 and 2.14 is required for sassc