### PR TITLE
Move all version-related functionality to a new service class

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -247,6 +247,7 @@ RSpec/SubjectStub:
     - 'spec/models/index_queue_spec.rb'
     - 'spec/search_builders/argo/date_field_queries_spec.rb'
     - 'spec/search_builders/argo/profile_queries_spec.rb'
+    - 'spec/services/version_service_spec.rb'
 
 # Offense count: 85
 # Configuration parameters: IgnoreNameless, IgnoreSymbolicNames.

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -35,7 +35,7 @@ class VersionsController < ApplicationController
       description: params[:description],
       opening_user_name: current_user.to_s
     }
-    Dor::Services::Client.object(@object.pid).version.open(vers_md_upd_info: vers_md_upd_info)
+    VersionService.open(identifier: @object.pid, vers_md_upd_info: vers_md_upd_info)
     msg = "#{@object.pid} is open for modification!"
     redirect_to solr_document_path(params[:item_id]), notice: msg
   rescue StandardError => e
@@ -51,9 +51,11 @@ class VersionsController < ApplicationController
     authorize! :manage_item, @object
 
     begin
-      Dor::Services::Client.object(@object.pid)
-                           .version.close(description: params[:description],
-                                          significance: params[:severity])
+      VersionService.close(
+        identifier: @object.pid,
+        description: params[:description],
+        significance: params[:severity]
+      )
       msg = "Version #{@object.current_version} closed"
       @object.events.add_event('close', current_user.to_s, msg)
       msg = "Version #{@object.current_version} of #{@object.pid} has been closed!"

--- a/app/jobs/close_version_job.rb
+++ b/app/jobs/close_version_job.rb
@@ -29,7 +29,7 @@ class CloseVersionJob < GenericJob
   private
 
   def close_object(pid, user_name, log)
-    Dor::Services::Client.object(pid).version.close
+    VersionService.close(identifier: pid)
     object = Dor.find(pid)
     msg = "Version #{object.current_version} closed"
     object.events.add_event('close', user_name, msg)

--- a/app/jobs/generic_job.rb
+++ b/app/jobs/generic_job.rb
@@ -85,10 +85,6 @@ class GenericJob < ActiveJob::Base
       description: description,
       opening_user_name: bulk_action.user.to_s
     }
-    Dor::Services::Client.object(object.pid).version.open(vers_md_upd_info: vers_md_upd_info)
-  end
-
-  def close_version(object)
-    Dor::Services::Client.object(object.pid).version.close
+    VersionService.open(identifier: object.pid, vers_md_upd_info: vers_md_upd_info)
   end
 end

--- a/app/jobs/manage_catkey_job.rb
+++ b/app/jobs/manage_catkey_job.rb
@@ -39,7 +39,7 @@ class ManageCatkeyJob < GenericJob
       open_new_version(current_obj, "Catkey updated to #{new_catkey}") unless current_obj.allows_modification?
       current_obj.catkey = new_catkey
       current_obj.save
-      close_version(current_obj) unless Dor::Services::Client.object(current_obj.pid).version.openable?
+      VersionService.close(identifier: current_obj.pid) unless VersionService.openable?(identifier: current_obj.pid)
       bulk_action.increment(:druid_count_success).save
       log.puts("#{Time.current} Catkey added/updated/removed successfully")
     rescue StandardError => e

--- a/app/jobs/prepare_job.rb
+++ b/app/jobs/prepare_job.rb
@@ -40,7 +40,7 @@ class PrepareJob < GenericJob
       description: description,
       opening_user_name: user_name
     }
-    Dor::Services::Client.object(pid).version.open(vers_md_upd_info: info)
+    VersionService.open(identifier: pid, vers_md_upd_info: info)
     bulk_action.increment(:druid_count_success).save
     log.puts("#{Time.current} Object successfully opened #{pid}")
   rescue StandardError => e

--- a/app/jobs/virtual_merge_job.rb
+++ b/app/jobs/virtual_merge_job.rb
@@ -9,14 +9,7 @@ class VirtualMergeJob < GenericJob
     client = Dor::Services::Client.object(parent_druid)
     client.add_constituents(child_druids: child_druids)
     ([parent_druid] + child_druids).each do |druid|
-      close(druid)
+      VersionService.close(identifier: druid)
     end
-  end
-
-  private
-
-  def close(druid)
-    object_client = Dor::Services::Client.object(druid)
-    object_client.version.close
   end
 end

--- a/app/services/apply_mods_metadata.rb
+++ b/app/services/apply_mods_metadata.rb
@@ -68,7 +68,7 @@ class ApplyModsMetadata
       description: "Descriptive metadata upload from #{original_filename}",
       opening_user_name: user_login
     }
-    Dor::Services::Client.object(item.pid).version.open(vers_md_upd_info: vers_md_upd_info)
+    VersionService.open(identifier: item.pid, vers_md_upd_info: vers_md_upd_info)
   end
 
   # Check if two MODS XML nodes are equivalent.

--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Encapsulates all version-related functionality
+class VersionService
+  class << self
+    def open(identifier:, **options)
+      new(identifier: identifier).open(**options)
+    end
+
+    def close(identifier:, **options)
+      new(identifier: identifier).close(**options)
+    end
+
+    def openable?(identifier:)
+      new(identifier: identifier).openable?
+    end
+  end
+
+  attr_reader :identifier
+
+  delegate :close, :open, :openable?, to: :version_client
+
+  def initialize(identifier:)
+    @identifier = identifier
+  end
+
+  private
+
+  def version_client
+    Dor::Services::Client.object(identifier).version
+  end
+end

--- a/spec/features/item_view_metadata_spec.rb
+++ b/spec/features/item_view_metadata_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'Item view', js: true do
         # rubocop:disable Style/BlockDelimiters
         expect {
           click_link 'M1090_S15_B02_F01_0126.jp2'
-          sleep(3)
+          sleep(5)
         }.to change { File.exist?('M1090_S15_B02_F01_0126.jp2') }.from(false).to(true)
         # rubocop:enable Style/BlockDelimiters
       end

--- a/spec/jobs/manage_catkey_job_spec.rb
+++ b/spec/jobs/manage_catkey_job_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe ManageCatkeyJob do
       expect(subject).to receive(:open_new_version).with(current_object, "Catkey updated to #{catkey}")
       expect(current_object).to receive(:catkey=).with(catkey)
       expect(current_object).to receive(:save)
-      expect(subject).to receive(:close_version).with(current_object)
+      expect(VersionService).to receive(:close).with(identifier: current_object.pid)
       subject.send(:update_catkey, pid, catkey, buffer)
     end
 
@@ -74,7 +74,7 @@ RSpec.describe ManageCatkeyJob do
       expect(subject).not_to receive(:open_new_version).with(current_object, "Catkey updated to #{catkey}")
       expect(current_object).to receive(:catkey=).with(catkey)
       expect(current_object).to receive(:save)
-      expect(subject).not_to receive(:close_version).with(current_object)
+      expect(VersionService).not_to receive(:close).with(identifier: current_object.pid)
       subject.send(:update_catkey, pid, catkey, buffer)
     end
   end

--- a/spec/jobs/prepare_job_spec.rb
+++ b/spec/jobs/prepare_job_spec.rb
@@ -6,16 +6,11 @@ RSpec.describe PrepareJob, type: :job do
   let(:pids) { ['druid:123', 'druid:456'] }
   let(:groups) { [] }
   let(:user) { instance_double(User, to_s: 'jcoyne85') }
-  let(:client) { instance_double(Dor::Services::Client::Object, version: version_client) }
-  let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, open: true) }
   let(:workflow_status) { instance_double(DorObjectWorkflowStatus, can_open_version?: true) }
-  let(:bulk_action) do
-    create(:bulk_action,
-           log_name: 'foo.txt')
-  end
+  let(:bulk_action) { create(:bulk_action, log_name: 'foo.txt') }
 
   before do
-    allow(Dor::Services::Client).to receive(:object).and_return(client)
+    allow(VersionService).to receive(:open)
     allow(DorObjectWorkflowStatus).to receive(:new).and_return(workflow_status)
   end
 
@@ -33,10 +28,11 @@ RSpec.describe PrepareJob, type: :job do
                                   'severity' => 'major'
                                 })
 
-    expect(version_client).to have_received(:open)
-      .with(vers_md_upd_info: { description: 'Changed dates',
-                                opening_user_name: 'jcoyne85',
-                                significance: 'major' })
-      .twice
+    expect(VersionService).to have_received(:open).with(identifier: anything,
+                                                        vers_md_upd_info: {
+                                                          description: 'Changed dates',
+                                                          opening_user_name: 'jcoyne85',
+                                                          significance: 'major'
+                                                        }).twice
   end
 end

--- a/spec/services/apply_mods_metadata_spec.rb
+++ b/spec/services/apply_mods_metadata_spec.rb
@@ -63,17 +63,15 @@ RSpec.describe ApplyModsMetadata do
   end
 
   describe '#commit_new_version' do
-    let(:client) { instance_double(Dor::Services::Client::Object, version: version_client) }
-    let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, open: true) }
-
     before do
-      allow(Dor::Services::Client).to receive(:object).and_return(client)
+      allow(VersionService).to receive(:open)
     end
 
     it 'opens a new minor version with filename and username' do
       action.send(:commit_new_version)
 
-      expect(version_client).to have_received(:open).with(
+      expect(VersionService).to have_received(:open).with(
+        identifier: item.pid,
         vers_md_upd_info: {
           significance: 'minor',
           description: 'Descriptive metadata upload from testfile.xlsx',

--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe VersionService do
+  subject(:service) { described_class.new(identifier: identifier) }
+
+  let(:identifier) { 'druid:abc123xyz' }
+
+  describe '.close' do
+    before do
+      allow(described_class).to receive(:new).and_return(service)
+      allow(service).to receive(:close)
+    end
+
+    it 'calls #close on a new instance' do
+      described_class.close(identifier: identifier)
+      expect(service).to have_received(:close).once
+    end
+  end
+
+  describe '#new' do
+    it 'has an identifier attribute' do
+      expect(service.identifier).to eq(identifier)
+    end
+  end
+
+  describe '#open' do
+    let(:version_client) { service.send(:version_client) }
+    let(:options) do
+      {
+        vers_md_upd_info: {
+          significance: 'major',
+          description: 'best version ever',
+          opening_user_name: 'mjgiarlo'
+        }
+      }
+    end
+
+    it 'delegates to the version client' do
+      allow(version_client).to receive(:open)
+      service.open(**options)
+      expect(version_client).to have_received(:open).with(**options).once
+    end
+  end
+
+  describe '#close' do
+    let(:version_client) { service.send(:version_client) }
+
+    it 'delegates to the version client' do
+      allow(version_client).to receive(:close)
+      service.close
+      expect(version_client).to have_received(:close).once
+    end
+  end
+
+  describe '#openable?' do
+    let(:version_client) { service.send(:version_client) }
+
+    it 'delegates to the version client' do
+      allow(version_client).to receive(:openable?)
+      service.openable?
+      expect(version_client).to have_received(:openable?).once
+    end
+  end
+end


### PR DESCRIPTION
This isolates versioning to a single spot in the codebase.

Done as an extension of work begun as part of #1499

