### PR TITLE
Don't need to load from Fedora to find workflows

### DIFF
--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -17,11 +17,6 @@ class RegistrationController < ApplicationController
   def workflows_for_apo(apo_id)
     docs = Dor::SearchService.query(%(id:"#{apo_id}"))['response']['docs']
     result = docs.collect { |doc| doc['registration_workflow_id_ssim'] }.compact
-    apo_object = Dor.find(apo_id)
-    adm_xml = apo_object.administrativeMetadata.ng_xml
-    adm_xml.search('//registration/workflow').each do |wf|
-      result << wf['id']
-    end
     # always put default workflow option first, then alpha sort the rest
     result.flatten.sort.unshift(Settings.apo.default_workflow_option).uniq
   end


### PR DESCRIPTION
Reverts https://github.com/sul-dlss/argo/commit/931273641a97f1587bdd9df14411d0a8ed905d60#diff-c7642c50c0b5716cfc364d7e3d0b3589R36-R41

This helps remove the dependency on parsing the Fedora 3 XML.