### PR TITLE
Rename severity to significance

### DIFF
--- a/app/controllers/bulk_actions_controller.rb
+++ b/app/controllers/bulk_actions_controller.rb
@@ -60,7 +60,7 @@ class BulkActionsController < ApplicationController
       manage_release: [:tag, :what, :who, :to],
       set_governing_apo: [:new_apo_id],
       manage_catkeys: [:catkeys],
-      prepare: [:severity, :description]
+      prepare: [:significance, :description]
     )
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -186,7 +186,7 @@ class ItemsController < ApplicationController
   # @param [String] cur_version_tag   current version tag
   # @param [String] prior_version_tag prior version tag
   # @return [Symbol] :major, :minor, :admin or nil
-  def which_severity_changed(cur_version_tag, prior_version_tag)
+  def which_significance_changed(cur_version_tag, prior_version_tag)
     return nil if cur_version_tag.nil? || prior_version_tag.nil?
     return :major if cur_version_tag.major != prior_version_tag.major
     return :minor if cur_version_tag.minor != prior_version_tag.minor

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -15,11 +15,11 @@ class VersionsController < ApplicationController
     @tag = @object.datastreams['versionMetadata'].current_tag
 
     # do some stuff to figure out which part of the version number changed when opening
-    # the item for versioning, so that the form can pre-select the correct severity level
-    @changed_severity = which_severity_changed(get_current_version_tag(@object), get_prior_version_tag(@object))
-    @severity_selected = {}
-    [:major, :minor, :admin].each do |severity|
-      @severity_selected[severity] = (@changed_severity == severity)
+    # the item for versioning, so that the form can pre-select the correct significance level
+    @changed_significance = which_significance_changed(get_current_version_tag(@object), get_prior_version_tag(@object))
+    @significance_selected = {}
+    [:major, :minor, :admin].each do |significance|
+      @significance_selected[significance] = (@changed_significance == significance)
     end
 
     respond_to do |format|
@@ -31,7 +31,7 @@ class VersionsController < ApplicationController
     authorize! :manage_item, @object
 
     vers_md_upd_info = {
-      significance: params[:severity],
+      significance: params[:significance],
       description: params[:description],
       opening_user_name: current_user.to_s
     }
@@ -45,7 +45,7 @@ class VersionsController < ApplicationController
     nil
   end
 
-  # as long as this isn't a bulk operation, and we get non-nil severity and description
+  # as long as this isn't a bulk operation, and we get non-nil significance and description
   # values, update those fields on the version metadata datastream
   def close
     authorize! :manage_item, @object
@@ -54,7 +54,7 @@ class VersionsController < ApplicationController
       VersionService.close(
         identifier: @object.pid,
         description: params[:description],
-        significance: params[:severity]
+        significance: params[:significance]
       )
       msg = "Version #{@object.current_version} closed"
       @object.events.add_event('close', current_user.to_s, msg)
@@ -88,7 +88,7 @@ class VersionsController < ApplicationController
   # @param [String] cur_version_tag   current version tag
   # @param [String] prior_version_tag prior version tag
   # @return [Symbol] :major, :minor, :admin or nil
-  def which_severity_changed(cur_version_tag, prior_version_tag)
+  def which_significance_changed(cur_version_tag, prior_version_tag)
     return nil if cur_version_tag.nil? || prior_version_tag.nil?
     return :major if cur_version_tag.major != prior_version_tag.major
     return :minor if cur_version_tag.minor != prior_version_tag.minor

--- a/app/jobs/prepare_job.rb
+++ b/app/jobs/prepare_job.rb
@@ -12,11 +12,11 @@ class PrepareJob < GenericJob
   # @option params [Array] :pids required list of pids
   # @option params [Array] :groups the groups the user belonged to when the started the job. Required for permissions check (can_manage?)
   # @option params [Array] :user the user
-  # @option params [Hash] :prepare parameters for the prepare job (:severity and :description)
+  # @option params [Hash] :prepare parameters for the prepare job (:significance and :description)
   def perform(bulk_action_id, params)
     super
 
-    severity = params[:prepare]['severity']
+    significance = params[:prepare]['significance']
     description = params[:prepare]['description']
 
     with_bulk_action_log do |log|
@@ -24,7 +24,7 @@ class PrepareJob < GenericJob
       update_druid_count
 
       pids.each do |current_druid|
-        open_object(current_druid, severity, description, @current_user.to_s, log)
+        open_object(current_druid, significance, description, @current_user.to_s, log)
       end
       log.puts("#{Time.current} Finished #{self.class} for BulkAction #{bulk_action_id}")
     end
@@ -32,11 +32,11 @@ class PrepareJob < GenericJob
 
   private
 
-  def open_object(pid, severity, description, user_name, log)
+  def open_object(pid, significance, description, user_name, log)
     return log.puts("#{Time.current} #{pid} is not openable") unless openable?(pid)
 
     info = {
-      significance: severity,
+      significance: significance,
       description: description,
       opening_user_name: user_name
     }

--- a/app/views/bulk_actions/forms/_prepare_form.html.erb
+++ b/app/views/bulk_actions/forms/_prepare_form.html.erb
@@ -1,7 +1,7 @@
 <%= f.fields_for :prepare do |prepare_fields| %>
   <div class='form-group'>
-    <%= prepare_fields.label :severity, 'Change type' %>
-    <%= prepare_fields.select :severity,
+    <%= prepare_fields.label :significance, 'Change type' %>
+    <%= prepare_fields.select :significance,
                               [['Major', 'major'], ['Minor', 'minor'], ['Admin', 'admin']],
                               class: 'form-control' %>
   </div>

--- a/app/views/versions/_close_ui.html.erb
+++ b/app/views/versions/_close_ui.html.erb
@@ -1,10 +1,10 @@
 <form action=<%= close_item_versions_path(@object.pid) %> method="POST">
   <div class='form-group'>
-    <label for="severity">Type</label>
-    <select id="severity" name="severity" class='form-control'>
-      <%- # loop through the severity levels and pre-select the one that was chosen when opening the version -%>
-      <% @severity_selected.keys.each do |severity| %>
-        <option value="<%= severity.to_s %>"<%= @severity_selected[severity] ? ' selected' : ''-%>><%=severity.to_s.capitalize-%></option>
+    <label for="significance">Type</label>
+    <select id="significance" name="significance" class='form-control'>
+      <%- # loop through the significance levels and pre-select the one that was chosen when opening the version -%>
+      <% @significance_selected.keys.each do |significance| %>
+        <option value="<%= significance.to_s %>"<%= @significance_selected[significance] ? ' selected' : ''-%>><%=significance.to_s.capitalize-%></option>
       <% end %>
     </select>
   </div>

--- a/app/views/versions/_open_ui.html.erb
+++ b/app/views/versions/_open_ui.html.erb
@@ -1,7 +1,7 @@
 <form action=<%= open_item_versions_path(item_id: @object.pid) %> method="POST">
   <div class='form-group'>
-    <label for="severity">Type</label>
-    <select id="severity" name="severity" class='form-control'>
+    <label for="significance">Type</label>
+    <select id="significance" name="significance" class='form-control'>
       <option value="major">Major</option>
       <option value="minor">Minor</option>
       <option value="admin">Admin</option>

--- a/spec/controllers/versions_controller_spec.rb
+++ b/spec/controllers/versions_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe VersionsController, type: :controller do
         expect(ActiveFedora.solr.conn).to receive(:add)
         get :open, params: {
           item_id: pid,
-          severity: vers_md_upd_info[:significance],
+          significance: vers_md_upd_info[:significance],
           description: vers_md_upd_info[:description]
         }
 
@@ -57,7 +57,7 @@ RSpec.describe VersionsController, type: :controller do
     context 'without manage item access' do
       it 'returns a 403' do
         allow(controller).to receive(:authorize!).with(:manage_item, Dor::Item).and_raise(CanCan::AccessDenied)
-        get :open, params: { item_id: pid, severity: 'major', description: 'something' }
+        get :open, params: { item_id: pid, significance: 'major', description: 'something' }
         expect(response.code).to eq('403')
       end
     end
@@ -77,7 +77,7 @@ RSpec.describe VersionsController, type: :controller do
       it 'calls dor-services to close the version' do
         expect(item).to receive(:save)
         expect(ActiveFedora.solr.conn).to receive(:add)
-        get :close, params: { item_id: pid, severity: 'major', description: 'something' }
+        get :close, params: { item_id: pid, significance: 'major', description: 'something' }
         expect(flash[:notice]).to eq "Version 2 of #{pid} has been closed!"
         expect(version_service).to have_received(:close).with(description: 'something', significance: 'major')
       end

--- a/spec/jobs/prepare_job_spec.rb
+++ b/spec/jobs/prepare_job_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe PrepareJob, type: :job do
                                 user: user,
                                 prepare: {
                                   'description' => 'Changed dates',
-                                  'severity' => 'major'
+                                  'significance' => 'major'
                                 })
 
     expect(VersionService).to have_received(:open).with(identifier: anything,

--- a/spec/services/bulk_action_persister_spec.rb
+++ b/spec/services/bulk_action_persister_spec.rb
@@ -75,11 +75,11 @@ RSpec.describe BulkActionPersister do
         BulkAction.create(
           action_type: 'PrepareJob',
           pids: 'a b c',
-          prepare: { 'severity' => 'minor', 'description' => 'change the data' }
+          prepare: { 'significance' => 'minor', 'description' => 'change the data' }
         )
       end
 
-      it { is_expected.to include(prepare: { 'description' => 'change the data', 'severity' => 'minor' }) }
+      it { is_expected.to include(prepare: { 'description' => 'change the data', 'significance' => 'minor' }) }
     end
   end
 end

--- a/spec/views/versions/_close_ui.html.erb_spec.rb
+++ b/spec/views/versions/_close_ui.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'versions/_close_ui.html.erb' do
 
   it 'renders the partial content' do
     assign(:object, object)
-    assign(:severity_selected, major: false, minor: true, admin: nil)
+    assign(:significance_selected, major: false, minor: true, admin: nil)
     render
     expect(rendered).to have_css 'form'
     expect(rendered).to have_css '.form-group label', text: 'Type'

--- a/spec/views/versions/_open_ui.html.erb_spec.rb
+++ b/spec/views/versions/_open_ui.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'versions/_open_ui.html.erb' do
     assign(:object, object)
     render
     expect(rendered).to have_css '.form-group label', text: 'Type'
-    expect(rendered).to have_css '.form-group select#severity.form-control'
+    expect(rendered).to have_css '.form-group select#significance.form-control'
     expect(rendered)
       .to have_css '.form-group label', text: 'Version description'
     expect(rendered).to have_css '.form-group textarea#description.form-control'


### PR DESCRIPTION
We call this significance everywhere else. Do this for consistency, so Argo is less of a special case.