### PR TITLE
Dump poorly named and unnecessary hash arg when opening versions

### DIFF
--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -30,12 +30,10 @@ class VersionsController < ApplicationController
   def open
     authorize! :manage_item, @object
 
-    vers_md_upd_info = {
-      significance: params[:significance],
-      description: params[:description],
-      opening_user_name: current_user.to_s
-    }
-    VersionService.open(identifier: @object.pid, vers_md_upd_info: vers_md_upd_info)
+    VersionService.open(identifier: @object.pid,
+                        significance: params[:significance],
+                        description: params[:description],
+                        opening_user_name: current_user.to_s)
     msg = "#{@object.pid} is open for modification!"
     redirect_to solr_document_path(params[:item_id]), notice: msg
   rescue StandardError => e

--- a/app/jobs/generic_job.rb
+++ b/app/jobs/generic_job.rb
@@ -80,11 +80,9 @@ class GenericJob < ActiveJob::Base
   def open_new_version(object, description)
     raise "#{Time.current} Unable to open new version for #{object.pid} (bulk_action.id=#{bulk_action.id})" unless DorObjectWorkflowStatus.new(object.pid).can_open_version?
 
-    vers_md_upd_info = {
-      significance: 'minor',
-      description: description,
-      opening_user_name: bulk_action.user.to_s
-    }
-    VersionService.open(identifier: object.pid, vers_md_upd_info: vers_md_upd_info)
+    VersionService.open(identifier: object.pid,
+                        significance: 'minor',
+                        description: description,
+                        opening_user_name: bulk_action.user.to_s)
   end
 end

--- a/app/jobs/prepare_job.rb
+++ b/app/jobs/prepare_job.rb
@@ -35,12 +35,10 @@ class PrepareJob < GenericJob
   def open_object(pid, significance, description, user_name, log)
     return log.puts("#{Time.current} #{pid} is not openable") unless openable?(pid)
 
-    info = {
-      significance: significance,
-      description: description,
-      opening_user_name: user_name
-    }
-    VersionService.open(identifier: pid, vers_md_upd_info: info)
+    VersionService.open(identifier: pid,
+                        significance: significance,
+                        description: description,
+                        opening_user_name: user_name)
     bulk_action.increment(:druid_count_success).save
     log.puts("#{Time.current} Object successfully opened #{pid}")
   rescue StandardError => e

--- a/app/services/apply_mods_metadata.rb
+++ b/app/services/apply_mods_metadata.rb
@@ -63,12 +63,10 @@ class ApplyModsMetadata
 
   # Open a new version for the given object.
   def commit_new_version
-    vers_md_upd_info = {
-      significance: 'minor',
-      description: "Descriptive metadata upload from #{original_filename}",
-      opening_user_name: user_login
-    }
-    VersionService.open(identifier: item.pid, vers_md_upd_info: vers_md_upd_info)
+    VersionService.open(identifier: item.pid,
+                        significance: 'minor',
+                        description: "Descriptive metadata upload from #{original_filename}",
+                        opening_user_name: user_login)
   end
 
   # Check if two MODS XML nodes are equivalent.

--- a/spec/controllers/versions_controller_spec.rb
+++ b/spec/controllers/versions_controller_spec.rb
@@ -39,18 +39,18 @@ RSpec.describe VersionsController, type: :controller do
 
       let(:client) { instance_double(Dor::Services::Client::Object, version: version_client) }
       let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, open: true) }
-      let(:vers_md_upd_info) { { significance: 'major', description: 'something', opening_user_name: user.to_s } }
+      let(:options) { { significance: 'major', description: 'something', opening_user_name: user.to_s } }
 
       it 'calls dor-services to open a new version' do
         expect(item).to receive(:save)
         expect(ActiveFedora.solr.conn).to receive(:add)
         get :open, params: {
           item_id: pid,
-          significance: vers_md_upd_info[:significance],
-          description: vers_md_upd_info[:description]
+          significance: options[:significance],
+          description: options[:description]
         }
 
-        expect(version_client).to have_received(:open).with(vers_md_upd_info: vers_md_upd_info)
+        expect(version_client).to have_received(:open).with(**options)
       end
     end
 

--- a/spec/jobs/generic_job_spec.rb
+++ b/spec/jobs/generic_job_spec.rb
@@ -73,11 +73,9 @@ RSpec.describe GenericJob do
       subject.send(:open_new_version, dor_object, 'Set new governing APO')
 
       expect(version_client).to have_received(:open).with(
-        vers_md_upd_info: {
-          significance: 'minor',
-          description: 'Set new governing APO',
-          opening_user_name: subject.bulk_action.user.to_s
-        }
+        significance: 'minor',
+        description: 'Set new governing APO',
+        opening_user_name: subject.bulk_action.user.to_s
       )
     end
 

--- a/spec/jobs/prepare_job_spec.rb
+++ b/spec/jobs/prepare_job_spec.rb
@@ -29,10 +29,8 @@ RSpec.describe PrepareJob, type: :job do
                                 })
 
     expect(VersionService).to have_received(:open).with(identifier: anything,
-                                                        vers_md_upd_info: {
-                                                          description: 'Changed dates',
-                                                          opening_user_name: 'jcoyne85',
-                                                          significance: 'major'
-                                                        }).twice
+                                                        description: 'Changed dates',
+                                                        opening_user_name: 'jcoyne85',
+                                                        significance: 'major').twice
   end
 end

--- a/spec/services/apply_mods_metadata_spec.rb
+++ b/spec/services/apply_mods_metadata_spec.rb
@@ -72,11 +72,9 @@ RSpec.describe ApplyModsMetadata do
 
       expect(VersionService).to have_received(:open).with(
         identifier: item.pid,
-        vers_md_upd_info: {
-          significance: 'minor',
-          description: 'Descriptive metadata upload from testfile.xlsx',
-          opening_user_name: 'username'
-        }
+        significance: 'minor',
+        description: 'Descriptive metadata upload from testfile.xlsx',
+        opening_user_name: 'username'
       )
     end
   end

--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -29,11 +29,9 @@ RSpec.describe VersionService do
     let(:version_client) { service.send(:version_client) }
     let(:options) do
       {
-        vers_md_upd_info: {
-          significance: 'major',
-          description: 'best version ever',
-          opening_user_name: 'mjgiarlo'
-        }
+        significance: 'major',
+        description: 'best version ever',
+        opening_user_name: 'mjgiarlo'
       }
     end
 


### PR DESCRIPTION
It has already been removed in dor-services-app: https://github.com/sul-dlss/dor-services-app/pull/349