### PR TITLE
Do not call #version_object with arguments

### DIFF
--- a/app/services/apply_mods_metadata.rb
+++ b/app/services/apply_mods_metadata.rb
@@ -35,20 +35,25 @@ class ApplyModsMetadata
       return
     end
 
-    version_object(original_filename, user_login, log)
+    version_object
 
     item.descMetadata.content = mods_node.to_s
     item.save!
     log.puts("argo.bulk_metadata.bulk_log_job_save_success #{item.pid}")
   rescue StandardError => e
-    log.puts("argo.bulk_metadata.bulk_log_error_exception #{item.pid}")
-    log.puts(e.message.to_s)
-    log.puts(e.backtrace.to_s)
+    log_error!(e)
   end
 
   private
 
   attr_reader :apo_druid, :mods_node, :item, :original_filename, :user_login, :log
+
+  # Log the error
+  def log_error!(exception)
+    log.puts("argo.bulk_metadata.bulk_log_error_exception #{item.pid}")
+    log.puts(exception.message.to_s)
+    log.puts(exception.backtrace.to_s)
+  end
 
   # Open a new version for the given object if it is in the accessioned state.
   def version_object

--- a/spec/services/apply_mods_metadata_spec.rb
+++ b/spec/services/apply_mods_metadata_spec.rb
@@ -5,7 +5,14 @@ require 'rails_helper'
 RSpec.describe ApplyModsMetadata do
   let(:apo_druid) {}
   let(:mods_node) {}
-  let(:item) { instance_double(Dor::Item, pid: 'druid:123abc') }
+  let(:item) do
+    instance_double(Dor::Item,
+                    pid: 'druid:123abc',
+                    admin_policy_object_id: apo_druid,
+                    descMetadata: desc_metadata,
+                    save!: true)
+  end
+  let(:desc_metadata) { instance_double(Dor::DescMetadataDS, content: '', 'content=' => nil) }
   let(:log) { instance_double(File, puts: true) }
   let(:action) do
     described_class.new(apo_druid: apo_druid,
@@ -14,6 +21,22 @@ RSpec.describe ApplyModsMetadata do
                         original_filename: 'testfile.xlsx',
                         user_login: 'username',
                         log: log)
+  end
+
+  describe '#apply' do
+    before do
+      allow(Dor::StatusService).to receive(:new).and_return(stub_service)
+    end
+
+    let(:stub_service) { instance_double(Dor::StatusService, status_info: { status_code: status_code }) }
+    let(:status_code) { 6 }
+    let(:workflow) { instance_double(DorObjectWorkflowStatus) }
+
+    it 'does not rescue and log an error' do
+      allow(action).to receive(:log_error!)
+      action.apply
+      expect(action).not_to have_received(:log_error!)
+    end
   end
 
   describe 'version_object' do


### PR DESCRIPTION
This resolve an ArgumentError caused by a combination of:

1. the refactoring in https://github.com/sul-dlss/argo/pull/1518;
1. eating all StandardError in `ApplyModsMetadata#apply`; and
1. insufficient test coverage, which I highlighted in https://github.com/sul-dlss/argo/pull/1518#pullrequestreview-281052275 but did not sufficient flag

And should help resolve a production outage related to bulk jobs.

Fixes #1543