### PR TITLE
Use the default remove icon

### DIFF
--- a/app/assets/javascripts/argo.js
+++ b/app/assets/javascripts/argo.js
@@ -34,9 +34,6 @@ $(document).ready(function() {
             $(this).toggleClass('collapsed');
         }
     });
-
-    // This prevents the glyphicon-remove from blacklight from drawing in the remove facet
-    $('#facets a.remove').map(function() { $(this).html('') })
 });
 
 

--- a/app/assets/stylesheets/argo/argo.sass
+++ b/app/assets/stylesheets/argo/argo.sass
@@ -68,9 +68,6 @@ legend
   a.remove
     margin-left: .5em
     float: right
-    &:after
-      color: red
-      content: '[X]'
 .blacklight-wf_error_ssim
   color: red
 #doc4


### PR DESCRIPTION
This means less custom code in Argo that we need to support.  I think this looks nicer too.

Before:

<img width="362" alt="Screen Shot 2019-09-06 at 11 01 46 AM" src="https://user-images.githubusercontent.com/92044/64442902-574f5700-d096-11e9-9b9d-155df53fdd8a.png">

After:

<img width="380" alt="Screen Shot 2019-09-06 at 11 03 19 AM" src="https://user-images.githubusercontent.com/92044/64442899-55859380-d096-11e9-87d0-b0bfa68d945d.png">



