### PR TITLE
Replace deprecated Rails application entrypoint

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,4 +6,4 @@
 require File.expand_path('../config/application', __FILE__)
 require 'rake'
 
-Argo::Application.load_tasks
+Rails.application.load_tasks

--- a/config.ru
+++ b/config.ru
@@ -3,4 +3,4 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment', __FILE__)
-run Argo::Application
+run Rails.application

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -6,4 +6,4 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-Argo::Application.config.secret_key_base = 'b82ec30e6fe76f9f9b6bdac84163f03de92ae714274324e5cd5f6e66253a70a68fe6921dbc3dab503b67ac9a1236c1882fb583dc6d06df515990252955b928ee'
+Rails.application.config.secret_key_base = 'b82ec30e6fe76f9f9b6bdac84163f03de92ae714274324e5cd5f6e66253a70a68fe6921dbc3dab503b67ac9a1236c1882fb583dc6d06df515990252955b928ee'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Argo::Application.routes.draw do
+Rails.application.routes.draw do
   get '/is_it_working' => 'ok_computer/ok_computer#show', defaults: { check: 'default' }
 
   resources :bulk_actions, except: [:edit, :show, :update] do


### PR DESCRIPTION
This will go away in Rails 6. See:

```
    DEPRECATION WARNING: Using `Rails::Application` subclass to start the server is deprecated and will be removed in Rails 6.0. Please change `run Argo::
    Application` to `run Rails.application` in config.ru. (called from <main> at bin/rails:6)
```