### PR TITLE
Improve refresh metadata err handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ vendor/ruby/
 .ruby-version
 .ruby-gemset
 .byebug_history
+.pry_history
 
 # The docker volume for the workflow database
 postgres-data

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -55,7 +55,7 @@ Metrics/AbcSize:
 # Offense count: 6
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 412
+  Max: 417
 
 # Offense count: 7
 Metrics/CyclomaticComplexity:

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -329,9 +329,14 @@ class ItemsController < ApplicationController
       if params[:bulk]
         format.html { render status: :ok, plain: 'Refreshed.' }
       else
-        format.any { redirect_to solr_document_path(params[:id]), notice: "Metadata for #{@object.pid} successfully refreshed from catkey:#{@object.catkey}" }
+        format.any { redirect_to solr_document_path(params[:id]), notice: "Metadata for #{@object.pid} successfully refreshed from catkey: #{@object.catkey}" }
       end
     end
+  rescue Dor::Services::Client::UnexpectedResponse => e
+    user_begin = 'An error occurred while attempting to refresh metadata'
+    user_end = 'Please try again or contact the sdr-operations Slack channel for assistance.'
+    Rails.logger.error "#{user_begin}: #{e.message}"
+    redirect_to solr_document_path(params[:id]), flash: { error: "#{user_begin}: #{e.message}. #{user_end}" }
   end
 
   def scrubbed_content_ng_utf8(content)


### PR DESCRIPTION
Fixes #1545;  The vanilla rails error experience here in Argo, if dor-services-app has trouble retrieving metadata from Symphony, did not give enough information to help with debugging.  This does help and also gives the user a better experience.

## Before

![image](https://user-images.githubusercontent.com/96775/64038464-f0b5c080-cb0c-11e9-831f-ce8a7274fa69.png)

## After

![image](https://user-images.githubusercontent.com/96775/64454071-dba5d800-d09e-11e9-86d3-f564dadd9494.png)

Note that this is specific to refresh_metadata;  it accommodates UnexpectedResponse errors with any message from dor-services-client, and Andrew approved this "design" here:  https://github.com/sul-dlss/argo/issues/1545#issuecomment-528909307

