### PR TITLE
Remove unused code 'delete_role'

### DIFF
--- a/app/controllers/apo_controller.rb
+++ b/app/controllers/apo_controller.rb
@@ -11,8 +11,7 @@ class ApoController < ApplicationController
     :add_collection, :delete_collection,
     :update_copyright, :update_creative_commons,
     :update_default_object_rights, :update_desc_metadata,
-    :update_title, :update_use,
-    :delete_role
+    :update_title, :update_use
   ]
 
   before_action :authorize, except: [
@@ -73,11 +72,6 @@ class ApoController < ApplicationController
 
   def add_roleplayer
     @object.add_roleplayer(params[:role], params[:roleplayer])
-    redirect
-  end
-
-  def delete_role
-    @object.delete_role(params[:role], params[:roleplayer])
     redirect
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,7 +66,6 @@ Rails.application.routes.draw do
       get :spreadsheet_template
     end
     member do
-      get 'delete_role'
       post 'add_collection'
       get  'delete_collection'
       post 'update_title'

--- a/spec/controllers/apo_controller_spec.rb
+++ b/spec/controllers/apo_controller_spec.rb
@@ -98,13 +98,6 @@ RSpec.describe ApoController, type: :controller do
     end
   end
 
-  describe '#delete_role' do
-    it 'calls delete_role' do
-      expect(apo).to receive(:delete_role)
-      post 'delete_role', params: { id: apo.pid, role: 'dor-apo-viewer', entity: 'Jon' }
-    end
-  end
-
   describe '#delete_collection' do
     it 'calls remove_default_collection' do
       expect(apo).to receive(:remove_default_collection)


### PR DESCRIPTION
dor-services hasn't had Item#delete_role for many years, this code doesn't work
and isn't called from anywhere.