### PR TITLE
Refactor to remove WorkflowStatus' dependency on WorkflowTemplate

### DIFF
--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -113,7 +113,7 @@ class WorkflowsController < ApplicationController
     status = WorkflowStatus.new(pid: @object.pid,
                                 workflow_name: params[:id],
                                 workflow: workflow,
-                                workflow_definition: wf_def)
+                                workflow_steps: wf_def.definition.processes.map(&:name))
     WorkflowPresenter.new(view: view_context, workflow_status: status)
   end
 

--- a/app/models/workflow_status.rb
+++ b/app/models/workflow_status.rb
@@ -5,12 +5,12 @@ class WorkflowStatus
   # @param [String] pid
   # @param [String] workflow_name
   # @param [Dor::Workflow::Response::Workflow] workflow the response from the workflow service for this object/workflow_name
-  # @param [Dor::WorkflowObject] workflow_definition the definition of the workflow
-  def initialize(pid:, workflow_name:, workflow:, workflow_definition:)
+  # @param [Array<String>] workflow_steps a list of steps in the workflow
+  def initialize(pid:, workflow_name:, workflow:, workflow_steps:)
     @pid = pid
     @workflow_name = workflow_name
     @workflow = workflow
-    @workflow_definition = workflow_definition
+    @workflow_steps = workflow_steps
   end
 
   attr_reader :workflow_name, :pid
@@ -21,15 +21,11 @@ class WorkflowStatus
     return [] if empty?
 
     workflow_steps.map do |process|
-      workflow.process_for_recent_version(name: process.name)
+      workflow.process_for_recent_version(name: process)
     end
   end
 
   private
 
-  attr_reader :workflow_definition, :workflow
-
-  def workflow_steps
-    workflow_definition.definition.processes
-  end
+  attr_reader :workflow_steps, :workflow
 end

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -54,7 +54,28 @@ RSpec.describe WorkflowsController, type: :controller do
   describe '#show' do
     let(:workflow) { instance_double(Dor::Workflow::Document) }
     let(:workflow_status) { instance_double(WorkflowStatus) }
-    let(:workflow_object) { instance_double(Dor::WorkflowObject) }
+    let(:workflow_object) { instance_double(Dor::WorkflowObject, definition: workflow_ds) }
+    let(:workflow_ds) { instance_double(Dor::WorkflowDefinitionDs, processes: workflow_steps) }
+    let(:workflow_name) { 'accessionWF' }
+
+    let(:workflow_steps) do
+      [
+        Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'start-accession', 'sequence' => 1),
+        Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'descriptive-metadata', 'sequence' => 2),
+        Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'rights-metadata', 'sequence' => 3),
+        Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'content-metadata', 'sequence' => 4),
+        Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'technical-metadata', 'sequence' => 5),
+        Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'remediate-object', 'sequence' => 6),
+        Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'shelve', 'sequence' => 7),
+        Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'published', 'sequence' => 8),
+        Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'provenance-metadata', 'sequence' => 9),
+        Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'sdr-ingest-transfer', 'sequence' => 10),
+        Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'sdr-ingest-received', 'sequence' => 11),
+        Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'reset-workspace', 'sequence' => 12),
+        Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'end-accession', 'sequence' => 13)
+      ]
+    end
+
     let(:workflow_client) do
       instance_double(Dor::Workflow::Client,
                       workflow: wf_response)
@@ -71,12 +92,12 @@ RSpec.describe WorkflowsController, type: :controller do
       it 'fetches the workflow on valid parameters' do
         allow(WorkflowPresenter).to receive(:new).and_return(presenter)
         allow(WorkflowStatus).to receive(:new).and_return(workflow_status)
-        allow(Dor::WorkflowObject).to receive(:find_by_name).with('accessionWF').and_return(workflow_object)
+        allow(Dor::WorkflowObject).to receive(:find_by_name).with(workflow_name).and_return(workflow_object)
 
         get :show, params: { item_id: pid, id: 'accessionWF', repo: 'dor', format: :html }
         expect(response).to have_http_status(:ok)
         expect(WorkflowStatus).to have_received(:new)
-          .with(pid: pid, workflow_name: 'accessionWF', workflow_definition: workflow_object, workflow: wf_response)
+          .with(pid: pid, workflow_name: 'accessionWF', workflow_steps: workflow_steps.map(&:name), workflow: wf_response)
         expect(WorkflowPresenter).to have_received(:new).with(view: Object, workflow_status: workflow_status)
         expect(assigns[:presenter]).to eq presenter
       end

--- a/spec/models/workflow_status_spec.rb
+++ b/spec/models/workflow_status_spec.rb
@@ -7,29 +7,27 @@ RSpec.describe WorkflowStatus do
     described_class.new(pid: pid,
                         workflow_name: workflow_name,
                         workflow: workflow,
-                        workflow_definition: definition)
+                        workflow_steps: workflow_steps)
   end
 
   let(:workflow) { Dor::Workflow::Response::Workflow.new(xml: xml) }
   let(:workflow_name) { 'accessionWF' }
-  let(:definition) { instance_double(Dor::WorkflowObject, definition: workflow_ds) }
-  let(:workflow_ds) { instance_double(Dor::WorkflowDefinitionDs, processes: workflow_steps) }
 
   let(:workflow_steps) do
-    [
-      Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'start-accession', 'sequence' => 1),
-      Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'descriptive-metadata', 'sequence' => 2),
-      Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'rights-metadata', 'sequence' => 3),
-      Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'content-metadata', 'sequence' => 4),
-      Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'technical-metadata', 'sequence' => 5),
-      Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'remediate-object', 'sequence' => 6),
-      Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'shelve', 'sequence' => 7),
-      Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'published', 'sequence' => 8),
-      Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'provenance-metadata', 'sequence' => 9),
-      Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'sdr-ingest-transfer', 'sequence' => 10),
-      Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'sdr-ingest-received', 'sequence' => 11),
-      Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'reset-workspace', 'sequence' => 12),
-      Dor::Workflow::Process.new('dor', workflow_name, 'name' => 'end-accession', 'sequence' => 13)
+    %w[
+      start-accession
+      descriptive-metadata
+      rights-metadata
+      content-metadata
+      technical-metadata
+      remediate-object
+      shelve
+      published
+      provenance-metadata
+      sdr-ingest-transfer
+      sdr-ingest-received
+      reset-workspace
+      end-accession
     ]
   end
   let(:pid) { 'druid:oo201oo0001' }


### PR DESCRIPTION
This positions us to completely remove the workflow definition fedora object at a later time.