### PR TITLE
Require the repository parameter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem 'blacklight', '~> 6.0'
 gem 'blacklight-hierarchy'
 gem 'dor-services', '~> 7.2'
 gem 'dor-services-client', '~> 2.2'
-gem 'dor-workflow-client', '~> 3.5'
+gem 'dor-workflow-client', '~> 3.6'
 gem 'mods_display'
 gem 'okcomputer' # monitors application and its dependencies
 gem 'responders', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,7 +222,7 @@ GEM
       moab-versioning (~> 4.0)
       nokogiri (~> 1.8)
       zeitwerk (~> 2.1)
-    dor-workflow-client (3.5.0)
+    dor-workflow-client (3.6.0)
       activesupport (>= 3.2.1, < 7)
       deprecation (>= 0.99.0)
       faraday (~> 0.9, >= 0.9.2)
@@ -654,7 +654,7 @@ DEPENDENCIES
   dlss-capistrano (~> 3.1)
   dor-services (~> 7.2)
   dor-services-client (~> 2.2)
-  dor-workflow-client (~> 3.5)
+  dor-workflow-client (~> 3.6)
   equivalent-xml (>= 0.6.0)
   eye
   factory_bot_rails

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -35,12 +35,8 @@ class WorkflowsController < ApplicationController
   # @option params [String] `:repo` The repo to which the workflow applies (optional).
   def update
     authorize! :update, :workflow
-    [:process, :status].each { |p| params.require(p) }
+    params.require [:process, :status, :repo]
     args = params.values_at(:item_id, :id, :process, :status)
-    # rubocop:disable Rails/DynamicFindBy
-    # the :repo parameter is optional, so fetch it based on the workflow name if blank
-    params[:repo] ||= Dor::WorkflowObject.find_by_name(params[:id]).definition.repo
-    # rubocop:enable Rails/DynamicFindBy
 
     # this will raise an exception if the item doesn't have that workflow step
     Dor::Config.workflow.client.workflow_status params[:repo], *args.take(3)

--- a/app/models/workflow_status.rb
+++ b/app/models/workflow_status.rb
@@ -9,7 +9,7 @@ class WorkflowStatus
     @workflow_steps = workflow_steps
   end
 
-  delegate :empty?, :workflow_name, :pid, to: :workflow
+  delegate :empty?, :workflow_name, :pid, :repository, to: :workflow
 
   def process_statuses
     return [] if empty?

--- a/app/presenters/workflow_process_presenter.rb
+++ b/app/presenters/workflow_process_presenter.rb
@@ -3,7 +3,7 @@
 # Displays a single step in a workflow for a single object/version
 class WorkflowProcessPresenter
   # @param [Object] view the view context
-  # @param [Dor::Workflow::Response::Workflow] process_status the model for the WorkflowProcess
+  # @param [Dor::Workflow::Response::Process] process_status the model for the WorkflowProcess
   def initialize(view:, process_status:)
     @view = view
     @process_status = process_status
@@ -31,7 +31,7 @@ class WorkflowProcessPresenter
   attr_reader :view, :process_status
 
   delegate :form_tag, :item_workflow_path, :hidden_field_tag, :button_tag, :content_tag, :options_for_select, :select_tag, to: :view
-  delegate :pid, :workflow_name, to: :process_status
+  delegate :pid, :repository, :workflow_name, to: :process_status
 
   CONFIRM_MESSAGE = 'You have selected to manually change the status. ' \
     'This could result in processing errors. Are you sure you want to proceed?'
@@ -40,6 +40,7 @@ class WorkflowProcessPresenter
     # workflow update requires id, workflow, process, and status parameters
     form_tag item_workflow_path(pid, workflow_name), method: 'put' do
       hidden_field_tag('process', name) +
+        hidden_field_tag('repo', repository) +
         content_tag(:div, class: 'input-group') do
           select_tag('status',
                      options_for_select([['Rerun', 'waiting'], ['Skip', 'skipped'], ['Complete', 'completed']]),
@@ -58,6 +59,7 @@ class WorkflowProcessPresenter
     # workflow update requires id, workflow, process, and status parameters
     form_tag item_workflow_path(pid, workflow_name), method: 'put' do
       hidden_field_tag('process', name) +
+        hidden_field_tag('repo', repository) +
         hidden_field_tag('status', new_status) +
         button_tag('Set to ' + new_status, type: 'submit', class: 'btn btn-default')
     end

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -155,12 +155,11 @@ RSpec.describe WorkflowsController, type: :controller do
     end
 
     it 'requires various workflow parameters' do
-      expect { post :update, params: { item_id: pid, id: 'accessionWF' } }.to raise_error(ActionController::ParameterMissing)
+      expect { post :update, params: { item_id: pid, repo: 'dor', id: 'accessionWF' } }.to raise_error(ActionController::ParameterMissing)
     end
 
     it 'changes the status' do
-      expect(Dor::WorkflowObject).to receive(:find_by_name).with('accessionWF').and_return(double(definition: double(repo: 'dor')))
-      post :update, params: { item_id: pid, id: 'accessionWF', process: 'publish', status: 'ready' }
+      post :update, params: { item_id: pid, id: 'accessionWF', repo: 'dor', process: 'publish', status: 'ready' }
       expect(controller).to have_received(:authorize!).with(:update, :workflow)
       expect(subject).to redirect_to(solr_document_path(pid))
       expect(workflow_client).to have_received(:workflow_status).with('dor', pid, 'accessionWF', 'publish')

--- a/spec/presenters/workflow_process_presenter_spec.rb
+++ b/spec/presenters/workflow_process_presenter_spec.rb
@@ -51,7 +51,8 @@ RSpec.describe WorkflowProcessPresenter, type: :view do
                       status: status,
                       pid: 'druid:132',
                       workflow_name: 'accessionWF',
-                      name: 'technical-metadata')
+                      name: 'technical-metadata',
+                      repository: 'dor')
     end
 
     context "when it's not an allowable change" do
@@ -65,6 +66,7 @@ RSpec.describe WorkflowProcessPresenter, type: :view do
 
       it { is_expected.to have_button 'Set to completed' }
       it { is_expected.to have_css 'input[name="_method"][value="put"]', visible: false }
+      it { is_expected.to have_css 'input[name="repo"][value="dor"]', visible: false }
     end
 
     context "when it's in error" do
@@ -72,6 +74,7 @@ RSpec.describe WorkflowProcessPresenter, type: :view do
 
       it { is_expected.to have_select 'status', options: %w[Select Rerun Skip Complete] }
       it { is_expected.to have_css 'input[name="_method"][value="put"]', visible: false }
+      it { is_expected.to have_css 'input[name="repo"][value="dor"]', visible: false }
     end
   end
 end

--- a/spec/views/workflows/_show.html.erb_spec.rb
+++ b/spec/views/workflows/_show.html.erb_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'workflows/_show.html.erb' do
                     elapsed: nil,
                     attempts: nil,
                     lifecycle: nil,
+                    repository: 'dor',
                     note: nil)
   end
 


### PR DESCRIPTION
This avoids the need to lookup the workflow template object and allows us
to remove unnecessary conditionals