### PR TITLE
Update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,8 @@ RUN apt-get update -qq && \
 
 WORKDIR /app
 ADD Gemfile Gemfile.lock /app/
+
+# Get bundler 2.0 for ruby 2.6.4
+RUN gem install bundler
+
 RUN bundle install


### PR DESCRIPTION
I had trouble getting argo to start using docker-compose :

```
web_1               | ! Unable to load application: Bundler::LockfileError: You must use Bundler 2 or greater with this lockfile.
```

This fix allowed me to rebuild the web app:

```
docker-compose build web
```

and continue.   If there's a way to do something better, let me know.