### PR TITLE
Switch to the new workflow client update_status method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem 'blacklight', '~> 6.0'
 gem 'blacklight-hierarchy'
 gem 'dor-services', '~> 7.2'
 gem 'dor-services-client', '~> 2.2'
-gem 'dor-workflow-client', '~> 3.6'
+gem 'dor-workflow-client', '~> 3.7'
 gem 'mods_display'
 gem 'okcomputer' # monitors application and its dependencies
 gem 'responders', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,7 +222,7 @@ GEM
       moab-versioning (~> 4.0)
       nokogiri (~> 1.8)
       zeitwerk (~> 2.1)
-    dor-workflow-client (3.6.0)
+    dor-workflow-client (3.7.0)
       activesupport (>= 3.2.1, < 7)
       deprecation (>= 0.99.0)
       faraday (~> 0.9, >= 0.9.2)
@@ -654,7 +654,7 @@ DEPENDENCIES
   dlss-capistrano (~> 3.1)
   dor-services (~> 7.2)
   dor-services-client (~> 2.2)
-  dor-workflow-client (~> 3.6)
+  dor-workflow-client (~> 3.7)
   equivalent-xml (>= 0.6.0)
   eye
   factory_bot_rails

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -504,8 +504,4 @@ class ItemsController < ApplicationController
   def dor_lifecycle(object, stage)
     Dor::Config.workflow.client.lifecycle('dor', object.pid, stage)
   end
-
-  def set_dor_accession_status(object, task, status)
-    Dor::Config.workflow.client.update_workflow_status('dor', object.pid, 'accessionWF', task, status)
-  end
 end

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -68,15 +68,13 @@ class ReportController < CatalogController
 
     @workflow = params[:reset_workflow]
     @step = params[:reset_step]
-    @repo = repo_from_workflow(@workflow)
     @ids  = Report.new(params, current_user: current_user).pids
     @ids.each do |pid|
-      Dor::Config.workflow.client.update_workflow_status(
-        @repo,
-        "druid:#{pid}",
-        @workflow,
-        @step,
-        'waiting'
+      Dor::Config.workflow.client.update_status(
+        druid: "druid:#{pid}",
+        workflow: @workflow,
+        process: @step,
+        status: 'waiting'
       )
     end
     ### XXX: Where's the authorization?
@@ -94,13 +92,5 @@ class ReportController < CatalogController
     respond_to do |format|
       format.html
     end
-  end
-
-  private
-
-  ##
-  # @return [String, nil]
-  def repo_from_workflow(workflow)
-    Dor::WorkflowObject.find_by_name(workflow).try(:definition).try(:repo)
   end
 end

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -36,12 +36,14 @@ class WorkflowsController < ApplicationController
   def update
     authorize! :update, :workflow
     params.require [:process, :status, :repo]
-    args = params.values_at(:item_id, :id, :process, :status)
 
     # this will raise an exception if the item doesn't have that workflow step
-    Dor::Config.workflow.client.workflow_status params[:repo], *args.take(3)
+    Dor::Config.workflow.client.workflow_status params[:repo], params[:item_id], params[:id], params[:process]
     # update the status for the step and redirect to the workflow view page
-    Dor::Config.workflow.client.update_workflow_status params[:repo], *args
+    Dor::Config.workflow.client.update_status(druid: params[:item_id],
+                                              workflow: params[:id],
+                                              process: params[:process],
+                                              status: params[:status])
     respond_to do |format|
       if params[:bulk].present?
         render status: :ok, plain: 'Updated!'

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe ReportController, type: :controller do
   end
 
   describe 'POST reset' do
-    let(:repo) { 'dor' }
     let(:workflow) { 'accessionWF' }
     let(:step) { 'descriptive-metadata' }
 
@@ -64,23 +63,14 @@ RSpec.describe ReportController, type: :controller do
       expect { post :reset, xhr: true, params: { reset_workflow: workflow } }.to raise_error(ArgumentError)
       expect { post :reset, xhr: true, params: { reset_step: step } }.to raise_error(ArgumentError)
     end
+
     it 'sets instance variables and calls update workflow service' do
-      expect(controller).to receive(:repo_from_workflow)
-        .and_return(repo)
-      expect(Dor::Config.workflow.client).to receive(:update_workflow_status)
-        .with(repo, 'druid:xb482bw3979', workflow, step, 'waiting')
+      expect(Dor::Config.workflow.client).to receive(:update_status)
+        .with(druid: 'druid:xb482bw3979', workflow: workflow, process: step, status: 'waiting')
       post :reset, xhr: true, params: { reset_workflow: workflow, reset_step: step, q: 'Cephalopods' } # has single match
       expect(assigns(:workflow)).to eq workflow
       expect(assigns(:step)).to eq step
       expect(assigns(:ids)).to eq(%w(xb482bw3979))
-      expect(assigns(:repo)).to eq(repo)
-      expect(response).to have_http_status(:ok)
-    end
-    it 'gets repo from the WorkflowObject' do
-      expect(Dor::WorkflowObject).to receive(:find_by_name)
-        .and_return double(definition: double(repo: repo)) # mocks dor-services call
-      post :reset, xhr: true, params: { reset_workflow: workflow, reset_step: step, q: 'NoMatchesForThisString' }
-      expect(assigns(:repo)).to eq repo
       expect(response).to have_http_status(:ok)
     end
   end

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe WorkflowsController, type: :controller do
     let(:workflow_client) do
       instance_double(Dor::Workflow::Client,
                       workflow_status: nil,
-                      update_workflow_status: nil)
+                      update_status: nil)
     end
 
     before do
@@ -163,7 +163,7 @@ RSpec.describe WorkflowsController, type: :controller do
       expect(controller).to have_received(:authorize!).with(:update, :workflow)
       expect(subject).to redirect_to(solr_document_path(pid))
       expect(workflow_client).to have_received(:workflow_status).with('dor', pid, 'accessionWF', 'publish')
-      expect(workflow_client).to have_received(:update_workflow_status).with('dor', pid, 'accessionWF', 'publish', 'ready')
+      expect(workflow_client).to have_received(:update_status).with(druid: pid, workflow: 'accessionWF', process: 'publish', status: 'ready')
     end
   end
 end


### PR DESCRIPTION
This method means we no longer have to load workflow templates from Fedora.