### PR TITLE
Preserve the search parameters when the workflow grid is displayed

### DIFF
--- a/app/views/report/workflow_grid.html.erb
+++ b/app/views/report/workflow_grid.html.erb
@@ -12,7 +12,7 @@
   <% end %>
   <%= render 'catalog/report_view_toggle' %>
   <a href="<%= Settings.ROBOT_STATUS_URL %>" target="_blank">Robots queue/job status</a>
-  <div data-controller="workflow-grid" data-workflow-grid-url="<%= report_workflow_grid_path %>" data-workflow-grid-refresh-interval="10000">
+  <div data-controller="workflow-grid" data-workflow-grid-url="<%= url_for(only_path: true) %>" data-workflow-grid-refresh-interval="10000">
     <%= render Throbber %>
   </div>
 </div>


### PR DESCRIPTION
This fixes a regression where it was always displaying the full grid.