### PR TITLE
Remove unused lifecycles "Indexed" and "Ingested" from display

### DIFF
--- a/app/views/catalog/_show_milestones.html.erb
+++ b/app/views/catalog/_show_milestones.html.erb
@@ -29,11 +29,13 @@
             </td>
           </tr>
         <% end -%>
-        <tr class="version<%= version%>">
-          <td></td>
-          <td><%= m[:display] || k.titleize %></td>
-          <td><%= m[:time].nil? ? 'pending' : m[:time].in_time_zone.to_s() %></td>
-        </tr>
+        <% if k != "indexed" && k != "ingested" -%>
+          <tr class="version<%= version%>">
+            <td></td>
+            <td><%= m[:display] || k.titleize %></td>
+            <td><%= m[:time].nil? ? 'pending' : m[:time].in_time_zone.to_s() %></td>
+          </tr>
+        <% end -%>
       <% end -%>
     <% end -%>
   </tbody>

--- a/app/views/catalog/_show_milestones.html.erb
+++ b/app/views/catalog/_show_milestones.html.erb
@@ -1,40 +1,42 @@
 <table class="detail" style="width:100%">
   <thead>
-  <tr><th>version</th><th>what</th><th>when</th></tr>
+    <tr><th>version</th><th>what</th><th>when</th></tr>
   </thead>
   <tbody>
-  <%
-  ## TODO: Pick a real date format for the date to_s calls.
-  ## Do it here and NOT in the model!!
-  version_hash = document.get_versions
-  milestones = document.get_milestones
-  milestones.keys.sort.each do |version|
-    steps=milestones[version]
-    first=true
-    steps.each_pair do |k,m| %>
-<%
-      if first
-%><tr style="display:none" class="last_step<%= version%>"><td><span style="cursor: pointer;" onclick='$(".version<%= version%>").toggle();$(".last_step<%= version%>").toggle();'">+</span><%= version%></td>
-    <td><%= steps['accessioned'][:display] || k.titleize %></td>
-    <td><%= steps['accessioned'][:time].nil? ? 'pending' : steps['accessioned'][:time].in_time_zone.to_s() %></td></tr>
-      <%end%>
-  <tr class="version<%= version%>">
-  <%if first
-    first=false
-    %><td colspan=3 onclick='$(".version<%= version%>") .toggle();$(".last_step<%= version%>").toggle();'><span style="cursor: pointer;">-</span>
-    <%=version%>
-    <%if version_hash[version]%>
-      (<%=version_hash[version][:tag]%>) <%=version_hash[version][:desc]%>
-    <%end%>
-      </td>
-    </tr>
-    <tr class="version<%= version%>">
-  <%end%>
-      <td></td>
-      <td><%= m[:display] || k.titleize %></td>
-      <td><%= m[:time].nil? ? 'pending' : m[:time].in_time_zone.to_s() %></td>
-    </tr>
-  <%end%>
-<%end%>
+    <%
+      ## TODO: Pick a real date format for the date to_s calls.
+      ## Do it here and NOT in the model!!
+      version_hash = document.get_versions
+      milestones = document.get_milestones
+      milestones.keys.sort.each do |version|
+        steps=milestones[version]
+        first=true
+        steps.each_pair do |k,m| -%>
+        <% if first -%>
+          <tr style="display:none" class="last_step<%= version%>">
+            <td><span style="cursor: pointer;" onclick='$(".version<%= version%>").toggle();$(".last_step<%= version%>").toggle();'">+</span><%= version%></td>
+            <td><%= steps['accessioned'][:display] || k.titleize %></td>
+            <td><%= steps['accessioned'][:time].nil? ? 'pending' : steps['accessioned'][:time].in_time_zone.to_s() %></td>
+          </tr>
+        <% end -%>
+          <tr class="version<%= version%>">
+          <% if first
+              first=false
+          -%>
+            <td colspan=3 onclick='$(".version<%= version%>") .toggle();$(".last_step<%= version%>").toggle();'><span style="cursor: pointer;">-</span>
+              <%=version%>
+              <% if version_hash[version] -%>
+                (<%=version_hash[version][:tag]%>) <%=version_hash[version][:desc]%>
+              <% end -%>
+            </td>
+          </tr>
+          <tr class="version<%= version%>">
+          <% end -%>
+            <td></td>
+            <td><%= m[:display] || k.titleize %></td>
+            <td><%= m[:time].nil? ? 'pending' : m[:time].in_time_zone.to_s() %></td>
+          </tr>
+      <% end -%>
+    <% end -%>
   </tbody>
 </table>

--- a/app/views/catalog/_show_milestones.html.erb
+++ b/app/views/catalog/_show_milestones.html.erb
@@ -12,17 +12,15 @@
         steps=milestones[version]
         first=true
         steps.each_pair do |k,m| -%>
-        <% if first -%>
+        <% if first
+            first=false
+        -%>
           <tr style="display:none" class="last_step<%= version%>">
             <td><span style="cursor: pointer;" onclick='$(".version<%= version%>").toggle();$(".last_step<%= version%>").toggle();'">+</span><%= version%></td>
             <td><%= steps['accessioned'][:display] || k.titleize %></td>
             <td><%= steps['accessioned'][:time].nil? ? 'pending' : steps['accessioned'][:time].in_time_zone.to_s() %></td>
           </tr>
-        <% end -%>
           <tr class="version<%= version%>">
-          <% if first
-              first=false
-          -%>
             <td colspan=3 onclick='$(".version<%= version%>") .toggle();$(".last_step<%= version%>").toggle();'><span style="cursor: pointer;">-</span>
               <%=version%>
               <% if version_hash[version] -%>
@@ -30,12 +28,12 @@
               <% end -%>
             </td>
           </tr>
-          <tr class="version<%= version%>">
-          <% end -%>
-            <td></td>
-            <td><%= m[:display] || k.titleize %></td>
-            <td><%= m[:time].nil? ? 'pending' : m[:time].in_time_zone.to_s() %></td>
-          </tr>
+        <% end -%>
+        <tr class="version<%= version%>">
+          <td></td>
+          <td><%= m[:display] || k.titleize %></td>
+          <td><%= m[:time].nil? ? 'pending' : m[:time].in_time_zone.to_s() %></td>
+        </tr>
       <% end -%>
     <% end -%>
   </tbody>


### PR DESCRIPTION
@andrewjbtw signed off in dlss-infrastructure channel this morning on getting rid of this particular noise in the Argo item view.

You may find it easier to review by commit - the first two commits should have NO functionality change whatsoever;  just easier to read code.

# Before (master branch)

![image](https://user-images.githubusercontent.com/96775/64988998-76619c00-d881-11e9-8eae-2fbfc73eecec.png)

# After (this branch)

![image](https://user-images.githubusercontent.com/96775/64989003-795c8c80-d881-11e9-8b58-539d09928b07.png)

