### PR TITLE
[WIP - do not merge] get last_accessioned_version from preservation

### DIFF
--- a/app/helpers/dor_object_helper.rb
+++ b/app/helpers/dor_object_helper.rb
@@ -56,7 +56,7 @@ module DorObjectHelper
   end
 
   def last_accessioned_version(pid)
-    Dor::Services::Client.object(pid).sdr.current_version
+    PreservationClient.current_version(pid)
   end
 
   def render_qfacet_value(facet_solr_field, item, options = {})

--- a/app/services/preservation_client.rb
+++ b/app/services/preservation_client.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# A client for calling the remote preservation service
+class PreservationClient
+  class ResponseError < StandardError; end
+
+  # @param [String] druid - with or without prefix: 'druid:ab123cd4567' OR 'ab123cd4567'
+  def self.current_version(druid)
+    new.current_version(druid)
+  end
+
+  def initialize
+    @conn = conn
+  end
+
+  # @param [String] druid - with or without prefix: 'druid:ab123cd4567' OR 'ab123cd4567'
+  def current_version(druid)
+    resp = get("objects/#{druid}.json")
+    raise ResponseError, "Got #{resp.status} retrieving version from Preservation Catalog at #{resp.env.url}: #{resp.body}" unless resp.success?
+
+    json = JSON.parse(resp.body)
+    json['current_version']
+  end
+
+  private
+
+  def get(path)
+    conn.get(path)
+  rescue Faraday::ClientError => e
+    errmsg = "HTTP GET to #{Settings.preservation_catalog.url}/#{path} failed with #{e.class}: #{e.message}"
+    raise ResponseError, errmsg
+  end
+
+  def conn
+    @conn || Faraday.new(url: Settings.preservation_catalog.url)
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -58,7 +58,7 @@ DOR_SERVICES:
   TOKEN: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJGb28ifQ.-BVfLTW9Q1_ZQEsGv4tuzGLs5rESN7LgdtEwUltnKv4
 
 preservation_catalog:
-  url: 'http://PRESCATURL'
+  url: 'https://example.org/prescat'
 
 # URLs
 DOR_INDEXING_URL: 'https://dor-indexing-app.example.com/dor'

--- a/spec/helpers/dor_object_helper_spec.rb
+++ b/spec/helpers/dor_object_helper_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+class DummyClass
+  include DorObjectHelper
+end
+
+describe DorObjectHelper, type: :helper do
+  describe '#last_accessioned_version' do
+    let(:druid) { 'oo000oo0000' }
+
+    it 'uses PreservationClient' do
+      allow(PreservationClient).to receive(:current_version).with(druid)
+      DummyClass.new.last_accessioned_version(druid)
+      expect(PreservationClient).to have_received(:current_version).with(druid)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
@@ -14,7 +13,7 @@ require 'webmock/rspec'
 WebMock.allow_net_connect!(net_http_connect_on_start: true)
 
 require 'simplecov'
-SimpleCov.start do
+SimpleCov.start :rails do
   add_filter '/spec/'
   add_filter '/vendor/'
 end

--- a/spec/services/preservation_client_spec.rb
+++ b/spec/services/preservation_client_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PreservationClient do
+  describe '#current_version' do
+    let(:bare_druid) { 'oo666oo1234' }
+    let(:full_druid) { "druid:#{bare_druid}" }
+
+    let(:valid_response) do
+      {
+        'id': 666,
+        'druid': full_druid,
+        'current_version': 3,
+        'created_at': '2019-09-06T13:01:29.076Z',
+        'updated_at': '2019-09-15T13:01:29.076Z',
+        'preservation_policy_id': 1
+      }
+    end
+
+    context 'when druid has "druid:" prefix' do
+      before do
+        stub_request(:get, "#{Settings.preservation_catalog.url}/objects/#{full_druid}.json")
+          .to_return(status: 200, body: JSON.generate(valid_response), headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'gets the current version as an integer' do
+        expect(subject.current_version(full_druid)).to eq 3
+      end
+    end
+
+    context 'when druid is bare (without "druid:" prefix)' do
+      before do
+        stub_request(:get, "#{Settings.preservation_catalog.url}/objects/#{bare_druid}.json")
+          .to_return(status: 200, body: JSON.generate(valid_response), headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'gets the current version as an integer' do
+        expect(subject.current_version(bare_druid)).to eq 3
+      end
+    end
+
+    context 'when there is a Faraday ClientError' do
+      before do
+        stub_request(:get, "#{Settings.preservation_catalog.url}/objects/#{bare_druid}.json")
+          .to_raise(Faraday::TimeoutError.new('my message'))
+      end
+
+      it 'raises ResponseError' do
+        errmsg = 'HTTP GET to https://example.org/prescat/objects/oo666oo1234.json failed with Faraday::TimeoutError: my message'
+        expect { subject.current_version(bare_druid) }.to raise_error(PreservationClient::ResponseError, errmsg)
+      end
+    end
+
+    context 'when response code from preservation catalog is not 200' do
+      before do
+        stub_request(:get, "#{Settings.preservation_catalog.url}/objects/#{bare_druid}.json")
+          .to_return(status: 404, body: "{ foo: 'bar' }", headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'raises ResponseError' do
+        errmsg = "Got 404 retrieving version from Preservation Catalog at https://example.org/prescat/objects/oo666oo1234.json: { foo: 'bar' }"
+        expect { subject.current_version(bare_druid) }.to raise_error(PreservationClient::ResponseError, errmsg)
+      end
+    end
+  end
+end

--- a/spec/views/files/index.html.erb_spec.rb
+++ b/spec/views/files/index.html.erb_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'files/index.html.erb' do
     assign(:available_in_workspace_error, nil)
     expect(view).to receive(:params).and_return(id: 'M1090_S15_B01_F07_0106.jp2', item_id: 'druid:rn653dy9317').at_least(1)
     expect(view).to receive(:has_been_accessioned?).with(obj.pid).and_return(true)
-    expect(view).to receive(:last_accessioned_version).with(obj.pid).and_return('1.0.0')
+    expect(view).to receive(:last_accessioned_version).with(obj.pid).and_return('ignored here')
 
     render
   end


### PR DESCRIPTION
DO NOT MERGE -- I'm working on the PR that will use the new preservation-client gem instead.

get `last_accessioned_version` from preservation rather than dor-services-app proxying for sdr-services-app.

Note that CodeClimate has our coverage at 97% but it also didn't have coverage stats for helpers.  I tweaked the SimpleCov config to hopefully fix this.