### PR TITLE
Skip checking yarn integrity

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -53,7 +53,7 @@ development:
   compile: true
 
   # Verifies that correct packages and versions are installed by inspecting package.json, yarn.lock, and node_modules
-  check_yarn_integrity: true
+  check_yarn_integrity: false
 
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:


### PR DESCRIPTION
When running `docker-compose up web` we get this error:
```
warning Integrity check: System parameters don't match
```
I believe this happens when we move the yarn.lock from macos to linux (docker)

Skipping the integrity check allows us to carry on.