### PR TITLE
DescmetadataDownloadJob:  add authorization check for each exported object, miscellaneous cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If you want to use the rails console use:
 docker-compose run --rm web rails console
 ```
 
-If you want to run background jobs, which are necessary for spreadsheet bulk uploads and indexing run:
+If you want to run background jobs, which are necessary for spreadsheet bulk uploads and indexing to run:
 
 ```
 docker-compose run web bin/delayed_job start

--- a/app/jobs/descmetadata_download_job.rb
+++ b/app/jobs/descmetadata_download_job.rb
@@ -12,7 +12,7 @@ class DescmetadataDownloadJob < GenericJob
   # @param [Hash] params Custom params for this job
   # requires `:pids` (an Array of pids) and output_directory
   def perform(bulk_action_id, params)
-    @pids = params[:pids]
+    super
     zip_filename = generate_zip_filename(params[:output_directory])
     with_bulk_action_log do |log|
       #  Fail with an error message if the calling BulkAction doesn't exist

--- a/app/jobs/descmetadata_download_job.rb
+++ b/app/jobs/descmetadata_download_job.rb
@@ -38,6 +38,11 @@ class DescmetadataDownloadJob < GenericJob
       return
     end
 
+    unless ability.can?(:view_metadata, dor_object)
+      log.puts("#{Time.current} Not authorized for #{current_druid}")
+      return
+    end
+
     desc_metadata = dor_object.descMetadata.content
 
     write_to_zip(desc_metadata, current_druid, zip_file)

--- a/spec/jobs/descmetadata_download_job_spec.rb
+++ b/spec/jobs/descmetadata_download_job_spec.rb
@@ -64,6 +64,13 @@ RSpec.describe DescmetadataDownloadJob, type: :job do
   end
 
   describe 'perform' do
+    let(:ability) { instance_double(Ability) }
+
+    before do
+      allow(Ability).to receive(:new).and_return(ability)
+      allow(ability).to receive(:can?).with(:view_metadata, kind_of(ActiveFedora::Base)).and_return(true)
+    end
+
     after do
       FileUtils.rm('foo.txt')
     end

--- a/spec/jobs/descmetadata_download_job_spec.rb
+++ b/spec/jobs/descmetadata_download_job_spec.rb
@@ -129,6 +129,7 @@ RSpec.describe DescmetadataDownloadJob, type: :job do
         Zip::File.open(@output_zip_filename) do |open_file|
           expect(open_file.glob('*').map(&:name)).to eq ["#{@pid_list_long.first}.xml"]
         end
+        expect(File.open(bulk_action.log_name).read).to match(/Not authorized for #{@pid_list_long.second}/)
       end
     end
   end

--- a/spec/jobs/descmetadata_download_job_spec.rb
+++ b/spec/jobs/descmetadata_download_job_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe DescmetadataDownloadJob, type: :job do
 
       expect(File).to be_exist(@output_zip_filename)
       Zip::File.open(@output_zip_filename) do |open_file|
-        expect(open_file.glob('*').length).to eq 2
+        expect(open_file.glob('*').map(&:name).sort).to eq ["#{@pid_list_long.first}.xml", "#{@pid_list_long.second}.xml"].sort
       end
     end
 

--- a/spec/jobs/descmetadata_download_job_spec.rb
+++ b/spec/jobs/descmetadata_download_job_spec.rb
@@ -23,23 +23,22 @@ RSpec.describe DescmetadataDownloadJob, type: :job do
   end
 
   describe 'start_log' do
-    before do
-      @log = double('log')
-      allow(@log).to receive(:flush)
-    end
+    let(:log) { double('log') }
+
+    before { allow(log).to receive(:flush) }
 
     it 'writes the correct information to the log' do
-      expect(@log).to receive(:puts).with(/^argo.bulk_metadata.bulk_log_job_start .*/)
-      expect(@log).to receive(:puts).with(/^argo.bulk_metadata.bulk_log_user .*/)
-      expect(@log).to receive(:puts).with(/^argo.bulk_metadata.bulk_log_input_file .*/)
-      expect(@log).to receive(:puts).with(/^argo.bulk_metadata.bulk_log_note .*/)
-      download_job.start_log(@log, 'fakeuser', 'fakefile', 'fakenote')
+      expect(log).to receive(:puts).with(/^argo.bulk_metadata.bulk_log_job_start .*/)
+      expect(log).to receive(:puts).with(/^argo.bulk_metadata.bulk_log_user .*/)
+      expect(log).to receive(:puts).with(/^argo.bulk_metadata.bulk_log_input_file .*/)
+      expect(log).to receive(:puts).with(/^argo.bulk_metadata.bulk_log_note .*/)
+      download_job.start_log(log, 'fakeuser', 'fakefile', 'fakenote')
     end
 
     it 'completes without erring given a nil argument for note, or no arg' do
-      allow(@log).to receive(:puts)
-      expect { download_job.start_log(@log, 'fakeuser', 'fakefile', nil) }.not_to raise_error
-      expect { download_job.start_log(@log, 'fakeuser', 'fakefile')      }.not_to raise_error
+      allow(log).to receive(:puts)
+      expect { download_job.start_log(log, 'fakeuser', 'fakefile', nil) }.not_to raise_error
+      expect { download_job.start_log(log, 'fakeuser', 'fakefile')      }.not_to raise_error
     end
   end
 
@@ -117,22 +116,20 @@ RSpec.describe DescmetadataDownloadJob, type: :job do
   end
 
   describe 'query_dor' do
-    before do
-      @log = double('log')
-    end
+    let(:log) { double('log') }
 
     it 'does not log anything upon success' do
-      result = download_job.query_dor('druid:hj185vb7593', @log)
+      result = download_job.query_dor('druid:hj185vb7593', log)
       expect(result).not_to be_nil
-      expect(@log).not_to receive(:puts)
+      expect(log).not_to receive(:puts)
     end
 
     it 'attempts three connections and logs failures' do
       dor_double = class_double('Dor').as_stubbed_const(transfer_nested_constants: false)
       expect(dor_double).to receive(:find).exactly(3).times.and_raise(RestClient::RequestTimeout)
-      expect(@log).to receive(:puts).twice.with('argo.bulk_metadata.bulk_log_retry druid:123')
-      expect(@log).to receive(:puts).once.with('argo.bulk_metadata.bulk_log_timeout druid:123')
-      result = download_job.query_dor('druid:123', @log)
+      expect(log).to receive(:puts).twice.with('argo.bulk_metadata.bulk_log_retry druid:123')
+      expect(log).to receive(:puts).once.with('argo.bulk_metadata.bulk_log_timeout druid:123')
+      result = download_job.query_dor('druid:123', log)
       expect(result).to eq(nil)
     end
   end

--- a/spec/jobs/descmetadata_download_job_spec.rb
+++ b/spec/jobs/descmetadata_download_job_spec.rb
@@ -4,10 +4,11 @@ require 'rails_helper'
 require 'fileutils'
 
 RSpec.describe DescmetadataDownloadJob, type: :job do
+  let(:download_job) { described_class.new }
+
   before :all do
     @output_directory = File.join(File.expand_path('../../../tmp/', __FILE__), 'descmetadata_download_job_spec')
     @output_zip_filename = File.join(@output_directory, Settings.BULK_METADATA.ZIP)
-    @download_job = described_class.new
     @pid_list_short = ['druid:hj185vb7593']
     @pid_list_long = ['druid:hj185vb7593', 'druid:kv840rx2720']
     @zip_params_short = {
@@ -26,7 +27,7 @@ RSpec.describe DescmetadataDownloadJob, type: :job do
 
   describe 'generate_zip_filename' do
     it 'returns a filename of the correct form' do
-      expect(@download_job.generate_zip_filename(@output_directory)).to eq(@output_zip_filename)
+      expect(download_job.generate_zip_filename(@output_directory)).to eq(@output_zip_filename)
     end
   end
 
@@ -41,13 +42,13 @@ RSpec.describe DescmetadataDownloadJob, type: :job do
       expect(@log).to receive(:puts).with(/^argo.bulk_metadata.bulk_log_user .*/)
       expect(@log).to receive(:puts).with(/^argo.bulk_metadata.bulk_log_input_file .*/)
       expect(@log).to receive(:puts).with(/^argo.bulk_metadata.bulk_log_note .*/)
-      @download_job.start_log(@log, 'fakeuser', 'fakefile', 'fakenote')
+      download_job.start_log(@log, 'fakeuser', 'fakefile', 'fakenote')
     end
 
     it 'completes without erring given a nil argument for note, or no arg' do
       allow(@log).to receive(:puts)
-      expect { @download_job.start_log(@log, 'fakeuser', 'fakefile', nil) }.not_to raise_error
-      expect { @download_job.start_log(@log, 'fakeuser', 'fakefile')      }.not_to raise_error
+      expect { download_job.start_log(@log, 'fakeuser', 'fakefile', nil) }.not_to raise_error
+      expect { download_job.start_log(@log, 'fakeuser', 'fakefile')      }.not_to raise_error
     end
   end
 
@@ -59,7 +60,7 @@ RSpec.describe DescmetadataDownloadJob, type: :job do
       string_value = 'descMetadata.xml'
       expect(zip).to receive(:get_output_stream).with("#{druid}.xml").and_yield(output_file)
       expect(output_file).to receive(:puts).with(string_value)
-      @download_job.write_to_zip(string_value, druid, zip)
+      download_job.write_to_zip(string_value, druid, zip)
     end
   end
 
@@ -80,9 +81,9 @@ RSpec.describe DescmetadataDownloadJob, type: :job do
                            action_type: 'DescmetadataDownloadJob',
                            pids: @pid_list_long,
                            log_name: 'foo.txt')
-      expect(@download_job).to receive(:bulk_action).and_return(bulk_action).at_least(:once)
+      expect(download_job).to receive(:bulk_action).and_return(bulk_action).at_least(:once)
 
-      @download_job.perform(bulk_action.id, @zip_params_long)
+      download_job.perform(bulk_action.id, @zip_params_long)
 
       expect(File).to be_exist(@output_zip_filename)
       Zip::File.open(@output_zip_filename) do |open_file|
@@ -99,9 +100,9 @@ RSpec.describe DescmetadataDownloadJob, type: :job do
                            log_name: 'foo.txt')
       allow(bulk_action).to receive_message_chain(:increment, :save)
       expect(bulk_action).to receive(:increment).with(:druid_count_fail)
-      expect(@download_job).to receive(:bulk_action).and_return(bulk_action).at_least(:once)
+      expect(download_job).to receive(:bulk_action).and_return(bulk_action).at_least(:once)
 
-      @download_job.perform(bulk_action.id, @zip_params_short)
+      download_job.perform(bulk_action.id, @zip_params_short)
 
       expect(File).to be_exist(@output_zip_filename)
       Zip::File.open(@output_zip_filename) do |open_file|
@@ -120,9 +121,9 @@ RSpec.describe DescmetadataDownloadJob, type: :job do
                              action_type: 'DescmetadataDownloadJob',
                              pids: @pid_list_long,
                              log_name: 'foo.txt')
-        expect(@download_job).to receive(:bulk_action).and_return(bulk_action).at_least(:once)
+        expect(download_job).to receive(:bulk_action).and_return(bulk_action).at_least(:once)
 
-        @download_job.perform(bulk_action.id, @zip_params_long)
+        download_job.perform(bulk_action.id, @zip_params_long)
 
         expect(File).to be_exist(@output_zip_filename)
         Zip::File.open(@output_zip_filename) do |open_file|
@@ -138,7 +139,7 @@ RSpec.describe DescmetadataDownloadJob, type: :job do
     end
 
     it 'does not log anything upon success' do
-      result = @download_job.query_dor('druid:hj185vb7593', @log)
+      result = download_job.query_dor('druid:hj185vb7593', @log)
       expect(result).not_to be_nil
       expect(@log).not_to receive(:puts)
     end
@@ -148,7 +149,7 @@ RSpec.describe DescmetadataDownloadJob, type: :job do
       expect(dor_double).to receive(:find).exactly(3).times.and_raise(RestClient::RequestTimeout)
       expect(@log).to receive(:puts).twice.with('argo.bulk_metadata.bulk_log_retry druid:123')
       expect(@log).to receive(:puts).once.with('argo.bulk_metadata.bulk_log_timeout druid:123')
-      result = @download_job.query_dor('druid:123', @log)
+      result = download_job.query_dor('druid:123', @log)
       expect(result).to eq(nil)
     end
   end


### PR DESCRIPTION
*  check whether user who started the job can view metadata for each object in the job's pid list.  if the user cannot, log the event, skip exporting the metadata for that object, and continue processing the rest.
  * corresponding new test for the permission check
* tighten up an existing expectation for the happy path use case (user has permission and all objects in job's pid list are successfully retrieved)
* refactoring/cleanup:
  * spec:  turn all the instance vars into `let` vars, turn a local example var into a `let` var (and consolidate on the longer pid list for all the tests)
  * job:  remove an unneeded setting of an instance var in the job, and instead rely on the parent class to do setup

i believe this...

closes #1491