### PR TITLE
Extract code from views by creating an ActionButton component

### DIFF
--- a/app/components/action_button.html.erb
+++ b/app/components/action_button.html.erb
@@ -1,0 +1,1 @@
+<%= link_to label, url, class: "btn button btn-primary #{'disabled' if disabled?}", data: button_data %>

--- a/app/components/action_button.rb
+++ b/app/components/action_button.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Draws a blue button in the side menu
+class ActionButton < ApplicationComponent
+  # @param [Hash] properties the button properties
+  def initialize(label:, url:, confirm: nil, new_page: nil, check_url: nil, disabled: nil)
+    @label = label
+    @url = url
+    @confirm = confirm
+    @new_page = new_page
+    @check_url = check_url
+    @disabled = disabled
+  end
+
+  def disabled?
+    check_url || disabled
+  end
+
+  def button_data
+    {}.tap do |data|
+      if confirm
+        # :confirm trumps :blacklight_modal, because :blacklight_modal would negate :confirm by firing the ajax request regardless of the user's decision
+        data[:confirm] = confirm
+      elsif !new_page
+        data[:blacklight_modal] = 'trigger'
+      end
+      data[:check_url] = check_url if check_url
+    end
+  end
+
+  attr_reader :label, :confirm, :new_page, :check_url, :url, :disabled
+end

--- a/app/views/items/_button_link_list.html.erb
+++ b/app/views/items/_button_link_list.html.erb
@@ -1,17 +1,5 @@
 <div class='btn-group-vertical argo-show-btn-group' role='group' aria-label='Argo action buttons'>
   <% buttons.each do |button|%>
-    <%
-      button_data = {}
-      if button[:confirm]
-        # :confirm trumps :blacklight_modal, because :blacklight_modal would negate :confirm by firing the ajax request regardless of the user's decision
-        button_data[:confirm] = button[:confirm]
-      elsif !button[:new_page]
-        button_data[:blacklight_modal] = 'trigger'
-      end
-      if button[:check_url]
-        button_data[:check_url] = button[:check_url]
-      end
-    %>
-    <%= link_to button[:label], button[:url], class: "btn button btn-primary #{'disabled' if button[:check_url] || button[:disabled]}", data: button_data %>
+    <%= render ActionButton, button %>
   <% end %>
 </div>

--- a/spec/views/items/_button_link_list.html.erb_spec.rb
+++ b/spec/views/items/_button_link_list.html.erb_spec.rb
@@ -16,8 +16,7 @@ describe 'items/_button_link_list.html.erb' do
       },
       {
         label: 'Ajax me',
-        url: 'http://www.example.com/ajax',
-        ajax_modal: true
+        url: 'http://www.example.com/ajax'
       },
       {
         label: 'Check me',


### PR DESCRIPTION
## Why was this change made?

Keep code out of the views.

## Was the documentation updated?

N/A