### PR TITLE
use preservation-client gem to get last_accessioned_version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ gem 'dor-services-client', '~> 2.2'
 gem 'dor-workflow-client', '~> 3.7'
 gem 'mods_display'
 gem 'okcomputer' # monitors application and its dependencies
+gem 'preservation-client'
 gem 'responders', '~> 2.0'
 gem 'rsolr'
 gem 'sul_styles', '~> 0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -388,6 +388,10 @@ GEM
       ttfunk (~> 1.4.0)
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
+    preservation-client (0.1.0)
+      activesupport (>= 4.2, < 7)
+      faraday (~> 0.15)
+      zeitwerk (~> 2.1)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -652,6 +656,7 @@ DEPENDENCIES
   okcomputer
   prawn (~> 1)
   prawn-table
+  preservation-client
   pry-byebug
   pry-rails
   pry-remote

--- a/app/helpers/dor_object_helper.rb
+++ b/app/helpers/dor_object_helper.rb
@@ -56,7 +56,7 @@ module DorObjectHelper
   end
 
   def last_accessioned_version(pid)
-    Dor::Services::Client.object(pid).sdr.current_version
+    Preservation::Client.objects.current_version(pid)
   end
 
   def render_qfacet_value(facet_solr_field, item, options = {})

--- a/config/initializers/preservation_client.rb
+++ b/config/initializers/preservation_client.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Configure preservation-client to use preservation catalog URL
+Preservation::Client.configure(url: Settings.preservation_catalog.url)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -58,7 +58,7 @@ DOR_SERVICES:
   TOKEN: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJGb28ifQ.-BVfLTW9Q1_ZQEsGv4tuzGLs5rESN7LgdtEwUltnKv4
 
 preservation_catalog:
-  url: 'http://PRESCATURL'
+  url: 'https://example.org/prescat'
 
 # URLs
 DOR_INDEXING_URL: 'https://dor-indexing-app.example.com/dor'

--- a/spec/helpers/dor_object_helper_spec.rb
+++ b/spec/helpers/dor_object_helper_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+class DummyClass
+  include DorObjectHelper
+end
+
+describe DorObjectHelper, type: :helper do
+  describe '#last_accessioned_version' do
+    let(:druid) { 'oo000oo0000' }
+
+    it 'uses preservation-client gem' do
+      allow(Preservation::Client.objects).to receive(:current_version).with(druid)
+      DummyClass.new.last_accessioned_version(druid)
+      expect(Preservation::Client.objects).to have_received(:current_version).with(druid)
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

get `last_accessioned_version` from preservation rather than dor-services-app proxying for sdr-services-app.  This PR uses the new preservation-client gem to get the info from a preservation-catalog ReST endpoint.

## Was the documentation updated?

N/A