### PR TITLE
Avoid looking in solr for workflow templates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ gem 'blacklight', '~> 6.0'
 gem 'blacklight-hierarchy'
 gem 'dor-services', '~> 8.1'
 gem 'dor-services-client', '~> 2.2'
-gem 'dor-workflow-client', '~> 3.7'
+gem 'dor-workflow-client', '~> 3.9'
 gem 'mods_display'
 gem 'okcomputer' # monitors application and its dependencies
 gem 'responders', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,7 +215,7 @@ GEM
       moab-versioning (~> 4.0)
       nokogiri (~> 1.8)
       zeitwerk (~> 2.1)
-    dor-workflow-client (3.8.0)
+    dor-workflow-client (3.9.0)
       activesupport (>= 3.2.1, < 7)
       deprecation (>= 0.99.0)
       faraday (~> 0.9, >= 0.9.2)
@@ -636,7 +636,7 @@ DEPENDENCIES
   dlss-capistrano (~> 3.1)
   dor-services (~> 8.1)
   dor-services-client (~> 2.2)
-  dor-workflow-client (~> 3.7)
+  dor-workflow-client (~> 3.9)
   equivalent-xml (>= 0.6.0)
   eye
   factory_bot_rails

--- a/app/controllers/workflow_service_controller.rb
+++ b/app/controllers/workflow_service_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# Calls the workflow service to determine the state of an object.
+# Used by AJAX requests mainly from the action buttons (check_url)
 class WorkflowServiceController < ApplicationController
   ##
   # Is a document closeable?

--- a/app/helpers/apo_helper.rb
+++ b/app/helpers/apo_helper.rb
@@ -11,14 +11,15 @@ module ApoHelper
     [['Symphony'], ['DOR']]
   end
 
+  # Retrieve a list of workflow templates from  the workflow service and return
+  # an array suitable for select_tag options
   def workflow_options
-    q = 'objectType_ssim:workflow '
-    result = Dor::SearchService.query(q, rows: 99999, fl: 'id,tag_ssim,sw_display_title_tesim')['response']['docs']
-    result.sort! do |a, b|
-      a['sw_display_title_tesim'].to_s <=> b['sw_display_title_tesim'].to_s
-    end
-    result.collect do |doc|
-      [Array(doc['sw_display_title_tesim']).first.to_s, Array(doc['sw_display_title_tesim']).first.to_s]
+    Rails.cache.fetch 'workflow-templates-select-options' do
+      client = Dor::Config.workflow.client
+      list = Dor::Workflow::Client::WorkflowTemplate.new(requestor: client.requestor).all
+      list.map do |name|
+        [name, name]
+      end
     end
   end
 

--- a/spec/features/workflow_service_creation_spec.rb
+++ b/spec/features/workflow_service_creation_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe 'Workflow Service Creation' do
     visit new_item_workflow_path 'druid:qq613vj0238'
     click_button 'Add'
     within '.flash_messages' do
-      expect(page).to have_css '.alert.alert-info', text: 'Added accessionWF'
+      # The selected workflow defaults to Settings.apo.default_workflow_option (registrationWF)
+      expect(page).to have_css '.alert.alert-info', text: 'Added registrationWF'
     end
     expect(workflow_client).to have_received(:create_workflow_by_name)
   end


### PR DESCRIPTION
Instead get them directly from the workflow service. 

## Why was this change made?


This will allow us to remove workflow templates from Fedora


## Was the documentation updated?
N/A