### PR TITLE
Rename a spec for clarity

### DIFF
--- a/spec/features/add_workflow_to_item_spec.rb
+++ b/spec/features/add_workflow_to_item_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Workflow Service Creation' do
+RSpec.describe 'Add a workflow to an item' do
   let(:stub_workflow) { instance_double(Dor::Workflow::Response::Workflow, active_for?: false) }
   let(:workflow_client) do
     instance_double(Dor::Workflow::Client,


### PR DESCRIPTION
## Why was this change made?

The old spec was misleading because this doesn't use the WorkflowServiceController.

## Was the documentation updated?

N/A