### PR TITLE
Stub out the workflow template client

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -55,4 +55,7 @@ Rails.application.configure do
 
   require 'test_shibboleth_headers'
   config.middleware.use TestShibbolethHeaders
+
+  # Turn off custom caching in tests
+  config.cache_store = :null_store
 end

--- a/spec/features/add_workflow_to_item_spec.rb
+++ b/spec/features/add_workflow_to_item_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Add a workflow to an item' do
   let(:stub_workflow) { instance_double(Dor::Workflow::Response::Workflow, active_for?: false) }
+  let(:requestor) { instance_double(Dor::Workflow::Client::Requestor) }
   let(:workflow_client) do
     instance_double(Dor::Workflow::Client,
                     workflow: stub_workflow,
@@ -11,12 +12,17 @@ RSpec.describe 'Add a workflow to an item' do
                     all_workflows_xml: '',
                     milestones: [],
                     lifecycle: [],
-                    active_lifecycle: [])
+                    active_lifecycle: [],
+                    requestor: requestor)
+  end
+  let(:workflow_template) do
+    instance_double(Dor::Workflow::Client::WorkflowTemplate, all: %w[assemblyWF registrationWF])
   end
 
   before do
     sign_in create(:user), groups: ['sdr:administrator-role']
     allow(Dor::Config.workflow).to receive(:client).and_return(workflow_client)
+    allow(Dor::Workflow::Client::WorkflowTemplate).to receive(:new).and_return(workflow_template)
   end
 
   it 'redirect and display on show page' do


### PR DESCRIPTION
previously the caching behavior was preventing this from being tested locally

## Why was this change made?

Test were failing on master.  The cache behavior was preventing all the code from running locally.


## Was the documentation updated?

N/a
