### PR TITLE
Use the simpler interface in dor-services-client 3.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ gem 'blacklight', '~> 6.0'
 gem 'blacklight-hierarchy'
 gem 'dor-services', '~> 8.1'
 gem 'dor-services-client', '~> 2.2'
-gem 'dor-workflow-client', '~> 3.9'
+gem 'dor-workflow-client', '~> 3.10'
 gem 'mods_display'
 gem 'okcomputer' # monitors application and its dependencies
 gem 'preservation-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,7 +215,7 @@ GEM
       moab-versioning (~> 4.0)
       nokogiri (~> 1.8)
       zeitwerk (~> 2.1)
-    dor-workflow-client (3.9.0)
+    dor-workflow-client (3.10.0)
       activesupport (>= 3.2.1, < 7)
       deprecation (>= 0.99.0)
       faraday (~> 0.9, >= 0.9.2)
@@ -640,7 +640,7 @@ DEPENDENCIES
   dlss-capistrano (~> 3.1)
   dor-services (~> 8.1)
   dor-services-client (~> 2.2)
-  dor-workflow-client (~> 3.9)
+  dor-workflow-client (~> 3.10)
   equivalent-xml (>= 0.6.0)
   eye
   factory_bot_rails

--- a/app/helpers/apo_helper.rb
+++ b/app/helpers/apo_helper.rb
@@ -15,8 +15,7 @@ module ApoHelper
   # an array suitable for select_tag options
   def workflow_options
     Rails.cache.fetch 'workflow-templates-select-options' do
-      client = Dor::Config.workflow.client
-      list = Dor::Workflow::Client::WorkflowTemplate.new(requestor: client.requestor).all
+      list = Dor::Config.workflow.client.workflow_templates
       list.map do |name|
         [name, name]
       end

--- a/spec/features/add_workflow_to_item_spec.rb
+++ b/spec/features/add_workflow_to_item_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 RSpec.describe 'Add a workflow to an item' do
   let(:stub_workflow) { instance_double(Dor::Workflow::Response::Workflow, active_for?: false) }
-  let(:requestor) { instance_double(Dor::Workflow::Client::Requestor) }
   let(:workflow_client) do
     instance_double(Dor::Workflow::Client,
                     workflow: stub_workflow,
@@ -12,17 +11,13 @@ RSpec.describe 'Add a workflow to an item' do
                     all_workflows_xml: '',
                     milestones: [],
                     lifecycle: [],
-                    active_lifecycle: [],
-                    requestor: requestor)
-  end
-  let(:workflow_template) do
-    instance_double(Dor::Workflow::Client::WorkflowTemplate, all: %w[assemblyWF registrationWF])
+                    workflow_templates: %w[assemblyWF registrationWF],
+                    active_lifecycle: [])
   end
 
   before do
     sign_in create(:user), groups: ['sdr:administrator-role']
     allow(Dor::Config.workflow).to receive(:client).and_return(workflow_client)
-    allow(Dor::Workflow::Client::WorkflowTemplate).to receive(:new).and_return(workflow_template)
   end
 
   it 'redirect and display on show page' do


### PR DESCRIPTION
## Why was this change made?

The previous code was a workaround for shortcomings in dor-services-client.  Now that the shortcomings are addressed, we should use the simpler way.

## Was the documentation updated?
n/a