### PR TITLE
preservation-client v0.2.1 fixes bug getting current_version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -388,7 +388,7 @@ GEM
       ttfunk (~> 1.4.0)
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
-    preservation-client (0.2.0)
+    preservation-client (0.2.1)
       activesupport (>= 4.2, < 7)
       faraday (~> 0.15)
       zeitwerk (~> 2.1)


### PR DESCRIPTION
## Why was this change made?

To fix any calls to dor_objects_helper.last_accessioned_version, which was broken, and to fix

![image](https://user-images.githubusercontent.com/96775/65550723-126c5280-ded5-11e9-81a5-cde83a02abc4.png)

## Was the documentation updated?

n/a