### PR TITLE
Spend less time scanning irrelevant and potentially large directories for Ruby files that are not there

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,13 @@ AllCops:
     - db/schema.rb
     - vendor/bundle/**/*
     - node_modules/**/*
+    - tmp/**/*
+    - log/**/*
+    - fedora_conf/**/*
+    - public/**/*
+    - coverage/**/*
+    - postgres-data/**/*
+    - spec/fixtures/**/*
 
 Rails:
   Enabled: true


### PR DESCRIPTION
## Why was this change made?


This helps rubocop start up more quickly, shaving at least a few seconds off the build

## Was the documentation updated?

n/a