### PR TITLE
fix the names of the Config gem settings that docker-compose.yml overrides via env var (for argo and dor-services-app)

### DIFF
--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -5,5 +5,5 @@ Config.setup do |config|
   config.use_env = true
   config.env_prefix = 'SETTINGS'
   config.env_separator = '__'
-  config.env_converter = nil # don't downcase
+  config.env_converter = :downcase
 end


### PR DESCRIPTION
## Why was this change made?

this prevents connection errors between the argo service and solr (and likely other services) when spinning up the application for local development via `docker-compose up`.  after #1644, there was a mismatch between what settings names the application expected, and what settings the `docker-compose.yml` file provided in practice via env vars.  instead of connecting to the right container within the docker environment, the argo service was attempting to connect to localhost:8984.  example error before the change:
![Screen Shot 2019-09-24 at 4 27 30 PM](https://user-images.githubusercontent.com/7741604/65559406-67b55d80-deef-11e9-967c-98c5dc44160d.png)

after the change, i spin up the services via `docker-compose up`, and get a working (blank) argo front page.


## Was the documentation updated?

N/A