### PR TITLE
add webpacker compile when building web container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,3 @@ RUN bundle install
 
 COPY package.json yarn.lock ./
 RUN yarn install
-
-RUN bundle exec rake webpacker:compile

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,3 +23,5 @@ RUN bundle install
 
 COPY package.json yarn.lock ./
 RUN yarn install
+
+RUN bundle exec rake webpacker:compile

--- a/README.md
+++ b/README.md
@@ -62,11 +62,19 @@ docker-compose run --rm web rake argo:repo:load
 
 If you run into errors related to the version of bundler when building the `web` container, that likely means you need to pull a newer copy of the base Ruby image specified in `Dockerfile`, e.g., `docker pull ruby:{MAJOR}.{MINOR}-stretch`.
 
+Also, if you run into webpacker related issues, you may need to manually install yarn and compile webpacker in your Docker container (or local laptop if you running that way):
+
+```
+docker-compose run --rm web yarn
+docker-compose run --rm web bundle exec rake webpacker:compile
+```
+
 ## Load and index records
 
 ```
 docker-compose run --rm web rake argo:repo:load
 ```
+
 
 ## Common tasks
 


### PR DESCRIPTION
## Why was this change made?

John and I had problems spinning up the web docker container unless we ran this step manually.

Note: Even though the Dockerfile currently installs Yarn, I had to re-do that before running the compile command, like this:

```yarn```

Not sure why.

## Was the documentation updated?

Should we update documentation instead?  
