### PR TITLE
Generate schema with underscore for date separator

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180510050959) do
+ActiveRecord::Schema.define(version: 2018_05_10_050959) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false


### PR DESCRIPTION
## Why was this change made?
This is the default when you run db:migrate.  it's easer to read


## Was the documentation updated?
N/A