### PR TITLE
Install bundler before moving the Gemfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,13 @@ RUN apt-get update \
     nodejs apt-transport-https yarn \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# Get bundler 2.0 for ruby 2.6.4
+RUN gem install bundler
+
+
 WORKDIR /app
 
 ADD Gemfile Gemfile.lock /app/
-
-# Get bundler 2.0 for ruby 2.6.4
-RUN gem install bundler
 
 RUN bundle install
 


### PR DESCRIPTION
## Why was this change made?

This is an optimizatiton so we don't need to reinstall bunder evertime we change the Gemfile.lock

## Was the documentation updated?
