### PR TITLE
bypass jqgrid column selector and just implement in plain html checkboxes

### DIFF
--- a/app/assets/stylesheets/argo/argo.sass
+++ b/app/assets/stylesheets/argo/argo.sass
@@ -170,3 +170,11 @@ button.close
 #import-csv
   margin-top: 10px
   margin-bottom: 10px
+
+#column_selector
+  border: 1px solid grey
+  margin-left: 110px
+  padding: 10px
+  width: 50%
+  font-size: 12px
+  line-height: 1.5

--- a/app/javascript/packs/report.js
+++ b/app/javascript/packs/report.js
@@ -52,11 +52,7 @@ $(document).ready(function() {
     caption: "Columns",
     title: "Choose Columns",
     buttonicon: 'ui-icon-script',
-    onClickButton() { return $('#report_grid').jqGrid('columnChooser', {
-      done(stuff) { return (
-        this.resize()
-      ); }
-    }); }
+    onClickButton() { $('#column_selector').toggleClass('hidden'); }
   }
   );
 
@@ -65,8 +61,8 @@ $(document).ready(function() {
     title: "Download as CSV",
     buttonicon: 'ui-icon-disk',
     onClickButton() {
-      const visible = $.grep($('#report_grid').jqGrid('getGridParam','colModel'), (col,idx) => (col.name !== 'rn') && !col.hidden);
-      const field_list = $.map(visible, (col,idx) => col.name).join(',');
+      var selected_columns = Array.from(document.querySelectorAll("input[name='selected_columns']:checked"));
+      var field_list = selected_columns.map(col => col.value).join(',');
       return $("body").append(`<iframe src='${report_model.download_url}&fields=${field_list}' style='display: none;' ></iframe>`);
     }
   }

--- a/app/javascript/packs/report.js
+++ b/app/javascript/packs/report.js
@@ -52,7 +52,7 @@ $(document).ready(function() {
     caption: "Columns",
     title: "Choose Columns",
     buttonicon: 'ui-icon-script',
-    onClickButton() { $('#column_selector').toggleClass('hidden'); }
+    onClickButton() { document.getElementById('column_selector').classList.toggle('hidden'); }
   }
   );
 
@@ -61,8 +61,8 @@ $(document).ready(function() {
     title: "Download as CSV",
     buttonicon: 'ui-icon-disk',
     onClickButton() {
-      var selected_columns = Array.from(document.querySelectorAll("input[name='selected_columns']:checked"));
-      var field_list = selected_columns.map(col => col.value).join(',');
+      const selected_columns = Array.from(document.querySelectorAll("input[name='selected_columns']:checked"));
+      const field_list = selected_columns.map(col => col.value).join(',');
       return $("body").append(`<iframe src='${report_model.download_url}&fields=${field_list}' style='display: none;' ></iframe>`);
     }
   }

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -23,124 +23,124 @@ class Report
       {
         field: :druid, label: 'Druid',
         proc: lambda { |doc| doc['id'].split(/:/).last },
-        sort: true, default: true, width: 100
+        sort: true, default: true, width: 100, download_default: true
       },
       {
         field: :purl, label: 'Purl',
         proc: lambda { |doc| File.join(Settings.purl_url, doc['id'].split(/:/).last) },
         solr_fields: %w(id),
-        sort: false, default: false, width: 100
+        sort: false, default: false, width: 100, download_default: true
       },
       {
         field: :title, label: 'Title',
         proc: lambda { |doc| retrieve_terms(doc)[:title] },
         solr_fields: %w(sw_display_title_tesim obj_label_ssim),
-        sort: false, default: false, width: 100
+        sort: false, default: false, width: 100, download_default: true
       },
       {
         field: :citation, label: 'Citation',
         proc: lambda { |doc| render_citation(doc) },
         solr_fields: %w(sw_author_tesim sw_display_title_tesim obj_label_ssim originInfo_place_placeTerm_tesim originInfo_publisher_tesim),
-        sort: false, default: true, width: 100
+        sort: false, default: true, width: 100, download_default: false
       },
       {
         field: :source_id_ssim, label: 'Source Id',
-        sort: false, default: true, width: 100
+        sort: false, default: true, width: 100, download_default: true
       },
       {
         field: SolrDocument::FIELD_APO_ID, label: 'Admin Policy ID',
         proc: lambda { |doc| doc[SolrDocument::FIELD_APO_ID].first.split(/:/).last },
-        sort: false, default: false, width: 100
+        sort: false, default: false, width: 100, download_default: false
       },
       {
         field: SolrDocument::FIELD_APO_TITLE, label: 'Admin Policy',
-        sort: false, default: true, width: 100
+        sort: false, default: true, width: 100, download_default: false
       },
       {
         field: SolrDocument::FIELD_COLLECTION_ID, label: 'Collection ID',
         proc: lambda { |doc| doc[SolrDocument::FIELD_COLLECTION_ID].map { |id| id.split(/:/).last } },
-        sort: false, default: false, width: 100
+        sort: false, default: false, width: 100, download_default: false
       },
       {
         field: SolrDocument::FIELD_COLLECTION_TITLE, label: 'Collection',
         proc: lambda { |doc| doc[SolrDocument::FIELD_COLLECTION_TITLE].join(',') },
-        sort: false, default: false, width: 100
+        sort: false, default: false, width: 100, download_default: false
       },
       {
         field: :project_tag_ssim, label: 'Project',
-        sort: true, default: false, width: 100
+        sort: true, default: false, width: 100, download_default: false
       },
       {
         field: :registered_by_tag_ssim, label: 'Registered By',
-        sort: true, default: false, width: 100
+        sort: true, default: false, width: 100, download_default: false
       },
       {
         field: :registered_earliest_dttsi, label: 'Registered',
         proc: lambda { |doc| render_datetime(doc[:registered_earliest_dttsi]) },
-        sort: true, default: false, width: 100
+        sort: true, default: false, width: 100, download_default: false
       },
       {
         field: :tag_ssim, label: 'Tags',
-        sort: true, default: false, width: 100
+        sort: true, default: false, width: 100, download_default: false
       },
       {
         field: :objectType_ssim, label: 'Object Type',
-        sort: true, default: false, width: 100
+        sort: true, default: false, width: 100, download_default: false
       },
       {
         field: :content_type_ssim, label: 'Content Type',
-        sort: true, default: false, width: 100
+        sort: true, default: false, width: 100, download_default: false
       },
       {
         field: SolrDocument::FIELD_CATKEY_ID, label: 'Catkey',
-        sort: true, default: false, width: 100
+        sort: true, default: false, width: 100, download_default: false
       },
       {
         field: :barcode_id_ssim, label: 'Barcode',
-        sort: true, default: false, width: 100
+        sort: true, default: false, width: 100, download_default: false
       },
       {
         field: :status_ssi, label: 'Status',
-        sort: false, default: true, width: 100
+        sort: false, default: true, width: 100, download_default: true
       },
       {
         field: :accessioned_dttsim, label: 'Accession. Datetime',
         proc: lambda { |doc| render_datetime(doc[:accessioned_dttsim]) },
-        sort: true, default: false, width: 100
+        sort: true, default: false, width: 100, download_default: false
       },
       {
         field: :published_dttsim, label: 'Pub. Date',
         proc: lambda { |doc| render_datetime(doc[:published_dttsim]) },
-        sort: true, default: true, width: 100
+        sort: true, default: true, width: 100, download_default: false
       },
       {
         field: :workflow_status_ssim, label: 'Errors',
         proc: lambda { |doc| doc[:workflow_status_ssim].first.split('|')[2] },
-        sort: true, default: false, width: 100
+        sort: true, default: false, width: 100, download_default: false
       },
       {
         field: :file_count, label: 'Files',
         proc: lambda { |doc| doc[:content_file_count_itsi] },
         solr_fields: %w(content_file_count_itsi),
-        sort: false, default: true, width: 50
+        sort: false, default: true, width: 50, download_default: false
       },
       {
         field: :shelved_file_count, label: 'Shelved Files',
         proc: lambda { |doc| doc[:shelved_content_file_count_itsi] },
         solr_fields: %w(shelved_content_file_count_itsi),
-        sort: false, default: true, width: 50
+        sort: false, default: true, width: 50, download_default: false
       },
       {
         field: :resource_count, label: 'Resources',
         proc: lambda { |doc| doc[:resource_count_itsi] },
         solr_fields: %w(resource_count_itsi),
-        sort: false, default: true, width: 50
+        sort: false, default: true, width: 50, download_default: false
       },
       {
         field: :preserved_size, label: 'Preservation Size',
         proc: lambda { |doc| doc.preservation_size },
         solr_fields: [SolrDocument::FIELD_PRESERVATION_SIZE],
-        sort: false, default: true, width: 50
+        sort: false, default: true, width: 50, download_default: false
       }
     ]
 

--- a/app/views/report/_column_selector.html.erb
+++ b/app/views/report/_column_selector.html.erb
@@ -1,6 +1,6 @@
 <div class="hidden" id="column_selector">
   <p>Select columns to download:</p>
-  <% Report.blacklight_config.column_model.each do |field| %>
-    <%= check_box_tag 'selected_columns', field['name'], !field['hidden'] %> <%= field['label'] %> <br>
+  <% Report.blacklight_config.report_fields.each do |field| %>
+    <%= check_box_tag 'selected_columns', field[:field], field[:download_default] %> <%= field[:label] %> <br>
   <% end %>
 </div>

--- a/app/views/report/_column_selector.html.erb
+++ b/app/views/report/_column_selector.html.erb
@@ -1,0 +1,6 @@
+<div class="hidden" id="column_selector">
+  <p>Select columns to download:</p>
+  <% Report.blacklight_config.column_model.each do |field| %>
+    <%= check_box_tag 'selected_columns', field['name'], !field['hidden'] %> <%= field['label'] %> <br>
+  <% end %>
+</div>

--- a/app/views/report/index.html.erb
+++ b/app/views/report/index.html.erb
@@ -31,5 +31,7 @@
       <table id="report_grid"></table>
       <div id="preport_grid"></div>
     </div>
+    <%= render partial: 'report/column_selector' %>
+
   <% end %>
 </div>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     ports:
       - 3000:3000
     environment:
+      NODE_ENV: development
       ROLES: sdr:administrator-role
       REMOTE_USER: blalbrit@stanford.edu
       RAILS_LOG_TO_STDOUT: 'true'

--- a/spec/features/report_view_spec.rb
+++ b/spec/features/report_view_spec.rb
@@ -13,6 +13,15 @@ RSpec.describe 'Report view' do
       expect(page).to have_css 'table#report_grid'
       expect(page).to have_content('hj185vb7593')
     end
+
+    it 'shows the column selector when clicked' do
+      visit report_path f: { objectType_ssim: ['item'] }
+      find('.ui-pg-button-text', text: 'Columns').click
+      expect(page).to have_css 'div#column_selector'
+      expect(page).to have_content('Select columns to download:')
+      expect(page).to have_selector('input[name="selected_columns"]', count: 25) # count the total
+      expect(page).to have_selector('input[name="selected_columns"]:checked', count: 5) # count the default
+    end
   end
 
   context 'bulk' do


### PR DESCRIPTION
fixes #1670 

## Why was this change made?

* jquery update broke our usage of column selectors built into jqgrid
* initial attempts at updating jqgrid were not successful

This replicates the functionality for downloading of reports without the use of jqgrid.  It does not allow for dynamic column selection for display on the screen, but that was deemed not important (downloading is more important).

Todo:
- [x] validate approach
- [x] improve UI/styling

## Was the documentation updated?
