### PR TITLE
Fix the node_modules mount in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+/log/*
+/tmp/*
+/node_modules
+/.bundle
+/public/assets
+/_*/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build: .
     volumes:
       - ./:/app
-      - node_modules:/usr/src/app/node_modules
+      - node_modules:/app/node_modules
     working_dir: /app
     command: puma
     ports:


### PR DESCRIPTION
## Why was this change made?

This prevents the errors reported on #1678
specifically this error in the javascript console:

```
Error: Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
Error: Missing binding /app/node_modules/node-sass/vendor/linux-x64-72/binding.node
Node Sass could not find a binding for your current environment: Linux 64-bit with Node.js 12.x

Found bindings for the following environments:
  - OS X 64-bit with Node.js 8.x

This usually happens because your environment has changed since running `npm install`.
Run `npm rebuild node-sass` to download the binding for your current environment.
```


## Was the documentation updated?

N/A