### PR TITLE
bulk action for download report as csv

### DIFF
--- a/app/controllers/bulk_actions_controller.rb
+++ b/app/controllers/bulk_actions_controller.rb
@@ -29,7 +29,8 @@ class BulkActionsController < ApplicationController
 
     # BulkActionPersister is responsible for enqueuing the job
     if BulkActionPersister.persist(@bulk_action)
-      redirect_to action: :index, notice: 'Bulk action was successfully created.'
+      flash[:notice] = 'Bulk action was successfully created.'
+      redirect_to action: :index
     else
       render :new
     end

--- a/app/controllers/bulk_actions_controller.rb
+++ b/app/controllers/bulk_actions_controller.rb
@@ -2,6 +2,8 @@
 
 class BulkActionsController < ApplicationController
   before_action :set_bulk_action, only: [:destroy, :file]
+  include Blacklight::Catalog
+  copy_blacklight_config_from CatalogController
 
   rescue_from ActiveRecord::RecordNotFound, with: -> { render plain: 'Record Not Found', status: :not_found }
 
@@ -27,8 +29,7 @@ class BulkActionsController < ApplicationController
 
     # BulkActionPersister is responsible for enqueuing the job
     if BulkActionPersister.persist(@bulk_action)
-      flash[:notice] = 'Bulk action was successfully created.'
-      redirect_to action: :index
+      redirect_to action: :index, notice: 'Bulk action was successfully created.'
     else
       render :new
     end
@@ -62,7 +63,8 @@ class BulkActionsController < ApplicationController
       set_governing_apo: [:new_apo_id],
       manage_catkeys: [:catkeys],
       prepare: [:significance, :description],
-      create_virtual_objects: [:csv_file]
+      create_virtual_objects: [:csv_file],
+      download_report: [:search_params, selected_columns: []]
     )
   end
 

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -54,7 +54,7 @@ class ReportController < CatalogController
     fields = params['fields'].present? ? params.delete('fields').split(/\s*,\s*/) : nil
     params[:per_page] = 10
     response.headers['Content-Type'] = 'application/octet-stream'
-    response.headers['Content-Disposition'] = 'attachment; filename=report.csv'
+    response.headers['Content-Disposition'] = "attachment; filename=#{Settings.download_report_job.csv_filename}"
     response.headers['Last-Modified'] = Time.now.utc.rfc2822 # HTTP requires GMT date/time
     self.response_body = Report.new(params, fields, current_user: current_user).to_csv
   end

--- a/app/javascript/controllers/bulk_actions.js
+++ b/app/javascript/controllers/bulk_actions.js
@@ -1,4 +1,5 @@
 import { Controller } from 'stimulus'
+const common_fields_hidden_jobs = [ 'CreateVirtualObjectsJob', 'DownloadReportJob' ]
 
 export default class extends Controller {
   // Shows the correct data tab based on the selected value of the dropdown
@@ -17,7 +18,6 @@ export default class extends Controller {
   // Toggles visibility of common fields based on selected tab
   toggleCommonFieldVisibility(selectedTab) {
     const commonFields = this.element.querySelector('#common_fields')
-    var common_fields_hidden_jobs = [ 'CreateVirtualObjectsJob', 'DownloadReportJob' ]
     if (common_fields_hidden_jobs.includes(selectedTab)) {
       commonFields.classList.add('hidden')
     } else {

--- a/app/javascript/controllers/bulk_actions.js
+++ b/app/javascript/controllers/bulk_actions.js
@@ -17,8 +17,8 @@ export default class extends Controller {
   // Toggles visibility of common fields based on selected tab
   toggleCommonFieldVisibility(selectedTab) {
     const commonFields = this.element.querySelector('#common_fields')
-
-    if (selectedTab == 'CreateVirtualObjectsJob') {
+    var common_fields_hidden_jobs = [ 'CreateVirtualObjectsJob', 'DownloadReportJob' ]
+    if (common_fields_hidden_jobs.includes(selectedTab)) {
       commonFields.classList.add('hidden')
     } else {
       commonFields.classList.remove('hidden')

--- a/app/jobs/download_report_job.rb
+++ b/app/jobs/download_report_job.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+##
+# Job to download a report from previous search results
+class DownloadReportJob < GenericJob
+  queue_as :default
+
+  ##
+  # A job that, given a search params, runs a download report for the selected columns and returns a CSV file to the user
+  # @param [Integer] bulk_action_id GlobalID for a BulkAction object
+  # @param [Hash] params additional parameters that an Argo job may need
+  # @option params [Array]  :groups the groups the user belonged to when the started the job. Required for because groups are not persisted with the user.
+  # @option params [Array]  :user the user
+  # @option params [String] :output_directory the output directory to write the CSV checksum report to
+  def perform(bulk_action_id, params)
+    super
+    report_filename = generate_report_filename(params[:output_directory])
+
+    with_bulk_action_log do |log|
+      log.puts("#{Time.current} Starting #{self.class} for BulkAction #{bulk_action_id}")
+      begin
+        csv_report = download_report(params)
+        File.open(report_filename, 'w') { |file| file.write(csv_report) }
+      rescue StandardError => e
+        bulk_action.update(druid_count_fail: 1)
+        message = "#{Time.current} DownloadReportJob creation failed #{e.class} #{e.message}"
+        log.puts(message)
+        # if we couldn't write out the file, we have an issue
+        Honeybadger.notify message
+        raise message
+      end
+      log.puts("#{Time.current} Finished #{self.class} for BulkAction #{bulk_action_id}")
+    end
+  end
+
+  private
+
+  # produce the report given the search results
+  def download_report(params)
+    log.puts("#{Time.current} Running report with #{params}")
+    results=[]
+    bulk_action.update(druid_count_total: results.size)
+    bulk_action.update(druid_count_success: results.size) # this whole job is run in one call, so it either all succeeds or fails
+    results
+  end
+
+  ##
+  # Generate a filename for the job's csv report output file.
+  # @param  [String] output_dir Where to store the csv file.
+  # @return [String] A filename for the csv file.
+  def generate_report_filename(output_dir)
+    FileUtils.mkdir_p(output_dir) unless File.directory?(output_dir)
+    File.join(output_dir, Settings.download_report_job.csv_filename)
+  end
+end

--- a/app/jobs/download_report_job.rb
+++ b/app/jobs/download_report_job.rb
@@ -24,9 +24,8 @@ class DownloadReportJob < GenericJob
         search_params = JSON.parse(params[:download_report][:search_params]).with_indifferent_access # reconstruct hash from the json string representation
         fields = params[:download_report][:selected_columns]
         log.puts("#{Time.current} Running report with #{search_params} for fields #{fields}")
-        user = bulk_action.user
-        user.set_groups_to_impersonate(@groups)
-        @report = Report.new(search_params, fields, current_user: user)
+        @current_user.set_groups_to_impersonate(@groups)
+        @report = Report.new(search_params, fields, current_user: @current_user)
         bulk_action.update(druid_count_total: @report.num_found)
         File.open(report_filename, 'w') { |file| file.write(@report.to_csv) }
         bulk_action.update(druid_count_success: @report.num_found) # this whole job is run in one call, so it either all succeeds or fails

--- a/app/jobs/download_report_job.rb
+++ b/app/jobs/download_report_job.rb
@@ -38,7 +38,7 @@ class DownloadReportJob < GenericJob
   # produce the report given the search results
   def download_report(params)
     log.puts("#{Time.current} Running report with #{params}")
-    results=[]
+    results = []
     bulk_action.update(druid_count_total: results.size)
     bulk_action.update(druid_count_success: results.size) # this whole job is run in one call, so it either all succeeds or fails
     results

--- a/app/models/bulk_action.rb
+++ b/app/models/bulk_action.rb
@@ -21,7 +21,7 @@ class BulkAction < ApplicationRecord
   before_destroy :remove_output_directory
 
   # A virtual attribute used for job creation but not persisted
-  attr_accessor :pids, :manage_release, :set_governing_apo, :manage_catkeys, :prepare, :create_virtual_objects
+  attr_accessor :pids, :manage_release, :set_governing_apo, :manage_catkeys, :prepare, :create_virtual_objects, :download_report
   attr_accessor :groups # the groups the user was a member of when they launched the job
 
   def file(filename)

--- a/app/models/bulk_action.rb
+++ b/app/models/bulk_action.rb
@@ -14,6 +14,7 @@ class BulkAction < ApplicationRecord
                      PrepareJob
                      CloseVersionJob
                      ChecksumReportJob
+                     DownloadReportJob
                      CreateVirtualObjectsJob)
             }
 

--- a/app/services/bulk_action_persister.rb
+++ b/app/services/bulk_action_persister.rb
@@ -22,7 +22,7 @@ class BulkActionPersister
 
   attr_reader :bulk_action
   delegate :id, :file, :pids, :output_directory, :manage_release, :set_governing_apo,
-           :manage_catkeys, :groups, :prepare, :create_virtual_objects, to: :bulk_action
+           :manage_catkeys, :groups, :prepare, :create_virtual_objects, :download_report, to: :bulk_action
 
   def create_log_file
     log_filename = file(Settings.bulk_metadata.log)
@@ -56,6 +56,7 @@ class BulkActionPersister
       manage_catkeys: manage_catkeys,
       prepare: prepare,
       create_virtual_objects: virtual_objects_csv_from_file(create_virtual_objects),
+      download_report: download_report,
       groups: groups
     }
   end

--- a/app/views/bulk_actions/_download_report_job.html.erb
+++ b/app/views/bulk_actions/_download_report_job.html.erb
@@ -1,0 +1,3 @@
+<% if bulk_action.present? && bulk_action.status == 'Completed' %>
+  <%= link_to('Download Report', file_bulk_action_path(bulk_action.id, filename: Settings.download_report_job.csv_filename, mime_type: 'text/csv')) %>
+<% end %>

--- a/app/views/bulk_actions/forms/_download_report_form.html.erb
+++ b/app/views/bulk_actions/forms/_download_report_form.html.erb
@@ -1,0 +1,9 @@
+<span class='help-block'>
+  Previous search query: <%= @last_search.query_params %>
+</span>
+<div class='form-group' id="column_selector">
+  <p>Select columns to download:</p>
+    <% Report.blacklight_config.report_fields.each do |field| %>
+      <%= check_box_tag 'bulk_action_download_report_form_selected_columns', field[:field], field[:default] %> <%= field[:label] %> <br>
+    <% end %>
+</div>

--- a/app/views/bulk_actions/forms/_download_report_form.html.erb
+++ b/app/views/bulk_actions/forms/_download_report_form.html.erb
@@ -1,15 +1,18 @@
-<% if @last_search && @last_search.query_params %>
+<% if @last_search && query_has_constraints?(@last_search.query_params) %>
   <span class='help-block'>
-    Previous search query: <%= @last_search.query_params %>
+    <p>Previous search query: <%= render_constraints(@last_search.query_params) %></p>
   </span>
   <div class='form-group' id="column_selector">
     <p>Select columns to download:</p>
+    <%= f.fields_for :download_report do |download_report_fields| %>
       <% Report.blacklight_config.report_fields.each do |field| %>
-        <%= check_box_tag 'bulk_action_download_report_form_selected_columns', field[:field], field[:default] %> <%= field[:label] %> <br>
+        <%= check_box_tag 'bulk_action_download_report_selected_columns[]', field[:field], field[:download_default], name: 'bulk_action[download_report][selected_columns][]' %> <%= field[:label] %> <br>
       <% end %>
+      <%= download_report_fields.hidden_field 'search_params', value: @last_search.query_params.to_json %>
+    <% end %>
   </div>
 <% else %>
   <span class='errortext'>
-    NOTE: This job cannot be run unless you came from a search result page.  This is because the report uses the previous search parameters.
+    <p>NOTE: This job should not be run unless you came from a search result page.  This is because the report uses the previous search parameters.</p>
   </span>
 <% end %>

--- a/app/views/bulk_actions/forms/_download_report_form.html.erb
+++ b/app/views/bulk_actions/forms/_download_report_form.html.erb
@@ -1,9 +1,15 @@
-<span class='help-block'>
-  Previous search query: <%= @last_search.query_params %>
-</span>
-<div class='form-group' id="column_selector">
-  <p>Select columns to download:</p>
-    <% Report.blacklight_config.report_fields.each do |field| %>
-      <%= check_box_tag 'bulk_action_download_report_form_selected_columns', field[:field], field[:default] %> <%= field[:label] %> <br>
-    <% end %>
-</div>
+<% if @last_search && @last_search.query_params %>
+  <span class='help-block'>
+    Previous search query: <%= @last_search.query_params %>
+  </span>
+  <div class='form-group' id="column_selector">
+    <p>Select columns to download:</p>
+      <% Report.blacklight_config.report_fields.each do |field| %>
+        <%= check_box_tag 'bulk_action_download_report_form_selected_columns', field[:field], field[:default] %> <%= field[:label] %> <br>
+      <% end %>
+  </div>
+<% else %>
+  <span class='errortext'>
+    NOTE: This job cannot be run unless you came from a search result page.  This is because the report uses the previous search parameters.
+  </span>
+<% end %>

--- a/app/views/bulk_actions/index.html.erb
+++ b/app/views/bulk_actions/index.html.erb
@@ -1,5 +1,4 @@
 <div class='container'>
-  <p id="notice"><%= notice %></p>
 
   <h1>Bulk Actions</h1>
   <%= link_to 'New Bulk Action', new_bulk_action_path, class: 'btn btn-success' %>
@@ -9,7 +8,6 @@
       <tr>
         <th>Submitted</th>
         <th>Action</th>
-
         <th>Description</th>
         <th>Status</th>
         <th>Total / Success / Failed</th>

--- a/app/views/bulk_actions/index.html.erb
+++ b/app/views/bulk_actions/index.html.erb
@@ -1,4 +1,5 @@
 <div class='container'>
+  <p id="notice"><%= notice %></p>
 
   <h1>Bulk Actions</h1>
   <%= link_to 'New Bulk Action', new_bulk_action_path, class: 'btn btn-success' %>
@@ -8,6 +9,7 @@
       <tr>
         <th>Submitted</th>
         <th>Action</th>
+
         <th>Description</th>
         <th>Status</th>
         <th>Total / Success / Failed</th>

--- a/app/views/bulk_actions/new.html.erb
+++ b/app/views/bulk_actions/new.html.erb
@@ -24,6 +24,7 @@
                       ['Prepare objects', 'PrepareJob'],
                       ['Close versions', 'CloseVersionJob'],
                       ['Checksum report', 'ChecksumReportJob'],
+                      ['Download search report view', 'DownloadReportJob'],
                       ['Create virtual object(s)', 'CreateVirtualObjectsJob']],
                      {},
                      class: 'form-control',
@@ -80,6 +81,13 @@
           <span class='help-block'>
             Download checksums of files in objects (as csv).
           </span>
+        </div>
+
+        <div role='tabpanel' class='tab-pane' id='DownloadReportJob'>
+          <span class='help-block'>
+            Download data from search results (as csv).
+          </span>
+          <%= render 'bulk_actions/forms/download_report_form', f: f %>
         </div>
 
         <div role='tabpanel' class='tab-pane' id='CreateVirtualObjectsJob'>

--- a/app/views/bulk_actions/new.html.erb
+++ b/app/views/bulk_actions/new.html.erb
@@ -24,7 +24,7 @@
                       ['Prepare objects', 'PrepareJob'],
                       ['Close versions', 'CloseVersionJob'],
                       ['Checksum report', 'ChecksumReportJob'],
-                      ['Download search report view', 'DownloadReportJob'],
+                      ['Download search results as CSV', 'DownloadReportJob'],
                       ['Create virtual object(s)', 'CreateVirtualObjectsJob']],
                      {},
                      class: 'form-control',
@@ -105,8 +105,7 @@
       </a>
       <div class='form-group'>
         <label>Druids to perform bulk action on</label>
-        <textarea id='pids' name='bulk_action[pids]' class='form-control' rows='10'>
-        </textarea>
+        <textarea id='pids' name='bulk_action[pids]' class='form-control' rows='10'></textarea>
       </div>
     </div>
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,6 +19,9 @@ bulk_metadata:
 checksum_report_job:
   csv_filename: 'checksum_report.csv'
 
+download_report_job:
+  csv_filename: 'report.csv'
+
 # Newrelic
 newrelic:
   enabled: false

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe ReportController, type: :controller do
     it 'downloads valid CSV data' do
       get :download, params: { fields: ' ' }
       expect(response).to have_http_status(:ok)
-      expect(response.header['Content-Disposition']).to eq('attachment; filename=report.csv')
+      expect(response.header['Content-Disposition']).to eq("attachment; filename=#{Settings.download_report_job.csv_filename}")
       data = CSV.parse(response.body)
       expect(data.first.length).to eq(25)
       expect(data.length > 1).to be_truthy

--- a/spec/jobs/download_report_job_spec.rb
+++ b/spec/jobs/download_report_job_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DownloadReportJob, type: :job do
+  let(:search_params) { { f: { exploded_tag_ssim: [] } }.with_indifferent_access }
+  let(:selected_columns) { ['Druid', 'Title'] }
+  let(:groups) { [] }
+  let(:report) { instance_double(Report) }
+  let(:output_directory) { 'tmp/download_report_job_success' }
+  let(:bulk_action) do
+    create(
+      :bulk_action,
+      action_type: 'DownloadReportJob',
+      log_name: 'tmp/download_report_job_log.txt'
+    )
+  end
+  let(:csv_response) { "Druid,Title\ndruid:123,Title\n\ndruid:345,Title2\n" }
+  let(:log_buffer) { StringIO.new }
+
+  before do
+    allow(subject).to receive(:bulk_action).and_return(bulk_action)
+    allow(Report).to receive(:new).with(search_params, selected_columns, current_user: bulk_action.user).and_return(report)
+    allow(report).to receive(:num_found).and_return(5)
+    allow(report).to receive(:to_csv).and_return(csv_response)
+  end
+
+  describe '#perform_now' do
+    it 'downloads a report' do
+      subject.perform(bulk_action.id,
+                      output_directory: output_directory,
+                      download_report: { search_params: search_params.to_json, selected_columns: selected_columns },
+                      groups: groups)
+      expect(File).to exist(File.join(output_directory, Settings.download_report_job.csv_filename))
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

Some big reports time out when you download.  Attempt at implementing the ability to download a report as a job.

Should helps address #1671, assuming #1693 doesn't make things so fast as to make this totally unncessary

## Was the documentation updated?
