### PR TITLE
actually show notices correctly in bulk actions

### DIFF
--- a/app/controllers/bulk_actions_controller.rb
+++ b/app/controllers/bulk_actions_controller.rb
@@ -27,7 +27,8 @@ class BulkActionsController < ApplicationController
 
     # BulkActionPersister is responsible for enqueuing the job
     if BulkActionPersister.persist(@bulk_action)
-      redirect_to action: :index, notice: 'Bulk action was successfully created.'
+      flash[:notice] = 'Bulk action was successfully created.'
+      redirect_to action: :index
     else
       render :new
     end

--- a/app/views/bulk_actions/index.html.erb
+++ b/app/views/bulk_actions/index.html.erb
@@ -1,5 +1,4 @@
 <div class='container'>
-  <p id="notice"><%= notice %></p>
 
   <h1>Bulk Actions</h1>
   <%= link_to 'New Bulk Action', new_bulk_action_path, class: 'btn btn-success' %>
@@ -9,7 +8,6 @@
       <tr>
         <th>Submitted</th>
         <th>Action</th>
-        
         <th>Description</th>
         <th>Status</th>
         <th>Total / Success / Failed</th>


### PR DESCRIPTION
## Why was this change made?

because notices were not actually being shown to users when bulk actions were created, and should be

## Was the documentation updated?
n/a