### PR TITLE
set the current user correctly in job context

### DIFF
--- a/app/jobs/generic_job.rb
+++ b/app/jobs/generic_job.rb
@@ -33,7 +33,7 @@ class GenericJob < ActiveJob::Base
   def perform(_bulk_action_id, params)
     @groups = params[:groups]
     @pids = params[:pids]
-    @current_user = params[:user]
+    @current_user = bulk_action.user
   end
 
   def bulk_action

--- a/spec/jobs/prepare_job_spec.rb
+++ b/spec/jobs/prepare_job_spec.rb
@@ -5,12 +5,12 @@ require 'rails_helper'
 RSpec.describe PrepareJob, type: :job do
   let(:pids) { ['druid:123', 'druid:456'] }
   let(:groups) { [] }
-  let(:user) { instance_double(User, to_s: 'jcoyne85') }
   let(:workflow_status) { instance_double(DorObjectWorkflowStatus, can_open_version?: true) }
   let(:bulk_action) do
     create(:bulk_action,
            log_name: 'foo.txt')
   end
+  let(:user) { bulk_action.user }
   let(:item1) { Dor::Item.new }
   let(:item2) { Dor::Item.new }
 
@@ -41,7 +41,7 @@ RSpec.describe PrepareJob, type: :job do
 
       expect(VersionService).to have_received(:open).with(identifier: anything,
                                                           description: 'Changed dates',
-                                                          opening_user_name: 'jcoyne85',
+                                                          opening_user_name: user.to_s,
                                                           significance: 'major').twice
     end
   end


### PR DESCRIPTION
## Why was this change made?

When implementing the download report (as csv) job, I realized the current user (which is necessary for running a report) is not being set in a way that can be used.  We need the actual user model object with persisted groups in order to run the job correctly (not just the username persisted in params).

If this is merged, the download job (PR #1688) can be refactored to make use of it.

## Was the documentation updated?
