### PR TITLE
enforce view restrictions for reports

### DIFF
--- a/app/search_builders/report_search_builder.rb
+++ b/app/search_builders/report_search_builder.rb
@@ -8,5 +8,8 @@ class ReportSearchBuilder < Blacklight::SearchBuilder
 
   self.default_processor_chain -= [:add_facetting_to_solr] # remove faceting from reports
 
-  self.default_processor_chain += [:add_date_field_queries] # ensure date field queries work
+  self.default_processor_chain += [
+    :add_access_controls_to_solr_params, # enforce restrictions
+    :add_date_field_queries # ensure date field queries work
+  ]
 end

--- a/spec/search_builders/report_search_builder_spec.rb
+++ b/spec/search_builders/report_search_builder_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ReportSearchBuilder do
+  subject { report_search_builder.with(user_params) }
+
+  let(:user_params) { {} }
+  let(:solr_params) { {} }
+  let(:context) { CatalogController.new }
+
+  let(:report_search_builder) { described_class.new(context) }
+
+  describe '#initialize' do
+    it 'has add_access_controls_to_solr_params in chain once' do
+      expect(subject.processor_chain)
+        .to include :add_access_controls_to_solr_params
+      expect(subject.processor_chain
+        .count { |x| x == :add_access_controls_to_solr_params }).to eq 1
+      new_search = described_class.new(subject.processor_chain, context)
+      expect(new_search.processor_chain)
+        .to include :add_access_controls_to_solr_params
+      expect(subject.processor_chain
+        .count { |x| x == :add_access_controls_to_solr_params }).to eq 1
+    end
+    it 'has add_date_field_queries in chain once' do
+      expect(subject.processor_chain)
+        .to include :add_date_field_queries
+      expect(subject.processor_chain
+        .count { |x| x == :add_date_field_queries }).to eq 1
+      new_search = described_class.new(subject.processor_chain, context)
+      expect(new_search.processor_chain)
+        .to include :add_date_field_queries
+      expect(subject.processor_chain
+        .count { |x| x == :add_date_field_queries }).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

reports/downloads are allowing users to see items for which they should not have permissions -- add back in the query limitations into the new SearchBuilder

we confirmed this is currently a problem and that this fix works on argo-stage

## Was the documentation updated?
