### PR TITLE
Remove Faraday config patch from initializer

### DIFF
--- a/config/initializers/dor_services_client.rb
+++ b/config/initializers/dor_services_client.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-Faraday.default_connection_options = Faraday::ConnectionOptions.new(timeout: 500, open_timeout: 10)
-
 # Configure dor-services-client to use the dor-services URL
 Dor::Services::Client.configure(url: Settings.dor_services.url,
                                 token: Settings.dor_services.token)


### PR DESCRIPTION
## Why was this change made?

This was added [recently](https://github.com/sul-dlss/argo/pull/1593) when virtual-merge was a synchronous operation, requiring Argo to hold a connection to dor-services-app open for up to 8 minutes for medium-sized batches. With the [pull request to make virtual-merge asynchronous](https://github.com/sul-dlss/argo/pull/1659) close to being merged, we should remove this; it will no longer be necessary and make in fact mask connection-related issues.

## Was the documentation updated?

No.