### PR TITLE
 Add access control enforcement for reset link 

### DIFF
--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -94,12 +94,7 @@ class WorkflowsController < ApplicationController
 
   private
 
-  # Returns true if they have been granted permission to update all workflows or
-  # The status is currently "waiting" and they can manage that item
-  def can_update_workflow?(status, object)
-    can?(:update, :workflow) ||
-     (status == 'waiting' && can?(:manage_item, object))
-  end
+  delegate :can_update_workflow?, to: :current_ability
 
   # Fetches the workflow from the workflow service and checks to see if it's active
   def workflow_active?(wf_name)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -81,6 +81,13 @@ class Ability
     end
   end
 
+  # Returns true if they have been granted permission to update all workflows or
+  # The status is currently "waiting" and they can manage that item
+  def can_update_workflow?(status, object)
+    can?(:update, :workflow) ||
+      (status == 'waiting' && can?(:manage_item, object))
+  end
+
   private
 
   GROUPS_WHICH_MANAGE_ITEMS = %w[dor-administrator sdr-administrator dor-apo-manager dor-apo-depositor].freeze


### PR DESCRIPTION
## Why was this change made?

The previous restriction was too strict, only allowing admins.

## Was the documentation updated?

N/A.