### PR TITLE
fix typo in html for refresh mods button

### DIFF
--- a/app/views/report/bulk.html.erb
+++ b/app/views/report/bulk.html.erb
@@ -58,7 +58,7 @@ ul li{
     <strong>Options that require versioning</strong>
     <div class="row bulk-buttons-row">
       <div class="col-sm-2">
-        <button class="bulk_button btn-block" class="update_buttons" id="referesh-mods-button">Refresh MODS</button>
+        <button class="bulk_button btn-block" class="update_buttons" id="refresh-mods-button">Refresh MODS</button>
         <button class="bulk_button btn-block" class="update_buttons" id="show_source_id" name="show_source_id">Set source Id</button>
         <button class="bulk_button btn-block" class="update_buttons" id="set-object-rights-button">Set object rights</button>
       </div>


### PR DESCRIPTION
## Why was this change made?

to fix the issue with the refresh mods button HTML ID not matching the JS code (needs to match https://github.com/sul-dlss/argo/blob/master/app/javascript/packs/bulk.js#L287)

fixes #1707 

## Was the documentation updated?

n/a