### PR TITLE
Tests run without dor-services-app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ before_install:
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
-  # Start everything except app
-  - docker-compose up -d db solr fcrepo dor-services-app suri
+  # Start Fedora, Solr, and Suri
+  - docker-compose up -d solr fcrepo suri
   - docker-compose ps
   - google-chrome-stable --headless --disable-gpu --no-sandbox --remote-debugging-port=9222 http://localhost &
 


### PR DESCRIPTION
## Why was this change made?

We don't need this server up to run tests.

## Was the documentation updated?

n/a
