### PR TITLE
fix purge bug

### DIFF
--- a/app/javascript/packs/bulk.js
+++ b/app/javascript/packs/bulk.js
@@ -318,7 +318,7 @@ Blacklight.onLoad(()=>{
 		$('#content_type').hide(400)
 	})
 
-	$('#confirm-set-content-type-button').on('click', () => {
+	$('#confirm-purge-button').on('click', () => {
 		fetch_druids(purge)
 		$('#purge').hide(400)
 	})


### PR DESCRIPTION
## Why was this change made?

To fix a bug where users inadvertently purged objects when they meant to change content types.  See #1715 

## Was the documentation updated?
