### PR TITLE
change purge action from get to delete

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -53,7 +53,7 @@ Metrics/AbcSize:
 # Offense count: 7
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 406
+  Max: 410
 
 # Offense count: 7
 Metrics/CyclomaticComplexity:

--- a/app/components/action_button.html.erb
+++ b/app/components/action_button.html.erb
@@ -1,1 +1,1 @@
-<%= link_to label, url, class: "btn button btn-primary #{'disabled' if disabled?}", data: button_data %>
+<%= link_to label, url, method: method, class: "btn button btn-primary #{'disabled' if disabled?}", data: button_data %>

--- a/app/components/action_button.rb
+++ b/app/components/action_button.rb
@@ -3,9 +3,10 @@
 # Draws a blue button in the side menu
 class ActionButton < ApplicationComponent
   # @param [Hash] properties the button properties
-  def initialize(label:, url:, confirm: nil, new_page: nil, check_url: nil, disabled: nil)
+  def initialize(label:, url:, method: nil, confirm: nil, new_page: nil, check_url: nil, disabled: nil)
     @label = label
     @url = url
+    @method = method
     @confirm = confirm
     @new_page = new_page
     @check_url = check_url
@@ -28,5 +29,5 @@ class ActionButton < ApplicationComponent
     end
   end
 
-  attr_reader :label, :confirm, :new_page, :check_url, :url, :disabled
+  attr_reader :label, :confirm, :new_page, :check_url, :url, :disabled, :method
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -279,7 +279,11 @@ class ItemsController < ApplicationController
     ActiveFedora.solr.conn.commit
 
     respond_to do |format|
-      format.any { redirect_to '/', notice: params[:id] + ' has been purged!' }
+      if params[:bulk]
+        format.html { render plain: 'Purged.' }
+      else
+        format.any { redirect_to '/', notice: params[:id] + ' has been purged!' }
+      end
     end
   end
 

--- a/app/javascript/packs/bulk.js
+++ b/app/javascript/packs/bulk.js
@@ -32,6 +32,10 @@ function process_patch(druids, action_url, req_params, success_string) {
 	process_request(druids, action_url, 'PATCH', req_params, success_string, show_buttons, show_buttons);
 }
 
+function process_delete(druids, action_url, req_params, success_string) {
+	process_request(druids, action_url, 'DELETE', req_params, success_string, show_buttons, show_buttons);
+}
+
 function set_content_type(druids){
 	var params={
 		'new_content_type': $('#new_content_type').val(),
@@ -43,7 +47,7 @@ function set_content_type(druids){
 }
 
 function purge(druids){
-	process_get(druids, purge_url, "Purged");
+	process_delete(druids, purge_url, null, "Purged");
 }
 
 function fetch_pids_txt() {

--- a/app/presenters/buttons_presenter.rb
+++ b/app/presenters/buttons_presenter.rb
@@ -135,6 +135,7 @@ class ButtonsPresenter
       url: purge_item_path(id: pid),
       label: 'Purge',
       new_page: true,
+      method: 'delete',
       confirm: 'This object will be permanently purged from DOR. This action cannot be undone. Are you sure?',
       disabled: !registered_only?
     }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,7 +137,7 @@ Rails.application.routes.draw do
       get 'collection/delete',   action: :remove_collection, as: 'remove_collection'
       post 'collection/add',     action: :add_collection,    as: 'add_collection'
       post 'collection/set',     action: :set_collection,    as: 'set_collection'
-      get 'purge',               action: :purge_object
+      delete 'purge', action: :purge_object
       get  'rights'
       post 'set_rights'
       get 'set_governing_apo_ui'

--- a/spec/presenters/buttons_presenter_spec.rb
+++ b/spec/presenters/buttons_presenter_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe ButtonsPresenter, type: :presenter do
             label: 'Purge',
             url: "/items/#{item_id}/purge",
             new_page: true,
+            method: 'delete',
             confirm: 'This object will be permanently purged from DOR. This action cannot be undone. Are you sure?',
             disabled: true
           },
@@ -234,6 +235,7 @@ RSpec.describe ButtonsPresenter, type: :presenter do
             label: 'Purge',
             url: "/items/#{view_apo_id}/purge",
             new_page: true,
+            method: 'delete',
             confirm: 'This object will be permanently purged from DOR. This action cannot be undone. Are you sure?',
             disabled: true
           },


### PR DESCRIPTION
## Why was this change made?

The purge action is currently a GET operation.  This is hazardous and it should be a DELETE.  Discovered after work done in #1716 

Also, fixed the problem where a purge from bulk actions was not showing the status correctly (it was silently redirecting to the home page after the purge was done and then showing the status as a 404)

Confirmed working as expected on localhost (both bulk action and single purge from item detail page) and also confirmed a GET request to the purge method no longer works.

## Was the documentation updated?
