### PR TITLE
allow webmock connections when loading fixtures

### DIFF
--- a/lib/tasks/argo_testing.rake
+++ b/lib/tasks/argo_testing.rake
@@ -61,8 +61,8 @@ if ['test', 'development'].include? Rails.env
         i = 0
 
         require 'webmock'
-        # only allow connections to Fcrepo and Solr
-        WebMock.disable_net_connect!(allow: ['localhost:8983', 'localhost:8984'])
+        # only allow connections to Fcrepo, Solr and workflow
+        WebMock.disable_net_connect!(allow: ['workflow:3000', 'solr:8983', 'fcrepo:8080', 'localhost:8983', 'localhost:8984'])
         include WebMock::API
         WebMock.enable!
         file_list.each do |file|


### PR DESCRIPTION
## Why was this change made?

so the `docker-compose run --rm web rake argo:repo:load` can work again

## Was the documentation updated?
