### PR TITLE
Don't use a layout when rendering the Add Workflow modal

### DIFF
--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -3,8 +3,10 @@
 class WorkflowsController < ApplicationController
   before_action :load_resource, except: [:history]
 
+  # Called from "Add Workflow" button. This is content for a modal invoked via XHR
+  # so we don't want a layout.
   def new
-    # does default render
+    render 'new', layout: false
   end
 
   ##

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -53,6 +53,13 @@ RSpec.describe WorkflowsController, type: :controller do
     end
   end
 
+  describe '#new' do
+    it 'renders the template with no layout' do
+      get :new, params: { item_id: pid }
+      expect(response).to render_template(layout: false)
+    end
+  end
+
   describe '#show' do
     let(:workflow) { instance_double(Dor::Workflow::Document) }
     let(:workflow_status) { instance_double(WorkflowStatus) }


### PR DESCRIPTION
## Why was this change made?

The modal currently has a duplicated site header in it.

## Was the documentation updated?

N/A