### PR TITLE
Remove class that caused bad layout

### DIFF
--- a/app/views/collections/new.html.erb
+++ b/app/views/collections/new.html.erb
@@ -11,7 +11,6 @@
   </h4>
   <%= form_tag apo_collections_path(@apo.pid), id: 'collection_form',
                                                role: 'form',
-                                               class: 'form-horizontal',
                                                data: { behavior: 'collection-form' } do %>
     <div class="form-group" style="padding-left:20px">
       <label class="radio">


### PR DESCRIPTION
## Why was this change made?

This class caused the modal to have no gutter

Before:

<img width="907" alt="Screen Shot 2019-11-20 at 2 50 43 PM" src="https://user-images.githubusercontent.com/92044/69285310-6cbc2380-0ba5-11ea-9ce4-b04982171348.png">

After
<img width="906" alt="Screen Shot 2019-11-20 at 2 52 01 PM" src="https://user-images.githubusercontent.com/92044/69285331-7d6c9980-0ba5-11ea-99ea-5c8651c9ffa5.png">

## Was the documentation updated?
n/a