### PR TITLE
virt obj jobs can run long and should not be retried

### DIFF
--- a/app/jobs/create_virtual_objects_job.rb
+++ b/app/jobs/create_virtual_objects_job.rb
@@ -5,6 +5,16 @@
 class CreateVirtualObjectsJob < GenericJob
   queue_as :default
 
+  # we don't want to retry these jobs -- too messy
+  def max_attempts
+    1
+  end
+
+  # big merges may run ridiculously long
+  def max_run_time
+    96.hours
+  end
+
   NOT_COMBINABLE_MESSAGE = 'Creating some or all virtual objects failed because some objects are not combinable'
   NOT_FOUND_MESSAGE = 'Could not create virtual objects because the following parent druids were not found'
   SUCCESS_MESSAGE = 'Successfully created virtual objects'


### PR DESCRIPTION
## Why was this change made?

- allow virtual object bulk actions a much longer time to complete (96 hours, not 48)
- don't retry virtual object bulk actions automatically.  This becomes messy for csv files with many parents, so require a manual retry (hopefully removing completed rows from the csv before rerunning).

@andrewjbtw just want you to be aware of this change, which should deploy on Monday.

## Was the documentation updated?

n/a