### PR TITLE
Preserved content from pres

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,7 +276,7 @@ GEM
     factory_bot_rails (5.1.1)
       factory_bot (~> 5.1.0)
       railties (>= 4.2.0)
-    faraday (0.17.0)
+    faraday (0.17.1)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
@@ -388,9 +388,10 @@ GEM
       ttfunk (~> 1.4.0)
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
-    preservation-client (0.2.2)
+    preservation-client (0.5.0)
       activesupport (>= 4.2, < 7)
       faraday (~> 0.15)
+      moab-versioning (~> 4.3)
       zeitwerk (~> 2.1)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -614,7 +615,7 @@ GEM
     xml-simple (1.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.2.1)
+    zeitwerk (2.2.2)
 
 PLATFORMS
   ruby

--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -25,7 +25,7 @@ class FilesController < ApplicationController
 
   def preserved
     authorize! :view_content, @object
-    file_content = Dor::Services::Client.object(@object.pid).files.preserved_content(filename: filename, version: params[:version].to_i)
+    file_content = Preservation::Client.objects.content(druid: @object.pid, filepath: filename, version: params[:version])
     response.headers['Content-Type'] = 'application/octet-stream'
     response.headers['Content-Disposition'] = "attachment; filename=#{filename}"
     response.headers['Last-Modified'] = Time.now.utc.rfc2822 # HTTP requires GMT date/time

--- a/spec/controllers/files_controller_spec.rb
+++ b/spec/controllers/files_controller_spec.rb
@@ -51,13 +51,13 @@ RSpec.describe FilesController, type: :controller do
   describe '#preserved' do
     context 'when they have manage access' do
       let(:mock_file_name) { 'preserved_file.txt' }
-      let(:mock_version) { 2 }
+      let(:mock_version) { '2' }
       let(:mock_content) { 'preserved file content' }
 
       before do
         allow(controller).to receive(:authorize!).and_return(true)
-        allow_any_instance_of(Dor::Services::Client::Files).to receive(:preserved_content)
-          .with(filename: mock_file_name, version: mock_version)
+        allow(Preservation::Client.objects).to receive(:content)
+          .with(druid: pid, filepath: mock_file_name, version: mock_version)
           .and_return(mock_content)
       end
 


### PR DESCRIPTION
## Why was this change made?

To get rid of `content` API endpoint in sdr-services-app.  We use preservation-client methods instead, which call equivalent methods in the preservation-catalog API.

## Was the documentation updated?

n/a, AFAIK