### PR TITLE
Provide the version when creating the workflow

### DIFF
--- a/app/controllers/dor/objects_controller.rb
+++ b/app/controllers/dor/objects_controller.rb
@@ -19,7 +19,7 @@ class Dor::ObjectsController < ApplicationController
 
     pid = response[:pid]
 
-    Dor::Config.workflow.client.create_workflow_by_name(pid, params[:workflow_id])
+    Dor::Config.workflow.client.create_workflow_by_name(pid, params[:workflow_id], version: '1')
 
     respond_to do |format|
       format.json { render json: response, location: object_location(pid) }

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -70,7 +70,7 @@ class WorkflowsController < ApplicationController
       return
     end
 
-    Dor::Config.workflow.client.create_workflow_by_name(@object.pid, wf_name)
+    Dor::Config.workflow.client.create_workflow_by_name(@object.pid, wf_name, version: @object.current_version)
 
     # We need to sync up the workflows datastream with workflow service (using #find)
     # and then force a committed Solr update before redirection.

--- a/app/forms/apo_form.rb
+++ b/app/forms/apo_form.rb
@@ -201,7 +201,7 @@ class ApoForm < BaseForm
   # @return [Dor::AdminPolicyObject] registers the APO
   def register_model
     response = Dor::Services::Client.objects.register(params: register_params)
-    Dor::Config.workflow.client.create_workflow_by_name(response[:pid], 'accessionWF')
+    Dor::Config.workflow.client.create_workflow_by_name(response[:pid], 'accessionWF', version: '1')
     # Once it's been created we populate it with its metadata
     Dor.find(response[:pid])
   end

--- a/app/forms/collection_form.rb
+++ b/app/forms/collection_form.rb
@@ -38,7 +38,7 @@ class CollectionForm < BaseForm
   # @return [Dor::Collection] registers the Collection
   def register_model
     response = Dor::Services::Client.objects.register(params: register_params)
-    Dor::Config.workflow.client.create_workflow_by_name(response[:pid], 'accessionWF')
+    Dor::Config.workflow.client.create_workflow_by_name(response[:pid], 'accessionWF', version: '1')
     # Once it's been created we populate it with its metadata
     Dor.find(response[:pid])
   end

--- a/app/jobs/release_object_job.rb
+++ b/app/jobs/release_object_job.rb
@@ -57,7 +57,7 @@ class ReleaseObjectJob < GenericJob
     end
     log.puts("#{Time.current} Trying to start release workflow")
     begin
-      Dor::Config.workflow.client.create_workflow_by_name(current_druid, 'releaseWF')
+      Dor::Config.workflow.client.create_workflow_by_name(current_druid, 'releaseWF', version: object.current_version)
       log.puts("#{Time.current} Workflow creation successful")
       bulk_action.increment(:druid_count_success).save
     rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Dor::WorkflowException => e

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe CollectionsController do
         )
         { pid: collection.pid }
       end
-      expect(Dor::Config.workflow.client).to receive(:create_workflow_by_name).with(collection.pid, 'accessionWF')
+      expect(Dor::Config.workflow.client).to receive(:create_workflow_by_name)
+        .with(collection.pid, 'accessionWF', version: '1')
 
       post :create, params: { 'label' => ':auto',
                               'collection_catkey' => catkey,
@@ -71,7 +72,8 @@ RSpec.describe CollectionsController do
         )
         { pid: collection.pid }
       end
-      expect(Dor::Config.workflow.client).to receive(:create_workflow_by_name).with(collection.pid, 'accessionWF')
+      expect(Dor::Config.workflow.client).to receive(:create_workflow_by_name)
+        .with(collection.pid, 'accessionWF', version: '1')
       expect(collection).to receive(:descMetadata).and_return(mock_desc_md_ds).exactly(4).times
 
       post :create, params: { 'collection_title' => title,
@@ -94,7 +96,8 @@ RSpec.describe CollectionsController do
         )
         { pid: collection.pid }
       end
-      expect(Dor::Config.workflow.client).to receive(:create_workflow_by_name).with(collection.pid, 'accessionWF')
+      expect(Dor::Config.workflow.client).to receive(:create_workflow_by_name)
+        .with(collection.pid, 'accessionWF', version: '1')
 
       expect_any_instance_of(CollectionForm).to receive(:sync)
       expect(apo).to receive(:add_default_collection).with(collection.pid)

--- a/spec/controllers/dor/objects_controller_spec.rb
+++ b/spec/controllers/dor/objects_controller_spec.rb
@@ -79,7 +79,8 @@ RSpec.describe Dor::ObjectsController, type: :controller do
             other_id: 'label:'
           }
         )
-        expect(workflow_service).to have_received(:create_workflow_by_name).with('druid:abc', 'registrationWF')
+        expect(workflow_service).to have_received(:create_workflow_by_name)
+          .with('druid:abc', 'registrationWF', version: '1')
       end
     end
 

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe WorkflowsController, type: :controller do
         it 'initializes the new workflow' do
           expect(controller).to receive(:flush_index)
           post :create, params: { item_id: pid, wf: 'accessionWF' }
-          expect(workflow_client).to have_received(:create_workflow_by_name).with(pid, 'accessionWF')
+          expect(workflow_client).to have_received(:create_workflow_by_name)
+            .with(pid, 'accessionWF', version: '1')
         end
       end
 

--- a/spec/forms/apo_form_spec.rb
+++ b/spec/forms/apo_form_spec.rb
@@ -309,7 +309,7 @@ RSpec.describe ApoForm do
           expect(args[:metadata_source]).to be_nil # descMD is created via the form
           { pid: apo.pid }
         end
-        expect(Dor::Config.workflow.client).to receive(:create_workflow_by_name).with(apo.pid, 'accessionWF')
+        expect(Dor::Config.workflow.client).to receive(:create_workflow_by_name).with(apo.pid, 'accessionWF', version: '1')
 
         expect(apo).to receive(:"use_license=").with(params['use_license'])
 
@@ -323,7 +323,7 @@ RSpec.describe ApoForm do
           )
           { pid: collection.pid }
         end
-        expect(Dor::Config.workflow.client).to receive(:create_workflow_by_name).with(collection.pid, 'accessionWF')
+        expect(Dor::Config.workflow.client).to receive(:create_workflow_by_name).with(collection.pid, 'accessionWF', version: '1')
 
         instance.validate(params)
         instance.save

--- a/spec/forms/collection_form_spec.rb
+++ b/spec/forms/collection_form_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe CollectionForm do
       )
       { pid: collection.pid }
     end
-    expect(Dor::Config.workflow.client).to receive(:create_workflow_by_name).with(collection.pid, 'accessionWF')
+    expect(Dor::Config.workflow.client).to receive(:create_workflow_by_name).with(collection.pid, 'accessionWF', version: '1')
 
     expect(collection).to receive(:update_index)
     expect(collection).to receive(:descMetadata).and_return(mock_desc_md_ds).exactly(4).times

--- a/spec/jobs/release_object_job_spec.rb
+++ b/spec/jobs/release_object_job_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe ReleaseObjectJob do
         webauth: { 'privgroup' => 'dorstuff', 'login' => 'esnowden' }
       }
     end
-    let(:item1) { instance_double(Dor::Item) }
-    let(:item2) { instance_double(Dor::Item) }
+    let(:item1) { instance_double(Dor::Item, current_version: '2') }
+    let(:item2) { instance_double(Dor::Item, current_version: '3') }
 
     before do
       allow(Dor).to receive(:find).with(pids[0]).and_return(item1)
@@ -48,8 +48,8 @@ RSpec.describe ReleaseObjectJob do
       it 'updates the total druid count' do
         subject.perform(bulk_action.id, params)
         expect(bulk_action.druid_count_total).to eq pids.length
-        expect(client).to have_received(:create_workflow_by_name).with(pids[0], 'releaseWF')
-        expect(client).to have_received(:create_workflow_by_name).with(pids[1], 'releaseWF')
+        expect(client).to have_received(:create_workflow_by_name).with(pids[0], 'releaseWF', version: '2')
+        expect(client).to have_received(:create_workflow_by_name).with(pids[1], 'releaseWF', version: '3')
       end
 
       it 'increments the bulk_actions druid count success' do


### PR DESCRIPTION

## Why was this change made?

Not providing a version is deprecated because it causes the workflow-server to make a request to dor-services-app to look it up


## Was the documentation updated?
n/a