### PR TITLE
Encode the filename when downloading from preservation

### DIFF
--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -27,7 +27,7 @@ class FilesController < ApplicationController
     authorize! :view_content, @object
     file_content = Preservation::Client.objects.content(druid: @object.pid, filepath: filename, version: params[:version])
     response.headers['Content-Type'] = 'application/octet-stream'
-    response.headers['Content-Disposition'] = "attachment; filename=#{filename}"
+    response.headers['Content-Disposition'] = "attachment; filename=#{CGI.escape(filename)}"
     response.headers['Last-Modified'] = Time.now.utc.rfc2822 # HTTP requires GMT date/time
     self.response_body = file_content
   rescue Preservation::Client::NotFoundError => e

--- a/spec/controllers/files_controller_spec.rb
+++ b/spec/controllers/files_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe FilesController, type: :controller do
 
   describe '#preserved' do
     context 'when they have manage access' do
-      let(:mock_file_name) { 'preserved_file.txt' }
+      let(:mock_file_name) { 'preserved file.txt' }
       let(:mock_version) { '2' }
       let(:mock_content) { 'preserved file content' }
 
@@ -67,7 +67,7 @@ RSpec.describe FilesController, type: :controller do
         expect(response.headers['Last-Modified']).to be <= Time.now.utc.rfc2822
         expect(response.headers['Last-Modified']).to be >= last_modified_lower_bound
         expect(response.headers['Content-Type']).to eq('application/octet-stream')
-        expect(response.headers['Content-Disposition']).to eq("attachment; filename=#{mock_file_name}")
+        expect(response.headers['Content-Disposition']).to eq("attachment; filename=#{CGI.escape(mock_file_name)}")
         expect(response.code).to eq('200')
         expect(response.body).to eq(mock_content)
       end


### PR DESCRIPTION
## Why was this change made?

fixes #1745 by encoding the filename in the headers when downloading through argo from the preservation link.

