### PR TITLE
Don't allow mysql 0.5.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,9 @@ gem 'equivalent-xml', '>= 0.6.0' # For ignoring_attr_values() with arguments
 gem 'eye' # NOTE: if eye is upgraded, see the note in the 'bin/eye' script about checking to see whether that script needs upgrading (which won't happen automatically).
 gem 'faraday'
 gem 'honeybadger', '~> 4.1'
-gem 'mysql2', '~> 0.5.2'
+
+# mysql 0.5.3 is not compatible with the version of MySQL we are using (5.1)
+gem 'mysql2', '< 0.5.3'
 gem 'newrelic_rpm'
 gem 'nokogiri', '~> 1.6'
 # Prawn is used to create "tracksheets"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -651,7 +651,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   mods_display
-  mysql2 (~> 0.5.2)
+  mysql2 (< 0.5.3)
   newrelic_rpm
   nokogiri (~> 1.6)
   okcomputer


### PR DESCRIPTION


## Why was this change made?
It doesn't support the version of mysql we use


## Was the documentation updated?
n/a
