### PR TITLE
Revert blacklight-hierarchy to 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ gem 'rubyzip'
 
 # Stanford/Hydra related gems
 gem 'blacklight', '~> 6.0'
-gem 'blacklight-hierarchy'
+gem 'blacklight-hierarchy', '~> 2.0'
 gem 'dor-services', '~> 8.1'
 gem 'dor-services-client', '~> 3.0'
 gem 'dor-workflow-client', '~> 3.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,10 +79,10 @@ GEM
       rails (>= 4.2, < 6)
       rsolr (>= 1.0.6, < 3)
       twitter-typeahead-rails (= 0.11.1.pre.corejavascript)
-    blacklight-hierarchy (4.0.0)
-      blacklight (> 6.20, < 8.0)
+    blacklight-hierarchy (2.0.0)
+      blacklight (~> 6.0)
       jquery-rails
-      rails (>= 5.1, < 7)
+      rails (>= 4.1, < 6)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
     bootstrap-sass (3.4.1)
@@ -624,7 +624,7 @@ DEPENDENCIES
   actionview-component (= 1.3.3)
   barby
   blacklight (~> 6.0)
-  blacklight-hierarchy
+  blacklight-hierarchy (~> 2.0)
   bootsnap (>= 1.1.0)
   byebug
   cancancan


### PR DESCRIPTION


## Why was this change made?

Previously it was too permissive in the scoping so automatic updates broke the UI
Fixes #1750 

## Was the documentation updated?
n/a