### PR TITLE
Display a useful message to the user when the file is not in preservation

### DIFF
--- a/app/helpers/dor_object_helper.rb
+++ b/app/helpers/dor_object_helper.rb
@@ -48,17 +48,6 @@ module DorObjectHelper
     end
   end
 
-  ##
-  # @deprecated Please use non-blocking requests rather than blocking helpers.
-  # See WorkflowServiceController#accesssioned for JSON API to this logic
-  def has_been_accessioned?(pid)
-    Dor::Config.workflow.client.lifecycle('dor', pid, 'accessioned')
-  end
-
-  def last_accessioned_version(pid)
-    Preservation::Client.objects.current_version(pid)
-  end
-
   def render_qfacet_value(facet_solr_field, item, options = {})
     params = add_facet_params(facet_solr_field, item.qvalue)
     Rails.cache.fetch('route_for' + params.to_s, expires_in: 1.hour) do

--- a/app/views/files/index.html.erb
+++ b/app/views/files/index.html.erb
@@ -20,11 +20,10 @@
     </p>
   <% end %>
 
-  <%# TODO: has_been_accessioned? is deprecated, migrate to async call %>
-  <% if file['preserve'] == 'yes' && has_been_accessioned?(@object.pid) %>
+  <% if file['preserve'] == 'yes' && @has_been_accessioned %>
         <p>
           Preservation:
-          <%= link_to params[:file], preserved_item_file_path(item_id: @object, id: params[:id], version: last_accessioned_version(@object.pid)) %>
+          <%= link_to params[:file], preserved_item_file_path(item_id: @object, id: params[:id], version: @last_accessioned_version) %>
         </p>
   <% end %>
 <% end %>

--- a/spec/helpers/dor_object_helper_spec.rb
+++ b/spec/helpers/dor_object_helper_spec.rb
@@ -2,18 +2,6 @@
 
 require 'rails_helper'
 
-class DummyClass
-  include DorObjectHelper
-end
-
 RSpec.describe DorObjectHelper, type: :helper do
-  describe '#last_accessioned_version' do
-    let(:druid) { 'oo000oo0000' }
-
-    it 'uses preservation-client gem' do
-      allow(Preservation::Client.objects).to receive(:current_version).with(druid)
-      DummyClass.new.last_accessioned_version(druid)
-      expect(Preservation::Client.objects).to have_received(:current_version).with(druid)
-    end
-  end
+  it 'does not have any tests'
 end

--- a/spec/views/files/index.html.erb_spec.rb
+++ b/spec/views/files/index.html.erb_spec.rb
@@ -24,16 +24,15 @@ RSpec.describe 'files/index.html.erb' do
 </contentMetadata>'
     cm
   end
-  let(:obj) { double(pid: 'druid:rn653dy9317', to_param: 'druid:rn653dy9317', contentMetadata: contentMetadata) }
+  let(:obj) { instance_double(Dor::Item, pid: 'druid:rn653dy9317', to_param: 'druid:rn653dy9317', contentMetadata: contentMetadata) }
 
   before do
-    assign(:object, obj)
-    assign(:available_in_workspace, true)
-    assign(:available_in_workspace_error, nil)
-    expect(view).to receive(:params).and_return(id: 'M1090_S15_B01_F07_0106.jp2', item_id: 'druid:rn653dy9317').at_least(1)
-    expect(view).to receive(:has_been_accessioned?).with(obj.pid).and_return(true)
-    expect(view).to receive(:last_accessioned_version).with(obj.pid)
-
+    @object = obj
+    @available_in_workspace = true
+    @has_been_accessioned = true
+    @last_accessioned_version = '7'
+    params[:id] = 'M1090_S15_B01_F07_0106.jp2'
+    params[:item_id] = 'druid:rn653dy9317'
     render
   end
 


### PR DESCRIPTION
## Why was this change made?

Previously this exception was uncaught which sent the user to the system status page.



## Was the documentation updated?

n/a
