### PR TITLE
Pass version to the workflow service

### DIFF
--- a/app/controllers/workflow_service_controller.rb
+++ b/app/controllers/workflow_service_controller.rb
@@ -40,12 +40,16 @@ class WorkflowServiceController < ApplicationController
 
   private
 
+  def version
+    @version ||= Dor::Services::Client.object(params[:pid]).version.current
+  end
+
   def get_lifecycle(task)
-    Dor::Config.workflow.client.lifecycle('dor', params[:pid], task)
+    Dor::Config.workflow.client.lifecycle('dor', params[:pid], task, version: version)
   end
 
   def get_active_lifecycle(task)
-    Dor::Config.workflow.client.active_lifecycle('dor', params[:pid], task)
+    Dor::Config.workflow.client.active_lifecycle('dor', params[:pid], task, version: version)
   end
 
   ##


### PR DESCRIPTION


## Why was this change made?

This allows the workflow service to skip the callback to dor-services-app

## Was the documentation updated?
