### PR TITLE
Use the models provided by the workflow client

### DIFF
--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -86,7 +86,7 @@ class WorkflowsController < ApplicationController
   end
 
   def history
-    @history_xml = Dor::Config.workflow.client.all_workflows_xml params[:item_id]
+    @history_xml = Dor::Config.workflow.client.workflow_routes.all_workflows(pid: params[:item_id]).xml
 
     respond_to do |format|
       format.html { render layout: !request.xhr? }

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -131,9 +131,10 @@ RSpec.describe WorkflowsController, type: :controller do
 
   describe '#history' do
     let(:xml) { instance_double(String) }
+    let(:workflows) { instance_double(Dor::Workflow::Response::Workflows, xml: xml) }
+    let(:workflow_routes) { instance_double(Dor::Workflow::Client::WorkflowRoutes, all_workflows: workflows) }
     let(:workflow_client) do
-      instance_double(Dor::Workflow::Client,
-                      all_workflows_xml: xml)
+      instance_double(Dor::Workflow::Client, workflow_routes: workflow_routes)
     end
 
     it 'fetches the workflow history' do


### PR DESCRIPTION


## Why was this change made?
This is trying to move us away from the all_workflows_xml method as it is deprecated


## Was the documentation updated?
n/a