### PR TITLE
pass auth token to pres-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem 'dor-services-client', '~> 4.0'
 gem 'dor-workflow-client', '~> 3.11'
 gem 'mods_display'
 gem 'okcomputer' # monitors application and its dependencies
-gem 'preservation-client', '~> 2.0'
+gem 'preservation-client', '>= 3.0' # 3.x or greater is needed for token auth
 gem 'responders', '~> 2.0'
 gem 'rsolr'
 gem 'sul_styles', '~> 0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,9 +393,9 @@ GEM
       ttfunk (~> 1.4.0)
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
-    preservation-client (2.1.0)
+    preservation-client (3.0.0)
       activesupport (>= 4.2, < 7)
-      faraday (~> 0.15)
+      faraday (>= 0.15, < 2.0)
       moab-versioning (~> 4.3)
       zeitwerk (~> 2.1)
     pry (0.12.2)
@@ -662,7 +662,7 @@ DEPENDENCIES
   okcomputer
   prawn (~> 1)
   prawn-table
-  preservation-client (~> 2.0)
+  preservation-client (>= 3.0)
   pry-byebug
   pry-rails
   pry-remote

--- a/config/initializers/preservation_client.rb
+++ b/config/initializers/preservation_client.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 # Configure preservation-client to use preservation catalog URL
-Preservation::Client.configure(url: Settings.preservation_catalog.url)
+Preservation::Client.configure(url: Settings.preservation_catalog.url, token: Settings.preservation_catalog.token)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -57,6 +57,7 @@ dor_services:
 
 preservation_catalog:
   url: 'https://example.org/prescat'
+  token: 'mint-token-with-target-preservation-catalog-rake-generate-token'
 
 # URLs
 dor_indexing_url: 'https://dor-indexing-app.example.com/dor'


### PR DESCRIPTION
HOLD until: 

- [x] shared_configs PRs are merged (sul-dlss/shared_configs/pull/1173, sul-dlss/shared_configs/pull/1176)
- [x] test this branch on stage!
- [x] sul-dlss/preservation-client/pull/29 is merged
- [x] new version of pres-client gem is released
- [x] Fix this branch to use released gem
- [x] Take this PR out of draft

## Why was this change made?

pres cat will start requiring that all API clients supply an auth token, or their requests will be rejected as Unauthorized.

Fixes #1770
connects to sul-dlss/preservation_catalog#1298
blocks sul-dlss/preservation_catalog#1306

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

n/a

