### PR TITLE
Send the current_version when requsting the active lifecycle

### DIFF
--- a/app/jobs/generic_job.rb
+++ b/app/jobs/generic_job.rb
@@ -73,7 +73,8 @@ class GenericJob < ActiveJob::Base
   end
 
   def open_new_version(object, description)
-    raise "#{Time.current} Unable to open new version for #{object.pid} (bulk_action.id=#{bulk_action.id})" unless DorObjectWorkflowStatus.new(object.pid).can_open_version?
+    wf_status = DorObjectWorkflowStatus.new(object.pid, version: object.current_version)
+    raise "#{Time.current} Unable to open new version for #{object.pid} (bulk_action.id=#{bulk_action.id})" unless wf_status.can_open_version?
 
     VersionService.open(identifier: object.pid,
                         significance: 'minor',

--- a/app/jobs/prepare_job.rb
+++ b/app/jobs/prepare_job.rb
@@ -33,9 +33,10 @@ class PrepareJob < GenericJob
   private
 
   def open_object(pid, significance, description, user_name, log)
-    return log.puts("#{Time.current} #{pid} is not openable") unless openable?(pid)
-
     object = Dor.find(pid)
+
+    return log.puts("#{Time.current} #{pid} is not openable") unless openable?(pid, version: object.current_version)
+
     return log.puts("#{Time.current} Not authorized for #{pid}") unless ability.can?(:manage_item, object)
 
     VersionService.open(identifier: pid,
@@ -49,7 +50,7 @@ class PrepareJob < GenericJob
     bulk_action.increment(:druid_count_fail).save
   end
 
-  def openable?(pid)
-    DorObjectWorkflowStatus.new(pid).can_open_version?
+  def openable?(pid, version:)
+    DorObjectWorkflowStatus.new(pid, version: version).can_open_version?
   end
 end

--- a/app/models/dor_object_workflow_status.rb
+++ b/app/models/dor_object_workflow_status.rb
@@ -1,20 +1,21 @@
 # frozen_string_literal: true
 
 class DorObjectWorkflowStatus
-  attr_reader :pid
+  attr_reader :pid, :version
 
   ##
   # @param [String] pid in format "druid:abc123def4567"
-  def initialize(pid)
+  def initialize(pid, version:)
     @pid = pid
+    @version = version
   end
 
   ##
   # @return [Boolean]
   def can_open_version?
     return false unless workflow.lifecycle('dor', pid, 'accessioned')
-    return false if workflow.active_lifecycle('dor', pid, 'submitted')
-    return false if workflow.active_lifecycle('dor', pid, 'opened')
+    return false if workflow.active_lifecycle('dor', pid, 'submitted', version: version)
+    return false if workflow.active_lifecycle('dor', pid, 'opened', version: version)
 
     true
   end

--- a/app/services/apply_mods_metadata.rb
+++ b/app/services/apply_mods_metadata.rb
@@ -70,7 +70,7 @@ class ApplyModsMetadata
   def version_object
     return unless accessioned?
 
-    unless DorObjectWorkflowStatus.new(item.pid).can_open_version?
+    unless DorObjectWorkflowStatus.new(item.pid, version: item.current_version).can_open_version?
       log.puts("argo.bulk_metadata.bulk_log_unable_to_version #{item.pid}") # totally unexpected
       return
     end

--- a/spec/controllers/workflow_service_controller_spec.rb
+++ b/spec/controllers/workflow_service_controller_spec.rb
@@ -5,18 +5,21 @@ require 'rails_helper'
 RSpec.describe WorkflowServiceController, type: :controller do
   before do
     sign_in(create(:user))
+    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
   end
 
+  let(:object_client) { instance_double(Dor::Services::Client::Object, version: version_client) }
+  let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, current: 1) }
   let(:druid) { 'druid:abc:123' }
 
   describe 'GET closeable' do
     context 'when closeable' do
       it 'returns true' do
         expect(Dor::Config.workflow.client)
-          .to receive(:active_lifecycle).with('dor', druid, 'opened')
+          .to receive(:active_lifecycle).with('dor', druid, 'opened', version: 1)
                                         .and_return(true)
         expect(Dor::Config.workflow.client)
-          .to receive(:active_lifecycle).with('dor', druid, 'submitted')
+          .to receive(:active_lifecycle).with('dor', druid, 'submitted', version: 1)
                                         .and_return(false)
         get :closeable, params: { pid: druid, format: :json }
         expect(assigns(:status)).to eq true
@@ -28,7 +31,7 @@ RSpec.describe WorkflowServiceController, type: :controller do
       context 'not opened' do
         it 'returns false' do
           expect(Dor::Config.workflow.client)
-            .to receive(:active_lifecycle).with('dor', druid, 'opened')
+            .to receive(:active_lifecycle).with('dor', druid, 'opened', version: 1)
                                           .and_return(false)
           get :closeable, params: { pid: druid, format: :json }
           expect(assigns(:status)).to eq false
@@ -39,10 +42,10 @@ RSpec.describe WorkflowServiceController, type: :controller do
       context 'when opened && is submitted' do
         it 'returns false' do
           expect(Dor::Config.workflow.client)
-            .to receive(:active_lifecycle).with('dor', druid, 'opened')
+            .to receive(:active_lifecycle).with('dor', druid, 'opened', version: 1)
                                           .and_return(true)
           expect(Dor::Config.workflow.client)
-            .to receive(:active_lifecycle).with('dor', druid, 'submitted')
+            .to receive(:active_lifecycle).with('dor', druid, 'submitted', version: 1)
                                           .and_return(true)
           get :closeable, params: { pid: druid, format: :json }
           expect(assigns(:status)).to eq false
@@ -70,7 +73,7 @@ RSpec.describe WorkflowServiceController, type: :controller do
           .to receive(:lifecycle).with('dor', druid, 'accessioned')
                                  .and_return(true)
         expect(Dor::Config.workflow.client)
-          .to receive(:active_lifecycle).with('dor', druid, 'submitted')
+          .to receive(:active_lifecycle).with('dor', druid, 'submitted', version: 1)
                                         .and_return(true)
         get :openable, params: { pid: druid, format: :json }
         expect(assigns(:status)).to eq false
@@ -84,10 +87,10 @@ RSpec.describe WorkflowServiceController, type: :controller do
           .to receive(:lifecycle).with('dor', druid, 'accessioned')
                                  .and_return(true)
         expect(Dor::Config.workflow.client)
-          .to receive(:active_lifecycle).with('dor', druid, 'submitted')
+          .to receive(:active_lifecycle).with('dor', druid, 'submitted', version: 1)
                                         .and_return(false)
         expect(Dor::Config.workflow.client)
-          .to receive(:active_lifecycle).with('dor', druid, 'opened')
+          .to receive(:active_lifecycle).with('dor', druid, 'opened', version: 1)
                                         .and_return(true)
         get :openable, params: { pid: druid, format: :json }
         expect(assigns(:status)).to eq false
@@ -101,10 +104,10 @@ RSpec.describe WorkflowServiceController, type: :controller do
           .to receive(:lifecycle).with('dor', druid, 'accessioned')
                                  .and_return(true)
         expect(Dor::Config.workflow.client)
-          .to receive(:active_lifecycle).with('dor', druid, 'submitted')
+          .to receive(:active_lifecycle).with('dor', druid, 'submitted', version: 1)
                                         .and_return(false)
         expect(Dor::Config.workflow.client)
-          .to receive(:active_lifecycle).with('dor', druid, 'opened')
+          .to receive(:active_lifecycle).with('dor', druid, 'opened', version: 1)
                                         .and_return(false)
         get :openable, params: { pid: druid, format: :json }
         expect(assigns(:status)).to eq true

--- a/spec/features/apo_spec.rb
+++ b/spec/features/apo_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe 'apo', js: true do
   let(:new_collection_druid) { 'druid:zy333wv6543' }
   let(:apo) { Dor::AdminPolicyObject.new(pid: new_apo_druid) }
   let(:collection) { Dor::Collection.new(pid: new_collection_druid, label: 'New Testing Collection') }
-  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+  let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, current: 1) }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, version: version_client) }
   let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative) }
   let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }
   let(:workflows_response) { instance_double(Dor::Workflow::Response::Workflows, workflows: []) }

--- a/spec/features/item_view_metadata_spec.rb
+++ b/spec/features/item_view_metadata_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe 'Item view', js: true do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
   end
 
-  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, files: files) }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, files: files, version: version_client) }
+  let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, current: 1) }
   let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative) }
   let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }
 

--- a/spec/models/dor_object_workflow_status_spec.rb
+++ b/spec/models/dor_object_workflow_status_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe DorObjectWorkflowStatus do
-  subject { described_class.new(pid) }
+  subject { described_class.new(pid, version: 1) }
 
   let(:pid) { 'druid:abc123def4567' }
 
@@ -24,7 +24,7 @@ RSpec.describe DorObjectWorkflowStatus do
           .to receive(:lifecycle).with('dor', pid, 'accessioned')
                                  .and_return(true)
         expect(Dor::Config.workflow.client)
-          .to receive(:active_lifecycle).with('dor', pid, 'submitted')
+          .to receive(:active_lifecycle).with('dor', pid, 'submitted', version: 1)
                                         .and_return(true)
       end
 
@@ -37,10 +37,10 @@ RSpec.describe DorObjectWorkflowStatus do
           .to receive(:lifecycle).with('dor', pid, 'accessioned')
                                  .and_return(true)
         expect(Dor::Config.workflow.client)
-          .to receive(:active_lifecycle).with('dor', pid, 'submitted')
+          .to receive(:active_lifecycle).with('dor', pid, 'submitted', version: 1)
                                         .and_return(false)
         expect(Dor::Config.workflow.client)
-          .to receive(:active_lifecycle).with('dor', pid, 'opened')
+          .to receive(:active_lifecycle).with('dor', pid, 'opened', version: 1)
                                         .and_return(true)
       end
 
@@ -53,10 +53,10 @@ RSpec.describe DorObjectWorkflowStatus do
           .to receive(:lifecycle).with('dor', pid, 'accessioned')
                                  .and_return(true)
         expect(Dor::Config.workflow.client)
-          .to receive(:active_lifecycle).with('dor', pid, 'submitted')
+          .to receive(:active_lifecycle).with('dor', pid, 'submitted', version: 1)
                                         .and_return(false)
         expect(Dor::Config.workflow.client)
-          .to receive(:active_lifecycle).with('dor', pid, 'opened')
+          .to receive(:active_lifecycle).with('dor', pid, 'opened', version: 1)
                                         .and_return(false)
       end
 

--- a/spec/services/apply_mods_metadata_spec.rb
+++ b/spec/services/apply_mods_metadata_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe ApplyModsMetadata do
     instance_double(Dor::Item,
                     descMetadata: desc_metadata,
                     pid: 'druid:123abc',
+                    current_version: 1,
                     admin_policy_object_id: apo_druid,
                     save!: true)
   end
@@ -69,7 +70,7 @@ RSpec.describe ApplyModsMetadata do
     let(:workflow) { instance_double(DorObjectWorkflowStatus) }
 
     it 'writes a log error message if a version cannot be opened' do
-      expect(DorObjectWorkflowStatus).to receive(:new).with(item.pid).and_return(workflow)
+      expect(DorObjectWorkflowStatus).to receive(:new).with(item.pid, version: 1).and_return(workflow)
       expect(workflow).to receive(:can_open_version?).and_return(false)
 
       action.send(:version_object)
@@ -97,7 +98,7 @@ RSpec.describe ApplyModsMetadata do
     end
 
     it 'updates the version if the object is past the registered state' do
-      expect(DorObjectWorkflowStatus).to receive(:new).with(item.pid).and_return(workflow)
+      expect(DorObjectWorkflowStatus).to receive(:new).with(item.pid, version: 1).and_return(workflow)
       expect(workflow).to receive(:can_open_version?).and_return(true)
       expect(action).to receive(:commit_new_version)
 
@@ -137,7 +138,7 @@ RSpec.describe ApplyModsMetadata do
 
   describe 'in_accessioning?' do
     (0..9).each do |i|
-      it "returns true for DOR objects that are currently in acccessioning, false otherwise (:status_code #{i})" do
+      it "returns true for DOR objects that are currently in accessioning, false otherwise (:status_code #{i})" do
         allow(action).to receive(:status).and_return(i)
         if [2, 3, 4, 5].include?(i)
           expect(action.send(:in_accessioning?)).to be_truthy
@@ -150,7 +151,7 @@ RSpec.describe ApplyModsMetadata do
 
   describe 'accessioned?' do
     (0..9).each do |i|
-      it "returns true for DOR objects that are acccessioned, false otherwise (:status_code #{i})" do
+      it "returns true for DOR objects that are accessioned, false otherwise (:status_code #{i})" do
         allow(action).to receive(:status).and_return(i)
         if [6, 7, 8].include?(i)
           expect(action.send(:accessioned?)).to be_truthy


### PR DESCRIPTION
## Why was this change made?

This prevents the workflow server from logging deprecation warnings.

## Was the documentation updated?
n/a