### PR TITLE
preservation-client 3.1 fixes POST for checksums report

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem 'dor-services-client', '~> 4.0'
 gem 'dor-workflow-client', '~> 3.11'
 gem 'mods_display'
 gem 'okcomputer' # monitors application and its dependencies
-gem 'preservation-client', '>= 3.0' # 3.x or greater is needed for token auth
+gem 'preservation-client', '>= 3.1' # 3.1 or greater is needed for token auth and fix for POST requests
 gem 'responders', '~> 2.0'
 gem 'rsolr'
 gem 'sul_styles', '~> 0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -389,7 +389,7 @@ GEM
       ttfunk (~> 1.4.0)
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
-    preservation-client (3.0.0)
+    preservation-client (3.1.0)
       activesupport (>= 4.2, < 7)
       faraday (>= 0.15, < 2.0)
       moab-versioning (~> 4.3)
@@ -658,7 +658,7 @@ DEPENDENCIES
   okcomputer
   prawn (~> 1)
   prawn-table
-  preservation-client (>= 3.0)
+  preservation-client (>= 3.1)
   pry-byebug
   pry-rails
   pry-remote


### PR DESCRIPTION
## Why was this change made?

Part of #1776 - checksum report problems.   Reports with lots of checksums should no longer error due to uri too long.

## Was the documentation updated?

n/a