### PR TITLE
Convert Datastream row to a component

### DIFF
--- a/app/components/datastream_row.html.erb
+++ b/app/components/datastream_row.html.erb
@@ -1,0 +1,8 @@
+<tr>
+  <td><%= link_to_identifier %></td>
+  <td><%= control_group %></td>
+  <td><%= mime_type %></td>
+  <td><%= version %></td>
+  <td><%= size %></td>
+  <td><%= label %></td>
+</tr>

--- a/app/components/datastream_row.rb
+++ b/app/components/datastream_row.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Draws a row for a datastream
+class DatastreamRow < ApplicationComponent
+  # @param [SolrDocument] document the Solr document model for the item
+  # @param [Hash] attributes the datastream attributes
+  def initialize(document:, attributes:)
+    @document = document
+    @specs = attributes
+  end
+
+  attr_reader :document, :specs
+
+  # Datastream helpers
+  CONTROL_GROUP_TEXT = { 'X' => 'inline', 'M' => 'managed', 'R' => 'redirect', 'E' => 'external' }.freeze
+
+  def control_group
+    cg = specs.fetch(:control_group, 'X')
+    "#{cg}/#{CONTROL_GROUP_TEXT[cg]}"
+  end
+
+  def link_to_identifier
+    link_to specs[:dsid], ds_solr_document_path(document, specs[:dsid]), title: specs[:dsid], data: { behavior: 'persistent-modal' }
+  end
+
+  def mime_type
+    specs[:mime_type]
+  end
+
+  def version
+    "v#{specs[:version]}"
+  end
+
+  def size
+    number_to_human_size(specs[:size])
+  end
+
+  def label
+    specs[:label]
+  end
+end

--- a/app/helpers/dor_object_helper.rb
+++ b/app/helpers/dor_object_helper.rb
@@ -64,37 +64,6 @@ module DorObjectHelper
     render 'catalog/show_workflows', document_id: doc.id, workflows: workflows
   end
 
-  # Datastream helpers
-  CONTROL_GROUP_TEXT = { 'X' => 'inline', 'M' => 'managed', 'R' => 'redirect', 'E' => 'external' }
-  def parse_specs(spec_string)
-    Hash[[:dsid, :control_group, :mime_type, :version, :size, :label].zip(spec_string.split(/\|/))]
-  end
-
-  def render_ds_control_group(doc, specs)
-    cg = specs[:control_group] || 'X'
-    "#{cg}/#{CONTROL_GROUP_TEXT[cg]}"
-  end
-
-  def render_ds_id(doc, specs)
-    link_to specs[:dsid], ds_solr_document_path(doc['id'], specs[:dsid]), title: specs[:dsid], data: { behavior: 'persistent-modal' }
-  end
-
-  def render_ds_mime_type(doc, specs)
-    specs[:mime_type]
-  end
-
-  def render_ds_version(doc, specs)
-    "v#{specs[:version]}"
-  end
-
-  def render_ds_size(doc, specs)
-    number_to_human_size(specs[:size])
-  end
-
-  def render_ds_label(doc, specs)
-    specs[:label]
-  end
-
   # rubocop:disable Metrics/LineLength
   def render_ds_profile_header(ds)
     dscd = ds.createDate

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -68,4 +68,11 @@ class SolrDocument
       }
     end
   end
+
+  # @return[Array<Hash>] the deserialized datastream attributes
+  def datastreams
+    fetch('ds_specs_ssim', []).map do |spec_string|
+      Hash[[:dsid, :control_group, :mime_type, :version, :size, :label].zip(spec_string.split(/\|/))]
+    end
+  end
 end

--- a/app/views/catalog/_datastreams_default.html.erb
+++ b/app/views/catalog/_datastreams_default.html.erb
@@ -4,19 +4,8 @@
 </h3>
 <div id="document-datastreams-section" class="document-section">
   <table class="detail">
-    <% 
-      document['ds_specs_ssim'].try(:each) do |dspecs| 
-        specs = parse_specs(dspecs)
-    %>
-      <tr>
-        <td><%= render_ds_id document, specs %></td>
-        <td><%= render_ds_control_group document, specs %></td>
-        <td><%= render_ds_mime_type document, specs %></td>
-        <td><%= render_ds_version document, specs %></td>
-        <td><%= render_ds_size document, specs %></td>
-        <td><%= render_ds_label document, specs %></td>
-      </tr>
+    <% document.datastreams.each do |attributes| %>
+      <%= render DatastreamRow, document: document, attributes: attributes %>
     <% end %>
   </table>
-
 </div>


### PR DESCRIPTION
## Why was this change made?

Components group methods together better than views + helpers.


## Was the documentation updated?
n/a