### PR TITLE
Remove workflows datastream from the datastreams table

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -69,10 +69,13 @@ class SolrDocument
     end
   end
 
+  # These values are used to drive the display for the datastream table on the item show page
+  # This method is now excluding the workflows datastream because this datastream is deprecated.
   # @return[Array<Hash>] the deserialized datastream attributes
   def datastreams
-    fetch('ds_specs_ssim', []).map do |spec_string|
+    specs = fetch('ds_specs_ssim', []).map do |spec_string|
       Hash[[:dsid, :control_group, :mime_type, :version, :size, :label].zip(spec_string.split(/\|/))]
     end
+    specs.filter { |spec| spec[:dsid] != 'workflows' }
   end
 end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -69,6 +69,56 @@ RSpec.describe SolrDocument, type: :model do
     end
   end
 
+  describe '#datastreams' do
+    subject(:datastreams) { doc.datastreams }
+
+    let(:doc) do
+      described_class.new('ds_specs_ssim' => [
+                            'DC|X|text/xml|0|475|Dublin Core Record for this object',
+                            'RELS-EXT|X|application/rdf+xml|0|821|Fedora Object-to-Object Relationship Metadata',
+                            'identityMetadata|M|text/xml|0|635|Identity Metadata',
+                            'rightsMetadata|M|text/xml|4|652|Rights metadata',
+                            'descMetadata|M|text/xml|3|5988|Descriptive Metadata',
+                            'workflows|E|application/xml|0|10780|Workflows'
+                          ])
+    end
+
+    it 'excludes workflows' do
+      expect(datastreams).to eq [
+        { control_group: 'X',
+          dsid: 'DC',
+          label: 'Dublin Core Record for this object',
+          mime_type: 'text/xml',
+          size: '475',
+          version: '0' },
+        { control_group: 'X',
+          dsid: 'RELS-EXT',
+          label: 'Fedora Object-to-Object Relationship Metadata',
+          mime_type: 'application/rdf+xml',
+          size: '821',
+          version: '0' },
+        { control_group: 'M',
+          dsid: 'identityMetadata',
+          label: 'Identity Metadata',
+          mime_type: 'text/xml',
+          size: '635',
+          version: '0' },
+        { control_group: 'M',
+          dsid: 'rightsMetadata',
+          label: 'Rights metadata',
+          mime_type: 'text/xml',
+          size: '652',
+          version: '4' },
+        { control_group: 'M',
+          dsid: 'descMetadata',
+          label: 'Descriptive Metadata',
+          mime_type: 'text/xml',
+          size: '5988',
+          version: '3' }
+      ]
+    end
+  end
+
   describe 'get_versions' do
     it 'builds a version hash' do
       data = []


### PR DESCRIPTION
## Why was this change made?

We're deprecating the workflows datastream because it is an external datastream (proxy) and has no analog in a post-Fedora 3 vision.

Part of https://github.com/sul-dlss/dor-services-app/issues/601 



## Was the documentation updated?
n/a