### PR TITLE
Use the status from the workflow service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ gem 'blacklight', '~> 6.0'
 gem 'blacklight-hierarchy', '~> 2.0'
 gem 'dor-services', '~> 8.1'
 gem 'dor-services-client', '~> 4.0'
-gem 'dor-workflow-client', '~> 3.11'
+gem 'dor-workflow-client', '~> 3.19'
 gem 'mods_display'
 gem 'okcomputer' # monitors application and its dependencies
 gem 'preservation-client', '>= 3.1' # 3.1 or greater is needed for token auth and fix for POST requests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ GEM
       moab-versioning (~> 4.0)
       nokogiri (~> 1.8)
       zeitwerk (~> 2.1)
-    dor-workflow-client (3.18.1)
+    dor-workflow-client (3.19.0)
       activesupport (>= 3.2.1, < 7)
       deprecation (>= 0.99.0)
       faraday (>= 0.9.2, < 2.0)
@@ -642,7 +642,7 @@ DEPENDENCIES
   dlss-capistrano (~> 3.1)
   dor-services (~> 8.1)
   dor-services-client (~> 4.0)
-  dor-workflow-client (~> 3.11)
+  dor-workflow-client (~> 3.19)
   equivalent-xml (>= 0.6.0)
   eye
   factory_bot_rails

--- a/app/services/apply_mods_metadata.rb
+++ b/app/services/apply_mods_metadata.rb
@@ -118,10 +118,10 @@ class ApplyModsMetadata
     [1, 6, 7, 8, 9].include?(status)
   end
 
-  # Returns the status_info for a DOR object from the StatusService
+  # Returns the status code for a DOR object
   #
   # @return [Integer] value corresponding to the status info list
   def status
-    @status ||= Dor::StatusService.new(item).status_info[:status_code]
+    @status ||= Dor::Config.workflow.client.status(druid: item.pid, version: item.current_version).info[:status_code]
   end
 end

--- a/spec/services/apply_mods_metadata_spec.rb
+++ b/spec/services/apply_mods_metadata_spec.rb
@@ -29,10 +29,10 @@ RSpec.describe ApplyModsMetadata do
   describe '#apply' do
     subject(:apply) { action.apply }
 
-    let(:status_service) { instance_double(Dor::StatusService, status_info: { status_code: 9 }) }
+    let(:status_service) { instance_double(Dor::Workflow::Client::Status, info: { status_code: 9 }) }
 
     before do
-      allow(Dor::StatusService).to receive(:new).and_return(status_service)
+      allow(Dor::Config.workflow.client).to receive(:status).and_return(status_service)
     end
 
     context 'with permission' do
@@ -62,10 +62,11 @@ RSpec.describe ApplyModsMetadata do
 
   describe 'version_object' do
     before do
-      allow(Dor::StatusService).to receive(:new).and_return(stub_service)
+      allow(Dor::Config.workflow.client).to receive(:status).and_return(status_service)
     end
 
-    let(:stub_service) { instance_double(Dor::StatusService, status_info: { status_code: status_code }) }
+    let(:status_service) { instance_double(Dor::Workflow::Client::Status, info: { status_code: status_code }) }
+
     let(:status_code) { 6 }
     let(:workflow) { instance_double(DorObjectWorkflowStatus) }
 


### PR DESCRIPTION


## Why was this change made?

The Dor::StatusService is deprecated and will be removed

## Was the documentation updated?
n/a