### PR TITLE
Show the cocina data model on the show page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ gem 'rubyzip'
 gem 'blacklight', '~> 6.0'
 gem 'blacklight-hierarchy', '~> 2.0'
 gem 'dor-services', '~> 9.0'
-gem 'dor-services-client', '~> 4.0'
+gem 'dor-services-client', '~> 4.4'
 gem 'dor-workflow-client', '~> 3.19'
 gem 'mods_display'
 gem 'okcomputer' # monitors application and its dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -640,7 +640,7 @@ DEPENDENCIES
   devise-remote-user (~> 1.0)
   dlss-capistrano (~> 3.1)
   dor-services (~> 9.0)
-  dor-services-client (~> 4.0)
+  dor-services-client (~> 4.4)
   dor-workflow-client (~> 3.19)
   equivalent-xml (>= 0.6.0)
   eye

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -166,7 +166,7 @@ class CatalogController < ApplicationController
     # Configure document actions framework
     config.index.document_actions.delete(:bookmark)
 
-    config.show.partials = %w(show_header full_view_links thumbnail show datastreams history contents)
+    config.show.partials = %w(show_header full_view_links thumbnail show datastreams cocina history contents)
   end
 
   def default_solr_doc_params(id = nil)

--- a/app/views/catalog/_cocina_default.html.erb
+++ b/app/views/catalog/_cocina_default.html.erb
@@ -1,0 +1,10 @@
+<% if params[:beta] %>
+  <h3 id="document-cocina-head" class="section-head collapsible-section">
+    Cocina Model
+  </h3>
+  <div id="document-cocina-section" class="document-section">
+    <table class="detail">
+      <pre><%= JSON.pretty_generate(@cocina.as_json) %></pre>
+    </table>
+  </div>
+<% end %>

--- a/spec/features/add_workflow_to_item_spec.rb
+++ b/spec/features/add_workflow_to_item_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Add a workflow to an item' do
                     active_lifecycle: [])
   end
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
-  let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative) }
+  let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
   let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }
 
   before do

--- a/spec/features/apo_spec.rb
+++ b/spec/features/apo_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'apo', js: true do
   let(:collection) { Dor::Collection.new(pid: new_collection_druid, label: 'New Testing Collection') }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, current: 1) }
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, version: version_client) }
-  let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative) }
+  let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
   let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }
   let(:workflows_response) { instance_double(Dor::Workflow::Response::Workflows, workflows: []) }
   let(:workflow_routes) { instance_double(Dor::Workflow::Client::WorkflowRoutes, all_workflows: workflows_response) }

--- a/spec/features/bulk_screen_spec.rb
+++ b/spec/features/bulk_screen_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Bulk actions view', js: true do
     instance_double(Dor::Services::Client::Object, publish: true, find: cocina_model)
   end
 
-  let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: admin_md) }
+  let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: admin_md, as_json: {}) }
   let(:admin_md) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: nil) }
   let(:workflow_client) { instance_double(Dor::Workflow::Client, workflow_templates: [], lifecycle: [], active_lifecycle: []) }
 

--- a/spec/features/collection_manage_release_spec.rb
+++ b/spec/features/collection_manage_release_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Collection manage release' do
   let(:state_service) { instance_double(StateService, allows_modification?: true) }
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, release_tags: release_tags_client) }
   let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, create: true) }
-  let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative) }
+  let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
   let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }
 
   it 'Has a manage release button' do

--- a/spec/features/consistent_titles_spec.rb
+++ b/spec/features/consistent_titles_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Consistent titles' do
 
     let(:workflow_client) { instance_double(Dor::Workflow::Client, lifecycle: [], active_lifecycle: []) }
     let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
-    let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative) }
+    let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
     let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }
 
     it 'displays the title' do

--- a/spec/features/enable_buttons_spec.rb
+++ b/spec/features/enable_buttons_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Enable buttons' do
 
   let(:state_service) { instance_double(StateService, allows_modification?: true) }
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
-  let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative) }
+  let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
   let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }
 
   it 'buttons are disabled by default that have check_url' do

--- a/spec/features/item_catkey_change_spec.rb
+++ b/spec/features/item_catkey_change_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Item catkey change' do
   describe 'when modification is allowed' do
     let(:state_service) { instance_double(StateService, allows_modification?: true) }
     let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
-    let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative) }
+    let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
     let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }
     let(:workflows_response) { instance_double(Dor::Workflow::Response::Workflows, workflows: []) }
     let(:workflow_routes) { instance_double(Dor::Workflow::Client::WorkflowRoutes, all_workflows: workflows_response) }

--- a/spec/features/item_manage_release_spec.rb
+++ b/spec/features/item_manage_release_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Item manage release' do
   let(:druid) { 'druid:qq613vj0238' }
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, release_tags: release_tags_client) }
   let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, create: true) }
-  let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative) }
+  let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
   let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }
 
   it 'Has a manage release button' do

--- a/spec/features/item_source_id_change_spec.rb
+++ b/spec/features/item_source_id_change_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Item source id change' do
   describe 'when modification is allowed' do
     let(:state_service) { instance_double(StateService, allows_modification?: true) }
     let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
-    let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative) }
+    let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
     let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }
     let(:workflows_response) { instance_double(Dor::Workflow::Response::Workflows, workflows: []) }
     let(:workflow_routes) { instance_double(Dor::Workflow::Client::WorkflowRoutes, all_workflows: workflows_response) }

--- a/spec/features/item_view_metadata_spec.rb
+++ b/spec/features/item_view_metadata_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Item view', js: true do
 
   context 'when the cocina_model exists' do
     let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, files: files, version: version_client) }
-    let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative) }
+    let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
     let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }
 
     context 'when the file is not on the workspace' do

--- a/spec/features/release_history_spec.rb
+++ b/spec/features/release_history_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Release history' do
   let(:workflow_client) { instance_double(Dor::Workflow::Client, active_lifecycle: [], lifecycle: []) }
 
   context 'for an item' do
-    let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative) }
+    let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
     let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: [tag]) }
     let(:tag) do
       instance_double(Cocina::Models::ReleaseTag,
@@ -34,7 +34,7 @@ RSpec.describe 'Release history' do
   end
 
   context 'for an adminPolicy' do
-    let(:cocina_model) { instance_double(Cocina::Models::AdminPolicy, administrative: administrative) }
+    let(:cocina_model) { instance_double(Cocina::Models::AdminPolicy, administrative: administrative, as_json: {}) }
     let(:administrative) { instance_double(Cocina::Models::AdminPolicy::Administrative) }
 
     it 'does not show release history' do

--- a/spec/features/set_governing_apo_spec.rb
+++ b/spec/features/set_governing_apo_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Set governing APO' do
   context 'when modification is allowed' do
     let(:state_service) { instance_double(StateService, allows_modification?: true) }
     let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
-    let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative) }
+    let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
     let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }
 
     before do


### PR DESCRIPTION
@andrewjbtw would something like this be desirable?  This is the data representation we are going to be moving to as we migrate away from Fedora.  Currently we have only mapped over the things we need to run the robots, so this is incomplete, but it might be helpful in showing how we're doing the mapping.  I'm curious to get your thoughts.


![Screenshot_2020-01-30 A thing - Argo](https://user-images.githubusercontent.com/92044/73466928-2e32aa00-4348-11ea-9c58-0fe62d34e3ea.png)

## Why was this change made?

As we move to a cocina based repository, argo users might want to see data as it is represented.


## Was the documentation updated?
n/a