### PR TITLE
Show events on the item show page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ gem 'rubyzip'
 gem 'blacklight', '~> 6.0'
 gem 'blacklight-hierarchy', '~> 2.0'
 gem 'dor-services', '~> 9.0'
-gem 'dor-services-client', '~> 4.4'
+gem 'dor-services-client', '~> 4.7'
 gem 'dor-workflow-client', '~> 3.19'
 gem 'mods_display'
 gem 'okcomputer' # monitors application and its dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -641,7 +641,7 @@ DEPENDENCIES
   devise-remote-user (~> 1.0)
   dlss-capistrano (~> 3.1)
   dor-services (~> 9.0)
-  dor-services-client (~> 4.4)
+  dor-services-client (~> 4.7)
   dor-workflow-client (~> 3.19)
   equivalent-xml (>= 0.6.0)
   eye

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -166,7 +166,7 @@ class CatalogController < ApplicationController
     # Configure document actions framework
     config.index.document_actions.delete(:bookmark)
 
-    config.show.partials = %w(show_header full_view_links thumbnail show datastreams cocina history contents)
+    config.show.partials = %w(show_header full_view_links thumbnail show datastreams events cocina history contents)
   end
 
   def default_solr_doc_params(id = nil)
@@ -187,12 +187,15 @@ class CatalogController < ApplicationController
     authorize! :view_metadata, @obj
     @response, @document = fetch params[:id]
 
+    object_client = Dor::Services::Client.object(params[:id])
+
     # Used for drawing releaseTags in the history section
     begin
-      @cocina = Dor::Services::Client.object(params[:id]).find
+      @cocina = object_client.find
     rescue Dor::Services::Client::UnexpectedResponse
       @cocina = NilModel.new(params[:id])
     end
+    @events = object_client.events.list
 
     @buttons_presenter = ButtonsPresenter.new(
       ability: current_ability,

--- a/app/views/catalog/_events_default.html.erb
+++ b/app/views/catalog/_events_default.html.erb
@@ -1,0 +1,17 @@
+<% if params[:beta] %>
+  <h3 id="document-events-head" class="section-head collapsible-section">
+    Events
+  </h3>
+  <div id="document-events-section" class="document-section">
+    <table class="detail">
+      <thead>
+        <tr><th>When</th><th>Event type</th><th>Data</th></tr>
+      </thead>
+      <tbody>
+      <% @events.each do |event| %>
+        <tr><td><time-ago datetime="<%= event.timestamp %>"><%= event.timestamp %></time-ago></td><td><%= event.event_type %></td><td><%= event.data %></td></tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -57,7 +57,8 @@ RSpec.describe CatalogController, type: :controller do
           allow(Dor::Services::Client).to receive(:object).and_return(object_client)
         end
 
-        let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+        let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
+        let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, events: events_client) }
         let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative) }
         let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }
 

--- a/spec/features/add_workflow_to_item_spec.rb
+++ b/spec/features/add_workflow_to_item_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe 'Add a workflow to an item' do
                     workflow_templates: %w[assemblyWF registrationWF],
                     active_lifecycle: [])
   end
-  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+  let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, events: events_client) }
   let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
   let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }
 

--- a/spec/features/apo_spec.rb
+++ b/spec/features/apo_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe 'apo', js: true do
   let(:apo) { Dor::AdminPolicyObject.new(pid: new_apo_druid) }
   let(:collection) { Dor::Collection.new(pid: new_collection_druid, label: 'New Testing Collection') }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, current: 1) }
-  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, version: version_client) }
+  let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, version: version_client, events: events_client) }
   let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
   let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }
   let(:workflows_response) { instance_double(Dor::Workflow::Response::Workflows, workflows: []) }

--- a/spec/features/bulk_screen_spec.rb
+++ b/spec/features/bulk_screen_spec.rb
@@ -4,8 +4,10 @@ require 'rails_helper'
 
 # Feature/view tests for the (old) bulk actions view.
 RSpec.describe 'Bulk actions view', js: true do
+  let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
+
   let(:object_client) do
-    instance_double(Dor::Services::Client::Object, publish: true, find: cocina_model)
+    instance_double(Dor::Services::Client::Object, publish: true, find: cocina_model, events: events_client)
   end
 
   let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: admin_md, as_json: {}) }

--- a/spec/features/collection_manage_release_spec.rb
+++ b/spec/features/collection_manage_release_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe 'Collection manage release' do
 
   let(:druid) { 'druid:pb873ty1662' }
   let(:state_service) { instance_double(StateService, allows_modification?: true) }
-  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, release_tags: release_tags_client) }
+  let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, release_tags: release_tags_client, events: events_client) }
   let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, create: true) }
   let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
   let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }

--- a/spec/features/consistent_titles_spec.rb
+++ b/spec/features/consistent_titles_spec.rb
@@ -20,8 +20,9 @@ RSpec.describe 'Consistent titles' do
       allow(Dor::Services::Client).to receive(:object).and_return(object_client)
     end
 
+    let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
     let(:workflow_client) { instance_double(Dor::Workflow::Client, lifecycle: [], active_lifecycle: []) }
-    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, events: events_client) }
     let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
     let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }
 

--- a/spec/features/enable_buttons_spec.rb
+++ b/spec/features/enable_buttons_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe 'Enable buttons' do
   end
 
   let(:state_service) { instance_double(StateService, allows_modification?: true) }
-  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+  let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, events: events_client) }
   let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
   let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }
 

--- a/spec/features/item_catkey_change_spec.rb
+++ b/spec/features/item_catkey_change_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe 'Item catkey change' do
 
   describe 'when modification is allowed' do
     let(:state_service) { instance_double(StateService, allows_modification?: true) }
-    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+    let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
+    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, events: events_client) }
     let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
     let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }
     let(:workflows_response) { instance_double(Dor::Workflow::Response::Workflows, workflows: []) }

--- a/spec/features/item_manage_release_spec.rb
+++ b/spec/features/item_manage_release_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe 'Item manage release' do
 
   let(:state_service) { instance_double(StateService, allows_modification?: true) }
   let(:druid) { 'druid:qq613vj0238' }
-  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, release_tags: release_tags_client) }
+  let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, release_tags: release_tags_client, events: events_client) }
   let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, create: true) }
   let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
   let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }

--- a/spec/features/item_source_id_change_spec.rb
+++ b/spec/features/item_source_id_change_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe 'Item source id change' do
 
   describe 'when modification is allowed' do
     let(:state_service) { instance_double(StateService, allows_modification?: true) }
-    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+    let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
+    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, events: events_client) }
     let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
     let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }
     let(:workflows_response) { instance_double(Dor::Workflow::Response::Workflows, workflows: []) }

--- a/spec/features/item_view_metadata_spec.rb
+++ b/spec/features/item_view_metadata_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe 'Item view', js: true do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
   end
 
+  let(:event) { Dor::Services::Client::Events::Event.new(event_type: 'shelve_request_received', data: { 'host' => 'dor-services-stage.stanford.edu' }) }
+  let(:events_client) { instance_double(Dor::Services::Client::Events, list: [event]) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, current: 1) }
   let(:workflow_client) { instance_double(Dor::Workflow::Client, active_lifecycle: [], lifecycle: []) }
 
@@ -17,7 +19,7 @@ RSpec.describe 'Item view', js: true do
     let(:files) do
       instance_double(Dor::Services::Client::Files, list: ['this_is_not_the_file_you_are_looking_for.txt'])
     end
-    let(:object_client) { instance_double(Dor::Services::Client::Object, files: files, version: version_client) }
+    let(:object_client) { instance_double(Dor::Services::Client::Object, files: files, version: version_client, events: events_client) }
 
     before do
       allow(object_client).to receive(:find).and_raise(Dor::Services::Client::UnexpectedResponse)
@@ -33,7 +35,7 @@ RSpec.describe 'Item view', js: true do
   end
 
   context 'when the cocina_model exists' do
-    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, files: files, version: version_client) }
+    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, files: files, version: version_client, events: events_client) }
     let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
     let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }
 

--- a/spec/features/release_history_spec.rb
+++ b/spec/features/release_history_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe 'Release history' do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
   end
 
-  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+  let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, events: events_client) }
   let(:workflow_client) { instance_double(Dor::Workflow::Client, active_lifecycle: [], lifecycle: []) }
 
   context 'for an item' do

--- a/spec/features/set_governing_apo_spec.rb
+++ b/spec/features/set_governing_apo_spec.rb
@@ -52,7 +52,8 @@ RSpec.describe 'Set governing APO' do
 
   context 'when modification is allowed' do
     let(:state_service) { instance_double(StateService, allows_modification?: true) }
-    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+    let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
+    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, events: events_client) }
     let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
     let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }
 


### PR DESCRIPTION
@andrewjbtw here is the event data. Should we stick it on the show page?
<img width="888" alt="Screen Shot 2020-01-30 at 1 12 12 PM" src="https://user-images.githubusercontent.com/92044/73481809-30096700-4362-11ea-9a22-cdbc8b90a24b.png">


## Why was this change made?

So we have a mechanism for using the event data.

## Was the documentation updated?
n/a