### PR TITLE
Pass seed_datastream to the registration service

### DIFF
--- a/app/controllers/dor/objects_controller.rb
+++ b/app/controllers/dor/objects_controller.rb
@@ -34,7 +34,7 @@ class Dor::ObjectsController < ApplicationController
   # source_id and label are required parameters
   def registration_params
     hash = params.permit(:object_type, :admin_policy, :metadata_source, :rights,
-                         :collection, :other_id, tag: [])
+                         :collection, :other_id, tag: [], seed_datastream: [])
     hash[:source_id] = params.require(:source_id)
     hash[:label] = params.require(:label)
     hash

--- a/spec/controllers/dor/objects_controller_spec.rb
+++ b/spec/controllers/dor/objects_controller_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe Dor::ObjectsController, type: :controller do
           label: 'test parameters for registration',
           tag: ['Process : Content Type : Book (ltr)',
                 'Registered By : jcoyne85'],
+          seed_datastream: ['descMetadata'],
           rights: 'default',
           source_id: 'foo:bar',
           other_id: 'label:'
@@ -74,6 +75,7 @@ RSpec.describe Dor::ObjectsController, type: :controller do
             label: 'test parameters for registration',
             tag: ['Process : Content Type : Book (ltr)',
                   'Registered By : jcoyne85'],
+            seed_datastream: ['descMetadata'],
             rights: 'default',
             source_id: 'foo:bar',
             other_id: 'label:'


### PR DESCRIPTION
## Why was this change made?
If this value is set to ['descMetadata'] then the registration service creates descMetadata. Fixes #1792


## Was the documentation updated?
n/a