### PR TITLE
Use symphony to get the collection descMetadata when providing a catkey

### DIFF
--- a/app/forms/collection_form.rb
+++ b/app/forms/collection_form.rb
@@ -24,13 +24,11 @@ class CollectionForm < BaseForm
 
   # Copies the values to the model
   def sync
+    # NOTE: collection_abstract only appears in conjunction with collection_title
+    #       and disjoint from collection_catkey
     return if params[:collection_abstract].blank?
 
     model.descMetadata.abstract = params[:collection_abstract]
-    model.descMetadata.content = model.descMetadata.ng_xml.to_s
-
-    # TODO: is this save necessary?
-    model.descMetadata.save
   end
 
   private
@@ -57,8 +55,14 @@ class CollectionForm < BaseForm
                           end
     reg_params[:rights] &&= reg_params[:rights].downcase
     col_catkey = params[:collection_catkey] || ''
-    reg_params[:metadata_source] = col_catkey.blank? ? 'label' : 'symphony'
-    reg_params[:other_id] = "symphony:#{col_catkey}" if col_catkey.present?
+
+    if col_catkey.present?
+      reg_params[:seed_datastream] = ['descMetadata']
+      reg_params[:metadata_source] = 'symphony'
+      reg_params[:other_id] = "symphony:#{col_catkey}"
+    else
+      reg_params[:metadata_source] = 'label'
+    end
     reg_params
   end
 end

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -58,9 +58,6 @@ RSpec.describe CollectionsController do
       abstract = 'this is the abstract'
       mock_desc_md_ds = double(Dor::DescMetadataDS)
       expect(mock_desc_md_ds).to receive(:abstract=).with(abstract)
-      expect(mock_desc_md_ds).to receive(:ng_xml)
-      expect(mock_desc_md_ds).to receive(:content=)
-      expect(mock_desc_md_ds).to receive(:save)
 
       expect(Dor::Services::Client.objects).to receive(:register) do |params|
         expect(params[:params]).to match a_hash_including(
@@ -74,7 +71,7 @@ RSpec.describe CollectionsController do
       end
       expect(Dor::Config.workflow.client).to receive(:create_workflow_by_name)
         .with(collection.pid, 'accessionWF', version: '1')
-      expect(collection).to receive(:descMetadata).and_return(mock_desc_md_ds).exactly(4).times
+      expect(collection).to receive(:descMetadata).and_return(mock_desc_md_ds)
 
       post :create, params: { 'collection_title' => title,
                               'collection_abstract' => abstract,

--- a/spec/forms/collection_form_spec.rb
+++ b/spec/forms/collection_form_spec.rb
@@ -6,45 +6,76 @@ RSpec.describe CollectionForm do
   let(:instance) { described_class.new }
   let(:title) { 'collection title' }
   let(:abstract) { 'this is the abstract' }
-  let(:params) do
-    {
-      collection_title: title,
-      collection_abstract: abstract,
-      collection_rights: 'dark'
-    }.with_indifferent_access
-  end
+
   let(:apo) { instantiate_fixture('zt570tx3016', Dor::AdminPolicyObject) }
   let(:collection) { instantiate_fixture('pb873ty1662', Dor::Collection) }
-  let(:mock_desc_md_ds) { double(Dor::DescMetadataDS) }
+  let(:mock_desc_md_ds) { double(Dor::DescMetadataDS, :abstract= => true) }
+  let(:objects_client) { instance_double(Dor::Services::Client::Objects, register: { pid: 'druid:pb873ty1662' }) }
+  let(:workflow_client) { instance_double(Dor::Workflow::Client, create_workflow_by_name: true) }
 
   before do
     allow(Dor).to receive(:find).with(collection.pid).and_return(collection)
-    allow(collection).to receive(:save)
     allow(Dor).to receive(:find).with(apo.pid).and_return(apo)
+    allow(Dor::Services::Client).to receive(:objects).and_return(objects_client)
+    allow(Dor::Config.workflow).to receive(:client).and_return(workflow_client)
+    allow(collection).to receive(:descMetadata).and_return(mock_desc_md_ds)
   end
 
-  it 'creates a collection from title/abstract by registering the collection, then adding the abstract' do
-    expect(mock_desc_md_ds).to receive(:abstract=).with(abstract)
-    expect(mock_desc_md_ds).to receive(:ng_xml)
-    expect(mock_desc_md_ds).to receive(:content=)
-    expect(mock_desc_md_ds).to receive(:save)
-
-    expect(Dor::Services::Client.objects).to receive(:register) do |p|
-      expect(p[:params]).to match a_hash_including(
-        label: title,
-        object_type: 'collection',
-        admin_policy: apo.pid,
-        metadata_source: 'label',
-        rights: 'dark'
-      )
-      { pid: collection.pid }
+  context 'when metadata_source is label' do
+    let(:params) do
+      {
+        collection_title: title,
+        collection_abstract: abstract,
+        collection_rights: 'dark'
+      }.with_indifferent_access
     end
-    expect(Dor::Config.workflow.client).to receive(:create_workflow_by_name).with(collection.pid, 'accessionWF', version: '1')
 
-    expect(collection).to receive(:update_index)
-    expect(collection).to receive(:descMetadata).and_return(mock_desc_md_ds).exactly(4).times
+    it 'creates a collection from title/abstract by registering the collection, then adding the abstract' do
+      expect(collection).to receive(:update_index)
 
-    instance.validate(params.merge(apo_pid: apo.pid))
-    instance.save
+      instance.validate(params.merge(apo_pid: apo.pid))
+      instance.save
+
+      expect(objects_client).to have_received(:register).with(
+        params: {
+          label: title,
+          object_type: 'collection',
+          admin_policy: apo.pid,
+          metadata_source: 'label',
+          rights: 'dark'
+        }
+      )
+      expect(workflow_client).to have_received(:create_workflow_by_name).with(collection.pid, 'accessionWF', version: '1')
+      expect(mock_desc_md_ds).to have_received(:abstract=).with(abstract)
+    end
+  end
+
+  context 'when metadata_source is catkey' do
+    let(:params) do
+      {
+        collection_rights_catkey: 'dark',
+        collection_catkey: '99998'
+      }.with_indifferent_access
+    end
+
+    it 'creates a collection from catkey by registering the collection and passing seed_datastream' do
+      expect(collection).to receive(:update_index)
+
+      instance.validate(params.merge(apo_pid: apo.pid))
+      instance.save
+
+      expect(objects_client).to have_received(:register).with(
+        params: {
+          label: ':auto',
+          object_type: 'collection',
+          admin_policy: apo.pid,
+          metadata_source: 'symphony',
+          rights: 'dark',
+          other_id: 'symphony:99998',
+          seed_datastream: ['descMetadata']
+        }
+      )
+      expect(workflow_client).to have_received(:create_workflow_by_name).with(collection.pid, 'accessionWF', version: '1')
+    end
   end
 end


### PR DESCRIPTION


## Why was this change made?

Fixes #1798

## Was the documentation updated?
n/a