### PR TITLE
Add QA environment to capistrano deployment

### DIFF
--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+server 'argo-qa-a.stanford.edu', user: 'lyberadmin', roles: %w(web db app)
+server 'argo-qa-b.stanford.edu', user: 'lyberadmin', roles: %w(web db app)
+
+Capistrano::OneTimeKey.generate_one_time_key!
+set :rails_env, 'production'
+set :bundle_without, %w(deployment test development).join(' ')
+
+set :deploy_to, '/opt/app/lyberadmin/argo'
+
+set :delayed_job_workers, 4


### PR DESCRIPTION
## Why was this change made?

To be able to begin deploying Argo to QA.

## Was the documentation updated?

Yes, [DevOpsDocs](https://github.com/sul-dlss/DevOpsDocs/pull/359)