### PR TITLE
Add "label" metadata source to APO form

### DIFF
--- a/app/helpers/apo_helper.rb
+++ b/app/helpers/apo_helper.rb
@@ -8,7 +8,7 @@ module ApoHelper
   end
 
   def apo_metadata_sources
-    [['Symphony'], ['DOR']]
+    [['Symphony'], ['DOR'], ['label']]
   end
 
   # Retrieve a list of workflow templates from  the workflow service and return


### PR DESCRIPTION
This allows dor-services-app to build descriptive metadata for an APO from its label, if it has no metadata already in DOR or Symphony.

## Why was this change made?



## Was the documentation updated?
