### PR TITLE
Handle unexpected response error

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -188,7 +188,11 @@ class CatalogController < ApplicationController
     @response, @document = fetch params[:id]
 
     # Used for drawing releaseTags in the history section
-    @cocina = Dor::Services::Client.object(params[:id]).find
+    begin
+      @cocina = Dor::Services::Client.object(params[:id]).find
+    rescue Dor::Services::Client::UnexpectedResponse
+      @cocina = NilModel.new(params[:id])
+    end
 
     @buttons_presenter = ButtonsPresenter.new(
       ability: current_ability,

--- a/app/models/nil_model.rb
+++ b/app/models/nil_model.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# This stands in place of a Cocina model, when the server returns an UnexpectedResponse
+class NilModel
+  def initialize(pid)
+    @pid = pid
+  end
+
+  def administrative
+    NilAdministrative.new
+  end
+
+  # This stands in for the administrative metadata
+  class NilAdministrative
+    # rubocop:disable Naming/MethodName
+    def releaseTags
+      []
+    end
+    # rubocop:enable Naming/MethodName
+  end
+end

--- a/spec/features/item_view_metadata_spec.rb
+++ b/spec/features/item_view_metadata_spec.rb
@@ -10,78 +10,100 @@ RSpec.describe 'Item view', js: true do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
   end
 
-  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, files: files, version: version_client) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, current: 1) }
-  let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative) }
-  let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }
 
-  context 'when the file is not on the workspace' do
+  context 'when there is an error retrieving the cocina_model' do
     let(:files) do
       instance_double(Dor::Services::Client::Files, list: ['this_is_not_the_file_you_are_looking_for.txt'])
     end
+    let(:object_client) { instance_double(Dor::Services::Client::Object, files: files, version: version_client) }
 
-    it 'shows the file info' do
+    before do
+      allow(object_client).to receive(:find).and_raise(Dor::Services::Client::UnexpectedResponse)
+    end
+
+    it 'shows the page' do
       visit solr_document_path 'druid:hj185vb7593'
       within '.dl-horizontal' do
         expect(page).to have_css 'dt', text: 'DRUID:'
         expect(page).to have_css 'dd', text: 'druid:hj185vb7593'
-        expect(page).to have_css 'dt', text: 'Object Type:'
-        expect(page).to have_css 'dd', text: 'item'
-        expect(page).to have_css 'dt', text: 'Content Type:'
-        expect(page).to have_css 'dd', text: 'image'
-        expect(page).to have_css 'dt', text: 'Admin Policy:'
-        expect(page).to have_css 'dd a', text: 'Stanford University Libraries - Special Collections'
-        expect(page).to have_css 'dt', text: 'Project:'
-        expect(page).to have_css 'dd a', text: 'Fuller Slides'
-        expect(page).to have_css 'dt', text: 'Source:'
-        expect(page).to have_css 'dd', text: 'fuller:M1090_S15_B02_F01_0126'
-        expect(page).to have_css 'dt', text: 'IDs:'
-        expect(page).to have_css 'dd', text: 'fuller:M1090_S15_B02_F01_0126, uuid:ad2d8894-7eba-11e1-b714-0016034322e7'
-        expect(page).to have_css 'dt', text: 'Tags:'
-        expect(page).to have_css 'dd a', text: 'Project : Fuller Slides'
-        expect(page).to have_css 'dd a', text: 'Registered By : renzo'
-        expect(page).to have_css 'dt', text: 'Status:'
-        expect(page).to have_css 'dd', text: 'v1 Unknown Status'
       end
-
-      click_link 'descMetadata' # Open the datastream modal
-      within '.code' do
-        expect(page).to have_content '<mods:title type="main">Slides, IA 11, Geodesic Domes, Double Skin "Growth" House, N.C. State, 1953</mods:title>'
-      end
-      click_button '×' # close the modal
-
-      within '.resource-list' do
-        click_link 'M1090_S15_B02_F01_0126.jp2'
-      end
-
-      expect(page).to have_content 'Workspace: not available'
-      expect(page).to have_link 'https://stacks.example.com/file/druid:hj185vb7593/M1090_S15_B02_F01_0126.jp2'
     end
   end
 
-  context 'when the file is on the workspace' do
-    let(:filename) { 'M1090_S15_B02_F01_0126.jp2' }
-    let(:files) do
-      instance_double(Dor::Services::Client::Files, list: [filename], retrieve: 'the file contents')
-    end
+  context 'when the cocina_model exists' do
+    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, files: files, version: version_client) }
+    let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative) }
+    let(:administrative) { instance_double(Cocina::Models::DRO::Administrative, releaseTags: []) }
 
-    before do
-      page.driver.browser.download_path = '.'
-    end
-
-    after do
-      File.delete(filename) if File.exist?(filename)
-    end
-
-    it 'can be downloaded' do
-      visit solr_document_path 'druid:hj185vb7593'
-
-      within '.resource-list' do
-        click_link 'M1090_S15_B02_F01_0126.jp2'
+    context 'when the file is not on the workspace' do
+      let(:files) do
+        instance_double(Dor::Services::Client::Files, list: ['this_is_not_the_file_you_are_looking_for.txt'])
       end
 
-      within '.modal-content' do
+      it 'shows the file info' do
+        visit solr_document_path 'druid:hj185vb7593'
+        within '.dl-horizontal' do
+          expect(page).to have_css 'dt', text: 'DRUID:'
+          expect(page).to have_css 'dd', text: 'druid:hj185vb7593'
+          expect(page).to have_css 'dt', text: 'Object Type:'
+          expect(page).to have_css 'dd', text: 'item'
+          expect(page).to have_css 'dt', text: 'Content Type:'
+          expect(page).to have_css 'dd', text: 'image'
+          expect(page).to have_css 'dt', text: 'Admin Policy:'
+          expect(page).to have_css 'dd a', text: 'Stanford University Libraries - Special Collections'
+          expect(page).to have_css 'dt', text: 'Project:'
+          expect(page).to have_css 'dd a', text: 'Fuller Slides'
+          expect(page).to have_css 'dt', text: 'Source:'
+          expect(page).to have_css 'dd', text: 'fuller:M1090_S15_B02_F01_0126'
+          expect(page).to have_css 'dt', text: 'IDs:'
+          expect(page).to have_css 'dd', text: 'fuller:M1090_S15_B02_F01_0126, uuid:ad2d8894-7eba-11e1-b714-0016034322e7'
+          expect(page).to have_css 'dt', text: 'Tags:'
+          expect(page).to have_css 'dd a', text: 'Project : Fuller Slides'
+          expect(page).to have_css 'dd a', text: 'Registered By : renzo'
+          expect(page).to have_css 'dt', text: 'Status:'
+          expect(page).to have_css 'dd', text: 'v1 Unknown Status'
+        end
+
+        click_link 'descMetadata' # Open the datastream modal
+        within '.code' do
+          expect(page).to have_content '<mods:title type="main">Slides, IA 11, Geodesic Domes, Double Skin "Growth" House, N.C. State, 1953</mods:title>'
+        end
+        click_button '×' # close the modal
+
+        within '.resource-list' do
+          click_link 'M1090_S15_B02_F01_0126.jp2'
+        end
+
+        expect(page).to have_content 'Workspace: not available'
         expect(page).to have_link 'https://stacks.example.com/file/druid:hj185vb7593/M1090_S15_B02_F01_0126.jp2'
+      end
+    end
+
+    context 'when the file is on the workspace' do
+      let(:filename) { 'M1090_S15_B02_F01_0126.jp2' }
+      let(:files) do
+        instance_double(Dor::Services::Client::Files, list: [filename], retrieve: 'the file contents')
+      end
+
+      before do
+        page.driver.browser.download_path = '.'
+      end
+
+      after do
+        File.delete(filename) if File.exist?(filename)
+      end
+
+      it 'can be downloaded' do
+        visit solr_document_path 'druid:hj185vb7593'
+
+        within '.resource-list' do
+          click_link 'M1090_S15_B02_F01_0126.jp2'
+        end
+
+        within '.modal-content' do
+          expect(page).to have_link 'https://stacks.example.com/file/druid:hj185vb7593/M1090_S15_B02_F01_0126.jp2'
+        end
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?

So that you can see the item page even if the cocina model can't be generated.

## Was the documentation updated?
n/a