### PR TITLE
Sort versions as numbers in lifecycle display

### DIFF
--- a/app/views/catalog/_show_milestones.html.erb
+++ b/app/views/catalog/_show_milestones.html.erb
@@ -4,27 +4,21 @@
   </thead>
   <tbody>
     <%
-      ## TODO: Pick a real date format for the date to_s calls.
-      ## Do it here and NOT in the model!!
       version_hash = document.get_versions
       milestones = document.milestones
-      milestones.keys.sort.each do |version|
-        steps=milestones[version]
-        first=true
+      milestones.keys.sort_by { |version_number_string| version_number_string.to_i }.each do |version|
+        steps = milestones[version]
         steps.each_pair do |k,m| -%>
-        <% if first
-            first=false
-        -%>
-          <tr style="display:none" class="last_step<%= version%>">
-            <td><span style="cursor: pointer;" onclick='$(".version<%= version%>").toggle();$(".last_step<%= version%>").toggle();'">+</span><%= version%></td>
+          <tr style="display:none" class="last_step<%= version %>">
+            <td><span style="cursor: pointer;" onclick='$(".version<%= version %>").toggle();$(".last_step<%= version %>").toggle();'>+</span><%= version %></td>
             <td><%= steps['accessioned'][:display] || k.titleize %></td>
             <td><%= steps['accessioned'][:time].nil? ? 'pending' : steps['accessioned'][:time].in_time_zone.to_s() %></td>
           </tr>
-          <tr class="version<%= version%>">
-            <td colspan=3 onclick='$(".version<%= version%>") .toggle();$(".last_step<%= version%>").toggle();'><span style="cursor: pointer;">-</span>
-              <%=version%>
+          <tr class="version<%= version %>">
+            <td colspan=3 onclick='$(".version<%= version %>").toggle();$(".last_step<%= version %>").toggle();'><span style="cursor: pointer;">-</span>
+              <%= version %>
               <% if version_hash[version] -%>
-                (<%=version_hash[version][:tag]%>) <%=version_hash[version][:desc]%>
+                (<%= version_hash[version][:tag] %>) <%= version_hash[version][:desc] %>
               <% end -%>
             </td>
           </tr>
@@ -35,6 +29,5 @@
           <td><%= m[:time].nil? ? 'pending' : m[:time].in_time_zone.to_s() %></td>
         </tr>
       <% end -%>
-    <% end -%>
   </tbody>
 </table>


### PR DESCRIPTION
## Why was this change made?

It is surprising to scroll to the bottom of an object with 30+ versions and see the last entry, which one would reasonably assume to be the latest version, show up as version 9.

I didn't see an obvious place to add a test. Happy to take a suggestion, but I'm not inclined to sink a lot more time into this branch, and sorting of versions right now is doubleplusungood.

## Was the documentation updated?

no