### PR TITLE
Load fixtures using dor-services indexing

### DIFF
--- a/lib/tasks/argo_testing.rake
+++ b/lib/tasks/argo_testing.rake
@@ -82,7 +82,7 @@ if ['test', 'development'].include? Rails.env
             puts "** File #{i}, Try #{attempt} ** file: #{file}"
 
             ActiveFedora::FixtureLoader.import_to_fedora(file, pid)
-            ActiveFedora::FixtureLoader.index(pid)
+            Dor.find(pid).update_index
           end
         end
         puts 'Done loading repo files'

--- a/spec/features/consistent_titles_spec.rb
+++ b/spec/features/consistent_titles_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Consistent titles' do
 
   it 'catalog index views' do
     visit search_catalog_path f: { objectType_ssim: ['item'] }
-    expect(page).to have_css '.index_title', text: '1. ' + title
+    expect(page).to have_css '.index_title a', text: title
   end
 
   describe 'catalog show view' do

--- a/spec/features/date_range_form_spec.rb
+++ b/spec/features/date_range_form_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'Date range form', js: true do
       end
 
       find('#appliedParams')
-      expect(page).to have_content '1 entry found'
+      expect(page).to have_content '1 - 5 of 5'
       within '.constraints-container' do
         expect(page).to have_css '.filterValue', text: 'Reports'
         expect(page).to have_css '.filterName', text: 'Last Modified'

--- a/spec/features/profile_spec.rb
+++ b/spec/features/profile_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Profile' do
         expect(page).to have_css 'td:nth-child(1)', text: 'SEARCHWORKS'
         expect(page).to have_css 'h5', text: 'Catkeys'
         expect(page).to have_css 'td:nth-child(1)', text: 'has value'
-        expect(page).to have_css 'td:nth-child(2)', text: '2'
+        expect(page).to have_css 'td:nth-child(2)', text: '33'
       end
     end
   end
@@ -54,7 +54,7 @@ RSpec.describe 'Profile' do
       within '#rights' do
         expect(page).to have_css 'h4', text: 'Rights'
         expect(page).to have_css 'td:nth-child(1)', text: 'dark'
-        expect(page).to have_css 'td:nth-child(2)', text: '2'
+        expect(page).to have_css 'td:nth-child(2)', text: '34'
       end
     end
   end
@@ -65,9 +65,9 @@ RSpec.describe 'Profile' do
       within '#contents' do
         expect(page).to have_css 'h4', text: 'Contents'
         expect(page).to have_css 'td:nth-child(1)', text: 'image'
-        expect(page).to have_css 'td:nth-child(2)', text: '3'
+        expect(page).to have_css 'td:nth-child(2)', text: '6'
         expect(page).to have_css 'td:nth-child(1)', text: 'Preserved file size'
-        expect(page).to have_css 'td:nth-child(2)', text: '160 MB'
+        expect(page).to have_css 'td:nth-child(2)', text: '1.58 GB'
       end
     end
   end
@@ -105,7 +105,7 @@ RSpec.describe 'Profile' do
         expect(page).to have_css 'td:nth-child(1)', text: 'has value'
         expect(page).to have_css 'td:nth-child(2)', text: '2'
         expect(page).to have_css 'td:nth-child(1)', text: 'English'
-        expect(page).to have_css 'td:nth-child(2)', text: '2'
+        expect(page).to have_css 'td:nth-child(2)', text: '22'
         expect(page).to have_css 'td:nth-child(1)', text: 'Cephalopoda'
         expect(page).to have_css 'td:nth-child(2)', text: '1'
         expect(page).to have_css 'td:nth-child(1)', text: 'Bermuda Islands'
@@ -120,7 +120,7 @@ RSpec.describe 'Profile' do
       within '#number-of-items' do
         expect(page).to have_css 'h4', text: 'Number of items'
         expect(page).to have_css 'td:nth-child(1)', text: 'item'
-        expect(page).to have_css 'td:nth-child(2)', text: '6'
+        expect(page).to have_css 'td:nth-child(2)', text: '10'
         expect(page).to have_css 'td.indented:nth-child(1)', text: 'Unknown Status'
         # TODO: this isn't always a dependable test, comment it out until we
         # find a way to make it true every time.

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Search results' do
   end
 
   it 'contains Blacklight default index page tools' do
-    visit search_catalog_path f: { empties: ['no_rights_characteristics'] }
+    visit search_catalog_path f: { content_type_ssim: ['book'] }
     within '.constraints-container' do
       expect(page).to have_css '#startOverLink', text: 'Start Over'
     end
@@ -35,7 +35,7 @@ RSpec.describe 'Search results' do
 
   it 'contains appropriate metadata fields' do
     visit search_catalog_path f: { objectType_ssim: ['item'] }
-    within('.document', match: :first) do
+    within('.document:nth-child(9)') do
       within '.document-metadata' do
         expect(page).to have_css 'dt', text: 'DRUID:'
         expect(page).to have_css 'dd', text: 'druid:hj185vb7593'
@@ -55,9 +55,6 @@ RSpec.describe 'Search results' do
         expect(page).to have_css 'dd', text: 'fuller:M1090_S15_B02_F01_0126'
       end
     end
-    expect(page).to have_css 'dt', text: 'Collection:'
-    expect(page).to have_css 'dd a', text: 'druid:pb873ty1662'
-    expect(page).to have_css 'dd a', text: 'State Banking Commission Annual Reports'
   end
 
   it 'contains document image thumbnail' do

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Report, type: :model do
       expect(described_class.new(
         { q: 'report' }, %w(druid),
         current_user: user
-      ).pids).to eq(%w(fg464dn8891 pb873ty1662 qq613vj0238))
+      ).pids).to eq %w[fg464dn8891 mb062dy1188 pb873ty1662 px302sd8187 qq613vj0238 vr263bv4910 zy430ms2268]
     end
     it 'returns druids and source ids' do
       expect(described_class.new(


### PR DESCRIPTION

## Why was this change made?

dor-services looks in identityMetadata to cast to the correct class.  This is different than the ActiveFedora defaults.  This is important before we move indexing to dor_indexing_app because this how it does the indexing.


## Was the documentation updated?

n/a
