### PR TITLE
revert simplecov to 0.17 to get current code coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,7 +103,7 @@ end
 group :test do
   gem 'capybara'
   gem 'selenium-webdriver' # for js testing
-  gem 'simplecov', require: false
+  gem 'simplecov', '~> 0.17.1', require: false # 0.18 breaks reporting https://github.com/codeclimate/test-reporter/issues/418
   gem 'webdrivers' # installs the chrome for selenium tests
   gem 'webmock', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -538,10 +538,11 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    simplecov (0.18.3)
+    simplecov (0.17.1)
       docile (~> 1.1)
-      simplecov-html (~> 0.11)
-    simplecov-html (0.12.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     slop (3.6.0)
     solrizer (3.4.1)
       activesupport
@@ -678,7 +679,7 @@ DEPENDENCIES
   rubyzip
   sass-rails (~> 5.0)
   selenium-webdriver
-  simplecov
+  simplecov (~> 0.17.1)
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3 (~> 1.3.13)


### PR DESCRIPTION
## Why was this change made?

To get fresh coverage data with every PR (again).

I believe codeclimate was showing us green status for maintainability, but the code coverage has not been updated since dependency updates changed simplecov to v0.18.

Can you see how the graph is dead level after Jan 26?  That is the last week before we upgraded simplecov gem to v0.18.

![image](https://user-images.githubusercontent.com/96775/75489550-4f96ae00-5967-11ea-962b-bf85f00ffb7b.png)


Note that we won't see the effect of this PR until after it is merged b/c code climate only does its thing for master branch.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

n/a

## Does this change affect how this application integrates with other services?

n/a

If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
