### PR TITLE
Add new -01 and -02 prod servers, remove -a and -b

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-server 'argo-prod-a.stanford.edu', user: 'lyberadmin', roles: %w(web db app)
-server 'argo-prod-b.stanford.edu', user: 'lyberadmin', roles: %w(web db app)
+server 'argo-prod-01.stanford.edu', user: 'lyberadmin', roles: %w(web db app)
+server 'argo-prod-02.stanford.edu', user: 'lyberadmin', roles: %w(web db app)
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'


### PR DESCRIPTION
## Why was this change made?

The new argo servers are prod-01 and -02, this removes the old (-a, -b) from the capistrano deployment for the new ones.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

N/A

## Does this change affect how this application integrates with other services?

I ran a cap prod deploy against this branch and was able to view a druid on prod-01 and prod-02: https://argo-prod-01.stanford.edu/catalog?utf8=%E2%9C%93&q=vq518cf9512 https://argo-prod-02.stanford.edu/catalog?utf8=%E2%9C%93&q=vq518cf9512