### PR TITLE
Use the correct method for reapplying APO defaults

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -382,7 +382,7 @@ class ItemsController < ApplicationController
 
   # set the rightsMetadata to the APO's defaultObjectRights
   def apply_apo_defaults
-    @object.reapplyAdminPolicyObjectDefaults
+    @object.reapply_admin_policy_object_defaults
     save_and_reindex
     render status: :ok, plain: 'Defaults applied.'
   end

--- a/app/javascript/packs/bulk.js
+++ b/app/javascript/packs/bulk.js
@@ -115,8 +115,8 @@ function set_collection(druids){
 	process_post(druids, set_collection_url, {collection: collection_id}, "Collection set");
 }
 
-function apply_apo_defaults(druids){
-	process_get(druids, apo_apply_defaults_url, 'Defaults_applied.')
+function apply_apo_defaults(druids) {
+	process_post(druids, apo_apply_defaults_url, {}, 'Defaults_applied.')
 }
 
 function add_workflow(druids){

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,7 +142,7 @@ Rails.application.routes.draw do
       post 'set_rights'
       get 'set_governing_apo_ui'
       post 'set_governing_apo'
-      get :apply_apo_defaults
+      post :apply_apo_defaults
       match :update_resource, action: :update_resource, as: 'update_resource', via: [:get, :post]
     end
   end

--- a/spec/requests/apply_apo_defaults_spec.rb
+++ b/spec/requests/apply_apo_defaults_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Apply APO defaults' do
+  let(:item) do
+    instance_double(Dor::Item,
+                    admin_policy_object: apo,
+                    reapply_admin_policy_object_defaults: nil,
+                    save: true,
+                    pid: 'druid:888')
+  end
+  let(:apo) { instance_double(Dor::AdminPolicyObject, pid: 'druid:999') }
+  let(:user) { create(:user) }
+
+  before do
+    sign_in user
+    allow(Dor).to receive(:find).and_return(item)
+    allow(Argo::Indexer).to receive(:reindex_pid_remotely)
+  end
+
+  it 'applies the defaults' do
+    post '/items/druid:123/apply_apo_defaults'
+    expect(item).to have_received(:reapply_admin_policy_object_defaults)
+    expect(Argo::Indexer).to have_received(:reindex_pid_remotely).with('druid:888')
+    expect(response).to be_successful
+  end
+end


### PR DESCRIPTION
## Why was this change made?

This was renamed in dor-services 8.  Also added a test that would have caught this.
fixes #1839 
## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

n/a

## Does this change affect how this application integrates with other services?
no
If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
