### PR TITLE
We still need to deploy to -a and -b while they are in the pool

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -2,6 +2,8 @@
 
 server 'argo-prod-01.stanford.edu', user: 'lyberadmin', roles: %w(web db app)
 server 'argo-prod-02.stanford.edu', user: 'lyberadmin', roles: %w(web db app)
+server 'argo-prod-a.stanford.edu', user: 'lyberadmin', roles: %w(web db app)
+server 'argo-prod-b.stanford.edu', user: 'lyberadmin', roles: %w(web db app)
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'


### PR DESCRIPTION
## Why was this change made?

This can be reverted once the old servers are removed from the lb pool.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?



## Does this change affect how this application integrates with other services?

If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
