### PR TITLE
Deprecate the embargoable methods.

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -120,7 +120,9 @@ class ItemsController < ApplicationController
   def embargo_update
     fail ArgumentError, 'Missing embargo_date parameter' unless params[:embargo_date].present?
 
-    @object.update_embargo(DateTime.parse(params[:embargo_date]).utc)
+    new_date = DateTime.parse(params[:embargo_date]).utc
+    Dor::EmbargoService.new(@object).update(new_date)
+
     @object.datastreams['events'].add_event('Embargo', current_user.to_s, 'Embargo date modified')
     save_and_reindex
     respond_to do |format|

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -112,14 +112,17 @@ RSpec.describe ItemsController, type: :controller do
     context 'when they have manage access' do
       before do
         allow(controller).to receive(:authorize!).and_return(true)
+        allow(Dor::EmbargoService).to receive(:new).and_return(service)
       end
 
-      it 'calls Dor::Item.update_embargo' do
-        expect(item).to receive(:update_embargo)
+      let(:service) { instance_double(Dor::EmbargoService, update: true) }
+
+      it 'calls Dor::EmbargoService#update' do
         expect(item.datastreams['events']).to receive(:add_event).and_call_original
         expect(controller).to receive(:save_and_reindex)
         post :embargo_update, params: { id: pid, embargo_date: '2100-01-01' }
         expect(response).to have_http_status(:found) # redirect to catalog page
+        expect(service).to have_received(:update)
       end
       it 'requires a date' do
         expect { post :embargo_update, params: { id: pid } }.to raise_error(ArgumentError)


### PR DESCRIPTION


## Why was this change made?

They are deprecated, because they are just extra indirection.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
n/a
## Does this change affect how this application integrates with other services?
no