### PR TITLE
Update the embargo by calling dor-services-app

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -120,10 +120,9 @@ class ItemsController < ApplicationController
   def embargo_update
     fail ArgumentError, 'Missing embargo_date parameter' unless params[:embargo_date].present?
 
-    new_date = DateTime.parse(params[:embargo_date]).utc
-    Dor::EmbargoService.new(@object).update(new_date)
+    object_client = Dor::Services::Client.object(@object.pid)
+    object_client.embargo.update(embargo_date: params[:embargo_date], requesting_user: current_user.to_s)
 
-    @object.datastreams['events'].add_event('Embargo', current_user.to_s, 'Embargo date modified')
     save_and_reindex
     respond_to do |format|
       format.any { redirect_to solr_document_path(params[:id]), notice: 'Embargo was successfully updated' }


### PR DESCRIPTION

## Why was this change made?
This removes one direct call to Fedora 3


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
n/a


## Does this change affect how this application integrates with other services?
yes

If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.

It was tested on stage.