### PR TITLE
Override facet_limit

### DIFF
--- a/app/views/catalog/_facet_limit.html.erb
+++ b/app/views/catalog/_facet_limit.html.erb
@@ -1,0 +1,15 @@
+<%# This was added to override the default in blacklight 6.22, because we're using
+    the javascript from blacklight 7, and the dom in blacklight 6.22 was not compatible.
+
+    This file can be removed when we upgrade to Blacklight 7 %>
+<ul class="facet-values list-unstyled">
+  <% paginator = facet_paginator(facet_field, display_facet) %>
+  <%= render_facet_limit_list paginator, facet_field.key %>
+
+  <% unless paginator.last_page? || params[:action] == "facet" %>
+    <li class="more_facets_link">
+      <%= link_to t("more_#{field_name}_html", scope: 'blacklight.search.facets', default: :more_html, field_name: facet_field.label),
+        search_facet_path(id: facet_field.key), data: { 'blacklight-modal' => 'trigger' } %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/catalog/_facet_pagination.html.erb
+++ b/app/views/catalog/_facet_pagination.html.erb
@@ -1,0 +1,32 @@
+<%# This was added to override the default in blacklight 6.22, because we're using
+    the javascript from blacklight 7, and the dom in blacklight 6.22 was not compatible.
+
+    This file can be removed when we upgrade to Blacklight 7 %>
+
+<div class="prev_next_links btn-group pull-left">
+  <%= link_to_previous_page @pagination, raw(t('views.pagination.previous')),
+        params: search_state.to_h, param_name: blacklight_config.facet_paginator_class.request_keys[:page],
+        class: 'btn btn-link', data: { blacklight_modal: "preserve" } do %>
+    <%= content_tag :span, raw(t('views.pagination.previous')), class: "disabled btn btn-disabled" %>
+  <% end %>
+
+  <%= link_to_next_page @pagination, raw(t('views.pagination.next')),
+        params: search_state.to_h,
+        param_name: blacklight_config.facet_paginator_class.request_keys[:page],
+        class: 'btn btn-link',
+        data: { blacklight_modal: "preserve" } do %>
+    <%= content_tag :span, raw(t('views.pagination.next')), class: "disabled btn btn-disabled" %>
+  <% end %>
+</div>
+
+<div class="sort_options btn-group pull-right">
+  <% if @pagination.sort == 'index' -%>
+    <span class="active az btn btn-default"><%= t('blacklight.search.facets.sort.index') %></span>
+    <%= link_to(t('blacklight.search.facets.sort.count'), @pagination.params_for_resort_url('count', search_state.to_h),
+          class: "sort_change numeric btn btn-default", data: { blacklight_modal: "preserve" }) %>
+  <% elsif @pagination.sort == 'count' -%>
+    <%= link_to(t('blacklight.search.facets.sort.index'), @pagination.params_for_resort_url('index', search_state.to_h),
+        class: "sort_change az btn btn-default",  data: { blacklight_modal: "preserve" }) %>
+    <span class="active numeric btn btn-default"><%= t('blacklight.search.facets.sort.count') %></span>
+  <% end -%>
+</div>


### PR DESCRIPTION


## Why was this change made?

So to set the DOM selectors as they are required for the blacklight-frontend javascript
Fixes #1849 

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?



## Does this change affect how this application integrates with other services?

If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
