### PR TITLE
Add a query for items with no source_id

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -107,6 +107,7 @@ class CatalogController < ApplicationController
     add_common_date_facet_fields_to_config! config
 
     config.add_facet_field 'empties', label: 'Empty Fields', home: false, query: {
+      no_source_id: { label: 'No Source ID', fq: '-source_id_ssim:*' },
       no_rights_characteristics: { label: 'No Rights Characteristics', fq: '-rights_characteristics_ssim:*' },
       no_content_type: { label: 'No Content Type', fq: '-content_type_ssim:*' },
       no_has_model: { label: 'No Object Model', fq: '-has_model_ssim:*' },


### PR DESCRIPTION


## Why was this change made?
This will help find and remediate objects that are missing this field we thought was required
Fixes #1864 


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

n/a

## Does this change affect how this application integrates with other services?
no
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
