### PR TITLE
Unquoted attributes are not legal html

### DIFF
--- a/app/views/catalog/_show_milestones.html.erb
+++ b/app/views/catalog/_show_milestones.html.erb
@@ -19,7 +19,7 @@
             <td><%= steps['accessioned'][:time].nil? ? 'pending' : steps['accessioned'][:time].in_time_zone.to_s %></td>
           </tr>
           <tr class="version<%= version %>">
-            <td colspan=3 onclick='$(".version<%= version %>").toggle();$(".last_step<%= version %>").toggle();'><span style="cursor: pointer;">-</span>
+            <td colspan="3" onclick='$(".version<%= version %>").toggle();$(".last_step<%= version %>").toggle();'><span style="cursor: pointer;">-</span>
               <%= version %>
               <% if version_hash[version] -%>
                 (<%= version_hash[version][:tag] %>) <%= version_hash[version][:desc] %>


### PR DESCRIPTION
## Why was this change made?

unquoted attributes are not valid.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?


no
## Does this change affect how this application integrates with other services?
no
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
