### PR TITLE
Downcase the sharing element

### DIFF
--- a/app/javascript/modules/apo_form.js
+++ b/app/javascript/modules/apo_form.js
@@ -16,7 +16,7 @@ export default class {
     }
 
     sharing() {
-      var sharing = new Sharing(this.element.find('Sharing')[0])
+      var sharing = new Sharing(this.element.find('sharing')[0])
       sharing.start()
       var form = this.element.closest('form')
 

--- a/app/views/apo/_form.html.erb
+++ b/app/views/apo/_form.html.erb
@@ -17,7 +17,7 @@
       <%= select_tag :metadata_source, options_for_select(apo_metadata_sources, @form.metadata_source) %>
   </div>
 
-  <Sharing data-permissions="<%= @form.permissions.to_json %>"></Sharing>
+  <sharing data-permissions="<%= @form.permissions.to_json %>">
 
   <% if @form.default_collection_objects.present? %>
     <label>Default Collections</label><br/>


### PR DESCRIPTION
## Why was this change made?

Even custom elements use all lowercase by default.  This enables us to use the erb linter.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
no


## Does this change affect how this application integrates with other services?
no

If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
