### PR TITLE
Activate webmock to block unstubbed calls

### DIFF
--- a/app/services/modsulator_client.rb
+++ b/app/services/modsulator_client.rb
@@ -77,7 +77,7 @@ class ModsulatorClient
   rescue Errno::EACCES => e
     delayed_log_url(e, url)
     log.puts "argo.bulk_metadata.bulk_log_invalid_permission #{e.message}"
-  rescue Faraday::ClientError => e
+  rescue Faraday::Error => e
     delayed_log_url(e, url)
     log.puts "argo.bulk_metadata.bulk_log_internal_error #{e.message}"
   rescue StandardError => e

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -66,7 +66,7 @@ OkComputer::Registry.register 'suri_url', OkComputer::HttpCheck.new(Settings.sur
 
 # Stacks
 OkComputer::Registry.register 'stacks_local_workspace_root', OkComputer::DirectoryCheck.new(Settings.stacks.local_workspace_root)
-OkComputer::Registry.register 'stacks_host', OkComputer::HttpCheck.new("https://#{Settings.stacks.HOST}")
+OkComputer::Registry.register 'stacks_host', OkComputer::HttpCheck.new("https://#{Settings.stacks.host}")
 OkComputer::Registry.register 'stacks_file_url', OkComputer::HttpCheck.new(Settings.stacks_file_url)
 OkComputer::Registry.register 'stacks_thumbnail_url', OkComputer::HttpCheck.new(Settings.stacks_url)
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -42,6 +42,7 @@ profiler:
 # Stacks
 stacks:
   local_workspace_root: '/foo/workspace'
+  host: 'stacks-test.stanford.edu'
 
 # Suri
 suri:

--- a/spec/features/status_spec.rb
+++ b/spec/features/status_spec.rb
@@ -8,14 +8,41 @@ RSpec.describe 'application and dependency monitoring' do
     expect(page.status_code).to eq 200
     expect(page).to have_text('Application is running')
   end
+
   it 'RubydoraCheck at /status/active_fedora_conn runs' do
     visit '/status/active_fedora_conn'
     expect(page.status_code).to eq 200
     expect(page).to have_text('active_fedora_conn')
   end
-  it '/status/all checks if required dependencies are ok and also shows non-crucial dependencies' do
-    visit '/status/all'
-    expect(page).to have_text('dor_search_service_solr') # required check
-    expect(page).to have_text('stacks_file_url') # non-crucial check
+
+  context 'all checks' do
+    before do
+      stub_request(:get, Settings.robot_status_url)
+        .to_return(status: 200, body: '', headers: {})
+
+      stub_request(:get, Settings.spreadsheet_url)
+        .to_return(status: 200, body: '', headers: {})
+
+      stub_request(:get, "https://#{Settings.stacks.host}")
+        .to_return(status: 200, body: '', headers: {})
+
+      stub_request(:get, Settings.stacks_file_url)
+        .to_return(status: 200, body: '', headers: {})
+
+      stub_request(:get, Settings.stacks_url)
+        .to_return(status: 200, body: '', headers: {})
+
+      stub_request(:get, Settings.modsulator_url)
+        .to_return(status: 200, body: '', headers: {})
+
+      stub_request(:get, Settings.normalizer_url)
+        .to_return(status: 200, body: '', headers: {})
+    end
+
+    it 'checks dependencies' do
+      visit '/status/all'
+      expect(page).to have_text('dor_search_service_solr') # required check
+      expect(page).to have_text('stacks_file_url') # non-crucial check
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,7 +11,7 @@ require 'capybara/rspec'
 require 'equivalent-xml/rspec_matchers'
 require 'view_component/test_helpers'
 require 'webmock/rspec'
-WebMock.allow_net_connect!(net_http_connect_on_start: true)
+WebMock.disable_net_connect!(allow_localhost: true, allow: ['https://chromedriver.storage.googleapis.com'])
 
 require 'simplecov'
 SimpleCov.start :rails do

--- a/spec/support/mock_index_depth.rb
+++ b/spec/support/mock_index_depth.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.before(:example, type: :feature) do
+    # This stubs out the call that IndexQueue makes
+    stub_request(:get, 'https://status.example.com/render/?format=json&other=params')
+      .to_return(status: 200, body: '1', headers: {})
+  end
+end


### PR DESCRIPTION
## Why was this change made?

The spec run was making several calls to remote services.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

no

## Does this change affect how this application integrates with other services?
no
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
