### PR TITLE
Adds reset of db connections for DescmetadataDownloadJob.

### DIFF
--- a/app/jobs/descmetadata_download_job.rb
+++ b/app/jobs/descmetadata_download_job.rb
@@ -33,6 +33,10 @@ class DescmetadataDownloadJob < GenericJob
 
   def process_druid(current_druid, log, zip_file)
     dor_object = query_dor(current_druid, log)
+
+    # This may be a long-running job, so this makes sure that the db connection is active.
+    ActiveRecord::Base.clear_active_connections!
+
     if dor_object.nil?
       bulk_action.increment(:druid_count_fail).save
       return


### PR DESCRIPTION
refs #1874

## Why was this change made?
DB connection was dropping since this was a long-running job.


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
No.


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
No.