### PR TITLE
Update the list of services allowing real http connections

### DIFF
--- a/lib/tasks/argo_testing.rake
+++ b/lib/tasks/argo_testing.rake
@@ -62,7 +62,16 @@ if ['test', 'development'].include? Rails.env
 
         require 'webmock'
         # only allow connections to Fcrepo, Solr and workflow
-        WebMock.disable_net_connect!(allow: ['workflow:3000', 'solr:8983', 'fcrepo:8080', 'localhost:8983', 'localhost:8984', 'localhost:3004'])
+        WebMock.disable_net_connect!(allow: ['workflow:3000',
+                                             'solr:8983',
+                                             'fcrepo:8080',
+                                             'localhost:8983',
+                                             'localhost:8984',
+                                             'localhost:3004',
+                                             'dor-indexing-app:3000',
+                                             'dor-services-app:3000',
+                                             'techmd::3000',
+                                             'redis:6379'])
         include WebMock::API
         WebMock.enable!
         file_list.each do |file|

--- a/lib/tasks/argo_testing.rake
+++ b/lib/tasks/argo_testing.rake
@@ -68,10 +68,7 @@ if ['test', 'development'].include? Rails.env
                                              'localhost:8983',
                                              'localhost:8984',
                                              'localhost:3004',
-                                             'dor-indexing-app:3000',
-                                             'dor-services-app:3000',
-                                             'techmd::3000',
-                                             'redis:6379'])
+                                             'dor-indexing-app:3000'])
         include WebMock::API
         WebMock.enable!
         file_list.each do |file|


### PR DESCRIPTION
## Why was this change made?

The load and index records command:

https://github.com/sul-dlss/argo/blob/master/README.md#load-and-index-records

Fails with:

```
WebMock::NetConnectNotAllowedError: Real HTTP connections are disabled. Unregistered request: POST http://dor-indexing-app:3000/dor/reindex/druid:br481xz7820 with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Length'=>'0', 'Host'=>'dor-indexing-app:3000', 'User-Agent'=>'rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.5p114'}
```

Currently. This allows the command to be run properly. 

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

N/A

## Does this change affect how this application integrates with other services?

No.