### PR TITLE
Restore bulk job deletion functionality

### DIFF
--- a/app/controllers/bulk_jobs_controller.rb
+++ b/app/controllers/bulk_jobs_controller.rb
@@ -49,12 +49,12 @@ class BulkJobsController < ApplicationController
 
   def help; end
 
-  # DELETE /items/:item_id/bulk_jobs
-  def delete
-    @apo = params[:item_id]
+  # DELETE /apos/:apo_id/bulk_jobs
+  def destroy
+    @apo = params[:apo_id]
     directory_to_delete = File.join(Settings.bulk_metadata.directory, params[:dir])
     FileUtils.remove_dir(directory_to_delete, true)
-    redirect_to item_bulk_jobs_path(@apo)
+    redirect_to apo_bulk_jobs_path(@apo), notice: "Bulk job for APO (#{@apo}) deleted."
   end
 
   def self.local_prefixes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,7 @@ Rails.application.routes.draw do
   end
 
   resources :apos, only: [] do
+    resource :bulk_jobs, only: :destroy
     resources :bulk_jobs, only: :index do
       collection do
         get 'status_help'


### PR DESCRIPTION
Fixes #1882

## Why was this change made?

To restore functionality that was inadvertently removed years ago but is still useful.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

No.

## Does this change affect how this application integrates with other services?

No.