### PR TITLE
Periodically commit zip to avoid memory issues with DescMetadata Down…

### DIFF
--- a/app/jobs/descmetadata_download_job.rb
+++ b/app/jobs/descmetadata_download_job.rb
@@ -23,7 +23,11 @@ class DescmetadataDownloadJob < GenericJob
         start_log(log, bulk_action.user_id, '', bulk_action.description)
         update_druid_count
         ::Zip::File.open(zip_filename, Zip::File::CREATE) do |zip_file|
-          pids.each { |current_druid| process_druid(current_druid, log, zip_file) }
+          pids.each_with_index do |current_druid, index|
+            process_druid(current_druid, log, zip_file)
+            # Commit every 250 to limit memory usage.
+            zip_file.commit if index % 250 == 0
+          end
           zip_file.close
         end
       end


### PR DESCRIPTION
…load job.

refs #1874

## Why was this change made?
Reduce the memory used by this operation so eye doesn't kill it.


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
No.


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
Tested on prod.