### PR TITLE
Update sass to 6.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'rails', '~> 5.2.1'
 # Use Puma as the app server
 gem 'puma', '~> 3.12'
 # Use SCSS for stylesheets
-gem 'sass-rails', '~> 5.0'
+gem 'sass-rails', '~> 6.0'
 
 gem 'webpacker', '~> 4.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -553,19 +553,16 @@ GEM
       rest-client
     rubyzip (2.3.0)
     safe_yaml (1.0.5)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.1.0)
-      railties (>= 5.2.0)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
+    sass-rails (6.0.0)
+      sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.2.1)
       ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     sdr-client (0.20.0)
       activesupport
       cocina-models (~> 0.31.0)
@@ -716,7 +713,7 @@ DEPENDENCIES
   rubocop-rspec (~> 1.31.0)
   ruby-prof
   rubyzip
-  sass-rails (~> 5.0)
+  sass-rails (~> 6.0)
   sdr-client (= 0.20.0)
   selenium-webdriver
   simplecov (~> 0.17.1)


### PR DESCRIPTION
## Why was this change made?
 Sass-rails 5 is eol


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

no

## Does this change affect how this application integrates with other services?
no
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
