### PR TITLE
Set the proper redis path in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,28 +72,6 @@ services:
       - dor-indexing-app
       - suri
       - redis
-
-  dor-services-worker:
-    image: suldlss/dor-services-app:latest
-    environment:
-      DATABASE_NAME: dor-services-app
-      DATABASE_USERNAME: postgres
-      DATABASE_PASSWORD: sekret
-      DATABASE_HOSTNAME: db
-      DATABASE_PORT: 5432
-      SOLR_URL: http://solr:8983/solr/argo
-      SETTINGS__DOR_INDEXING__URL: http://dor-indexing-app:3000/dor
-      SETTINGS__SOLR__URL: http://solr:8983/solr/argo
-      SETTINGS__FEDORA_URL: http://fedoraAdmin:fedoraAdmin@fcrepo:8080/fedora
-      SETTINGS__SURI__URL: http://suri:3000
-      SETTINGS__WORKFLOW_URL: http://workflow:3000
-      REDIS_URL: redis://redis:6379/
-    depends_on:
-      - db
-      - dor-indexing-app
-      - suri
-      - redis
-    command: bundle exec sidekiq -C config/sidekiq.yml
     
   solr:
     image: solr:7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,30 @@ services:
       - db
       - dor-indexing-app
       - suri
+      - redis
 
+  dor-services-worker:
+    image: suldlss/dor-services-app:latest
+    environment:
+      DATABASE_NAME: dor-services-app
+      DATABASE_USERNAME: postgres
+      DATABASE_PASSWORD: sekret
+      DATABASE_HOSTNAME: db
+      DATABASE_PORT: 5432
+      SOLR_URL: http://solr:8983/solr/argo
+      SETTINGS__DOR_INDEXING__URL: http://dor-indexing-app:3000/dor
+      SETTINGS__SOLR__URL: http://solr:8983/solr/argo
+      SETTINGS__FEDORA_URL: http://fedoraAdmin:fedoraAdmin@fcrepo:8080/fedora
+      SETTINGS__SURI__URL: http://suri:3000
+      SETTINGS__WORKFLOW_URL: http://workflow:3000
+      REDIS_URL: redis://redis:6379/
+    depends_on:
+      - db
+      - dor-indexing-app
+      - suri
+      - redis
+    command: bundle exec sidekiq -C config/sidekiq.yml
+    
   solr:
     image: solr:7
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,7 @@ services:
       SETTINGS__FEDORA_URL: http://fedoraAdmin:fedoraAdmin@fcrepo:8080/fedora
       SETTINGS__SURI__URL: http://suri:3000
       SETTINGS__WORKFLOW_URL: http://workflow:3000
+      REDIS_URL: redis://redis:6379/
     depends_on:
       - db
       - dor-indexing-app


### PR DESCRIPTION
## Why was this change made?

Adds the redis url in docker compose to dor-services-app so that queues work properly.


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

N/A


## Does this change affect how this application integrates with other services?

If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.

