### PR TITLE
Call dor-workflow-services in a non-deprecated way

### DIFF
--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -10,7 +10,7 @@ class FilesController < ApplicationController
 
     object_client = Dor::Services::Client.object(params[:item_id])
     @available_in_workspace = object_client.files.list.include?(filename)
-    @has_been_accessioned = WorkflowClientFactory.build.lifecycle('dor', params[:item_id], 'accessioned')
+    @has_been_accessioned = WorkflowClientFactory.build.lifecycle(druid: params[:item_id], milestone_name: 'accessioned')
     files = object_client.find.structural.contains.map { |fs| fs.structural.contains }.flatten
     @file = files.find { |file| file.externalIdentifier == "#{params[:item_id]}/#{params[:id]}" }
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -492,6 +492,6 @@ class ItemsController < ApplicationController
   # Dor::Workflow utils
 
   def dor_lifecycle(object, stage)
-    WorkflowClientFactory.build.lifecycle('dor', object.pid, stage)
+    WorkflowClientFactory.build.lifecycle(druid: object.pid, milestone_name: stage)
   end
 end

--- a/app/controllers/workflow_service_controller.rb
+++ b/app/controllers/workflow_service_controller.rb
@@ -41,11 +41,11 @@ class WorkflowServiceController < ApplicationController
   private
 
   def get_lifecycle(task)
-    WorkflowClientFactory.build.lifecycle('dor', params[:pid], task)
+    WorkflowClientFactory.build.lifecycle(druid: params[:pid], milestone_name: task)
   end
 
   def active_lifecycle(task, druid:, version:)
-    WorkflowClientFactory.build.active_lifecycle('dor', druid, task, version: version)
+    WorkflowClientFactory.build.active_lifecycle(druid: druid, milestone_name: task, version: version)
   end
 
   ##

--- a/app/models/dor_object_workflow_status.rb
+++ b/app/models/dor_object_workflow_status.rb
@@ -13,9 +13,9 @@ class DorObjectWorkflowStatus
   ##
   # @return [Boolean]
   def can_open_version?
-    return false unless workflow.lifecycle('dor', pid, 'accessioned')
-    return false if workflow.active_lifecycle('dor', pid, 'submitted', version: version)
-    return false if workflow.active_lifecycle('dor', pid, 'opened', version: version)
+    return false unless workflow.lifecycle(druid: pid, milestone_name: 'accessioned')
+    return false if workflow.active_lifecycle(druid: pid, milestone_name: 'submitted', version: version)
+    return false if workflow.active_lifecycle(druid: pid, milestone_name: 'opened', version: version)
 
     true
   end

--- a/app/services/milestone_service.rb
+++ b/app/services/milestone_service.rb
@@ -24,7 +24,7 @@ class MilestoneService
   end
 
   def self.milestone_client
-    WorkflowClientFactory.build.milestones('dor', @druid)
+    WorkflowClientFactory.build.milestones(druid: @druid)
   end
 
   private_class_method :milestone_client

--- a/app/services/state_service.rb
+++ b/app/services/state_service.rb
@@ -9,8 +9,8 @@ class StateService
   end
 
   def allows_modification?
-    !client.lifecycle('dor', pid, 'submitted') ||
-      client.active_lifecycle('dor', pid, 'opened', version: version)
+    !client.lifecycle(druid: pid, milestone_name: 'submitted') ||
+      client.active_lifecycle(druid: pid, milestone_name: 'opened', version: version)
   end
 
   private

--- a/spec/controllers/workflow_service_controller_spec.rb
+++ b/spec/controllers/workflow_service_controller_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe WorkflowServiceController, type: :controller do
     context 'when closeable' do
       it 'returns true' do
         expect(workflow_client).to receive(:active_lifecycle)
-          .with('dor', druid, 'opened', version: 1).and_return(true)
+          .with(druid: druid, milestone_name: 'opened', version: 1).and_return(true)
         expect(workflow_client).to receive(:active_lifecycle)
-          .with('dor', druid, 'submitted', version: 1).and_return(false)
+          .with(druid: druid, milestone_name: 'submitted', version: 1).and_return(false)
 
         get :closeable, params: { pid: druid, format: :json }
         expect(assigns(:status)).to eq true
@@ -32,7 +32,7 @@ RSpec.describe WorkflowServiceController, type: :controller do
       context 'not opened' do
         it 'returns false' do
           expect(workflow_client)
-            .to receive(:active_lifecycle).with('dor', druid, 'opened', version: 1)
+            .to receive(:active_lifecycle).with(druid: druid, milestone_name: 'opened', version: 1)
                                           .and_return(false)
           get :closeable, params: { pid: druid, format: :json }
           expect(assigns(:status)).to eq false
@@ -43,10 +43,10 @@ RSpec.describe WorkflowServiceController, type: :controller do
       context 'when opened && is submitted' do
         it 'returns false' do
           expect(workflow_client)
-            .to receive(:active_lifecycle).with('dor', druid, 'opened', version: 1)
+            .to receive(:active_lifecycle).with(druid: druid, milestone_name: 'opened', version: 1)
                                           .and_return(true)
           expect(workflow_client)
-            .to receive(:active_lifecycle).with('dor', druid, 'submitted', version: 1)
+            .to receive(:active_lifecycle).with(druid: druid, milestone_name: 'submitted', version: 1)
                                           .and_return(true)
           get :closeable, params: { pid: druid, format: :json }
           expect(assigns(:status)).to eq false
@@ -60,7 +60,7 @@ RSpec.describe WorkflowServiceController, type: :controller do
     context 'when not accessioned' do
       it 'returns false' do
         expect(workflow_client)
-          .to receive(:lifecycle).with('dor', druid, 'accessioned')
+          .to receive(:lifecycle).with(druid: druid, milestone_name: 'accessioned')
                                  .and_return(false)
         get :openable, params: { pid: druid, format: :json }
         expect(assigns(:status)).to eq false
@@ -71,10 +71,10 @@ RSpec.describe WorkflowServiceController, type: :controller do
     context 'when accessioned && submitted' do
       it 'returns false' do
         expect(workflow_client)
-          .to receive(:lifecycle).with('dor', druid, 'accessioned')
+          .to receive(:lifecycle).with(druid: druid, milestone_name: 'accessioned')
                                  .and_return(true)
         expect(workflow_client)
-          .to receive(:active_lifecycle).with('dor', druid, 'submitted', version: 1)
+          .to receive(:active_lifecycle).with(druid: druid, milestone_name: 'submitted', version: 1)
                                         .and_return(true)
         get :openable, params: { pid: druid, format: :json }
         expect(assigns(:status)).to eq false
@@ -85,13 +85,13 @@ RSpec.describe WorkflowServiceController, type: :controller do
     context 'when accessioned && !submitted && opened' do
       it 'returns false' do
         expect(workflow_client)
-          .to receive(:lifecycle).with('dor', druid, 'accessioned')
+          .to receive(:lifecycle).with(druid: druid, milestone_name: 'accessioned')
                                  .and_return(true)
         expect(workflow_client)
-          .to receive(:active_lifecycle).with('dor', druid, 'submitted', version: 1)
+          .to receive(:active_lifecycle).with(druid: druid, milestone_name: 'submitted', version: 1)
                                         .and_return(false)
         expect(workflow_client)
-          .to receive(:active_lifecycle).with('dor', druid, 'opened', version: 1)
+          .to receive(:active_lifecycle).with(druid: druid, milestone_name: 'opened', version: 1)
                                         .and_return(true)
         get :openable, params: { pid: druid, format: :json }
         expect(assigns(:status)).to eq false
@@ -102,13 +102,13 @@ RSpec.describe WorkflowServiceController, type: :controller do
     context 'when accessioned && !submitted && !opened' do
       it 'returns true' do
         expect(workflow_client)
-          .to receive(:lifecycle).with('dor', druid, 'accessioned')
+          .to receive(:lifecycle).with(druid: druid, milestone_name: 'accessioned')
                                  .and_return(true)
         expect(workflow_client)
-          .to receive(:active_lifecycle).with('dor', druid, 'submitted', version: 1)
+          .to receive(:active_lifecycle).with(druid: druid, milestone_name: 'submitted', version: 1)
                                         .and_return(false)
         expect(workflow_client)
-          .to receive(:active_lifecycle).with('dor', druid, 'opened', version: 1)
+          .to receive(:active_lifecycle).with(druid: druid, milestone_name: 'opened', version: 1)
                                         .and_return(false)
         get :openable, params: { pid: druid, format: :json }
         expect(assigns(:status)).to eq true
@@ -121,7 +121,7 @@ RSpec.describe WorkflowServiceController, type: :controller do
     context 'when published' do
       it 'returns true' do
         expect(workflow_client)
-          .to receive(:lifecycle).with('dor', druid, 'published')
+          .to receive(:lifecycle).with(druid: druid, milestone_name: 'published')
                                  .and_return(true)
         get :published, params: { pid: druid, format: :json }
         expect(assigns(:status)).to eq true
@@ -132,7 +132,7 @@ RSpec.describe WorkflowServiceController, type: :controller do
     context 'when not published' do
       it 'returns false' do
         expect(workflow_client)
-          .to receive(:lifecycle).with('dor', druid, 'published')
+          .to receive(:lifecycle).with(druid: druid, milestone_name: 'published')
                                  .and_return(false)
         get :published, params: { pid: druid, format: :json }
         expect(assigns(:status)).to eq false
@@ -145,7 +145,7 @@ RSpec.describe WorkflowServiceController, type: :controller do
     context 'when submitted' do
       it 'returns true' do
         expect(workflow_client)
-          .to receive(:lifecycle).with('dor', druid, 'submitted')
+          .to receive(:lifecycle).with(druid: druid, milestone_name: 'submitted')
                                  .and_return(true)
         get :submitted, params: { pid: druid, format: :json }
         expect(assigns(:status)).to eq true
@@ -156,7 +156,7 @@ RSpec.describe WorkflowServiceController, type: :controller do
     context 'when not submitted' do
       it 'returns false' do
         expect(workflow_client)
-          .to receive(:lifecycle).with('dor', druid, 'submitted')
+          .to receive(:lifecycle).with(druid: druid, milestone_name: 'submitted')
                                  .and_return(false)
         get :submitted, params: { pid: druid, format: :json }
         expect(assigns(:status)).to eq false
@@ -169,7 +169,7 @@ RSpec.describe WorkflowServiceController, type: :controller do
     context 'when accessioned' do
       it 'returns true' do
         expect(workflow_client)
-          .to receive(:lifecycle).with('dor', druid, 'accessioned')
+          .to receive(:lifecycle).with(druid: druid, milestone_name: 'accessioned')
                                  .and_return(true)
         get :accessioned, params: { pid: druid, format: :json }
         expect(assigns(:status)).to eq true
@@ -180,7 +180,7 @@ RSpec.describe WorkflowServiceController, type: :controller do
     context 'when not accessioned' do
       it 'returns false' do
         expect(workflow_client)
-          .to receive(:lifecycle).with('dor', druid, 'accessioned')
+          .to receive(:lifecycle).with(druid: druid, milestone_name: 'accessioned')
                                  .and_return(false)
         get :accessioned, params: { pid: druid, format: :json }
         expect(assigns(:status)).to eq false

--- a/spec/models/dor_object_workflow_status_spec.rb
+++ b/spec/models/dor_object_workflow_status_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe DorObjectWorkflowStatus do
     context 'when not accessioned' do
       before do
         expect(workflow_client)
-          .to receive(:lifecycle).with('dor', pid, 'accessioned')
+          .to receive(:lifecycle).with(druid: pid, milestone_name: 'accessioned')
                                  .and_return(false)
       end
 
@@ -27,9 +27,9 @@ RSpec.describe DorObjectWorkflowStatus do
     context 'when accessioned and submitted' do
       before do
         expect(workflow_client).to receive(:lifecycle)
-          .with('dor', pid, 'accessioned').and_return(true)
+          .with(druid: pid, milestone_name: 'accessioned').and_return(true)
         expect(workflow_client).to receive(:active_lifecycle)
-          .with('dor', pid, 'submitted', version: 1).and_return(true)
+          .with(druid: pid, milestone_name: 'submitted', version: 1).and_return(true)
       end
 
       it { expect(subject.can_open_version?).to eq false }
@@ -38,13 +38,13 @@ RSpec.describe DorObjectWorkflowStatus do
     context 'when accessioned, not submitted, and opened' do
       before do
         expect(workflow_client)
-          .to receive(:lifecycle).with('dor', pid, 'accessioned')
+          .to receive(:lifecycle).with(druid: pid, milestone_name: 'accessioned')
                                  .and_return(true)
         expect(workflow_client)
-          .to receive(:active_lifecycle).with('dor', pid, 'submitted', version: 1)
+          .to receive(:active_lifecycle).with(druid: pid, milestone_name: 'submitted', version: 1)
                                         .and_return(false)
         expect(workflow_client)
-          .to receive(:active_lifecycle).with('dor', pid, 'opened', version: 1)
+          .to receive(:active_lifecycle).with(druid: pid, milestone_name: 'opened', version: 1)
                                         .and_return(true)
       end
 
@@ -54,13 +54,13 @@ RSpec.describe DorObjectWorkflowStatus do
     context 'when accessioned, not submitted, and not opened' do
       before do
         expect(workflow_client)
-          .to receive(:lifecycle).with('dor', pid, 'accessioned')
+          .to receive(:lifecycle).with(druid: pid, milestone_name: 'accessioned')
                                  .and_return(true)
         expect(workflow_client)
-          .to receive(:active_lifecycle).with('dor', pid, 'submitted', version: 1)
+          .to receive(:active_lifecycle).with(druid: pid, milestone_name: 'submitted', version: 1)
                                         .and_return(false)
         expect(workflow_client)
-          .to receive(:active_lifecycle).with('dor', pid, 'opened', version: 1)
+          .to receive(:active_lifecycle).with(druid: pid, milestone_name: 'opened', version: 1)
                                         .and_return(false)
       end
 

--- a/spec/services/state_service_spec.rb
+++ b/spec/services/state_service_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe StateService do
 
         it 'returns true' do
           expect(allows_modification?).to be true
-          expect(workflow_client).to have_received(:lifecycle).with('dor', 'ab12cd3456', 'submitted')
+          expect(workflow_client).to have_received(:lifecycle).with(druid: 'ab12cd3456', milestone_name: 'submitted')
         end
       end
 
@@ -40,8 +40,8 @@ RSpec.describe StateService do
 
         it 'returns true' do
           expect(allows_modification?).to be true
-          expect(workflow_client).to have_received(:lifecycle).with('dor', 'ab12cd3456', 'submitted')
-          expect(workflow_client).to have_received(:active_lifecycle).with('dor', 'ab12cd3456', 'opened', version: 4)
+          expect(workflow_client).to have_received(:lifecycle).with(druid: 'ab12cd3456', milestone_name: 'submitted')
+          expect(workflow_client).to have_received(:active_lifecycle).with(druid: 'ab12cd3456', milestone_name: 'opened', version: 4)
         end
       end
     end
@@ -56,7 +56,7 @@ RSpec.describe StateService do
 
         it 'returns true' do
           expect(allows_modification?).to be true
-          expect(workflow_client).to have_received(:lifecycle).with('dor', 'ab12cd3456', 'submitted')
+          expect(workflow_client).to have_received(:lifecycle).with(druid: 'ab12cd3456', milestone_name: 'submitted')
         end
       end
 
@@ -68,8 +68,8 @@ RSpec.describe StateService do
 
         it 'returns true' do
           expect(allows_modification?).to be true
-          expect(workflow_client).to have_received(:lifecycle).with('dor', 'ab12cd3456', 'submitted')
-          expect(workflow_client).to have_received(:active_lifecycle).with('dor', 'ab12cd3456', 'opened', version: 3)
+          expect(workflow_client).to have_received(:lifecycle).with(druid: 'ab12cd3456', milestone_name: 'submitted')
+          expect(workflow_client).to have_received(:active_lifecycle).with(druid: 'ab12cd3456', milestone_name: 'opened', version: 3)
         end
       end
     end


### PR DESCRIPTION
## Why was this change made?

Previously we were making deprecated calls and getting warnings in the logs

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

no.

## Does this change affect how this application integrates with other services?
no
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
