### PR TITLE
Register APOs and collections with Cocina

### DIFF
--- a/app/forms/apo_form.rb
+++ b/app/forms/apo_form.rb
@@ -178,19 +178,22 @@ class ApoForm < BaseForm
 
   # @return [Dor::AdminPolicyObject] registers the APO
   def register_model
-    response = Dor::Services::Client.objects.register(params: register_params)
+    response = Dor::Services::Client.objects.register(params: cocina_model)
     @needs_accession_workflow = true
     # Once it's been created we populate it with its metadata
-    Dor.find(response[:pid])
+    Dor.find(response.externalIdentifier)
   end
 
   # @return [Hash] the parameters used to register an apo. Must be called after `validate`
-  def register_params
-    {
+  def cocina_model
+    Cocina::Models::RequestAdminPolicy.new(
       label: params[:title],
-      object_type: 'adminPolicy',
-      admin_policy: SolrDocument::UBER_APO_ID
-    }
+      version: 1,
+      type: Cocina::Models::Vocab.admin_policy,
+      administrative: {
+        hasAdminPolicy: SolrDocument::UBER_APO_ID
+      }
+    )
   end
 
   def param_cleanup(params)

--- a/spec/forms/collection_form_spec.rb
+++ b/spec/forms/collection_form_spec.rb
@@ -10,13 +10,18 @@ RSpec.describe CollectionForm do
   let(:apo) { instantiate_fixture('zt570tx3016', Dor::AdminPolicyObject) }
   let(:collection) { instantiate_fixture('pb873ty1662', Dor::Collection) }
   let(:mock_desc_md_ds) { double(Dor::DescMetadataDS, :abstract= => true) }
-  let(:objects_client) { instance_double(Dor::Services::Client::Objects, register: { pid: 'druid:pb873ty1662' }) }
   let(:workflow_client) { instance_double(Dor::Workflow::Client, create_workflow_by_name: true) }
+  let(:created_collection) do
+    Cocina::Models::Collection.new(externalIdentifier: 'druid:pb873ty1662',
+                                   type: Cocina::Models::Vocab.collection,
+                                   label: '',
+                                   version: 1,
+                                   access: {}).to_json
+  end
 
   before do
     allow(Dor).to receive(:find).with(collection.pid).and_return(collection)
     allow(Dor).to receive(:find).with(apo.pid).and_return(apo)
-    allow(Dor::Services::Client).to receive(:objects).and_return(objects_client)
     allow(Dor::Workflow::Client).to receive(:new).and_return(workflow_client)
     allow(collection).to receive(:descMetadata).and_return(mock_desc_md_ds)
   end
@@ -30,21 +35,22 @@ RSpec.describe CollectionForm do
       }.with_indifferent_access
     end
 
+    before do
+      stub_request(:post, 'http://localhost:3003/v1/objects')
+        .with(
+          body: '{"type":"http://cocina.sul.stanford.edu/models/collection.jsonld",' \
+          '"label":"collection title","version":1,"access":{"access":"dark","download":"none"},' \
+          '"administrative":{"hasAdminPolicy":"druid:zt570tx3016"}}'
+        )
+        .to_return(status: 200, body: created_collection, headers: {})
+    end
+
     it 'creates a collection from title/abstract by registering the collection, then adding the abstract' do
       expect(Argo::Indexer).to receive(:reindex_pid_remotely)
 
       instance.validate(params.merge(apo_pid: apo.pid))
       instance.save
 
-      expect(objects_client).to have_received(:register).with(
-        params: {
-          label: title,
-          object_type: 'collection',
-          admin_policy: apo.pid,
-          metadata_source: 'label',
-          rights: 'dark'
-        }
-      )
       expect(workflow_client).to have_received(:create_workflow_by_name).with(collection.pid, 'accessionWF', version: '1')
       expect(mock_desc_md_ds).to have_received(:abstract=).with(abstract)
     end
@@ -58,24 +64,25 @@ RSpec.describe CollectionForm do
       }.with_indifferent_access
     end
 
+    before do
+      stub_request(:post, 'http://localhost:3003/v1/objects')
+        .with(
+          body: '{"type":"http://cocina.sul.stanford.edu/models/collection.jsonld",' \
+          '"label":":auto","version":1,"access":{"access":"dark","download":"none"},' \
+          '"administrative":{"hasAdminPolicy":"druid:zt570tx3016"},' \
+          '"identification":{"catalogLinks":[{"catalog":"symphony","catalogRecordId":"99998"}]}}'
+        )
+        .to_return(status: 200, body: created_collection, headers: {})
+    end
+
     it 'creates a collection from catkey by registering the collection and passing seed_datastream' do
       expect(Argo::Indexer).to receive(:reindex_pid_remotely)
 
       instance.validate(params.merge(apo_pid: apo.pid))
       instance.save
 
-      expect(objects_client).to have_received(:register).with(
-        params: {
-          label: ':auto',
-          object_type: 'collection',
-          admin_policy: apo.pid,
-          metadata_source: 'symphony',
-          rights: 'dark',
-          other_id: 'symphony:99998',
-          seed_datastream: ['descMetadata']
-        }
-      )
-      expect(workflow_client).to have_received(:create_workflow_by_name).with(collection.pid, 'accessionWF', version: '1')
+      expect(workflow_client).to have_received(:create_workflow_by_name)
+        .with(collection.pid, 'accessionWF', version: '1')
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?
Registering APOs and Collections was not compatible with the current version of dor-services-client


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
no


## Does this change affect how this application integrates with other services?
yes, tested on stage