### PR TITLE
Handle no-download access appropriately

### DIFF
--- a/app/controllers/dor/objects_controller.rb
+++ b/app/controllers/dor/objects_controller.rb
@@ -104,14 +104,21 @@ class Dor::ObjectsController < ApplicationController
   # @param [String] the rights representation from the form
   # @return [Hash<Symbol,String>] a hash representing the Access subschema of the Cocina model
   def access(rights)
-    if rights.start_with?('loc:')
+    if rights.end_with?('-nd')
+      {
+        access: rights.delete_suffix('-nd'),
+        download: 'none'
+      }
+    elsif rights.start_with?('loc:')
       {
         access: 'location-based',
-        readLocation: rights.delete_prefix('loc:')
+        readLocation: rights.delete_prefix('loc:'),
+        download: 'location-based'
       }
     else
       {
-        access: rights
+        access: rights,
+        download: rights
       }
     end
   end

--- a/spec/controllers/dor/objects_controller_spec.rb
+++ b/spec/controllers/dor/objects_controller_spec.rb
@@ -93,6 +93,56 @@ RSpec.describe Dor::ObjectsController, type: :controller do
       end
     end
 
+    context 'when register is successful with explicit rights' do
+      let(:submitted) do
+        {
+          object_type: 'item',
+          admin_policy: 'druid:hv992ry2431',
+          collection: 'druid:hv992ry7777',
+          workflow_id: 'registrationWF',
+          metadata_source: 'label',
+          label: 'test parameters for registration',
+          tag: ['Process : Content Type : Image',
+                'Registered By : jcoyne85'],
+          seed_datastream: ['descMetadata'],
+          rights: 'stanford',
+          source_id: 'foo:bar',
+          other_id: 'label:'
+        }
+      end
+
+      let(:json) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc234fg5678',
+                                type: Cocina::Models::Vocab.image,
+                                label: '',
+                                version: 1,
+                                access: {
+                                  access: 'stanford',
+                                  download: 'stanford'
+                                }).to_json
+      end
+
+      before do
+        stub_request(:post, 'http://localhost:3003/v1/objects')
+          .with(
+            body: '{"type":"http://cocina.sul.stanford.edu/models/image.jsonld",' \
+            '"label":"test parameters for registration","version":1,' \
+            '"access":{"access":"stanford","download":"stanford"},' \
+            '"administrative":{"hasAdminPolicy":"druid:hv992ry2431"},' \
+            '"identification":{"sourceId":"foo:bar","catalogLinks":[]},' \
+            '"structural":{"isMemberOf":"druid:hv992ry7777"}}'
+          )
+          .to_return(status: 200, body: json, headers: {})
+      end
+
+      it 'registers the object' do
+        post :create, params: submitted
+        expect(response).to be_created
+        expect(workflow_service).to have_received(:create_workflow_by_name)
+          .with('druid:bc234fg5678', 'registrationWF', version: '1')
+      end
+    end
+
     context 'when register is successful with location access' do
       let(:submitted) do
         {
@@ -126,11 +176,61 @@ RSpec.describe Dor::ObjectsController, type: :controller do
           .with(
             body: '{"type":"http://cocina.sul.stanford.edu/models/book.jsonld",' \
             '"label":"test parameters for registration","version":1,' \
-            '"access":{"access":"location-based","download":"none","readLocation":"music"},' \
+            '"access":{"access":"location-based","download":"location-based","readLocation":"music"},' \
             '"administrative":{"hasAdminPolicy":"druid:hv992ry2431"},' \
             '"identification":{"sourceId":"foo:bar","catalogLinks":[]},' \
             '"structural":{"hasMemberOrders":[{"viewingDirection":"left-to-right"}],' \
             '"isMemberOf":"druid:hv992ry7777"}}'
+          )
+          .to_return(status: 200, body: json, headers: {})
+      end
+
+      it 'registers the object' do
+        post :create, params: submitted
+        expect(response).to be_created
+        expect(workflow_service).to have_received(:create_workflow_by_name)
+          .with('druid:bc234fg5678', 'registrationWF', version: '1')
+      end
+    end
+
+    context 'when register is successful with no-download' do
+      let(:submitted) do
+        {
+          object_type: 'item',
+          admin_policy: 'druid:hv992ry2431',
+          collection: 'druid:hv992ry7777',
+          workflow_id: 'registrationWF',
+          metadata_source: 'label',
+          label: 'test parameters for registration',
+          tag: ['Process : Content Type : Image',
+                'Registered By : jcoyne85'],
+          seed_datastream: ['descMetadata'],
+          rights: 'world-nd',
+          source_id: 'foo:bar',
+          other_id: 'label:'
+        }
+      end
+
+      let(:json) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc234fg5678',
+                                type: Cocina::Models::Vocab.image,
+                                label: '',
+                                version: 1,
+                                access: {
+                                  access: 'world',
+                                  download: 'none'
+                                }).to_json
+      end
+
+      before do
+        stub_request(:post, 'http://localhost:3003/v1/objects')
+          .with(
+            body: '{"type":"http://cocina.sul.stanford.edu/models/image.jsonld",' \
+            '"label":"test parameters for registration","version":1,' \
+            '"access":{"access":"world","download":"none"},' \
+            '"administrative":{"hasAdminPolicy":"druid:hv992ry2431"},' \
+            '"identification":{"sourceId":"foo:bar","catalogLinks":[]},' \
+            '"structural":{"isMemberOf":"druid:hv992ry7777"}}'
           )
           .to_return(status: 200, body: json, headers: {})
       end


### PR DESCRIPTION
## Why was this change made?

No-download access had been broken.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

no

## Does this change affect how this application integrates with other services?
no

If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
