### PR TITLE
Add dissertation id to report view

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -135,6 +135,12 @@ class Report
       proc: lambda { |doc| doc.preservation_size },
       solr_fields: [SolrDocument::FIELD_PRESERVATION_SIZE],
       sort: false, default: true, width: 50, download_default: false
+    },
+    {
+      field: :dissertation_id, label: 'Dissertation ID',
+      proc: lambda { |doc| doc[:identifier_ssim].filter { |id| id.include?('dissertationid') }.map { |id| id.split(/:/).last } },
+      solr_fields: %w(identifier_ssim),
+      sort: false, default: true, width: 50, download_default: false
     }
   ].freeze
 

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe ReportController, type: :controller do
         expect(response).to have_http_status(:ok)
         expect(response.header['Content-Disposition']).to eq('attachment; filename=report.csv')
         data = CSV.parse(response.body)
-        expect(data.first.length).to eq(25)
+        expect(data.first.length).to eq(26)
         expect(data.length > 1).to be_truthy
         expect(data[1].first).to eq('br481xz7820') # first data row starts with pid
       end

--- a/spec/features/report_view_spec.rb
+++ b/spec/features/report_view_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Report view' do
       find('.ui-pg-button-text', text: 'Columns').click
       expect(page).to have_css 'div#column_selector'
       expect(page).to have_content('Select columns to download:')
-      expect(page).to have_selector('input[name="selected_columns"]', count: 25) # count the total
+      expect(page).to have_selector('input[name="selected_columns"]', count: 26) # count the total
       expect(page).to have_selector('input[name="selected_columns"]:checked', count: 5) # count the default
     end
   end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Report, type: :model do
       rows = CSV.parse(@csv)
       expect(rows).to be_a(Array)
       expect(rows.length).to be > 1    # at least headers + data
-      expect(rows[0].length).to eq(25) # default headers
+      expect(rows[0].length).to eq(26) # default headers
     end
 
     it 'forces double quotes for all fields' do
@@ -42,7 +42,7 @@ RSpec.describe Report, type: :model do
     subject(:report_fields) { described_class::REPORT_FIELDS }
 
     it 'has report fields' do
-      expect(report_fields.length).to eq(25)
+      expect(report_fields.length).to eq(26)
       expect(report_fields).to be_all { |f| f[:field].is_a? Symbol } # all :field keys are symbols
     end
 
@@ -58,7 +58,8 @@ RSpec.describe Report, type: :model do
         :file_count,
         :shelved_file_count,
         :resource_count,
-        :preserved_size
+        :preserved_size,
+        :dissertation_id
       ].each do |k|
         expect(report_fields).to be_any { |f| f[:field] == k }
       end


### PR DESCRIPTION
## Why was this change made?

Fixes #1433

Adds a `Dissertation ID` column to the report output.

<img width="248" alt="Screen Shot 2020-04-23 at 3 09 15 PM" src="https://user-images.githubusercontent.com/2294288/80154442-6aa32a00-8574-11ea-9db0-fb795ecd4168.png">


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

N/A


## Does this change affect how this application integrates with other services?

If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.

No.