### PR TITLE
Make text size for tables in modals be smaller

### DIFF
--- a/app/javascript/style/argo.scss
+++ b/app/javascript/style/argo.scss
@@ -1,3 +1,9 @@
+.modal {
+  table.detail {
+    font-size: 14px;
+  }
+}
+
 .report-toggle {
   .dropdown-item.active {
     background-color: inherit;


### PR DESCRIPTION
## Why was this change made?

In Bootstrap 4 the font size got bigger making the table overflow the modal.


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

no

## Does this change affect how this application integrates with other services?
no