### PR TITLE
Convert btn-default to btn-secondary

### DIFF
--- a/app/components/workflow_step_status_selector.html.erb
+++ b/app/components/workflow_step_status_selector.html.erb
@@ -9,7 +9,7 @@
                    class: 'form-control') %>
     <span class="input-group-btn">
         <%= button_tag('Save', type: 'submit',
-                               class: 'btn btn-default',
+                               class: 'btn btn-secondary',
                                data: { confirm: confirm }) %>
     </span>
   </div>

--- a/app/components/workflow_update_button.html.erb
+++ b/app/components/workflow_update_button.html.erb
@@ -4,6 +4,6 @@
     <%= hidden_field_tag('process', name) %>
     <%= hidden_field_tag('repo', repository) %>
     <%= hidden_field_tag('status', next_status) %>
-    <%= button_tag(label, type: 'submit', class: 'btn btn-default') %>
+    <%= button_tag(label, type: 'submit', class: 'btn btn-secondary') %>
   <% end %>
 <% end %>

--- a/app/javascript/jquery.persistentModal.js
+++ b/app/javascript/jquery.persistentModal.js
@@ -104,7 +104,7 @@
           '    <div class="modal-content">',
           '      ' + modalBody,
           '      <div class="modal-footer">',
-          '        <button data-dismiss="modal" class="btn btn-default">',
+          '        <button data-dismiss="modal" class="btn btn-secondary">',
           '          Cancel',
           '        </button>',
           '      </div>',

--- a/app/javascript/modules/permission_add.js
+++ b/app/javascript/modules/permission_add.js
@@ -24,7 +24,7 @@ export default class {
 
       var button = document.createElement('button')
       button.innerHTML = 'Add'
-      button.className = 'btn btn-default'
+      button.className = 'btn btn-secondary'
       button.addEventListener('click', (event) => {
           event.preventDefault()
           this.parent.add({name: document.getElementById('permissionName').value, type: "group", access: document.getElementById('permissionRole').value}, )

--- a/app/javascript/modules/permission_grant.js
+++ b/app/javascript/modules/permission_grant.js
@@ -17,7 +17,7 @@ export default class {
         var element = this.rootElement()
         var button = document.createElement('button')
         button.innerHTML = 'Remove'
-        button.className = 'btn btn-default'
+        button.className = 'btn btn-secondary'
         button.addEventListener('click', (event) => {
             event.preventDefault()
             this.destroy()

--- a/app/views/apo/_form.html.erb
+++ b/app/views/apo/_form.html.erb
@@ -130,10 +130,10 @@
   <div class="form-group">
     <% if @form.new_record? %>
       <%= submit_tag 'Register APO', class: 'btn btn-primary' %>
-      <%= link_to 'Cancel', '/', class: 'btn btn-default' %>
+      <%= link_to 'Cancel', '/', class: 'btn btn-secondary' %>
     <% else %>
       <%= submit_tag 'Update APO', class: 'btn btn-primary' %>
-      <%= link_to 'Cancel', solr_document_path(@form), class: 'btn btn-default' %>
+      <%= link_to 'Cancel', solr_document_path(@form), class: 'btn btn-secondary' %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/auth/groups.html.erb
+++ b/app/views/auth/groups.html.erb
@@ -21,7 +21,7 @@
           <%= text_field_tag :groups, nil, class: 'form-control' %>
         </div>
         <%= submit_tag 'Impersonate', class: 'btn btn-primary btn-lg btn-block' %>
-        <%= link_to 'Cancel', :back, class: 'btn btn btn-default btn-lg btn-block' %>
+        <%= link_to 'Cancel', :back, class: 'btn btn btn-secondary btn-lg btn-block' %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/bulk_jobs/_bulk_index_table.html.erb
+++ b/app/views/bulk_jobs/_bulk_index_table.html.erb
@@ -59,7 +59,7 @@
       </div>
       <div class="modal-footer">
         <a href="#" id="confirm-delete-job" class="btn btn-success success">Delete</a>
-        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
       </div>
     </div>
   </div>

--- a/app/views/catalog/_facet_pagination.html.erb
+++ b/app/views/catalog/_facet_pagination.html.erb
@@ -21,12 +21,12 @@
 
 <div class="sort_options btn-group pull-right">
   <% if @pagination.sort == 'index' -%>
-    <span class="active az btn btn-default"><%= t('blacklight.search.facets.sort.index') %></span>
+    <span class="active az btn btn-secondary"><%= t('blacklight.search.facets.sort.index') %></span>
     <%= link_to(t('blacklight.search.facets.sort.count'), @pagination.params_for_resort_url('count', search_state.to_h),
-                class: 'sort_change numeric btn btn-default', data: { blacklight_modal: 'preserve' }) %>
+                class: 'sort_change numeric btn btn-secondary', data: { blacklight_modal: 'preserve' }) %>
   <% elsif @pagination.sort == 'count' -%>
     <%= link_to(t('blacklight.search.facets.sort.index'), @pagination.params_for_resort_url('index', search_state.to_h),
-                class: 'sort_change az btn btn-default', data: { blacklight_modal: 'preserve' }) %>
-    <span class="active numeric btn btn-default"><%= t('blacklight.search.facets.sort.count') %></span>
+                class: 'sort_change az btn btn-secondary', data: { blacklight_modal: 'preserve' }) %>
+    <span class="active numeric btn btn-secondary"><%= t('blacklight.search.facets.sort.count') %></span>
   <% end -%>
 </div>

--- a/app/views/catalog/_full_view_links_default.html.erb
+++ b/app/views/catalog/_full_view_links_default.html.erb
@@ -1,4 +1,4 @@
 <div class='btn-group full-view-links' role='group'>
-  <%= link_to 'View full Dublin Core', dc_solr_document_path(document.id), title: 'Dublin Core (derived from MODS)', class: 'btn btn-default btn-sm', data: { blacklight_modal: 'trigger' } %>
-  <%= link_to 'View MODS', purl_preview_item_url(document.id), title: 'MODS View', class: 'btn btn-default btn-sm', data: { blacklight_modal: 'trigger' } %>
+  <%= link_to 'View full Dublin Core', dc_solr_document_path(document.id), title: 'Dublin Core (derived from MODS)', class: 'btn btn-secondary btn-sm', data: { blacklight_modal: 'trigger' } %>
+  <%= link_to 'View MODS', purl_preview_item_url(document.id), title: 'MODS View', class: 'btn btn-secondary btn-sm', data: { blacklight_modal: 'trigger' } %>
 </div>

--- a/app/views/collections/new.html.erb
+++ b/app/views/collections/new.html.erb
@@ -55,12 +55,12 @@
       </div>
     </div>
     <div class="form-group">
-      <%= button_tag 'register', id: 'register', class: 'btn btn-default' do 'Register Collection' end %>
+      <%= button_tag 'register', id: 'register', class: 'btn btn-secondary' do 'Register Collection' end %>
     </div>
 
     <% if !request.xhr? %>
       <div class="form-group">
-        <%= button_to 'Cancel', solr_document_path(@apo.pid), method: :get, class: 'btn btn-default' %>
+        <%= button_to 'Cancel', solr_document_path(@apo.pid), method: :get, class: 'btn btn-secondary' %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/files/index.html.erb
+++ b/app/views/files/index.html.erb
@@ -26,5 +26,5 @@
 <% end %>
 </div>
 <div class="modal-footer">
-  <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+  <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
 </div>

--- a/app/views/items/_tags_ui.html.erb
+++ b/app/views/items/_tags_ui.html.erb
@@ -5,7 +5,7 @@
       <div class="input-group">
         <input class="form-control tag" name="tag<%= count + 1 %>" id="tag<%= count + 1 %>" type="text" value="<%= tag %>">
         <span class='input-group-btn'>
-          <%= link_to url_for(controller: :items, action: :tags, id: @pid, del: 'true', tag: count + 1), class: 'btn btn-default' do %>
+          <%= link_to url_for(controller: :items, action: :tags, id: @pid, del: 'true', tag: count + 1), class: 'btn btn-secondary' do %>
             <span class='glyphicon glyphicon-remove glyphicon text-danger'></span>
           <% end %>
         </span>

--- a/app/views/items/embargo_form.html.erb
+++ b/app/views/items/embargo_form.html.erb
@@ -6,5 +6,5 @@
 <div class='modal-body'>
   <%= render 'embargo_form' %>
   <br>
-  <button class='btn btn-default' data-dismiss='modal'>Cancel</button>
+  <button class='btn btn-secondary' data-dismiss='modal'>Cancel</button>
 </div>

--- a/app/views/tokens/index.html.erb
+++ b/app/views/tokens/index.html.erb
@@ -1,6 +1,6 @@
 <div data-controller="tokens" data-tokens-url="<%= tokens_path %>" class="col-md-3 col-md-offset-1">
   <div class="form-group" data-target="tokens.button">
-    <button data-action="click->tokens#fetchToken" class="btn btn-default">Generate new token</button>
+    <button data-action="click->tokens#fetchToken" class="btn btn-secondary">Generate new token</button>
   </div>
   <div data-target="tokens.result" style="display: none" class="form-group">
     <label for="token">Token</label>

--- a/spec/components/workflow_update_button_spec.rb
+++ b/spec/components/workflow_update_button_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe WorkflowUpdateButton, type: :component do
 
     it 'renders a form with a button' do
       expect(body.css('input[name="process"]').first['value']).to eq 'technical-metadata'
-      expect(body.css('button').to_html).to eq '<button name="button" type="submit" class="btn btn-default">Set to waiting</button>'
+      expect(body.css('button').to_html).to eq '<button name="button" type="submit" class="btn btn-secondary">Set to waiting</button>'
     end
   end
 
@@ -27,7 +27,7 @@ RSpec.describe WorkflowUpdateButton, type: :component do
     let(:status) { 'waiting' }
 
     it 'renders a button' do
-      expect(body.css('button').to_html).to eq '<button name="button" type="submit" class="btn btn-default">Set to completed</button>'
+      expect(body.css('button').to_html).to eq '<button name="button" type="submit" class="btn btn-secondary">Set to completed</button>'
     end
   end
 

--- a/spec/views/auth/groups.html.erb_spec.rb
+++ b/spec/views/auth/groups.html.erb_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'auth/groups.html.erb' do
       expect(rendered).to have_css 'label', text: 'Enter a group or a comma separated list of groups to impersonate'
       expect(rendered).to have_css 'input#groups[type="text"]'
       expect(rendered).to have_css 'input[type="submit"][value="Impersonate"]'
-      expect(rendered).to have_css 'a.btn.btn-default[href="javascript:history.back()"]', text: 'Cancel'
+      expect(rendered).to have_css 'a.btn.btn-secondary[href="javascript:history.back()"]', text: 'Cancel'
     end
   end
 


### PR DESCRIPTION


## Why was this change made?
btn-default doesn't exist in bootstrap 4


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

no

## Does this change affect how this application integrates with other services?
no