### PR TITLE
When access is dark download should be none

### DIFF
--- a/app/controllers/dor/objects_controller.rb
+++ b/app/controllers/dor/objects_controller.rb
@@ -104,7 +104,7 @@ class Dor::ObjectsController < ApplicationController
   # @param [String] the rights representation from the form
   # @return [Hash<Symbol,String>] a hash representing the Access subschema of the Cocina model
   def access(rights)
-    if rights.end_with?('-nd')
+    if rights.end_with?('-nd') || rights == 'dark'
       {
         access: rights.delete_suffix('-nd'),
         download: 'none'


### PR DESCRIPTION
## Why was this change made?
Andrew found an error where registering dark objects does not work.


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

no

## Does this change affect how this application integrates with other services?
no