### PR TITLE
Use the correct field for citation-only for cocina registration

### DIFF
--- a/app/controllers/dor/objects_controller.rb
+++ b/app/controllers/dor/objects_controller.rb
@@ -104,7 +104,7 @@ class Dor::ObjectsController < ApplicationController
   # @param [String] the rights representation from the form
   # @return [Hash<Symbol,String>] a hash representing the Access subschema of the Cocina model
   def access(rights)
-    if rights.end_with?('-nd') || rights == 'dark'
+    if rights.end_with?('-nd') || %w[dark citation-only].include?(rights)
       {
         access: rights.delete_suffix('-nd'),
         download: 'none'

--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -69,13 +69,14 @@ class RegistrationController < ApplicationController
     apo_object = Dor.find(params[:apo_id])
 
     default_opt = apo_object.default_rights
+    default_opt = 'citation-only' if default_opt == 'none'
 
     # iterate through the default version of the rights list.  if we found a default option
     # selection, label it in the UI text and key it as 'default' (instead of its own name).  if
     # we didn't find a default option, we'll just return the default list of rights options with no
     # specified selection.
     result = {}
-    Constants::DEFAULT_RIGHTS_OPTIONS.each do |val|
+    Constants::REGISTRATION_RIGHTS_OPTIONS.each do |val|
       if default_opt == val[1]
         result['default'] = "#{val[0]} (APO default)"
       else

--- a/app/views/items/register.html.erb
+++ b/app/views/items/register.html.erb
@@ -11,7 +11,7 @@
         <div class="property-item"><label for='apo_id'>Admin Policy</label><%= select_tag :apo_id, options_for_select(apo_list(@perm_keys)), 'data-rcparam': 'apoId' %></div>
         <div class="property-item"><label for='collection'>Collection</label><%= select_tag :collection, '', 'data-rcparam': 'collection' %></div>
 
-        <div class="property-item"><label for="rights">Rights</label><%= select_tag :rights, options_for_select(Constants::DEFAULT_RIGHTS_OPTIONS), 'data-tagname': 'Process : Rights' %></div>
+        <div class="property-item"><label for="rights">Rights</label><%= select_tag :rights, options_for_select(Constants::REGISTRATION_RIGHTS_OPTIONS), 'data-tagname': 'Process : Rights' %></div>
         <div class="property-item"><label for='workflow_id'>Initial Workflow</label><%= select_tag :workflow_id, '', 'data-rcparam': 'workflowId' %></div>
         <div class="property-item"><label for='content_type'>Content Type</label><%= select_tag :content_type, options_for_select(valid_content_types), class: 'tag-field', 'data-tagname': 'Process : Content Type' %></div>
         <div class="property-item break"><label for='project'>Project Name</label><%= text_field_tag :project, nil, class: 'tag-field', 'data-tagname': 'Project', 'data-rcparam': 'projectName' %></div>
@@ -33,7 +33,6 @@
           </span>
         </div>
         <div class="break"></div>
-    </table>
 </div>
 
 <div id='dialogs'>

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -7,6 +7,10 @@ module Constants
     [human_readable, type_code]
   end
 
+  REGISTRATION_RIGHTS_OPTIONS = Dor::RightsMetadataDS::RIGHTS_TYPE_CODES.map do |type_code, human_readable|
+    [human_readable, type_code == 'none' ? 'citation-only' : type_code]
+  end
+
   CONTENT_TYPES = %w(image book file map media document 3d).freeze
 
   RESOURCE_TYPES = %w(image page file audio video document 3d).freeze

--- a/spec/controllers/registration_controller_spec.rb
+++ b/spec/controllers/registration_controller_spec.rb
@@ -180,14 +180,10 @@ RSpec.describe RegistrationController, type: :controller do
       </rightsMetadata>
       XML
 
-      @item = double(Dor::Item)
-      xml = Nokogiri::XML(content)
-      allow(Dor).to receive(:find).and_return(@item)
+      object_rights = instance_double(Dor::ContentMetadataDS, ng_xml: Nokogiri::XML(content))
+      apo = instance_double(Dor::AdminPolicyObject, defaultObjectRights: object_rights, default_rights: 'none')
+      allow(Dor).to receive(:find).and_return(apo)
       # using content metadata, but any datastream would do
-      object_rights = double(Dor::ContentMetadataDS)
-      allow(object_rights).to receive(:ng_xml).and_return xml
-      allow(@item).to receive(:defaultObjectRights).and_return object_rights
-      allow(@item).to receive(:default_rights).and_return 'none'
       get 'rights_list', params: { apo_id: 'abc', format: :xml }
       expect(response.body.include?('Citation Only (APO default)')).to eq(true)
     end


### PR DESCRIPTION
## Why was this change made?
Fixes broken functionality for Citation only registration


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

no

## Does this change affect how this application integrates with other services?
no