### PR TITLE
Update ruby to 2.7.1 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
   chrome: stable
 rvm:
   - 2.6.4 # deployed
+  - 2.7.1
 
 before_install:
   # Get bundler 2.0 for ruby 2.6.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.4-alpine
+FROM ruby:2.7.1-alpine
 
 RUN apk add --update --no-cache \
   build-base \


### PR DESCRIPTION
## Why was this change made?

Adds ruby 2.7.1 to travis and Dockerfile

