### PR TITLE
Upgrade rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,3 +43,24 @@ Metrics/BlockLength:
 
 RSpec/MultipleExpectations:
   Enabled: false
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
+Style/ExponentialNotation:
+  Enabled: true
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ group :test, :development do
   gem 'pry-remote' # allows you to attach remote session to pry
   gem 'rails-controller-testing'
   gem 'rspec-rails', '~> 3.5'
-  gem 'rubocop', '~> 0.79.0', require: false # we're stuck with this until erb_lint upgrades
+  gem 'rubocop', require: false
   gem 'rubocop-rails'
   gem 'rubocop-rspec', '~> 1.31.0', require: false
   gem 'sqlite3', '~> 1.3.13'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -504,6 +504,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retries (0.0.5)
+    rexml (3.2.4)
     rsolr (2.3.0)
       builder (>= 2.1.2)
       faraday (>= 0.9.0)
@@ -524,13 +525,14 @@ GEM
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
-    rubocop (0.79.0)
+    rubocop (0.82.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-rails (2.5.2)
       activesupport
       rack (>= 1.1)
@@ -615,7 +617,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
-    unicode-display_width (1.6.1)
+    unicode-display_width (1.7.0)
     view_component (2.5.1)
       activesupport (>= 5.0.0, < 7.0)
     warden (1.2.8)
@@ -700,7 +702,7 @@ DEPENDENCIES
   retries
   rsolr
   rspec-rails (~> 3.5)
-  rubocop (~> 0.79.0)
+  rubocop
   rubocop-rails
   rubocop-rspec (~> 1.31.0)
   ruby-prof


### PR DESCRIPTION
## Why was this change made?

There's no reason to lock rubocop any longer as all the cops are now opt-in.


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
no


## Does this change affect how this application integrates with other services?
no