### PR TITLE
Robot status is not a service we depend on, so don't check it

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -58,7 +58,6 @@ OkComputer::Registry.register 'dor_search_service_solr', OkComputer::HttpCheck.n
 #   - at individual endpoint, HTTP response code reflects the actual result
 #   - in /status/all, these checks will display their result text, but will not affect HTTP response code
 OkComputer::Registry.register 'dor_services_url', OkComputer::HttpCheck.new(Settings.dor_services.url)
-OkComputer::Registry.register 'robot_status_url', OkComputer::HttpCheck.new(Settings.robot_status_url)
 OkComputer::Registry.register 'workflow_url', OkComputer::HttpCheck.new(Settings.workflow_url)
 
 # suri is essential for registering objects
@@ -87,7 +86,6 @@ OkComputer.make_optional %w(
   dor_services_url
   modsulator_url
   normalizer_url
-  robot_status_url
   spreadsheet_url
   stacks_file_url
   stacks_host

--- a/spec/features/status_spec.rb
+++ b/spec/features/status_spec.rb
@@ -17,9 +17,6 @@ RSpec.describe 'application and dependency monitoring' do
 
   context 'all checks' do
     before do
-      stub_request(:get, Settings.robot_status_url)
-        .to_return(status: 200, body: '', headers: {})
-
       stub_request(:get, Settings.spreadsheet_url)
         .to_return(status: 200, body: '', headers: {})
 


### PR DESCRIPTION


## Why was this change made?

It's just a host that we link to, not a service that gets called. Remove unnecessary code.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

no

## Does this change affect how this application integrates with other services?
no