### PR TITLE
Rename spec to reflect that it's testing an APO not an item

### DIFF
--- a/spec/features/apo_displays_spec.rb
+++ b/spec/features/apo_displays_spec.rb
@@ -2,8 +2,8 @@
 
 require 'rails_helper'
 
-RSpec.describe 'mods_view' do
-  let(:object) { instantiate_fixture('druid_zt570tx3016', Dor::Item) }
+RSpec.describe 'Viewing an Admin policy' do
+  let(:object) { instantiate_fixture('druid_zt570tx3016', Dor::AdminPolicyObject) }
   let(:current_user) { create(:user) }
 
   before do


### PR DESCRIPTION
## Why was this change made?
It was confusing that it was testing an APO object, but the test was written to lead you to believe it was an item.


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

no

## Does this change affect how this application integrates with other services?
no