### PR TITLE
Remove a field we don't use from qf

### DIFF
--- a/app/helpers/blacklight_config_helper.rb
+++ b/app/helpers/blacklight_config_helper.rb
@@ -6,7 +6,6 @@ module BlacklightConfigHelper
       'q.alt': '*:*',
       defType: 'dismax',
       qf: %(
-        text^3
         collection_title_tesim
         creator_tesim
         dor_id_tesim


### PR DESCRIPTION
## Why was this change made?
The `text` field was the destination of a `copyField` https://github.com/sul-dlss/sul-solr-configs/blob/ae4e469b67912aa08c93f7ea623b7f82ceb4c8b8/argo3_prod/schema.xml#L189

However, we no longer index anything into the source `*_t` for that copyfield.

This causes queryies with wildcards to return no results.





## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

no

## Does this change affect how this application integrates with other services?
no
