### PR TITLE
Don't allow setting rights on admin policy objects

### DIFF
--- a/app/presenters/buttons_presenter.rb
+++ b/app/presenters/buttons_presenter.rb
@@ -79,7 +79,7 @@ class ButtonsPresenter
     end
 
     buttons << { url: item_content_type_path(item_id: pid), label: 'Set content type' } if object.datastreams.include? 'contentMetadata'
-    buttons << { url: rights_item_path(id: pid), label: 'Set rights' } if object.datastreams.include? 'rightsMetadata'
+    buttons << { url: rights_item_path(id: pid), label: 'Set rights' } unless object.is_a?(Dor::AdminPolicyObject)
     if object.datastreams.include?('identityMetadata') && object.identityMetadata.otherId('catkey').present? # indicates there's a symphony record
       buttons << { url: refresh_metadata_item_path(id: pid), label: 'Refresh descMetadata', new_page: true, disabled: !state_service.allows_modification? }
     end

--- a/spec/features/apo_displays_spec.rb
+++ b/spec/features/apo_displays_spec.rb
@@ -97,13 +97,6 @@ RSpec.describe 'Viewing an Admin policy' do
       end
     end
 
-    context 'rights form' do
-      it 'renders the access rights update ui' do
-        visit '/items/druid:zt570tx3016/rights'
-        expect(page).to have_content('Dark (Preserve Only)')
-      end
-    end
-
     context 'source id ui' do
       it 'renders the source id update ui' do
         idmd = double(Dor::IdentityMetadataDS)
@@ -121,15 +114,6 @@ RSpec.describe 'Viewing an Admin policy' do
         allow(idmd).to receive(:tags).and_return(['something:123'])
         visit '/items/druid:zt570tx3016/tags_ui'
         expect(page).to have_content('Update tags')
-      end
-    end
-
-    context 'register' do
-      it 'loads the registration form' do
-        skip "appears to pass even if blacklight JS isn't included in application.js or register.js, which you'd expect to break things. skipping since it might be useless anyway."
-        visit '/items/register'
-        expect(page).to have_content('Admin Policy')
-        expect(page).to have_content('Register')
       end
     end
   end

--- a/spec/presenters/buttons_presenter_spec.rb
+++ b/spec/presenters/buttons_presenter_spec.rb
@@ -248,10 +248,6 @@ RSpec.describe ButtonsPresenter, type: :presenter do
             url: "/items/#{view_apo_id}/tags_ui"
           },
           {
-            label: 'Set rights',
-            url: "/items/#{view_apo_id}/rights"
-          },
-          {
             label: 'Manage release',
             url: "/view/#{view_apo_id}/manage_release"
           }


### PR DESCRIPTION


## Why was this change made?

They aren't ever published, so they should always just be dark

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

no

## Does this change affect how this application integrates with other services?
no