### PR TITLE
Set proper return codes in items_controller

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -255,7 +255,7 @@ class ItemsController < ApplicationController
 
   def purge_object
     if dor_lifecycle(@object, 'submitted')
-      render status: :forbidden, plain: 'Cannot purge an object after it is submitted.'
+      render status: :bad_request, plain: 'Cannot purge an object after it is submitted.'
       return
     end
 
@@ -309,7 +309,7 @@ class ItemsController < ApplicationController
 
   def refresh_metadata
     if @object.catkey.blank?
-      render status: :forbidden, plain: 'object must have catkey to refresh descMetadata'
+      render status: :bad_request, plain: 'object must have catkey to refresh descMetadata'
       return
     end
 
@@ -373,7 +373,7 @@ class ItemsController < ApplicationController
       end
     end
   rescue ArgumentError
-    render status: :forbidden, plain: 'Invalid new rights setting.'
+    render status: :bad_request, plain: 'Invalid new rights setting.'
   end
 
   # set the rightsMetadata to the APO's defaultObjectRights
@@ -385,7 +385,7 @@ class ItemsController < ApplicationController
 
   def set_governing_apo
     if params[:bulk]
-      render status: :forbidden, plain: 'the old bulk update mechanism is deprecated.  please use the new bulk actions framework going forward.'
+      render status: :gone, plain: 'the old bulk update mechanism is deprecated.  please use the new bulk actions framework going forward.'
       return
     end
 
@@ -480,7 +480,7 @@ class ItemsController < ApplicationController
     # if this object has been submitted and doesn't have an open version, they cannot change it.
     return true if state_service.allows_modification?
 
-    render status: :forbidden, plain: 'Object cannot be modified in its current state.'
+    render status: :bad_request, plain: 'Object cannot be modified in its current state.'
     false
   end
 

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe ItemsController, type: :controller do
       it 'blocks purge on submitted objects' do
         expect(controller).to receive(:dor_lifecycle).with(item, 'submitted').and_return(true)
         delete 'purge_object', params: { id: pid }
-        expect(response.code).to eq('403')
+        expect(response.code).to eq('400')
         expect(response.body).to eq('Cannot purge an object after it is submitted.')
       end
     end
@@ -511,10 +511,10 @@ RSpec.describe ItemsController, type: :controller do
 
       let(:object_service) { instance_double(Dor::Services::Client::Object, refresh_metadata: true) }
 
-      it 'returns a 403 with an error message if there is no catkey' do
+      it 'returns a 400 with an error message if there is no catkey' do
         expect(item).to receive(:catkey).and_return('')
         get :refresh_metadata, params: { id: pid }
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to have_http_status(:bad_request)
         expect(response.body).to eq 'object must have catkey to refresh descMetadata'
       end
 
@@ -561,9 +561,9 @@ RSpec.describe ItemsController, type: :controller do
           context "when the object doesn't allow modification" do
             let(:state_service) { instance_double(StateService, allows_modification?: false) }
 
-            it 'returns a 403 with an error message' do
+            it 'returns a 400 with an error message' do
               get :refresh_metadata, params: { id: pid }
-              expect(response).to have_http_status(:forbidden)
+              expect(response).to have_http_status(:bad_request)
               expect(response.body).to eq 'Object cannot be modified in its current state.'
             end
           end
@@ -597,12 +597,12 @@ RSpec.describe ItemsController, type: :controller do
         allow(controller).to receive(:authorize!).with(:manage_governing_apo, item, new_apo_id)
       end
 
-      it 'returns a 403' do
+      it 'returns a 400' do
         expect(item).not_to receive(:admin_policy_object=)
         expect(item.identityMetadata).not_to receive(:adminPolicy)
         expect(item.datastreams['identityMetadata']).not_to receive(:adminPolicy=)
         post :set_governing_apo, params: { id: pid, new_apo_id: new_apo_id }
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to have_http_status(:bad_request)
         expect(response.body).to eq 'Object cannot be modified in its current state.'
       end
     end
@@ -662,7 +662,7 @@ RSpec.describe ItemsController, type: :controller do
         expect(item.identityMetadata).not_to receive(:adminPolicy)
         expect(item.datastreams['identityMetadata']).not_to receive(:adminPolicy=)
         post :set_governing_apo, params: { id: pid, new_apo_id: new_apo_id, bulk: true }
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to have_http_status(:gone)
         expect(response.body).to eq 'the old bulk update mechanism is deprecated.  please use the new bulk actions framework going forward.'
       end
     end

--- a/spec/features/set_governing_apo_spec.rb
+++ b/spec/features/set_governing_apo_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Set governing APO' do
       visit set_governing_apo_ui_item_path 'druid:kv840rx2720'
       select 'Stanford University Libraries - Special Collections', from: 'new_apo_id', match: :first
       click_button 'Update'
-      expect(page.status_code).to eq 403
+      expect(page.status_code).to eq 400
       expect(page).to have_css 'body', text: 'Object cannot be modified in its current state.'
     end
 


### PR DESCRIPTION
## Why was this change made?

Fixes #500 - in which we are currently returning forbidden (403) http codes when we should be returning bad_request (400). I believe the remaining 403 returns are valid forbidden responses.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

N/A

## Does this change affect how this application integrates with other services?

If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
