### PR TITLE
Extract MilestonesPresenter from the view

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -200,7 +200,8 @@ class CatalogController < ApplicationController
     end
     @events = object_client.events.list
 
-    @milestones = MilestoneService.milestones_for(druid: params[:id])
+    milestones = MilestoneService.milestones_for(druid: params[:id])
+    @milestones_presenter = MilestonesPresenter.new(milestones: milestones, versions: @document.versions)
 
     @buttons_presenter = ButtonsPresenter.new(
       ability: current_ability,

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -33,17 +33,18 @@ class SolrDocument
     format: 'sw_format_ssim'
   )
 
+  attribute :versions, Blacklight::Types::Array, 'versions_ssm'
+
   def get_versions
-    versions = {}
-    recs = self['versions_ssm']
-    recs&.each do |rec|
+    version_hash = {}
+    versions&.each do |rec|
       (version, tag, desc) = rec.split(';')
-      versions[version] = {
+      version_hash[version] = {
         tag: tag,
         desc: desc
       }
     end
-    versions
+    version_hash
   end
 
   # These values are used to drive the display for the datastream table on the item show page

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -35,18 +35,6 @@ class SolrDocument
 
   attribute :versions, Blacklight::Types::Array, 'versions_ssm'
 
-  def get_versions
-    version_hash = {}
-    versions&.each do |rec|
-      (version, tag, desc) = rec.split(';')
-      version_hash[version] = {
-        tag: tag,
-        desc: desc
-      }
-    end
-    version_hash
-  end
-
   # These values are used to drive the display for the datastream table on the item show page
   # This method is now excluding the workflows datastream because this datastream is deprecated.
   # @return[Array<Hash>] the deserialized datastream attributes

--- a/app/presenters/milestones_presenter.rb
+++ b/app/presenters/milestones_presenter.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Displays milestones for each of the versions for an object
+class MilestonesPresenter
+  def initialize(milestones:, versions:)
+    @milestones = milestones
+    @versions = versions
+  end
+
+  def each_version
+    milestones.keys.sort_by(&:to_i)
+  end
+
+  def steps_for(version)
+    @milestones[version].each_with_index { |(key, milestone), index| yield(key, milestone, index) }
+  end
+
+  def version_title(version)
+    version_hash[version] ? "#{version} (#{version_hash[version][:tag]}) #{version_hash[version][:desc]}" : version
+  end
+
+  private
+
+  attr_reader :milestones, :versions
+
+  def version_hash
+    @version_hash ||= versions&.each_with_object({}) do |rec, obj|
+      (version, tag, desc) = rec.split(';')
+      obj[version] = {
+        tag: tag,
+        desc: desc
+      }
+    end
+  end
+end

--- a/app/views/catalog/_show_milestones.html.erb
+++ b/app/views/catalog/_show_milestones.html.erb
@@ -3,27 +3,18 @@
     <tr><th>version</th><th>what</th><th>when</th></tr>
   </thead>
   <tbody>
-    <%
-      version_hash = document.get_versions
-      milestones = @milestones
-      milestones.keys.sort_by { |version_number_string| version_number_string.to_i }.each do |version|
-        steps = milestones[version]
-        first = true
-        steps.each_pair do |k,m|
-    -%>
-          <% if first
-               first = false -%>
-          <tr style="display:none" class="last_step<%= version %>">
+    <% @milestones_presenter.each_version do |version|
+         steps = @milestones_presenter.steps_for(version)
+         steps.each_with_index do |k, m, index| %>
+        <% if index.zero? %>
+          <tr style="display: none" class="last_step<%= version %>">
             <td><span style="cursor: pointer;" onclick='$(".version<%= version %>").toggle();$(".last_step<%= version %>").toggle();'>+</span><%= version %></td>
             <td><%= steps['accessioned'][:display] || k.titleize %></td>
             <td><%= steps['accessioned'][:time].nil? ? 'pending' : steps['accessioned'][:time].in_time_zone.to_s %></td>
           </tr>
           <tr class="version<%= version %>">
             <td colspan="3" onclick='$(".version<%= version %>").toggle();$(".last_step<%= version %>").toggle();'><span style="cursor: pointer;">-</span>
-              <%= version %>
-              <% if version_hash[version] -%>
-                (<%= version_hash[version][:tag] %>) <%= version_hash[version][:desc] %>
-              <% end -%>
+              <%= @milestones_presenter.version_title(version) %>
             </td>
           </tr>
         <% end -%>
@@ -32,7 +23,7 @@
           <td><%= m[:display] || k.titleize %></td>
           <td><%= m[:time].nil? ? 'pending' : m[:time].in_time_zone.to_s %></td>
         </tr>
-      <% end -%>
-    <% end -%>
+      <% end %>
+    <% end %>
   </tbody>
 </table>

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -53,12 +53,22 @@ RSpec.describe SolrDocument, type: :model do
     end
   end
 
-  describe 'get_versions' do
+  describe '#versions' do
+    let(:data) { ['1;1.0.0;Initial version', '2;1.1.0;Minor change'] }
+    let(:document) { described_class.new('versions_ssm' => data) }
+    subject(:versions) { document.versions }
+
+    it 'is a list of versions' do
+      expect(versions).to eq data
+    end
+  end
+
+  describe '#get_versions' do
+    let(:data) { ['1;1.0.0;Initial version', '2;1.1.0;Minor change'] }
+    let(:document) { described_class.new('versions_ssm' => data) }
+    subject(:versions) { document.get_versions }
+
     it 'builds a version hash' do
-      data = []
-      data << '1;1.0.0;Initial version'
-      data << '2;1.1.0;Minor change'
-      versions = SolrDocument.new('versions_ssm' => data).get_versions
       expect(versions['1']).to match a_hash_including(tag: '1.0.0', desc: 'Initial version')
       expect(versions['2']).to match a_hash_including(tag: '1.1.0', desc: 'Minor change')
     end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -54,23 +54,13 @@ RSpec.describe SolrDocument, type: :model do
   end
 
   describe '#versions' do
+    subject(:versions) { document.versions }
+
     let(:data) { ['1;1.0.0;Initial version', '2;1.1.0;Minor change'] }
     let(:document) { described_class.new('versions_ssm' => data) }
-    subject(:versions) { document.versions }
 
     it 'is a list of versions' do
       expect(versions).to eq data
-    end
-  end
-
-  describe '#get_versions' do
-    let(:data) { ['1;1.0.0;Initial version', '2;1.1.0;Minor change'] }
-    let(:document) { described_class.new('versions_ssm' => data) }
-    subject(:versions) { document.get_versions }
-
-    it 'builds a version hash' do
-      expect(versions['1']).to match a_hash_including(tag: '1.0.0', desc: 'Initial version')
-      expect(versions['2']).to match a_hash_including(tag: '1.1.0', desc: 'Minor change')
     end
   end
 end

--- a/spec/presenters/milestones_presenter_spec.rb
+++ b/spec/presenters/milestones_presenter_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MilestonesPresenter do
+  subject(:presenter) do
+    described_class.new(milestones: milestones, versions: versions)
+  end
+
+  let(:milestones) { {} }
+  let(:versions) { ['1;1.0.0;Initial version', '2;1.1.0;Minor change'] }
+
+  describe '#version_title' do
+    subject { presenter.version_title(version) }
+
+    context 'when the version is 1' do
+      let(:version) { '1' }
+
+      it { is_expected.to eq '1 (1.0.0) Initial version' }
+    end
+
+    context 'when the version is 2' do
+      let(:version) { '2' }
+
+      it { is_expected.to eq '2 (1.1.0) Minor change' }
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

The model method `get_versions` was only used by the view and there was a lot of code in the view templates. This helps to put this in a class.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

no.

## Does this change affect how this application integrates with other services?

no