### PR TITLE
Set the page to 1 when downloading

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -53,6 +53,7 @@ class ReportController < CatalogController
   def download
     fields = params['fields'].present? ? params.delete('fields').split(/\s*,\s*/) : nil
     params[:per_page] = 10
+    params[:page] = 1
     response.headers['Content-Type'] = 'application/octet-stream'
     response.headers['Content-Disposition'] = 'attachment; filename=report.csv'
     response.headers['Last-Modified'] = Time.now.utc.rfc2822 # HTTP requires GMT date/time

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ReportController, type: :controller do
         expect(response).to have_http_status(:ok)
         pids = JSON.parse(response.body)['druids']
         expect(pids).to be_a(Array)
-        expect(pids.length > 1).to be_truthy
+        expect(pids.length).to be > 1
         expect(pids.first).to eq('br481xz7820')
       end
     end
@@ -70,7 +70,7 @@ RSpec.describe ReportController, type: :controller do
         expect(response.header['Content-Disposition']).to eq('attachment; filename=report.csv')
         data = CSV.parse(response.body)
         expect(data.first.length).to eq(26)
-        expect(data.length > 1).to be_truthy
+        expect(data.length).to be > 1
         expect(data[1].first).to eq('br481xz7820') # first data row starts with pid
       end
 
@@ -80,7 +80,7 @@ RSpec.describe ReportController, type: :controller do
         expect(response.header['Content-Disposition']).to eq('attachment; filename=report.csv')
         data = CSV.parse(response.body)
         expect(data.first.length).to eq(26)
-        expect(data.length > 1).to be_truthy
+        expect(data.length).to be > 1
         expect(data[1].first).to eq('br481xz7820') # first data row starts with pid
       end
 
@@ -89,7 +89,7 @@ RSpec.describe ReportController, type: :controller do
         expect(response).to have_http_status(:ok)
         data = CSV.parse(response.body)
         expect(data.first).to eq(%w(Druid Purl Source\ Id Tags))
-        expect(data.length > 1).to be_truthy
+        expect(data.length).to be > 1
         expect(data[1].first).to eq('br481xz7820') # first data row starts with pid
       end
     end

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -73,6 +73,17 @@ RSpec.describe ReportController, type: :controller do
         expect(data.length > 1).to be_truthy
         expect(data[1].first).to eq('br481xz7820') # first data row starts with pid
       end
+
+      it 'downloads valid CSV data when not on the first page' do
+        get :download, params: { fields: ' ', page: 3 }
+        expect(response).to have_http_status(:ok)
+        expect(response.header['Content-Disposition']).to eq('attachment; filename=report.csv')
+        data = CSV.parse(response.body)
+        expect(data.first.length).to eq(26)
+        expect(data.length > 1).to be_truthy
+        expect(data[1].first).to eq('br481xz7820') # first data row starts with pid
+      end
+
       it 'downloads valid CSV data for specific fields' do
         get :download, params: { fields: 'druid,purl,source_id_ssim,tag_ssim' }
         expect(response).to have_http_status(:ok)


### PR DESCRIPTION
## Why was this change made?

Fixes #794 - without forcing the page to 1 on download, the current page param is sent and used as the initial page.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

N/A


## Does this change affect how this application integrates with other services?

If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.

No.