### PR TITLE
Move the thumbnail url method to the SolrDocument model

### DIFF
--- a/app/helpers/argo_helper.rb
+++ b/app/helpers/argo_helper.rb
@@ -5,22 +5,8 @@ module ArgoHelper
   include BlacklightHelper
   include ValueHelper
 
-  def get_thumbnail_info(doc)
-    fname = doc['first_shelved_image_ss']
-    return nil unless fname
-
-    fname = File.basename(fname, File.extname(fname))
-    druid = doc['id'].to_s.split(/:/).last
-    url = "#{Settings.stacks_url}/iiif/#{druid}%2F#{ERB::Util.url_encode(fname)}/full/!400,400/0/default.jpg"
-    { fname: fname, druid: druid, url: url }
-  end
-
   def render_thumbnail_helper(doc, thumb_class = '', thumb_alt = '', thumb_style = 'max-width:240px;max-height:240px;')
-    thumbnail_info = get_thumbnail_info(doc)
-    return nil unless thumbnail_info
-
-    thumbnail_url = thumbnail_info[:url]
-    image_tag thumbnail_url, class: thumb_class, alt: thumb_alt, style: thumb_style
+    image_tag doc.thumbnail_url, class: thumb_class, alt: thumb_alt, style: thumb_style if doc.thumbnail_url
   end
 
   def render_purl_link(document, link_text = 'PURL', opts = { target: '_blank' })

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -16,6 +16,7 @@ class SolrDocument
 
   attribute :embargo_status, Blacklight::Types::String, FIELD_EMBARGO_STATUS
   attribute :embargo_release_date, Blacklight::Types::String, FIELD_EMBARGO_RELEASE_DATE
+  attribute :first_shelved_image, Blacklight::Types::String, :first_shelved_image_ss
 
   def embargoed?
     embargo_status == 'embargoed'
@@ -43,6 +44,16 @@ class SolrDocument
   )
 
   attribute :versions, Blacklight::Types::Array, 'versions_ssm'
+
+  def thumbnail_url
+    return nil unless first_shelved_image
+
+    @thumbnail_url ||= begin
+      file_id = File.basename(first_shelved_image, '.*')
+      druid = id.delete_prefix('druid:')
+      "#{Settings.stacks_url}/iiif/#{druid}%2F#{ERB::Util.url_encode(file_id)}/full/!400,400/0/default.jpg"
+    end
+  end
 
   # These values are used to drive the display for the datastream table on the item show page
   # This method is now excluding the workflows datastream because this datastream is deprecated.


### PR DESCRIPTION
## Why was this change made?

The view scope is crowded with methods, move this into a real class where it is encapsulated.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

no


## Does this change affect how this application integrates with other services?
no