### PR TITLE
Fix the back button on workflow grid

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -81,17 +81,11 @@ class ReportController < CatalogController
     end
   end
 
+  # This draws the full page that supports the workflow grid
   def workflow_grid
     (@response, @document_list) = search_results(params)
 
-    if request.xhr?
-      # This is triggered by javascript that refreshes the data every 10s
-      render partial: 'workflow_grid'
-      return
-    end
-
-    respond_to do |format|
-      format.html
-    end
+    # This is triggered by javascript that refreshes the data every 10s
+    return render partial: 'workflow_grid' if request.headers['X-Requester'] == 'frontend'
   end
 end

--- a/app/javascript/controllers/workflow_grid_controller.js
+++ b/app/javascript/controllers/workflow_grid_controller.js
@@ -17,7 +17,7 @@ export default class extends Controller {
 
   load() {
     // We're setting this header so that the controller can check for request.xhr?
-    fetch(this.data.get("url"), { headers: { 'X-Requested-With': 'XMLHttpRequest' }})
+    fetch(this.data.get("url"), { headers: { 'X-Requester': 'frontend' }})
       .then(response => response.text())
       .then(html => {
         this.element.innerHTML = html


### PR DESCRIPTION

## Why was this change made?
Previously if you hit back after linking from the workflow grid, you would get a partial rendered rather than a full page. I believe this is because Turbolinks was setting the XHR header.  We avoid this problem by switching to a different header for this conditional.



## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
no


## Does this change affect how this application integrates with other services?
no
