### PR TITLE
Disable tag update

### DIFF
--- a/app/views/items/_tags_ui.html.erb
+++ b/app/views/items/_tags_ui.html.erb
@@ -1,5 +1,6 @@
-
-<%= form_tag url_for(controller: :items, action: :tags, id: @pid, update: 'true') do %>
+<% # Temporarily disable this form, until tags migration is complete %>
+<%= form_tag url_for(controller: :items, action: :tags, id: @pid, update: 'true'), onsubmit: "return false;" do %>
+  <p><em>Tag update is presently disabled for a migration until 5/14/2020</em>. See jcoyne85@stanford.edu with questions.</p>
   <% @tags.each_with_index do |tag, count| %>
     <div class="form-group">
       <div class="input-group">


### PR DESCRIPTION
## Why was this change made?

This temporarily disables tag updates until the table can be normalized: https://github.com/sul-dlss/dor-services-app/pull/854

This is being done so that #165 can be done.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

no

## Does this change affect how this application integrates with other services?
no