### PR TITLE
Changes ocr_exporter to work with zips.

### DIFF
--- a/app/services/ocr_exporter.rb
+++ b/app/services/ocr_exporter.rb
@@ -2,6 +2,7 @@
 
 # This exports OCR files that are in preservation for a provided list of barcodes
 # This is used by researchers who want to get a dump of OCR files from the google books project
+# The OCR files for a book are zipped.
 class OCRExporter
   # @param [String] filename the input file name
   # @param [String] directory the output directory path
@@ -35,10 +36,9 @@ class OCRExporter
   attr_reader :filename, :directory, :finder
 
   def filenames(object)
-    object.structural.contains.map do |file_set|
-      # TODO: using label in place of filename for now: https://github.com/sul-dlss/google-books/issues/444
-      file_set.structural.contains.find { |file| file.hasMimeType == 'text/plain' }&.label
-    end.compact
+    object.structural.contains.flat_map do |file_set|
+      file_set.structural.contains.filter { |file| file.filename.match?(/-gb-txt.zip/) }.map(&:filename)
+    end
   end
 
   class Downloader
@@ -51,7 +51,6 @@ class OCRExporter
 
     def download_files
       FileUtils.mkdir File.join(@directory, @id)
-
       @filenames.each do |filename|
         File.open(File.join(@directory, @id, filename), 'wb') do |f|
           f.puts Preservation::Client.objects.content(druid: @id, filepath: filename, version: @version)

--- a/spec/services/ocr_exporter_spec.rb
+++ b/spec/services/ocr_exporter_spec.rb
@@ -20,18 +20,12 @@ RSpec.describe OCRExporter do
       structural: {
         contains: [
           {
-            externalIdentifier: 'fs1/00000001.jp2',
+            externalIdentifier: 'fs1/fs1-gb-jp2.zip',
             type: Cocina::Models::Vocab.file,
             version: 1,
-            hasMimeType: 'image/jp2',
-            label: '00000001.jp2'
-          },
-          {
-            externalIdentifier: 'fs1/00000001.txt',
-            type: Cocina::Models::Vocab.file,
-            version: 1,
-            hasMimeType: 'text/plain',
-            label: '00000001.txt'
+            hasMimeType: 'application/zip',
+            label: 'fs1-gb-jp2.zip',
+            filename: 'fs1-gb-jp2.zip'
           }
         ]
       }
@@ -44,18 +38,12 @@ RSpec.describe OCRExporter do
       structural: {
         contains: [
           {
-            externalIdentifier: 'fs2/00000002.jp2',
+            externalIdentifier: 'fs2/fs2-gb-txt.zip',
             type: Cocina::Models::Vocab.file,
             version: 1,
-            hasMimeType: 'image/jp2',
-            label: '00000002.jp2'
-          },
-          {
-            externalIdentifier: 'fs2/00000002.txt',
-            type: Cocina::Models::Vocab.file,
-            version: 1,
-            hasMimeType: 'text/plain',
-            label: '00000002.txt'
+            hasMimeType: 'application/zip',
+            label: 'fs2-gb-txt.zip',
+            filename: 'fs2-gb-txt.zip'
           }
         ]
       }
@@ -68,18 +56,12 @@ RSpec.describe OCRExporter do
       structural: {
         contains: [
           {
-            externalIdentifier: 'fs3/00000001.jp2',
+            externalIdentifier: 'fs3/fs3-gb-jp2.zip',
             type: Cocina::Models::Vocab.file,
             version: 1,
-            hasMimeType: 'image/jp2',
-            label: '00000001.jp2'
-          },
-          {
-            externalIdentifier: 'fs3/00000001.txt',
-            type: Cocina::Models::Vocab.file,
-            version: 1,
-            hasMimeType: 'text/plain',
-            label: '00000001.txt'
+            hasMimeType: 'application/zip',
+            label: 'fs3-gb-jp2.zip',
+            filename: 'fs3-gb-jp2.zip'
           }
         ]
       }
@@ -92,18 +74,12 @@ RSpec.describe OCRExporter do
       structural: {
         contains: [
           {
-            externalIdentifier: 'fs4/00000002.jp2',
+            externalIdentifier: 'fs4/fs4-gb-txt.zip',
             type: Cocina::Models::Vocab.file,
             version: 1,
-            hasMimeType: 'image/jp2',
-            label: '00000002.jp2'
-          },
-          {
-            externalIdentifier: 'fs4/00000002.txt',
-            type: Cocina::Models::Vocab.file,
-            version: 1,
-            hasMimeType: 'text/plain',
-            label: '00000002.txt'
+            hasMimeType: 'application/zip',
+            label: 'fs4-gb-txt.zip',
+            filename: 'fs4-gb-txt.zip'
           }
         ]
       }
@@ -125,9 +101,7 @@ RSpec.describe OCRExporter do
   it 'downloads files' do
     exporter.export
 
-    expect(File).to exist('tmp/druid:one/00000001.txt')
-    expect(File).to exist('tmp/druid:one/00000002.txt')
-    expect(File).to exist('tmp/druid:two/00000001.txt')
-    expect(File).to exist('tmp/druid:two/00000002.txt')
+    expect(File).to exist('tmp/druid:one/fs2-gb-txt.zip')
+    expect(File).to exist('tmp/druid:two/fs4-gb-txt.zip')
   end
 end


### PR DESCRIPTION
refs https://github.com/sul-dlss/google-books/issues/511

## Why was this change made?
Switch from exporting by page to exporting by zip.


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
No


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
No