### PR TITLE
Remove unused seed_datastream from the registration form

### DIFF
--- a/app/javascript/registration/register.js
+++ b/app/javascript/registration/register.js
@@ -49,7 +49,6 @@ export default function DorRegistration(initOpts) {
         'object_type' : $t.objectType,
         'admin_policy' : apo,
         'workflow_id' : $('#workflow_id').val(),
-        'seed_datastream' : ($t.metadataSource === 'label' ) ? null : ['descMetadata'],
         'metadata_source' : ($t.metadataSource !== 'label') ? null : $t.metadataSource,
         'label' : data.label || ':auto',
         'tag' : tags,

--- a/spec/controllers/dor/objects_controller_spec.rb
+++ b/spec/controllers/dor/objects_controller_spec.rb
@@ -56,7 +56,6 @@ RSpec.describe Dor::ObjectsController, type: :controller do
           label: 'test parameters for registration',
           tag: ['Process : Content Type : Document',
                 'Registered By : jcoyne85'],
-          seed_datastream: ['descMetadata'],
           rights: 'default',
           source_id: 'foo:bar',
           other_id: 'label:'
@@ -104,7 +103,6 @@ RSpec.describe Dor::ObjectsController, type: :controller do
           label: 'test parameters for registration',
           tag: ['Process : Content Type : Image',
                 'Registered By : jcoyne85'],
-          seed_datastream: ['descMetadata'],
           rights: 'stanford',
           source_id: 'foo:bar',
           other_id: 'label:'
@@ -154,7 +152,6 @@ RSpec.describe Dor::ObjectsController, type: :controller do
           label: 'test parameters for registration',
           tag: ['Process : Content Type : Book (ltr)',
                 'Registered By : jcoyne85'],
-          seed_datastream: ['descMetadata'],
           rights: 'loc:music',
           source_id: 'foo:bar',
           other_id: 'label:'
@@ -204,7 +201,6 @@ RSpec.describe Dor::ObjectsController, type: :controller do
           label: 'test parameters for registration',
           tag: ['Process : Content Type : Image',
                 'Registered By : jcoyne85'],
-          seed_datastream: ['descMetadata'],
           rights: 'world-nd',
           source_id: 'foo:bar',
           other_id: 'label:'
@@ -254,7 +250,6 @@ RSpec.describe Dor::ObjectsController, type: :controller do
           label: 'test parameters for registration',
           tag: ['Process : Content Type : Image',
                 'Registered By : jcoyne85'],
-          seed_datastream: ['descMetadata'],
           rights: 'dark',
           source_id: 'foo:bar',
           other_id: 'label:'

--- a/spec/forms/collection_form_spec.rb
+++ b/spec/forms/collection_form_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe CollectionForm do
         .to_return(status: 200, body: created_collection, headers: {})
     end
 
-    it 'creates a collection from catkey by registering the collection and passing seed_datastream' do
+    it 'creates a collection from catkey by registering the collection' do
       expect(Argo::Indexer).to receive(:reindex_pid_remotely)
 
       instance.validate(params.merge(apo_pid: apo.pid))


### PR DESCRIPTION
## Why was this change made?
This is no longer used.  This was required for the legacy registration api.


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

no.

## Does this change affect how this application integrates with other services?
no