### PR TITLE
Add a "back to seach" button on bulk actions index

### DIFF
--- a/app/controllers/bulk_actions_controller.rb
+++ b/app/controllers/bulk_actions_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class BulkActionsController < ApplicationController
+  include Blacklight::SearchContext
+
   before_action :set_bulk_action, only: %i[destroy file]
 
   rescue_from ActiveRecord::RecordNotFound, with: -> { render plain: 'Record Not Found', status: :not_found }

--- a/app/views/bulk_actions/index.html.erb
+++ b/app/views/bulk_actions/index.html.erb
@@ -1,7 +1,16 @@
 <div class='container'>
 
   <h1>Bulk Actions</h1>
-  <%= link_to 'New Bulk Action', new_bulk_action_path, class: 'btn btn-success' %>
+  <div class="container">
+    <div class="row">
+      <div class="col-md-10">
+        <%= link_to 'New Bulk Action', new_bulk_action_path, class: 'btn btn-success' %>
+      </div>
+      <div class="col-md-2">
+        <%= link_back_to_catalog label: 'Back to search', class: 'btn btn-default' %>
+      </div>
+    </div>
+  </div>
 
   <table class='table'>
     <thead>


### PR DESCRIPTION
## Why was this change made?

Fixes #997 

This adds a "Back to search" button to the top right of the Bulk actions list and utilizes the last search used before bulk actions so that it returns after a new bulk action is created.

<img width="1185" alt="Screen Shot 2020-05-11 at 1 50 40 PM" src="https://user-images.githubusercontent.com/2294288/81610467-6fe2e000-938e-11ea-9b08-e76d9a449190.png">



## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

N/A


## Does this change affect how this application integrates with other services?

If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.

No.