### PR TITLE
When registering don't send project as empty string

### DIFF
--- a/app/controllers/dor/objects_controller.rb
+++ b/app/controllers/dor/objects_controller.rb
@@ -5,8 +5,9 @@ class Dor::ObjectsController < ApplicationController
   before_action :munge_parameters
 
   def create
+    form = RegistrationForm.new(params)
     begin
-      response = Dor::Services::Client.objects.register(params: cocina_model)
+      response = Dor::Services::Client.objects.register(params: form.cocina_model)
     rescue Cocina::Models::ValidationError => e
       return render plain: e.message, status: :bad_request
     rescue Dor::Services::Client::UnexpectedResponse => e
@@ -19,102 +20,12 @@ class Dor::ObjectsController < ApplicationController
 
     WorkflowClientFactory.build.create_workflow_by_name(pid, params[:workflow_id], version: '1')
 
-    Dor::Services::Client.object(pid).administrative_tags.create(tags: administrative_tags)
+    Dor::Services::Client.object(pid).administrative_tags.create(tags: form.administrative_tags)
 
     render json: { pid: pid }, status: :created, location: object_location(pid)
   end
 
   private
-
-  def dro_type
-    case content_type_tag
-    when 'Image'
-      Cocina::Models::Vocab.image
-    when '3D'
-      Cocina::Models::Vocab.three_dimensional
-    when 'Map'
-      Cocina::Models::Vocab.map
-    when 'Media'
-      Cocina::Models::Vocab.media
-    when 'Document'
-      Cocina::Models::Vocab.document
-    when /^Manuscript/
-      Cocina::Models::Vocab.manuscript
-    when 'Book (ltr)', 'Book (rtl)'
-      Cocina::Models::Vocab.book
-    else
-      Cocina::Models::Vocab.object
-    end
-  end
-
-  # helper method to get just the content type tag
-  def content_type_tag
-    content_tag = params[:tag].find { |tag| tag.start_with?('Process : Content Type') }
-    content_tag.split(':').last.strip
-  end
-
-  # All the tags from the form except the project and content type, which are handled specially
-  def administrative_tags
-    params[:tag].filter { |t| !t.start_with?('Process : Content Type') }
-  end
-
-  # @raises [Cocina::Models::ValidationError]
-  def cocina_model
-    catalog_links = []
-    if params[:other_id] != 'label:'
-      catalog, record_id = params[:other_id].split(':')
-      catalog_links = [{ catalog: catalog, catalogRecordId: record_id }]
-    end
-
-    model_params = {
-      type: dro_type,
-      label: params.require(:label),
-      version: 1,
-      administrative: {
-        hasAdminPolicy: params[:admin_policy]
-      },
-      identification: {
-        sourceId: params.require(:source_id),
-        catalogLinks: catalog_links
-      }
-    }
-    model_params[:access] = access(params[:rights]) if params[:rights] != 'default'
-
-    structural = {}
-    structural[:isMemberOf] = params[:collection] if params[:collection].present?
-    case content_type_tag
-    when 'Book (ltr)'
-      structural[:hasMemberOrders] = [{ viewingDirection: 'left-to-right' }]
-    when 'Book (rtl)'
-      structural[:hasMemberOrders] = [{ viewingDirection: 'right-to-left' }]
-    end
-    model_params[:structural] = structural
-    model_params[:administrative][:partOfProject] = params[:project] if params[:project]
-
-    Cocina::Models::RequestDRO.new(model_params)
-  end
-
-  # @param [String] the rights representation from the form
-  # @return [Hash<Symbol,String>] a hash representing the Access subschema of the Cocina model
-  def access(rights)
-    if rights.end_with?('-nd') || %w[dark citation-only].include?(rights)
-      {
-        access: rights.delete_suffix('-nd'),
-        download: 'none'
-      }
-    elsif rights.start_with?('loc:')
-      {
-        access: 'location-based',
-        readLocation: rights.delete_prefix('loc:'),
-        download: 'location-based'
-      }
-    else
-      {
-        access: rights,
-        download: rights
-      }
-    end
-  end
 
   def munge_parameters
     case request.content_type

--- a/spec/forms/registration_form_spec.rb
+++ b/spec/forms/registration_form_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RegistrationForm do
+  let(:instance) { described_class.new(ActionController::Parameters.new(params)) }
+
+  describe '#cocina_model' do
+    subject(:cocina_model) { instance.cocina_model }
+
+    context 'when project is an empty string' do
+      let(:params) do
+        {
+          other_id: 'label:',
+          source_id: 'foo:bar',
+          admin_policy: 'druid:hv992ry2431',
+          label: 'test parameters for registration',
+          tag: ['Process : Content Type : File'],
+          rights: 'default',
+          project: ''
+        }
+      end
+
+      it 'does not have a project' do
+        expect(cocina_model.administrative.partOfProject).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

Dor-services-app sees this as an invalid tag and raises an error.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

no


## Does this change affect how this application integrates with other services?
no
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
