### PR TITLE
Extract a VersionMilestonesComponent

### DIFF
--- a/app/components/version_milestones_component.html.erb
+++ b/app/components/version_milestones_component.html.erb
@@ -1,11 +1,11 @@
-<tr style="display: none" class="last_step<%= version %>">
- <td><span style="cursor: pointer;" onclick='$(".version<%= version %>").toggle();$(".last_step<%= version %>").toggle();'>+</span><%= version %></td>
+<tr class="hidden last_step<%= version %>">
+ <td><span style="cursor: pointer;" onclick="document.querySelectorAll('.version<%= version %>').forEach((elem) => elem.classList.toggle('hidden'));document.querySelector('.last_step<%= version %>').classList.toggle('hidden')">+</span><%= version %></td>
  <td><%= steps['accessioned'][:display] || steps.keys.first.titleize %></td>
  <td><%= steps['accessioned'][:time].nil? ? 'pending' : steps['accessioned'][:time].in_time_zone.to_s %></td>
 </tr>
 
 <tr class="version<%= version %>">
- <td colspan="3" onclick='$(".version<%= version %>").toggle();$(".last_step<%= version %>").toggle();'><span style="cursor: pointer;">-</span>
+ <td colspan="3" onclick="document.querySelectorAll('.version<%= version %>').forEach((elem) => elem.classList.toggle('hidden'));document.querySelector('.last_step<%= version %>').classList.toggle('hidden')"><span style="cursor: pointer;">-</span>
    <%= title %>
  </td>
 </tr>

--- a/app/components/version_milestones_component.html.erb
+++ b/app/components/version_milestones_component.html.erb
@@ -1,0 +1,19 @@
+<tr style="display: none" class="last_step<%= version %>">
+ <td><span style="cursor: pointer;" onclick='$(".version<%= version %>").toggle();$(".last_step<%= version %>").toggle();'>+</span><%= version %></td>
+ <td><%= steps['accessioned'][:display] || steps.keys.first.titleize %></td>
+ <td><%= steps['accessioned'][:time].nil? ? 'pending' : steps['accessioned'][:time].in_time_zone.to_s %></td>
+</tr>
+
+<tr class="version<%= version %>">
+ <td colspan="3" onclick='$(".version<%= version %>").toggle();$(".last_step<%= version %>").toggle();'><span style="cursor: pointer;">-</span>
+   <%= title %>
+ </td>
+</tr>
+
+<% steps.each do |k, m| %>
+<tr class="version<%= version %>">
+  <td></td>
+  <td><%= m[:display] || k.titleize %></td>
+  <td><%= m[:time].nil? ? 'pending' : m[:time].in_time_zone.to_s %></td>
+</tr>
+<% end %>

--- a/app/components/version_milestones_component.rb
+++ b/app/components/version_milestones_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class VersionMilestonesComponent < ViewComponent::Base
+  def initialize(version:, title:, steps:)
+    @version = version
+    @title = title
+    @steps = steps
+  end
+
+  attr_reader :version, :title, :steps
+end

--- a/app/views/catalog/_show_milestones.html.erb
+++ b/app/views/catalog/_show_milestones.html.erb
@@ -3,27 +3,10 @@
     <tr><th>version</th><th>what</th><th>when</th></tr>
   </thead>
   <tbody>
-    <% @milestones_presenter.each_version do |version|
-         steps = @milestones_presenter.steps_for(version)
-         steps.each_with_index do |(k, m), index| %>
-        <% if index.zero? %>
-          <tr style="display: none" class="last_step<%= version %>">
-            <td><span style="cursor: pointer;" onclick='$(".version<%= version %>").toggle();$(".last_step<%= version %>").toggle();'>+</span><%= version %></td>
-            <td><%= steps['accessioned'][:display] || k.titleize %></td>
-            <td><%= steps['accessioned'][:time].nil? ? 'pending' : steps['accessioned'][:time].in_time_zone.to_s %></td>
-          </tr>
-          <tr class="version<%= version %>">
-            <td colspan="3" onclick='$(".version<%= version %>").toggle();$(".last_step<%= version %>").toggle();'><span style="cursor: pointer;">-</span>
-              <%= @milestones_presenter.version_title(version) %>
-            </td>
-          </tr>
-        <% end -%>
-        <tr class="version<%= version %>">
-          <td></td>
-          <td><%= m[:display] || k.titleize %></td>
-          <td><%= m[:time].nil? ? 'pending' : m[:time].in_time_zone.to_s %></td>
-        </tr>
-      <% end %>
+    <% @milestones_presenter.each_version do |version| %>
+      <%= render VersionMilestonesComponent.new(version: version,
+                                                title: @milestones_presenter.version_title(version),
+                                                steps: @milestones_presenter.steps_for(version)) %>
     <% end %>
   </tbody>
 </table>

--- a/spec/components/version_milestones_component_spec.rb
+++ b/spec/components/version_milestones_component_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe VersionMilestonesComponent, type: :component do
+  subject(:instance) do
+    described_class.new(version: 2,
+                        title: '2 (2.0.0) Add collection, set rights to citations',
+                        steps: steps)
+  end
+
+  context 'when the accessioned milestone has display' do
+    let(:steps) do
+      { 'accessioned' => { display: 'foo',
+                           time: DateTime.parse('2020-05-12') } }
+    end
+
+    it 'renders something useful' do
+      render_inline(instance)
+      expect(page).to have_text '2 (2.0.0) Add collection, set rights to citations'
+      expect(page).to have_css '.last_step2', visible: false
+      expect(page).to have_css 'tr.version2', count: 2
+    end
+  end
+
+  context "when the accessioned milestone doesn't have display" do
+    let(:steps) do
+      { 'accessioned' => {} }
+    end
+
+    it 'renders something useful' do
+      render_inline(instance)
+      expect(page).to have_text '2 (2.0.0) Add collection, set rights to citations'
+      expect(page).to have_css '.last_step2', visible: false
+      expect(page).to have_css 'tr.version2', count: 2
+    end
+  end
+end


### PR DESCRIPTION

## Why was this change made?

This allows us to test the milestones view. It also fixes the collapse behavior which is broken in prod:
<img width="370" alt="Screen Shot 2020-05-12 at 10 53 46 AM" src="https://user-images.githubusercontent.com/92044/81717532-48e4e680-9440-11ea-8e5d-150ef3ad85fc.png">


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
no


## Does this change affect how this application integrates with other services?

no
