### PR TITLE
Enable new cops for rubocop 0.82

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,9 @@ Metrics/BlockLength:
 RSpec/MultipleExpectations:
   Enabled: false
 
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+
 Layout/SpaceAroundMethodCallOperator:
   Enabled: true
 
@@ -63,4 +66,7 @@ Style/HashTransformKeys:
   Enabled: true
 
 Style/HashTransformValues:
+  Enabled: true
+
+Style/SlicingWithRange:
   Enabled: true

--- a/app/jobs/manage_catkey_job.rb
+++ b/app/jobs/manage_catkey_job.rb
@@ -6,6 +6,7 @@ class ManageCatkeyJob < GenericJob
   queue_as :manage_catkey
 
   attr_reader :catkeys
+
   ##
   # A job that allows a user to specify a list of pids and a list of catkeys to be associated with these pids
   # @param [Integer] bulk_action_id GlobalID for a BulkAction object

--- a/app/jobs/release_object_job.rb
+++ b/app/jobs/release_object_job.rb
@@ -6,6 +6,7 @@ class ReleaseObjectJob < GenericJob
   queue_as :release_object
 
   attr_reader :manage_release
+
   ##
   # This is a shameless green approach to a job that calls release from dor
   # services app and then kicks off release WF.

--- a/app/models/view_switcher.rb
+++ b/app/models/view_switcher.rb
@@ -4,6 +4,7 @@
 # Holds structure needed to switch views between controllers
 class ViewSwitcher
   attr_reader :name, :path
+
   ##
   # @param [Symbol] name name of "view" used for switching between controllers
   # @param [Symbol] path named route path helper method

--- a/app/presenters/home_text_presenter.rb
+++ b/app/presenters/home_text_presenter.rb
@@ -14,5 +14,6 @@ class HomeTextPresenter
   private
 
   attr_reader :current_user
+
   delegate :is_admin?, :is_manager?, :is_viewer?, :permitted_apos, to: :current_user
 end

--- a/app/services/bulk_action_persister.rb
+++ b/app/services/bulk_action_persister.rb
@@ -21,6 +21,7 @@ class BulkActionPersister
   private
 
   attr_reader :bulk_action
+
   delegate :id, :file, :pids, :output_directory, :manage_release, :set_governing_apo,
            :manage_catkeys, :groups, :prepare, :create_virtual_objects, to: :bulk_action
 


### PR DESCRIPTION
## Why was this change made?

This removes a warning when you run rubocop

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

no

## Does this change affect how this application integrates with other services?
no