### PR TITLE
Document usage of eye to manage background workers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,7 +38,7 @@ Metrics/BlockLength:
   Exclude:
     - 'config/routes.rb'
     - 'spec/**/*'
-    - 'lib/tasks/*.rake'
+    - 'lib/**/*.rake'
     - 'app/jobs/create_virtual_objects_job.rb'
 
 RSpec/MultipleExpectations:

--- a/Capfile
+++ b/Capfile
@@ -27,7 +27,6 @@ install_plugin Capistrano::SCM::Git
 # require 'capistrano/rails/migrations'
 
 require 'capistrano/bundler'
-require 'capistrano/delayed_job'
 require 'capistrano/honeybadger'
 require 'capistrano/passenger'
 require 'capistrano/rails'

--- a/Gemfile
+++ b/Gemfile
@@ -110,6 +110,5 @@ end
 group :deployment do
   gem 'capistrano-passenger'
   gem 'capistrano-rails'
-  gem 'capistrano3-delayed-job', '~> 1.0'
   gem 'dlss-capistrano', '~> 3.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,9 +120,6 @@ GEM
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
     capistrano-shared_configs (0.2.2)
-    capistrano3-delayed-job (1.7.6)
-      capistrano (~> 3.0, >= 3.0.0)
-      daemons (~> 1.3)
     capybara (3.32.1)
       addressable
       mini_mime (>= 0.1.3)
@@ -658,7 +655,6 @@ DEPENDENCIES
   cancancan
   capistrano-passenger
   capistrano-rails
-  capistrano3-delayed-job (~> 1.0)
   capybara
   coderay
   config

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ bundle install
 
 Note that `bundle install` may complain if MySQL isn't installed.  You can either comment out the `mysql2` inclusion in `Gemfile` and come back to it later (you can develop using `sqlite3`), or you can install MySQL.
 
-### Install components
 ## Run the servers
 
 ```
@@ -115,6 +114,7 @@ rspec
 _Important Note: Running `rake ci` will reload fixtures for the `test` environment only._
 
 The continuous integration build can be run by:
+
 ```bash
 RAILS_ENV=test bundle exec rake ci
 ```
@@ -149,6 +149,32 @@ and in development or testing mode:
 - RSpec
 - Capybara
 - Chrome
+
+## Background Job Workers (in deployed environments)
+
+Argo uses the [eye](https://github.com/kostya/eye) gem to manage and monitor its DelayedJob-based background job workers in all deployed environments. To facilitate this, Argo defines Capistrano tasks in order to start, stop, and provide information about running workers:
+
+```
+$ cap {ENV} delayed_job:stop # stop workers in ENV environment
+$ cap {ENV} delayed_job:start # start workers in ENV environment
+$ cap {ENV} delayed_job:restart # restart workers in ENV environment
+$ cap {ENV} delayed_job:status # view status of workers in ENV environment
+```
+
+The above tasks are linked into the [Capistrano flow](https://capistranorb.com/documentation/getting-started/flow/) so that workers are started and stopped at appropriate stages of deployments and rollbacks.
+
+NOTE: If when invoking the `delayed_job:status` task, you see output like the following:
+
+```
+00:00 delayed_job:status
+      01 ./bin/eye info delayed_job
+      01 command :info, objects not found!
+      01 command :info, objects not found!
+    ✘ 01 lyberadmin@argo-qa-a.stanford.edu 0.801s
+    ✘ 01 lyberadmin@argo-qa-b.stanford.edu 0.813s
+```
+
+This means the eye daemon was shutdown and did not restart. To start it back up, invoke `cap {ENV} delayed_job:reload`. Note that this is for reloading eye, not for restarting the workers. You should not have to invoke this task with any regularity; it is for recovering from unusual circumstances only.
 
 ## Further reading
 

--- a/config/eye/delayed_job_workers.eye
+++ b/config/eye/delayed_job_workers.eye
@@ -8,11 +8,11 @@ end
 workers_count = ENV['ARGO_DELAYED_JOB_WORKER_COUNT'].to_i
 Logger.info "workers_count=#{workers_count}"
 
-Eye.application 'delayed_job' do
+Eye.application :delayed_job do
   working_dir cwd
   stop_on_delete true
 
-  group 'workers' do
+  group :workers do
     # workers can take a while to restart, especially when they've consumed a lot of memory
     start_timeout 90.seconds
     start_grace 10.seconds
@@ -28,7 +28,7 @@ Eye.application 'delayed_job' do
     # "delayed_job.0").  in that situation, this configuration will have trouble monitoring the worker (and will
     # start its own "delayed_job.0" by calling "delayed_job start 1", because it will think no workers are running).
     # as such, it's best to just use this configuration with two or more workers.
-    (0..workers_count-1).each do |i|
+    workers_count.times do |i|
       process "delayed_job.#{i}" do
         pid_file "tmp/pids/delayed_job.#{i}.pid"
         start_command "bundle exec bin/delayed_job start -i #{i}"

--- a/lib/capistrano/tasks/delayed_job.rake
+++ b/lib/capistrano/tasks/delayed_job.rake
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+namespace :delayed_job do
+  # NOTE: For below tasks, :delayed_job_workers is set by the env-specific cap
+  # configs. it won't yet be set when this task is defined though it will be by
+  # the time it's executed.
+
+  # reload the delayed_job_workers.eye config, which should monitor workers for
+  # memory consumption (restarting them individually if and when they exceed the
+  # configured threshold).
+  desc 'Quit and re-load the eye daemon that manages delayed_job workers'
+  task :reload do
+    on roles(:app) do
+      within release_path do
+        with rails_env: fetch(:rails_env), argo_delayed_job_worker_count: fetch(:delayed_job_workers) do
+          # quit first to make sure the new config is loaded
+          execute :'./bin/eye', :quit, raise_on_non_zero_exit: false
+          # avoid spaces in the command name, see http://capistranorb.com/documentation/getting-started/tasks/
+          execute :'./bin/eye', :load, :'config/eye/delayed_job_workers.eye'
+        end
+      end
+    end
+  end
+
+  desc 'Start delayed_job workers via eye'
+  task :start do
+    on roles(:app) do
+      within release_path do
+        with rails_env: fetch(:rails_env), argo_delayed_job_worker_count: fetch(:delayed_job_workers) do
+          execute :'./bin/eye', :start, :delayed_job
+        end
+      end
+    end
+  end
+
+  desc 'Stop delayed_job workers via eye'
+  task :stop do
+    on roles(:app) do
+      within release_path do
+        with rails_env: fetch(:rails_env), argo_delayed_job_worker_count: fetch(:delayed_job_workers) do
+          execute :'./bin/eye', :stop, :delayed_job
+        end
+      end
+    end
+  end
+
+  desc 'Restart delayed_job_workers via eye'
+  task :restart do
+    on roles(:app) do
+      within release_path do
+        with rails_env: fetch(:rails_env), argo_delayed_job_worker_count: fetch(:delayed_job_workers) do
+          execute :'./bin/eye', :restart, :delayed_job
+        end
+      end
+    end
+  end
+
+  desc 'Show status of delayed_job workers via eye'
+  task :status do
+    on roles(:app) do
+      within release_path do
+        with rails_env: fetch(:rails_env), argo_delayed_job_worker_count: fetch(:delayed_job_workers) do
+          execute :'./bin/eye', :info, :delayed_job, raise_on_non_zero_exit: false
+        end
+      end
+    end
+  end
+end
+
+# These hooks after used in both deployments and rollbacks
+after 'deploy:starting', 'delayed_job:reload'
+after 'deploy:started', 'delayed_job:stop'
+before 'deploy:published', 'delayed_job:start'
+before 'deploy:finished', 'delayed_job:status'
+
+# This hook is only used when a Capistrano deployment or rollback fails
+after 'deploy:failed', 'delayed_job:restart'

--- a/lib/capistrano/tasks/yarn.rake
+++ b/lib/capistrano/tasks/yarn.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+desc 'Install Javascript dependencies via `yarn`'
+task :yarn_install do
+  on roles(:web) do
+    within release_path do
+      execute("cd #{release_path} && yarn install")
+    end
+  end
+end
+
+before 'deploy:assets:precompile', 'yarn_install'


### PR DESCRIPTION
Fixes #768

## Why was this change made?

This commit better documents how Argo uses the eye gem to manage DelayedJob-based background workers. As part of this work, also:

* Stop using the capistrano3-delayed-job gem to manage delayed_job, since it does not have knowledge of eye. Instead, define our own eye-based Capistrano tasks in lib/capistrano/tasks/delayed_job.rake.
* Move custom Argo tasks to lib/capistrano/tasks/*.rake
* Use eye to start, restart, stop, and view status of delayed_job workers

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

Yes.

## Does this change affect how this application integrates with other services?

No, it does not. I tested the tasks individually, and in the usual deployment flow (both deploy and rollback scenarios), in the QA environment and everything worked flawlessly.