### PR TITLE
Remove the ability to register a workflow definition

### DIFF
--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -24,13 +24,6 @@ module RegistrationHelper
     end
   end
 
-  def valid_object_types
-    [
-      %w[Item item],
-      ['Workflow Definition', 'workflow']
-    ]
-  end
-
   def valid_content_types
     [
       'Book (ltr)',

--- a/app/javascript/registration/register.js
+++ b/app/javascript/registration/register.js
@@ -4,7 +4,6 @@ import pathTo from './pathTo'
 export default function DorRegistration(initOpts) {
   var $t = {
     defaultValues: {
-      objectType: 'item',
       projectName: '',
       apoId: 'druid:hv992ry2431',   // TODO: uber APO druid must be pulled from config, not hardcoded
       workflowId: null,
@@ -32,7 +31,6 @@ export default function DorRegistration(initOpts) {
 
     register : function(rowid, progressFunction) {
       var apo = $t.apoId;
-      var sourcePrefix = $t.metadataSource;
       progressFunction = progressFunction || function() {}
 
       // Grab list of tags from textarea, split, and reject blanks
@@ -46,11 +44,9 @@ export default function DorRegistration(initOpts) {
       data.id = rowid
 
       var params = {
-        'object_type' : $t.objectType,
         'admin_policy' : apo,
         'project' : $t.projectName,
         'workflow_id' : $('#workflow_id').val(),
-        'metadata_source' : ($t.metadataSource !== 'label') ? null : $t.metadataSource,
         'label' : data.label || ':auto',
         'tag' : tags,
         'rights' : $('#rights').val(),
@@ -61,7 +57,7 @@ export default function DorRegistration(initOpts) {
         params.source_id = data.source_id;
       }
 
-      params.other_id = sourcePrefix + ':' + data.metadata_id;
+      params.other_id = $t.metadataSource + ':' + data.metadata_id;
 
       if (data.druid) {
         params.pid = 'druid:' + data.druid;
@@ -131,8 +127,7 @@ export default function DorRegistration(initOpts) {
               return false;
           }
       }
-      var sourcePrefix = $t.metadataSource;
-      if (sourcePrefix === 'symphony') {
+      if ($t.metadataSource === 'symphony') {
         if ($.grep(mdIds,function(id) { return id.trim() === '' }).length > 0) {
           $t.displayRequirements('Metadata source was detected as "symphony", which requires metadata IDs for all items.');
           return false
@@ -158,7 +153,6 @@ export default function DorRegistration(initOpts) {
 
     registerAll : function() {
       var apo = $t.apoId;
-      var sourcePrefix = $t.metadataSource;
       if (this.validate()) {
         var ids = $t.getDataIds();
         $t.progress(true);

--- a/app/views/items/register.html.erb
+++ b/app/views/items/register.html.erb
@@ -6,33 +6,33 @@
     var dor_path = "<%= fedora_base %>";
   </script>
 <% end %>
-<div id='properties' class="ui-widget" style="display: none">
-        <div class="property-item"><label for="object_type">Type of Object</label><%= select_tag :object_type, options_for_select(valid_object_types), 'data-rcparam': 'objectType' %></div>
-        <div class="property-item"><label for='apo_id'>Admin Policy</label><%= select_tag :apo_id, options_for_select(apo_list(@perm_keys)), 'data-rcparam': 'apoId' %></div>
-        <div class="property-item"><label for='collection'>Collection</label><%= select_tag :collection, '', 'data-rcparam': 'collection' %></div>
 
-        <div class="property-item"><label for="rights">Rights</label><%= select_tag :rights, options_for_select(Constants::REGISTRATION_RIGHTS_OPTIONS), 'data-tagname': 'Process : Rights' %></div>
-        <div class="property-item"><label for='workflow_id'>Initial Workflow</label><%= select_tag :workflow_id, '', 'data-rcparam': 'workflowId' %></div>
-        <div class="property-item"><label for='content_type'>Content Type</label><%= select_tag :content_type, options_for_select(valid_content_types), class: 'tag-field', 'data-tagname': 'Process : Content Type' %></div>
-        <div class="property-item break"><label for='project'>Project Name</label><%= text_field_tag :project, nil, 'data-rcparam': 'projectName' %></div>
-        <div class="property-item wide"><label for='tag_1'>Tags</label>
-          <span id="tags" style="width: auto">
-            <%= text_field_tag :'tags[]', nil, id: 'tags_0', class: 'free tag-field' %>
-            <%= text_field_tag :'tags[]', nil, id: 'tags_1', class: 'free tag-field' %>
-            <%= text_field_tag :'tags[]', nil, id: 'tags_2', class: 'free tag-field' %>
-            <%= text_field_tag :'tags[]', nil, id: 'tags_3', class: 'free tag-field' %>
-          </span>
-          <div class="break"></div>
-          <label for='tag_4'>&nbsp;</label>
-          <span id="tags" style="width: auto">
-            <%= text_field_tag :'tags[]', nil, id: 'tags_4', class: 'free tag-field' %>
-            <%= text_field_tag :'tags[]', nil, id: 'tags_5', class: 'free tag-field' %>
-            <%= text_field_tag :'tags[]', nil, id: 'tags_6', class: 'free tag-field' %>
-            <%= text_field_tag :'tags[]', nil, id: 'tags_7', class: 'free tag-field' %>
-            <%= hidden_field_tag :registered_by, current_user.login, class: 'tag-field ', 'data-tagname': 'Registered By' %>
-          </span>
-        </div>
-        <div class="break"></div>
+<div id='properties' class="ui-widget" style="display: none">
+  <div class="property-item"><label for='apo_id'>Admin Policy</label><%= select_tag :apo_id, options_for_select(apo_list(@perm_keys)), 'data-rcparam': 'apoId' %></div>
+  <div class="property-item"><label for='collection'>Collection</label><%= select_tag :collection, '', 'data-rcparam': 'collection' %></div>
+
+  <div class="property-item"><label for="rights">Rights</label><%= select_tag :rights, options_for_select(Constants::REGISTRATION_RIGHTS_OPTIONS), 'data-tagname': 'Process : Rights' %></div>
+  <div class="property-item"><label for='workflow_id'>Initial Workflow</label><%= select_tag :workflow_id, '', 'data-rcparam': 'workflowId' %></div>
+  <div class="property-item"><label for='content_type'>Content Type</label><%= select_tag :content_type, options_for_select(valid_content_types), class: 'tag-field', 'data-tagname': 'Process : Content Type' %></div>
+  <div class="property-item break"><label for='project'>Project Name</label><%= text_field_tag :project, nil, 'data-rcparam': 'projectName' %></div>
+  <div class="property-item wide"><label for='tag_1'>Tags</label>
+    <span id="tags" style="width: auto">
+      <%= text_field_tag :'tags[]', nil, id: 'tags_0', class: 'free tag-field' %>
+      <%= text_field_tag :'tags[]', nil, id: 'tags_1', class: 'free tag-field' %>
+      <%= text_field_tag :'tags[]', nil, id: 'tags_2', class: 'free tag-field' %>
+      <%= text_field_tag :'tags[]', nil, id: 'tags_3', class: 'free tag-field' %>
+    </span>
+    <div class="break"></div>
+    <label for='tag_4'>&nbsp;</label>
+    <span id="tags" style="width: auto">
+      <%= text_field_tag :'tags[]', nil, id: 'tags_4', class: 'free tag-field' %>
+      <%= text_field_tag :'tags[]', nil, id: 'tags_5', class: 'free tag-field' %>
+      <%= text_field_tag :'tags[]', nil, id: 'tags_6', class: 'free tag-field' %>
+      <%= text_field_tag :'tags[]', nil, id: 'tags_7', class: 'free tag-field' %>
+      <%= hidden_field_tag :registered_by, current_user.login, class: 'tag-field ', 'data-tagname': 'Registered By' %>
+    </span>
+  </div>
+  <div class="break"></div>
 </div>
 
 <div id='dialogs'>

--- a/spec/controllers/dor/objects_controller_spec.rb
+++ b/spec/controllers/dor/objects_controller_spec.rb
@@ -24,11 +24,9 @@ RSpec.describe Dor::ObjectsController, type: :controller do
     context 'when source_id is not provided' do
       let(:submitted) do
         {
-          object_type: 'item',
           admin_policy: 'druid:hv992ry2431',
           collection: 'druid:hv992ry7777',
           workflow_id: 'registrationWF',
-          metadata_source: 'label',
           label: 'test parameters for registration',
           tag: ['Process : Content Type : Book (ltr)',
                 'Registered By : jcoyne85'],
@@ -48,11 +46,9 @@ RSpec.describe Dor::ObjectsController, type: :controller do
     context 'when register is successful with default rights' do
       let(:submitted) do
         {
-          object_type: 'item',
           admin_policy: 'druid:hv992ry2431',
           collection: 'druid:hv992ry7777',
           workflow_id: 'registrationWF',
-          metadata_source: 'label',
           label: 'test parameters for registration',
           tag: ['Process : Content Type : Document',
                 'Registered By : jcoyne85'],
@@ -95,11 +91,9 @@ RSpec.describe Dor::ObjectsController, type: :controller do
     context 'when register is successful with explicit rights' do
       let(:submitted) do
         {
-          object_type: 'item',
           admin_policy: 'druid:hv992ry2431',
           collection: 'druid:hv992ry7777',
           workflow_id: 'registrationWF',
-          metadata_source: 'label',
           label: 'test parameters for registration',
           tag: ['Process : Content Type : Image',
                 'Registered By : jcoyne85'],
@@ -144,11 +138,9 @@ RSpec.describe Dor::ObjectsController, type: :controller do
     context 'when register is successful with location access' do
       let(:submitted) do
         {
-          object_type: 'item',
           admin_policy: 'druid:hv992ry2431',
           collection: 'druid:hv992ry7777',
           workflow_id: 'registrationWF',
-          metadata_source: 'label',
           label: 'test parameters for registration',
           tag: ['Process : Content Type : Book (ltr)',
                 'Registered By : jcoyne85'],
@@ -193,11 +185,9 @@ RSpec.describe Dor::ObjectsController, type: :controller do
     context 'when register is successful with no-download' do
       let(:submitted) do
         {
-          object_type: 'item',
           admin_policy: 'druid:hv992ry2431',
           collection: 'druid:hv992ry7777',
           workflow_id: 'registrationWF',
-          metadata_source: 'label',
           label: 'test parameters for registration',
           tag: ['Process : Content Type : Image',
                 'Registered By : jcoyne85'],
@@ -242,11 +232,9 @@ RSpec.describe Dor::ObjectsController, type: :controller do
     context 'when register is successful with dark' do
       let(:submitted) do
         {
-          object_type: 'item',
           admin_policy: 'druid:hv992ry2431',
           collection: 'druid:hv992ry7777',
           workflow_id: 'registrationWF',
-          metadata_source: 'label',
           label: 'test parameters for registration',
           tag: ['Process : Content Type : Image',
                 'Registered By : jcoyne85'],

--- a/spec/features/item_registration_spec.rb
+++ b/spec/features/item_registration_spec.rb
@@ -63,10 +63,8 @@ RSpec.describe 'Item registration page', js: true do
     # to check the params below.
     expect(page).to have_css('span.glyphicon-exclamation-sign', visible: true)
     expect(registration_params).to include(
-      'object_type' => 'item',
       'admin_policy' => 'druid:hv992ry2431',
       'workflow_id' => 'goobiWF',
-      'metadata_source' => 'label',
       'label' => 'object title',
       'tag' => ['Process : Content Type : Book (ltr)', 'tag : test', "Registered By : #{user.sunetid}"],
       'rights' => 'default',


### PR DESCRIPTION


## Why was this change made?

We don't keep workflow definitions in Fedora
<img width="314" alt="Screen Shot 2020-05-13 at 4 27 50 PM" src="https://user-images.githubusercontent.com/92044/81867722-cc80ff00-9536-11ea-9c45-8fab388fbb35.png">



## How was this change tested?
manually on laptop


## Which documentation and/or configurations were updated?
none
