### PR TITLE
Remove unimplemented help link

### DIFF
--- a/app/controllers/bulk_jobs_controller.rb
+++ b/app/controllers/bulk_jobs_controller.rb
@@ -47,8 +47,6 @@ class BulkJobsController < ApplicationController
 
   def status_help; end
 
-  def help; end
-
   # DELETE /apos/:apo_id/bulk_jobs
   def destroy
     @apo = params[:apo_id]

--- a/app/views/bulk_jobs/help.html.erb
+++ b/app/views/bulk_jobs/help.html.erb
@@ -1,2 +1,0 @@
-<% @page_title = 'Bulk Uploads Help' %>
-  <%= render 'bulk_jobs_help' %>

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -1,14 +1,11 @@
 <div data-blacklight-modal="container">
     <div id="spreadsheet-upload-container">
   <%= form_tag(apo_uploads_path(@obj.id), multipart: true, data: { controller: 'bulk_upload' }) do %>
-        <div id="bulk-upload-form" class="container-fluid">
+    <div id="bulk-upload-form" class="container-fluid">
       <div class="row spreadsheet-row">
-    <div class="col-md-10">
-        <strong>Submit MODS descriptive metadata for bulk processing</strong>
-    </div>
-    <div class="col-md-2 spreadsheet-right">
-        <%= link_to('Help', help_apo_bulk_jobs_path(@obj.id), data: { blacklight_modal: 'trigger' }) %>
-    </div>
+        <div class="col-md-12">
+            <strong>Submit MODS descriptive metadata for bulk processing</strong>
+        </div>
       </div>
       <div class="row spreadsheet-row">
     <div class="col-md-2 spreadsheet-file-action-column"><strong>1. Select</strong></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,7 +83,6 @@ Rails.application.routes.draw do
     resources :bulk_jobs, only: :index do
       collection do
         get 'status_help'
-        get 'help'
         get ':time/log', action: :show, as: 'show'
       end
     end

--- a/spec/views/uploads/new.html.erb_spec.rb
+++ b/spec/views/uploads/new.html.erb_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe 'uploads/new.html.erb', type: :view do
     expect(rendered).to have_css('div#bulk-upload-form')
     expect(rendered).to have_css('div#spreadsheet-upload-container form div#bulk-upload-form')
     expect(rendered).to have_css('div.row.spreadsheet-row', count: 5)
-    expect(rendered).to have_link('Help', href: help_apo_bulk_jobs_path('druid:hv992ry2431'))
   end
 
   it 'has Browse, Submit and Cancel buttons' do


### PR DESCRIPTION

## Why was this change made?

Pressing this link raises an error because the partial is not found. I combed through the git history and found it here: https://github.com/sul-dlss/argo/blob/7868d89c7b24aa9aa9389308d1e707ecb5e68d01/app/views/catalog/_bulk_jobs_help

> This page not yet implemented.



## How was this change tested?

n/a

## Which documentation and/or configurations were updated?


n/a
