### PR TITLE
Revert #2008 until we can sort out #2007

### DIFF
--- a/app/javascript/packs/bulk.js
+++ b/app/javascript/packs/bulk.js
@@ -126,7 +126,7 @@ function get_druids() {
 
 // create a callback function that will request a list of druids based on the current search, but which
 // will also filter the list of druids on the list the user entered in the pids list text area, so that
-// unwanted druids can get filtered out of search results.  useful for, e.g., get_source_ids.
+// unwanted druids can get filtered out of search results.  useful for, e.g., get_source_ids and get_tags.
 function get_filtered_druid_each_callback(log) {
 	var pids_txt = fetch_pids_txt();
 	var selected_druids = (pids_txt.length > 5) ? extract_pids_list(pids_txt) : null; //in case the user entered druids on which to filter
@@ -145,6 +145,13 @@ function get_source_ids() {
 	var log = document.getElementById('source_ids');
 	var druid_each_callback = get_filtered_druid_each_callback(log);
 	var req_url = report_model['data_url']+'&source_id=true';
+	get_druids_req(log, null, druid_each_callback, null, null, req_url);
+}
+
+function get_tags() {
+	var log = document.getElementById('tags');
+	var druid_each_callback = get_filtered_druid_each_callback(log);
+	var req_url = report_model['data_url']+'&tags=true';
 	get_druids_req(log, null, druid_each_callback, null, null, req_url);
 }
 
@@ -206,7 +213,8 @@ function upd_values_for_druids(upd_req_url, upd_textarea_id, row_processing_fn, 
 	var druid_upd_rows = [];
 	for (i=0; i<druid_upd_lines.length; i++) {
 		dr = druid_upd_lines[i];
-		row_result = row_processing_fn(dr);
+    if (upd_textarea_id !== "tags") // Using this with tag strings breaks tag validation
+		  dr = dr.replace(/ : /g,':');		row_result = row_processing_fn(dr);
 		druid_upd_rows.push(row_result);
 	}
 	log.innerHTML = "Using " + druid_upd_lines.length + " " + custom_wait_msg + "<br/>\n";
@@ -247,6 +255,19 @@ function source_id() {
 	upd_values_for_druids(source_id_url, 'source_ids', row_processing_fn, "user supplied druids and source ids.", is_invalid_row_fn, "invalid source id", get_upd_req_params_from_row_fn);
 }
 
+function set_tags() {
+	var row_processing_fn = function(row_str) {
+		parts = row_str.split("\t");
+		druid = parts.shift();
+		tags = parts.join("\t");
+		row_result = {'druid': druid, 'upd_data': tags};
+		return row_result;
+	};
+	var is_invalid_row_fn = function(row_obj) { return (row_obj['upd_data']==null || row_obj['upd_data'].length<=1 || row_obj['upd_data'].indexOf(':')<1); };
+	var get_upd_req_params_from_row_fn = function(row_obj) { return { 'tags': row_obj['upd_data'] }; };
+	upd_values_for_druids(tags_url, 'tags', row_processing_fn, "user supplied druids and tags.", is_invalid_row_fn, "invalid tags", get_upd_req_params_from_row_fn);
+}
+
 Blacklight.onLoad(()=>{
   $('#get_druids').on('click', get_druids)
 	$('#paste-druids-button').on('click', () => $('#pid_list').show(400))
@@ -263,6 +284,10 @@ Blacklight.onLoad(()=>{
 	$('#apply-apo-defaults-button').on('click', () => $('#apply_apo_defaults').show(400))
 	$('#add-workflow-button').on('click', () => $('#add_workflow').show(400))
 	$('#close-versions-button').on('click', () => $('#close').show(400))
+  $('#show_tags').on('click', () => {
+		$('#tag').show(400)
+		get_tags()
+	})
 
   $('#confirm-apo-defaults-button').on('click', () => {
 		fetch_druids(apply_apo_defaults)
@@ -287,6 +312,11 @@ Blacklight.onLoad(()=>{
 	$('#confirm-refresh-metadata-button').on('click', () => {
 		fetch_druids(refresh_metadata)
 		$('#refresh_metadata').hide(400)
+	})
+
+  $('#set_tags').on('click', () => {
+		set_tags()
+		$('#tag').hide(400)
 	})
 
 	$('#set_source_id').on('click', () => {

--- a/app/views/bulk_actions/new.html.erb
+++ b/app/views/bulk_actions/new.html.erb
@@ -24,7 +24,7 @@
                       ['Manage Catkeys', 'ManageCatkeyJob'],
                       ['Prepare objects', 'PrepareJob'],
                       ['Republish objects', 'RepublishJob'],
-                      ['Update tags', 'SetTagsJob'],
+                      # ['Update tags', 'SetTagsJob'], # NOTE: temporarily commented out until argo#2007 is resolved
                       ['Close versions', 'CloseVersionJob'],
                       ['Checksum report', 'ChecksumReportJob'],
                       ['Create virtual object(s)', 'CreateVirtualObjectsJob']],
@@ -85,6 +85,7 @@
           </span>
         </div>
 
+        <!-- # NOTE: temporarily commented out until argo#2007 is resolved
         <div role='tabpanel' class='tab-pane' id='SetTagsJob'>
           <span class='help-block'>
           <p>This needs a list of pids and tags, with a tab between the pid and each tag. E.g.:<br>
@@ -92,6 +93,7 @@
           </p>
           <p>This formatting is easier to perform by using Excel or a text editor, and then copying the result to this text area.</p>          </span>
         </div>
+        -->
 
         <div role='tabpanel' class='tab-pane' id='CloseVersionJob'>
           <span class='help-block'>

--- a/app/views/report/bulk.html.erb
+++ b/app/views/report/bulk.html.erb
@@ -19,6 +19,7 @@ apo_apply_defaults_url='<%= url_for controller: :items, action: :apply_apo_defau
 add_workflow_url = '<%= item_workflows_path 'druid:xxxxxxxxx', bulk: 'true' %>'
 refresh_metadata_url='<%= refresh_metadata_item_path(id: 'druid:xxxxxxxxx', bulk: 'true') %>'
 source_id_url='<%= url_for controller: :items, action: :source_id, id: 'druid:xxxxxxxxx', bulk: 'true' %>'
+tags_url='<%= url_for controller: :items, action: :tags_bulk, id: 'druid:xxxxxxxxx', bulk: 'true' %>'
 </script>
 
 <style>
@@ -65,6 +66,12 @@ ul li{
       <div class="col-sm-2">
         <button class="bulk_button btn-block bulk-btn-danger" id="apply-apo-defaults-button">Apply APO defaults</button>
         <button class="bulk_button bulk-btn-danger btn-block" id="add-workflow-button">Add a workflow</button>
+      </div>
+    </div>
+    <strong>Options that do not require versioning</strong>
+    <div class="row bulk-buttons-row">
+      <div class="col-sm-2">
+        <button class="bulk_button btn-block" id="show_tags" name="show_tags">Tags</button>
       </div>
     </div>
   </div>
@@ -127,6 +134,16 @@ ul li{
 <div class="bulk_operation" id="refresh_metadata" name="refresh_metadata">
   <h1>Refresh metadata from the external source.</h1>
   <span class="bulk_button" id="confirm-refresh-metadata-button">Refresh metadata</span><br>
+</div>
+
+<div class="bulk_operation" id="tag">
+  <h1>Change tags</h1>
+  <p>This needs a list of pids and tags, with a tab between the pid and each tag. E.g.:<br>
+  druid:bc088fn5010&lt;tab&gt;Project : Something&lt;tab&gt;Process : Content Type : Book
+  </p>
+  <p>This formatting is easier to perform by using Excel or a text editor, and then copying the result to this text area.</p>
+  <textarea style="width:50%" id="tags" name="tags"></textarea><br>
+  <span class="bulk_button" id="set_tags" name="set_tags">Update tags</span>
 </div>
 
 <div class="bulk_operation" id="source_id">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,6 +127,7 @@ Rails.application.routes.draw do
       post 'datastream', action: :datastream_update, as: 'datastream_update'
       get 'source_id_ui'
       get 'catkey_ui'
+      match 'tags_bulk', via: %i[get post]
       get 'collection_ui'
       get 'collection/delete',   action: :remove_collection, as: 'remove_collection'
       post 'collection/add',     action: :add_collection,    as: 'add_collection'

--- a/spec/views/bulk_actions/new.html.erb_spec.rb
+++ b/spec/views/bulk_actions/new.html.erb_spec.rb
@@ -52,7 +52,8 @@ RSpec.describe 'bulk_actions/new.html.erb' do
   end
 
   describe 'Set Tags form' do
-    it 'has proper form input values' do
+    # NOTE: temporarily commented out until argo#2007 is resolved
+    xit 'has proper form input values' do
       expect(rendered).to have_css 'select option[value="SetTagsJob"]'
     end
   end


### PR DESCRIPTION
## Why was this change made?

To revert a feature change that may not have satisfied the identified requirements. In the meantime, Argo users are having trouble doing bulk tag operations. (Reverting this PR will be part of work done in #2007.)

## How was this change tested?

Tested by infrastructure-integration-tests in staging environment

## Which documentation and/or configurations were updated?

None.

