### PR TITLE
Upgrade dor-services to 9.4.0 so that agreements on APOs are replaceable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem 'rubyzip'
 # Stanford/Hydra related gems
 gem 'blacklight', '~> 6.0'
 gem 'blacklight-hierarchy', '~> 2.0'
-gem 'dor-services', '~> 9.0'
+gem 'dor-services', '~> 9.4'
 gem 'dor-services-client', '~> 6.0'
 gem 'dor-workflow-client', '~> 3.19'
 gem 'mods_display'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,7 +196,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dor-rights-auth (1.4.0)
       nokogiri
-    dor-services (9.3.0)
+    dor-services (9.4.0)
       active-fedora (>= 8.7.0, < 9)
       activesupport (~> 5.1)
       deprecation (~> 0)
@@ -663,7 +663,7 @@ DEPENDENCIES
   devise
   devise-remote-user (~> 1.0)
   dlss-capistrano (~> 3.1)
-  dor-services (~> 9.0)
+  dor-services (~> 9.4)
   dor-services-client (~> 6.0)
   dor-workflow-client (~> 3.19)
   equivalent-xml (>= 0.6.0)

--- a/spec/forms/apo_form_spec.rb
+++ b/spec/forms/apo_form_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ApoForm do
 
   context 'with a model (update)' do
     let(:instance) { described_class.new(apo) }
-    let(:agreement) { instantiate_fixture('dd327qr3670', Dor::Item) }
+    let(:agreement) { instantiate_fixture('dd327qr3670', Dor::Agreement) }
     let(:apo) { instantiate_fixture('zt570tx3016', Dor::AdminPolicyObject) }
     let(:md_info) do
       {
@@ -275,7 +275,7 @@ RSpec.describe ApoForm do
 
     describe '#save' do
       let(:apo) { instantiate_fixture('zt570tx3016', Dor::AdminPolicyObject) }
-      let(:agreement) { instantiate_fixture('dd327qr3670', Dor::Item) }
+      let(:agreement) { instantiate_fixture('dd327qr3670', Dor::Agreement) }
       let(:collection) { instantiate_fixture('pb873ty1662', Dor::Collection) }
 
       let(:base_params) do


### PR DESCRIPTION
## Why was this change made?

Fixes #2061 



## How was this change tested?

Tested on stage

## Which documentation and/or configurations were updated?

none

