### PR TITLE
Align argo layouts with the blacklight default layouts

### DIFF
--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -1,0 +1,18 @@
+<%= render 'previous_next_doc' %>
+
+<div id="document" class="<%= render_document_class %>">
+  <div id="doc_<%= @document.id.to_s.parameterize %>">
+    <div class="document">
+      <%= render_document_partials @document, blacklight_config.view_config(:show).partials, object: @obj, document_counter: 0 %>
+    </div>
+  </div>
+</div>
+
+<% if @document.respond_to?(:export_as_openurl_ctx_kev) %>
+  <!--
+       // COinS, for Zotero among others.
+       // This document_partial_name(@document) business is not quite right,
+       // but has been there for a while.
+  -->
+  <span class="Z3988" title="<%= @document.export_as_openurl_ctx_kev(document_partial_name(@document)) %>"></span>
+<% end %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -4,29 +4,5 @@
   <%= render_document_sidebar_partial %>
 </div>
 <div id="content" class="col-md-9 col-sm-8 show-document">
-  <%= render 'constraints', localized_params: session[:search] %>
-
-  <div class="pageEntriesInfo">
-    <%= item_page_entry_info %>
-  </div>
-
-  <%= render 'previous_next_doc' %>
-
-  <%# this should be in a partial -%>
-  <div id="document" class="<%= render_document_class %>">
-    <div id="doc_<%= @document.id.to_s.parameterize %>">
-      <div class="document">
-        <%= render_document_partials @document, blacklight_config.view_config(:show).partials, object: @obj, document_counter: 0 %>
-      </div>
-    </div>
-  </div>
-
-  <% if @document.respond_to?(:export_as_openurl_ctx_kev) %>
-    <!--
-         // COinS, for Zotero among others.
-         // This document_partial_name(@document) business is not quite right,
-         // but has been there for a while.
-    -->
-    <span class="Z3988" title="<%= @document.export_as_openurl_ctx_kev(document_partial_name(@document)) %>"></span>
-  <% end %>
+  <%= render_document_main_content_partial %>
 </div>

--- a/spec/views/catalog/show.html.erb_spec.rb
+++ b/spec/views/catalog/show.html.erb_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe 'catalog/show.html.erb' do
   it 'assigns page title, truncating it' do
     expect(view).to receive(:document_show_html_title).and_return(title)
     expect(view).to receive(:render_document_sidebar_partial)
-    expect(view).to receive(:item_page_entry_info)
     expect(view).to receive(:render_document_partial).twice
     expect(view).to receive(:current_search_session)
     expect(view).to receive(:should_render_field?).at_least(:once).and_return false


### PR DESCRIPTION


## Why was this change made?
This makes it easier to upgrade Blacklight, because customizations are in the expected places


## How was this change tested?

Tested locally

## Which documentation and/or configurations were updated?

n/a

