### PR TITLE
Add default tag to rights for set rights modal in item view

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -295,7 +295,7 @@ class ItemsController < ApplicationController
 
     apo_object = Dor.find(@apo)
     @form = AccessForm.new(cocina, apo_object)
-    
+
     respond_to do |format|
       format.html { render layout: !request.xhr? }
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -292,9 +292,10 @@ class ItemsController < ApplicationController
     rescue Dor::Services::Client::UnexpectedResponse
       cocina = NilModel.new(params[:id])
     end
-    @form = AccessForm.new(cocina)
-    @rights_list = rights_list_for_apo(@apo)
 
+    apo_object = Dor.find(@apo)
+    @form = AccessForm.new(cocina, apo_object)
+    
     respond_to do |format|
       format.html { render layout: !request.xhr? }
     end
@@ -346,27 +347,6 @@ class ItemsController < ApplicationController
     return if params[:bulk] && params[:tags].nil?
 
     Argo::Indexer.reindex_pid_remotely(@object.pid)
-  end
-
-  def rights_list_for_apo(apo_id)
-    return Constants::REGISTRATION_RIGHTS_OPTIONS if apo_id.blank?
-
-    apo_object = Dor.find(apo_id)
-    default_opt = apo_object.default_rights || 'citation-only'
-
-    # iterate through the default version of the rights list.  if we found a default option
-    # selection, label it in the UI text and key it as 'default' (instead of its own name).  if
-    # we didn't find a default option, we'll just return the default list of rights options with no
-    # specified selection.
-    result = []
-    Constants::REGISTRATION_RIGHTS_OPTIONS.each do |val|
-      result << if default_opt == val[1]
-                  ["#{val[0]} (APO default)", val[1]]
-                else
-                  val
-                end
-    end
-    result
   end
 
   # ---

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -352,8 +352,7 @@ class ItemsController < ApplicationController
     return Constants::REGISTRATION_RIGHTS_OPTIONS if apo_id.blank?
 
     apo_object = Dor.find(apo_id)
-    default_opt = apo_object.default_rights
-    default_opt = 'citation-only' if default_opt == 'none'
+    default_opt = apo_object.default_rights || 'citation-only'
 
     # iterate through the default version of the rights list.  if we found a default option
     # selection, label it in the UI text and key it as 'default' (instead of its own name).  if

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -293,6 +293,7 @@ class ItemsController < ApplicationController
       cocina = NilModel.new(params[:id])
     end
     @form = AccessForm.new(cocina)
+    @rights_list = rights_list_for_apo(@apo)
 
     respond_to do |format|
       format.html { render layout: !request.xhr? }
@@ -345,6 +346,28 @@ class ItemsController < ApplicationController
     return if params[:bulk] && params[:tags].nil?
 
     Argo::Indexer.reindex_pid_remotely(@object.pid)
+  end
+
+  def rights_list_for_apo(apo_id)
+    return Constants::REGISTRATION_RIGHTS_OPTIONS if apo_id.blank?
+
+    apo_object = Dor.find(apo_id)
+    default_opt = apo_object.default_rights
+    default_opt = 'citation-only' if default_opt == 'none'
+
+    # iterate through the default version of the rights list.  if we found a default option
+    # selection, label it in the UI text and key it as 'default' (instead of its own name).  if
+    # we didn't find a default option, we'll just return the default list of rights options with no
+    # specified selection.
+    result = []
+    Constants::REGISTRATION_RIGHTS_OPTIONS.each do |val|
+      result << if default_opt == val[1]
+                  ["#{val[0]} (APO default)", val[1]]
+                else
+                  val
+                end
+    end
+    result
   end
 
   # ---

--- a/app/forms/access_form.rb
+++ b/app/forms/access_form.rb
@@ -5,12 +5,17 @@ class AccessForm
   extend ActiveModel::Naming
 
   # @param [Cocina::Models::DRO]
-  def initialize(model)
+  def initialize(model, apo)
     @model = model
+    @apo = apo
   end
 
   def rights
     @rights ||= derive_rights_from_cocina
+  end
+
+  def rights_list
+    @rights_list ||= rights_list_for_apo
   end
 
   private
@@ -26,5 +31,23 @@ class AccessForm
 
     rights += '-nd' if @model.access.download == 'none' && !%w[citation-only dark].include?(@model.access.access)
     rights
+  end
+
+  def rights_list_for_apo
+    default_opt = @apo.default_rights || 'citation-only'
+
+    # iterate through the default version of the rights list.  if we found a default option
+    # selection, label it in the UI text and key it as 'default' (instead of its own name).  if
+    # we didn't find a default option, we'll just return the default list of rights options with no
+    # specified selection.
+    result = []
+    Constants::REGISTRATION_RIGHTS_OPTIONS.each do |val|
+      result << if default_opt == val[1]
+                  ["#{val[0]} (APO default)", val[1]]
+                else
+                  val
+                end
+    end
+    result
   end
 end

--- a/app/views/items/_rights.html.erb
+++ b/app/views/items/_rights.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: @form, url: url_for(controller: :items, action: :set_rights, id: @object.pid) do |f| %>
   <div class='form-group'>
-    <%= f.select :rights, Constants::DEFAULT_RIGHTS_OPTIONS, {}, class: 'form-control' %>
+    <%= f.select :rights, @rights_list, {}, class: 'form-control' %>
   </div>
   <button class='btn btn-primary'>Update</button>
 <% end %>

--- a/app/views/items/_rights.html.erb
+++ b/app/views/items/_rights.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: @form, url: url_for(controller: :items, action: :set_rights, id: @object.pid) do |f| %>
   <div class='form-group'>
-    <%= f.select :rights, @rights_list, {}, class: 'form-control' %>
+    <%= f.select :rights, f.object.rights_list, {}, class: 'form-control' %>
   </div>
   <button class='btn btn-primary'>Update</button>
 <% end %>

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ItemsController, type: :controller do
     allow(idmd).to receive(:"content_will_change!")
     allow(idmd).to receive(:ng_xml).and_return idmd_ng_xml
     allow(idmd).to receive(:"content=").with(idmd_ds_content)
-    allow(apo).to receive(:pid).and_return('druid:apo')
+    allow(apo).to receive(:pid).and_return('')
     allow(item).to receive_messages(save: nil, delete: nil,
                                     identityMetadata: idmd,
                                     datastreams: { 'identityMetadata' => idmd, 'events' => Dor::EventsDS.new },
@@ -217,6 +217,20 @@ RSpec.describe ItemsController, type: :controller do
     it 'sets an item to dark' do
       expect(item).to receive(:read_rights=).with('dark')
       get 'set_rights', params: { id: pid, access_form: { rights: 'dark' } }
+    end
+  end
+
+  describe '#rights' do
+    before do
+      allow(Dor::Services::Client).to receive(:object).with(pid).and_return(object_client)
+    end
+
+    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina) }
+    let(:cocina) { instance_double(Cocina::Models::DRO, version: 1) }
+
+    it 'renders the modal with rights selector' do
+      get :rights, params: { id: pid }
+      expect(response).to have_http_status(:ok)
     end
   end
 

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -8,13 +8,12 @@ RSpec.describe ItemsController, type: :controller do
     sign_in user
     allow(Dor).to receive(:find).with(pid).and_return(item)
     idmd = double
-    apo  = double
     idmd_ds_content = '<test-xml/>'
     idmd_ng_xml = instance_double(Nokogiri::XML::Document, to_xml: idmd_ds_content)
     allow(idmd).to receive(:"content_will_change!")
     allow(idmd).to receive(:ng_xml).and_return idmd_ng_xml
     allow(idmd).to receive(:"content=").with(idmd_ds_content)
-    allow(apo).to receive(:pid).and_return('')
+    allow(apo).to receive(:pid).and_return('druid:zt570tx3016')
     allow(item).to receive_messages(save: nil, delete: nil,
                                     identityMetadata: idmd,
                                     datastreams: { 'identityMetadata' => idmd, 'events' => Dor::EventsDS.new },
@@ -29,6 +28,7 @@ RSpec.describe ItemsController, type: :controller do
   let(:item) { Dor::Item.new pid: pid }
   let(:user) { create(:user) }
   let(:state_service) { instance_double(StateService, allows_modification?: true) }
+  let(:apo) { instantiate_fixture('zt570tx3016', Dor::AdminPolicyObject) }
 
   describe '#purl_preview' do
     before do
@@ -223,6 +223,7 @@ RSpec.describe ItemsController, type: :controller do
   describe '#rights' do
     before do
       allow(Dor::Services::Client).to receive(:object).with(pid).and_return(object_client)
+      allow(Dor).to receive(:find).with(apo.pid).and_return(apo)
     end
 
     let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina) }

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -223,15 +223,55 @@ RSpec.describe ItemsController, type: :controller do
   describe '#rights' do
     before do
       allow(Dor::Services::Client).to receive(:object).with(pid).and_return(object_client)
-      allow(Dor).to receive(:find).with(apo.pid).and_return(apo)
     end
 
     let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina) }
     let(:cocina) { instance_double(Cocina::Models::DRO, version: 1) }
 
-    it 'renders the modal with rights selector' do
-      get :rights, params: { id: pid }
-      expect(response).to have_http_status(:ok)
+    context 'without an assigned apo' do
+      before do
+        get :rights, params: { id: pid }
+      end
+
+      let(:apo) { nil }
+
+      it 'returns the rights list constant' do
+        expect(assigns(:rights_list)).to eq(Constants::REGISTRATION_RIGHTS_OPTIONS)
+      end
+
+      it 'renders the modal' do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'with an assigned apo' do
+      before do
+        allow(Dor).to receive(:find).with(apo.pid).and_return(apo)
+        get :rights, params: { id: pid }
+      end
+
+      let(:rights_with_default) {
+        [["World (APO default)", "world"],
+         ["World (no-download)", "world-nd"],
+         ["Stanford", "stanford"],
+         ["Stanford (no-download)", "stanford-nd"],
+         ["Location: Special Collections", "loc:spec"],
+         ["Location: Music Library", "loc:music"],
+         ["Location: Archive of Recorded Sound", "loc:ars"],
+         ["Location: Art Library", "loc:art"], 
+         ["Location: Hoover Library", "loc:hoover"],
+         ["Location: Media & Microtext", "loc:m&m"],
+         ["Dark (Preserve Only)", "dark"],
+         ["Citation Only", "citation-only"]]
+      }
+
+      it 'updates the rights_list with (APO default)' do
+        expect(assigns(:rights_list)).to eq(rights_with_default)
+      end
+
+      it 'renders the modal' do
+        expect(response).to have_http_status(:ok)
+      end
     end
   end
 

--- a/spec/forms/access_form_spec.rb
+++ b/spec/forms/access_form_spec.rb
@@ -49,20 +49,20 @@ RSpec.describe AccessForm do
   end
 
   describe '#rights_list' do
-    let(:rights_with_default) {
+    let(:rights_with_default) do
       [['World (APO default)', 'world'],
-      ['World (no-download)', 'world-nd'],
-      ['Stanford', 'stanford'],
-      ['Stanford (no-download)', 'stanford-nd'],
-      ['Location: Special Collections', 'loc:spec'],
-      ['Location: Music Library', 'loc:music'],
-      ['Location: Archive of Recorded Sound', 'loc:ars'],
-      ['Location: Art Library', 'loc:art'], 
-      ['Location: Hoover Library', 'loc:hoover'],
-      ['Location: Media & Microtext', 'loc:m&m'],
-      ['Dark (Preserve Only)', 'dark'],
-      ['Citation Only', 'citation-only']]
-    }
+       ['World (no-download)', 'world-nd'],
+       %w[Stanford stanford],
+       ['Stanford (no-download)', 'stanford-nd'],
+       ['Location: Special Collections', 'loc:spec'],
+       ['Location: Music Library', 'loc:music'],
+       ['Location: Archive of Recorded Sound', 'loc:ars'],
+       ['Location: Art Library', 'loc:art'],
+       ['Location: Hoover Library', 'loc:hoover'],
+       ['Location: Media & Microtext', 'loc:m&m'],
+       ['Dark (Preserve Only)', 'dark'],
+       ['Citation Only', 'citation-only']]
+    end
 
     it 'displays the rights list with (APO default)' do
       expect(instance.rights_list).to eq(rights_with_default)

--- a/spec/forms/access_form_spec.rb
+++ b/spec/forms/access_form_spec.rb
@@ -3,8 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe AccessForm do
-  let(:instance) { described_class.new(model) }
+  let(:instance) { described_class.new(model, apo) }
   let(:model) { instance_double(Cocina::Models::DRO, access: cocina_access) }
+  let(:apo) { instantiate_fixture('zt570tx3016', Dor::AdminPolicyObject) }
   let(:cocina_access) do
     instance_double(Cocina::Models::Access, access: access, download: download, readLocation: read_location)
   end
@@ -44,6 +45,27 @@ RSpec.describe AccessForm do
       let(:download) { 'none' }
 
       it { is_expected.to eq 'dark' }
+    end
+  end
+
+  describe '#rights_list' do
+    let(:rights_with_default) {
+      [['World (APO default)', 'world'],
+      ['World (no-download)', 'world-nd'],
+      ['Stanford', 'stanford'],
+      ['Stanford (no-download)', 'stanford-nd'],
+      ['Location: Special Collections', 'loc:spec'],
+      ['Location: Music Library', 'loc:music'],
+      ['Location: Archive of Recorded Sound', 'loc:ars'],
+      ['Location: Art Library', 'loc:art'], 
+      ['Location: Hoover Library', 'loc:hoover'],
+      ['Location: Media & Microtext', 'loc:m&m'],
+      ['Dark (Preserve Only)', 'dark'],
+      ['Citation Only', 'citation-only']]
+    }
+
+    it 'displays the rights list with (APO default)' do
+      expect(instance.rights_list).to eq(rights_with_default)
     end
   end
 end

--- a/spec/views/items/_rights.html.erb_spec.rb
+++ b/spec/views/items/_rights.html.erb_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe 'items/_rights.html.erb' do
   before do
     @object = instance_double(Dor::Item, pid: 'druid:abc123')
+    @rights_list = Constants::REGISTRATION_RIGHTS_OPTIONS
     @form = instance_double(AccessForm, model_name: instance_double(ActiveModel::Name, param_key: 'pid'))
     render
   end

--- a/spec/views/items/_rights.html.erb_spec.rb
+++ b/spec/views/items/_rights.html.erb_spec.rb
@@ -5,8 +5,7 @@ require 'rails_helper'
 RSpec.describe 'items/_rights.html.erb' do
   before do
     @object = instance_double(Dor::Item, pid: 'druid:abc123')
-    @rights_list = Constants::REGISTRATION_RIGHTS_OPTIONS
-    @form = instance_double(AccessForm, model_name: instance_double(ActiveModel::Name, param_key: 'pid'))
+    @form = instance_double(AccessForm, model_name: instance_double(ActiveModel::Name, param_key: 'pid'), rights_list: Constants::REGISTRATION_RIGHTS_OPTIONS)
     render
   end
 


### PR DESCRIPTION
## Why was this change made?

Fixes #446 

This adds "(APO default)" to the proper rights selection in the modal for setting the rights on an item. If no APO is present, it leaves the list untouched.

Before:
<img width="895" alt="Screen Shot 2020-05-28 at 10 04 12 AM" src="https://user-images.githubusercontent.com/2294288/83171225-a4fb6c00-a0ca-11ea-9a29-3267616ad42d.png">

After:

<img width="913" alt="Screen Shot 2020-05-28 at 9 50 48 AM" src="https://user-images.githubusercontent.com/2294288/83170200-06224000-a0c9-11ea-8844-24346f0e3f62.png">

## How was this change tested?

Unit test.

## Which documentation and/or configurations were updated?

N/A

