### PR TITLE
Properly close div tag to prevent unintended blue background

### DIFF
--- a/app/views/items/_collection_ui.html.erb
+++ b/app/views/items/_collection_ui.html.erb
@@ -1,4 +1,4 @@
-<div id='collection_message' class='alert-info' />
+<div id='collection_message' class='alert-info'></div>
 
 <div class='panel panel-default'>
   <div class='panel-heading'>


### PR DESCRIPTION

## Why was this change made?

An unintended blue stripe is displayed:
<img width="895" alt="Screen Shot 2020-06-01 at 12 08 33 PM" src="https://user-images.githubusercontent.com/92044/83434967-0f7d1680-a401-11ea-8d2a-75471d968dc9.png">

Fixes #2081 

## How was this change tested?

Tested locally

## Which documentation and/or configurations were updated?
none


