### PR TITLE
Do not display the edit xml link for datastreams that should not be editable

### DIFF
--- a/app/views/catalog/ds.html.erb
+++ b/app/views/catalog/ds.html.erb
@@ -21,9 +21,7 @@
         # If the user is a repo admin or is permitted to manage both content and
         # rights, display raw xml editing
     %>
-      <%= if can?(:manage_item, @obj) &&
-             @obj.datastreams[params[:dsid]].respond_to?(:ng_xml) &&
-             Settings.editable_datastreams.include?(params[:dsid])
+      <%= if can?(:manage_item, @obj) && Settings.editable_datastreams.include?(params[:dsid])
             link_to "Edit #{params[:dsid]}", ds_solr_document_path(params[:id], params[:dsid], edit: 'true'), title: params[:dsid], data: { blacklight_modal: 'preserve' }
         end %>
     <% content = if params[:dsid] == 'full_dc'

--- a/app/views/catalog/ds.html.erb
+++ b/app/views/catalog/ds.html.erb
@@ -22,10 +22,7 @@
         # rights, display raw xml editing
     %>
       <%= if can?(:manage_item, @obj) &&
-             (
-               @obj.datastreams[params[:dsid]].respond_to?(:ng_xml) ||
-               params[:dsid] == 'RELS-EXT'
-             ) &&
+             @obj.datastreams[params[:dsid]].respond_to?(:ng_xml) &&
              Settings.editable_datastreams.include?(params[:dsid])
             link_to "Edit #{params[:dsid]}", ds_solr_document_path(params[:id], params[:dsid], edit: 'true'), title: params[:dsid], data: { blacklight_modal: 'preserve' }
         end %>

--- a/app/views/catalog/ds.html.erb
+++ b/app/views/catalog/ds.html.erb
@@ -21,9 +21,9 @@
         # If the user is a repo admin or is permitted to manage both content and
         # rights, display raw xml editing
     %>
-      <%= if can?(:manage_item, @obj) && Settings.editable_datastreams.include?(params[:dsid])
-            link_to "Edit #{params[:dsid]}", ds_solr_document_path(params[:id], params[:dsid], edit: 'true'), title: params[:dsid], data: { blacklight_modal: 'preserve' }
-        end %>
+      <% if can?(:manage_item, @obj) && Settings.editable_datastreams.include?(params[:dsid]) %>
+        <%= link_to "Edit #{params[:dsid]}", ds_solr_document_path(params[:id], params[:dsid], edit: 'true'), title: params[:dsid], data: { blacklight_modal: 'preserve' } %>
+      <% end %>
     <% content = if params[:dsid] == 'full_dc'
                    Nokogiri::XML(Dor::Services::Client.object(@obj.pid).metadata.dublin_core).prettify
                  elsif @obj.datastreams[params[:dsid]].respond_to? :ng_xml

--- a/app/views/catalog/ds.html.erb
+++ b/app/views/catalog/ds.html.erb
@@ -26,7 +26,6 @@
                @obj.datastreams[params[:dsid]].respond_to?(:ng_xml) ||
                params[:dsid] == 'RELS-EXT'
              ) &&
-             params[:dsid] != 'workflows' &&
              Settings.editable_datastreams.include?(params[:dsid])
             link_to "Edit #{params[:dsid]}", ds_solr_document_path(params[:id], params[:dsid], edit: 'true'), title: params[:dsid], data: { blacklight_modal: 'preserve' }
         end %>

--- a/app/views/catalog/ds.html.erb
+++ b/app/views/catalog/ds.html.erb
@@ -26,7 +26,8 @@
                @obj.datastreams[params[:dsid]].respond_to?(:ng_xml) ||
                params[:dsid] == 'RELS-EXT'
              ) &&
-             params[:dsid] != 'workflows'
+             params[:dsid] != 'workflows' &&
+             Settings.editable_datastreams.include?(params[:dsid])
             link_to "Edit #{params[:dsid]}", ds_solr_document_path(params[:id], params[:dsid], edit: 'true'), title: params[:dsid], data: { blacklight_modal: 'preserve' }
         end %>
     <% content = if params[:dsid] == 'full_dc'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -106,3 +106,11 @@ tech_md_service:
   url: 'http://localhost:3005'
   # To generate the token: docker-compose run techmd rake generate_token
   token: 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhcmdvLXRlc3QifQ.nhJQsj8V98agZxzDP2OSCVPkIb70yE9_dyLUiTzcKko'
+
+editable_datastreams:
+  - RELS-EXT
+  - descMetadata
+  - identityMetadata
+  - contentMetadata
+  - versionMetadata
+  - rightsMetadata

--- a/spec/views/catalog/ds.html.erb_spec.rb
+++ b/spec/views/catalog/ds.html.erb_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'catalog/ds.html.erb' do
-  let(:stub_ds) { instance_double(Dor::IdentityMetadataDS, content: '<xml />', ng_xml: true) }
+  let(:stub_ds) { instance_double(Dor::IdentityMetadataDS, content: '<xml />') }
 
   before do
     params[:dsid] = dsid

--- a/spec/views/catalog/ds.html.erb_spec.rb
+++ b/spec/views/catalog/ds.html.erb_spec.rb
@@ -3,19 +3,35 @@
 require 'rails_helper'
 
 RSpec.describe 'catalog/ds.html.erb' do
-  let(:dsid) { 'identityMetadata' }
-  let(:stub_ds) { instance_double(Dor::IdentityMetadataDS, content: '<xml />') }
+  let(:stub_ds) { instance_double(Dor::IdentityMetadataDS, content: '<xml />', ng_xml: true) }
 
   before do
     params[:dsid] = dsid
+    params[:id] = 'druid:abc123'
     allow(view).to receive(:can?).and_return(true)
     allow(view).to receive(:render_ds_profile_header)
     @obj = instance_double(Dor::Item, datastreams: { dsid => stub_ds })
   end
 
-  it 'renders the modal' do
-    render
-    expect(rendered).to have_css '.modal-header h3.modal-title'
-    expect(rendered).to have_css '.modal-body', text: '<xml/>'
+  context 'with an editable datastream' do
+    let(:dsid) { 'identityMetadata' }
+
+    it 'renders the modal with edit link' do
+      render
+      expect(rendered).to have_css '.modal-header h3.modal-title'
+      expect(rendered).to have_css '.modal-body'
+      expect(rendered).to include 'Edit identityMetadata'
+    end
+  end
+
+  context 'with an non-editable datastream' do
+    let(:dsid) { 'fakeMetadata' }
+
+    it 'renders the modal without the edit link' do
+      render
+      expect(rendered).to have_css '.modal-header h3.modal-title'
+      expect(rendered).to have_css '.modal-body'
+      expect(rendered).not_to include 'Edit fakeMetadata'
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Fixes #1913 

When included in the settings as editable:

<img width="316" alt="Screen Shot 2020-06-03 at 3 05 48 PM" src="https://user-images.githubusercontent.com/2294288/83693874-c9b08180-a5ab-11ea-9a43-18e6d97e209c.png">

When not included in the settings as editable:

<img width="323" alt="Screen Shot 2020-06-03 at 3 06 11 PM" src="https://user-images.githubusercontent.com/2294288/83693875-cc12db80-a5ab-11ea-9651-cbe851265953.png">


## How was this change tested?

Unit test

## Which documentation and/or configurations were updated?

config/settings.yml updated (no need to update shared_configs)
