### PR TITLE
Stop using deprecated model method #agreement

### DIFF
--- a/app/forms/apo_form.rb
+++ b/app/forms/apo_form.rb
@@ -39,7 +39,7 @@ class ApoForm < BaseForm
     model.mods_title           = params[:title]
     model.desc_metadata_format = params[:desc_md]
     model.metadata_source      = params[:metadata_source]
-    model.agreement            = params[:agreement]
+    model.agreement_object_id  = params[:agreement]
 
     model.default_workflow     = params[:workflow]
     model.default_rights       = params[:default_object_rights]
@@ -65,7 +65,7 @@ class ApoForm < BaseForm
     model.administrativeMetadata.ng_xml.xpath('//registration/workflow/@id').to_s
   end
 
-  delegate :use_license, :agreement, :use_statement, :copyright_statement,
+  delegate :use_license, :agreement_object_id, :use_statement, :copyright_statement,
            :default_rights, :mods_title, to: :model
 
   def desc_metadata_format

--- a/app/views/apo/_form.html.erb
+++ b/app/views/apo/_form.html.erb
@@ -8,7 +8,7 @@
 
   <div class="form-group">
     <label>Agreement</label><br>
-    <%= select_tag :agreement, options_for_select(agreement_options, @form.agreement) %>
+    <%= select_tag :agreement, options_for_select(agreement_options, @form.agreement_object_id) %>
   </div>
 
   <div class="form-group">

--- a/spec/forms/apo_form_spec.rb
+++ b/spec/forms/apo_form_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe ApoForm do
 
     before do
       allow(apo).to receive(:new_record?).and_return(false) # instantiate_fixture creates unsaved objects
-      allow(Dor).to receive(:find).with(agreement.pid, cast: true).and_return(agreement)
     end
 
     describe '#sync' do
@@ -42,7 +41,7 @@ RSpec.describe ApoForm do
         expect(apo.mods_title).to           eq(md_info[:title])
         expect(apo.desc_metadata_format).to eq(md_info[:desc_md])
         expect(apo.metadata_source).to      eq(md_info[:metadata_source])
-        expect(apo.agreement).to            eq(md_info[:agreement])
+        expect(apo.agreement_object_id).to  eq(md_info[:agreement])
         expect(apo.default_workflows).to    eq([md_info[:workflow]])
         expect(apo.default_rights).to       eq(md_info[:default_object_rights])
         expect(apo.use_license).to          eq(md_info[:use_license])
@@ -117,8 +116,8 @@ RSpec.describe ApoForm do
       it { is_expected.to eq 'digitizationWF' }
     end
 
-    describe '#agreement' do
-      subject { instance.agreement }
+    describe '#agreement_object_id' do
+      subject { instance.agreement_object_id }
 
       it { is_expected.to eq agreement.pid }
     end
@@ -332,7 +331,6 @@ RSpec.describe ApoForm do
 
       before do
         allow(Dor::Workflow::Client).to receive(:new).and_return(workflow_client)
-        expect(Dor).to receive(:find).with(agreement.pid, cast: true).and_return(agreement)
         expect(Dor).to receive(:find).with(collection.pid).and_return(collection)
         expect(collection).to receive(:save)
         expect(Argo::Indexer).to receive(:reindex_pid_remotely).twice


### PR DESCRIPTION
Use #agreement_object_id instead

## Why was this change made?

Avoids a deprecation warning. Futureproofs the code

## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?
n/a


