### PR TITLE
Get verison info from the source

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -55,7 +55,7 @@ Metrics/AbcSize:
 # Offense count: 6
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 219
+  Max: 220
 
 # Offense count: 7
 # Configuration parameters: IgnoredMethods.

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -201,7 +201,9 @@ class CatalogController < ApplicationController
     @events = object_client.events.list
 
     milestones = MilestoneService.milestones_for(druid: params[:id])
-    @milestones_presenter = MilestonesPresenter.new(milestones: milestones, versions: @document.versions)
+    versions = VersionService.list(resource: @obj)
+
+    @milestones_presenter = MilestonesPresenter.new(milestones: milestones, versions: versions)
 
     @buttons_presenter = ButtonsPresenter.new(
       ability: current_ability,

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -58,8 +58,6 @@ class SolrDocument
     format: 'sw_format_ssim'
   )
 
-  attribute :versions, Blacklight::Types::Array, 'versions_ssm'
-
   def embargoed?
     embargo_status == 'embargoed'
   end

--- a/app/presenters/milestones_presenter.rb
+++ b/app/presenters/milestones_presenter.rb
@@ -2,6 +2,8 @@
 
 # Displays milestones for each of the versions for an object
 class MilestonesPresenter
+  # @param [Hash<String,Hash>] milestones the milestone data
+  # @param [Hash<Integer,Hash>] versions the version tag data
   def initialize(milestones:, versions:)
     @milestones = milestones
     @versions = versions
@@ -16,20 +18,13 @@ class MilestonesPresenter
   end
 
   def version_title(version)
-    version_hash[version] ? "#{version} (#{version_hash[version][:tag]}) #{version_hash[version][:desc]}" : version
+    val = versions[version.to_i]
+    return version unless val
+
+    "#{version} (#{val[:tag]}) #{val[:desc]}"
   end
 
   private
 
   attr_reader :milestones, :versions
-
-  def version_hash
-    @version_hash ||= versions&.each_with_object({}) do |rec, obj|
-      (version, tag, desc) = rec.split(';')
-      obj[version] = {
-        tag: tag,
-        desc: desc
-      }
-    end
-  end
 end

--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -14,6 +14,18 @@ class VersionService
     def openable?(identifier:)
       new(identifier: identifier).openable?
     end
+
+    def list(resource:)
+      return {} unless resource.respond_to?(:versionMetadata)
+
+      # add an entry with version id, tag and description for each version
+      (1..resource.current_version.to_i).each_with_object({}) do |current_version_num, obj|
+        obj[current_version_num] = {
+          tag: resource.versionMetadata.tag_for_version(current_version_num.to_s),
+          desc: resource.versionMetadata.description_for_version(current_version_num.to_s)
+        }
+      end
+    end
   end
 
   attr_reader :identifier

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -140,17 +140,6 @@ RSpec.describe SolrDocument, type: :model do
     end
   end
 
-  describe '#versions' do
-    subject(:versions) { document.versions }
-
-    let(:data) { ['1;1.0.0;Initial version', '2;1.1.0;Minor change'] }
-    let(:document) { described_class.new('versions_ssm' => data) }
-
-    it 'is a list of versions' do
-      expect(versions).to eq data
-    end
-  end
-
   describe '#druid' do
     let(:document_attributes) { { id: 'druid:abc123456' } }
 

--- a/spec/presenters/milestones_presenter_spec.rb
+++ b/spec/presenters/milestones_presenter_spec.rb
@@ -28,7 +28,10 @@ RSpec.describe MilestonesPresenter do
       'accessioned' => { time: '2020-05-01 19:26:37 +0000' }
     }, '2' => milestone2 }
   end
-  let(:versions) { ['1;1.0.0;Initial version', '2;1.1.0;Minor change'] }
+
+  let(:versions) do
+    { 1 => { tag: '1.0.0', desc: 'Initial version' }, 2 => { tag: '1.1.0', desc: 'Minor change' } }
+  end
 
   describe '#each_version' do
     let(:actual_versions) do

--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -19,6 +19,23 @@ RSpec.describe VersionService do
     end
   end
 
+  describe '.list' do
+    subject(:versions) { described_class.list(resource: resource) }
+
+    let(:resource) { Dor::Item.new }
+
+    before do
+      allow(resource.versionMetadata).to receive(:tag_for_version).and_return('1.0.0', '1.1.0')
+      allow(resource.versionMetadata).to receive(:description_for_version)
+        .and_return('Initial version', 'Minor change')
+      allow(resource).to receive(:current_version).and_return('2')
+    end
+
+    it 'is a list of versions' do
+      expect(versions).to eq(1 => { tag: '1.0.0', desc: 'Initial version' }, 2 => { tag: '1.1.0', desc: 'Minor change' })
+    end
+  end
+
   describe '#new' do
     it 'has an identifier attribute' do
       expect(service.identifier).to eq(identifier)


### PR DESCRIPTION
So we don't have to have this in dor-indexing-app (inflating the index).  Adapted from https://github.com/sul-dlss/argo/pull/1341

## Why was this change made?

Extracted from https://github.com/sul-dlss/argo/pull/1341/files so that can be closed.


## How was this change tested?



## Which documentation and/or configurations were updated?



