### PR TITLE
Draw datastreams without depending on ds_specs_ssim

### DIFF
--- a/app/components/datastream_row.rb
+++ b/app/components/datastream_row.rb
@@ -2,40 +2,38 @@
 
 # Draws a row for a datastream
 class DatastreamRow < ApplicationComponent
-  # @param [SolrDocument] document the Solr document model for the item
-  # @param [Hash] attributes the datastream attributes
-  def initialize(document:, attributes:)
-    @document = document
-    @specs = attributes
+  with_collection_parameter :datastream
+
+  # @param [ActiveFedora::Datastream] datastream
+  def initialize(datastream:)
+    @datastream = datastream
   end
 
-  attr_reader :document, :specs
+  attr_reader :datastream
+
+  delegate :label, :dsid, :pid, to: :datastream
 
   # Datastream helpers
   CONTROL_GROUP_TEXT = { 'X' => 'inline', 'M' => 'managed', 'R' => 'redirect', 'E' => 'external' }.freeze
 
   def control_group
-    cg = specs.fetch(:control_group, 'X')
-    "#{cg}/#{CONTROL_GROUP_TEXT[cg]}"
+    "#{datastream.controlGroup}/#{CONTROL_GROUP_TEXT[datastream.controlGroup]}"
   end
 
   def link_to_identifier
-    link_to specs[:dsid], ds_solr_document_path(document, specs[:dsid]), title: specs[:dsid], data: { blacklight_modal: 'trigger' }
-  end
-
-  def mime_type
-    specs[:mime_type]
-  end
-
-  def version
-    "v#{specs[:version]}"
+    link_to dsid, ds_solr_document_path(pid, dsid), title: dsid, data: { blacklight_modal: 'trigger' }
   end
 
   def size
-    number_to_human_size(specs[:size])
+    number_to_human_size(datastream.size)
   end
 
-  def label
-    specs[:label]
+  def mime_type
+    datastream.mimeType
+  end
+
+  def version
+    v = datastream.versionID.nil? ? '0' : datastream.versionID.to_s.split(/\./).last
+    "v#{v}"
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -85,16 +85,6 @@ class SolrDocument
     catkey&.delete_prefix('catkey:')
   end
 
-  # These values are used to drive the display for the datastream table on the item show page
-  # This method is now excluding the workflows datastream because this datastream is deprecated.
-  # @return[Array<Hash>] the deserialized datastream attributes
-  def datastreams
-    specs = fetch('ds_specs_ssim', []).map do |spec_string|
-      Hash[%i[dsid control_group mime_type version size label].zip(spec_string.split(/\|/))]
-    end
-    specs.filter { |spec| spec[:dsid] != 'workflows' }
-  end
-
   ##
   # Access a SolrDocument's druid parsed from the id format of 'druid:abc123'
   # @return [String]

--- a/app/views/catalog/_datastreams_default.html.erb
+++ b/app/views/catalog/_datastreams_default.html.erb
@@ -4,8 +4,6 @@
 </h3>
 <div id="document-datastreams-section" class="document-section">
   <table class="detail">
-    <% document.datastreams.each do |attributes| %>
-      <%= render DatastreamRow.new(document: document, attributes: attributes) %>
-    <% end %>
+    <%= render DatastreamRow.with_collection(object.datastreams.values.reject(&:new?)) %>
   </table>
 </div>

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -90,56 +90,6 @@ RSpec.describe SolrDocument, type: :model do
     end
   end
 
-  describe '#datastreams' do
-    subject(:datastreams) { document.datastreams }
-
-    let(:document_attributes) do
-      { 'ds_specs_ssim' => [
-        'DC|X|text/xml|0|475|Dublin Core Record for this object',
-        'RELS-EXT|X|application/rdf+xml|0|821|Fedora Object-to-Object Relationship Metadata',
-        'identityMetadata|M|text/xml|0|635|Identity Metadata',
-        'rightsMetadata|M|text/xml|4|652|Rights metadata',
-        'descMetadata|M|text/xml|3|5988|Descriptive Metadata',
-        'workflows|E|application/xml|0|10780|Workflows'
-      ] }
-    end
-
-    it 'excludes workflows' do
-      expect(datastreams).to eq [
-        { control_group: 'X',
-          dsid: 'DC',
-          label: 'Dublin Core Record for this object',
-          mime_type: 'text/xml',
-          size: '475',
-          version: '0' },
-        { control_group: 'X',
-          dsid: 'RELS-EXT',
-          label: 'Fedora Object-to-Object Relationship Metadata',
-          mime_type: 'application/rdf+xml',
-          size: '821',
-          version: '0' },
-        { control_group: 'M',
-          dsid: 'identityMetadata',
-          label: 'Identity Metadata',
-          mime_type: 'text/xml',
-          size: '635',
-          version: '0' },
-        { control_group: 'M',
-          dsid: 'rightsMetadata',
-          label: 'Rights metadata',
-          mime_type: 'text/xml',
-          size: '652',
-          version: '4' },
-        { control_group: 'M',
-          dsid: 'descMetadata',
-          label: 'Descriptive Metadata',
-          mime_type: 'text/xml',
-          size: '5988',
-          version: '3' }
-      ]
-    end
-  end
-
   describe '#druid' do
     let(:document_attributes) { { id: 'druid:abc123456' } }
 


### PR DESCRIPTION

## Why was this change made?

This makes the dataflow a lot easier to follow as there's no indirection via dor_indexing_app. This also allows for a smaller solr index. Fixes #2100


## How was this change tested?

Tested locally on my laptop

## Which documentation and/or configurations were updated?
n/a


