### PR TITLE
remove all suri settings from argo (no longer used)

### DIFF
--- a/config/initializers/dor_config.rb
+++ b/config/initializers/dor_config.rb
@@ -17,14 +17,6 @@ Dor.configure do
     url Settings.solrizer_url
   end
 
-  suri do
-    mint_ids     Settings.suri.mint_ids
-    id_namespace Settings.suri.id_namespace
-    url          Settings.suri.url
-    user         Settings.suri.user
-    pass         Settings.suri.pass
-  end
-
   stacks do
     local_workspace_root Settings.stacks.local_workspace_root
   end

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -60,9 +60,6 @@ OkComputer::Registry.register 'dor_search_service_solr', OkComputer::HttpCheck.n
 OkComputer::Registry.register 'dor_services_url', OkComputer::HttpCheck.new(Settings.dor_services.url)
 OkComputer::Registry.register 'workflow_url', OkComputer::HttpCheck.new(Settings.workflow_url)
 
-# suri is essential for registering objects
-OkComputer::Registry.register 'suri_url', OkComputer::HttpCheck.new(Settings.suri.url)
-
 # Stacks
 OkComputer::Registry.register 'stacks_local_workspace_root', OkComputer::DirectoryCheck.new(Settings.stacks.local_workspace_root)
 OkComputer::Registry.register 'stacks_host', OkComputer::HttpCheck.new("https://#{Settings.stacks.host}")
@@ -91,6 +88,5 @@ OkComputer.make_optional %w[
   stacks_host
   stacks_local_workspace_root
   stacks_thumbnail_url
-  suri_url
   workflow_url
 ]

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -44,14 +44,6 @@ stacks:
   local_workspace_root: '/foo/workspace'
   host: 'stacks-test.stanford.edu'
 
-# Suri
-suri:
-  mint_ids: true
-  id_namespace: 'druid'
-  url: 'http://localhost:3002'
-  user: 'user'
-  pass: 'pass'
-
 dor_services:
   url: 'http://localhost:3003'
   # To generate the token: docker-compose run dor-services-app rake generate_token

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ services:
       SETTINGS__BULK_METADATA__TEMPORARY_DIRECTORY: '/app/tmp/tmp'
       SETTINGS__SOLRIZER_URL: http://solr:8983/solr/argo
       SETTINGS__FEDORA_URL: http://fedoraAdmin:fedoraAdmin@fcrepo:8080/fedora
-      SETTINGS__SURI__URL: http://suri:3000
       SETTINGS__WORKFLOW_URL: http://workflow:3000
       SETTINGS__DOR_INDEXING_URL: http://dor-indexing-app:3000/dor
       SETTINGS__DOR_SERVICES__URL: http://dor-services-app:3000
@@ -42,7 +41,6 @@ services:
       SETTINGS__DOR_SERVICES__TOKEN: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJGb28ifQ.-BVfLTW9Q1_ZQEsGv4tuzGLs5rESN7LgdtEwUltnKv4
       SETTINGS__FEDORA_URL: http://fedoraAdmin:fedoraAdmin@fcrepo:8080/fedora
       SETTINGS__SOLRIZER_URL: http://solr:8983/solr/argo
-      SETTINGS__SURI__URL: http://suri:3000
       SETTINGS__WORKFLOW_URL: http://workflow:3000
       SETTINGS__DOR_SERVICES__URL: http://dor-services-app:3000
     depends_on:
@@ -72,7 +70,7 @@ services:
       - dor-indexing-app
       - suri
       - redis
-    
+
   solr:
     image: solr:7
     volumes:

--- a/spec/features/item_view_metadata_spec.rb
+++ b/spec/features/item_view_metadata_spec.rb
@@ -119,7 +119,8 @@ RSpec.describe 'Item view', js: true do
 
     context 'when the title has an ampersand in it' do
       let(:item) do
-        Dor::Item.create!(label: 'Road & Track')
+        # this is not how items are created in the app -- this is for testing purposes only
+        Dor::Item.create!(label: 'Road & Track', pid: 'druid:fc123ky4567')
       end
 
       let(:dro_struct) { instance_double(Cocina::Models::DROStructural, contains: []) }


### PR DESCRIPTION
## Why was this change made?

To reduce confusion about suri configuration settings

## How was this change tested?

test suite

## Which documentation and/or configurations were updated?

shared_configs for qa, for stage, config files in app (see Files changed), and a PR for shared_configs for prod:  please merge sul-dlss/shared_configs/pull/1381 after this is merged.

