### PR TITLE
Unpin sdr-client and update dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem 'okcomputer' # monitors application and its dependencies
 gem 'preservation-client', '~> 3.2'
 gem 'responders', '~> 2.0'
 gem 'rsolr'
-gem 'sdr-client', '0.24.0'
+gem 'sdr-client', '~> 0.27'
 
 gem 'devise'
 gem 'devise-remote-user', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
     arel (9.0.0)
-    ast (2.4.0)
+    ast (2.4.1)
     autoprefixer-rails (9.7.6)
       execjs
     barby (0.6.8)
@@ -101,7 +101,7 @@ GEM
       thor (~> 0.18)
     byebug (11.1.3)
     cancancan (3.1.0)
-    capistrano (3.14.0)
+    capistrano (3.14.1)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
@@ -150,7 +150,7 @@ GEM
     celluloid-supervision (0.20.6)
       timers (>= 4.1.1)
     childprocess (3.0.0)
-    cocina-models (0.32.0)
+    cocina-models (0.33.0)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -177,7 +177,7 @@ GEM
       delayed_job (>= 3.0, < 5)
     deprecation (0.99.0)
       activesupport
-    devise (4.7.1)
+    devise (4.7.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)
@@ -211,9 +211,9 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-services-client (6.4.0)
+    dor-services-client (6.5.0)
       activesupport (>= 4.2, < 7)
-      cocina-models (~> 0.32.0)
+      cocina-models (~> 0.33.0)
       deprecation
       faraday (>= 0.15, < 2)
       moab-versioning (~> 4.0)
@@ -302,7 +302,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
-    ffi (1.13.0)
+    ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     haml (5.1.2)
@@ -380,7 +380,7 @@ GEM
     mysql2 (0.5.2)
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
-    net-ssh (6.0.2)
+    net-ssh (6.1.0)
     netrc (0.11.0)
     newrelic_rpm (6.11.0.365)
     nio4r (2.5.2)
@@ -556,9 +556,9 @@ GEM
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
-    sdr-client (0.24.0)
+    sdr-client (0.27.0)
       activesupport
-      cocina-models (~> 0.32.0)
+      cocina-models (~> 0.33.0)
       dry-monads
       faraday (>= 0.16)
     selenium-webdriver (3.142.7)
@@ -617,7 +617,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
-    view_component (2.7.0)
+    view_component (2.8.0)
       activesupport (>= 5.0.0, < 7.0)
     warden (1.2.8)
       rack (>= 2.0.6)
@@ -704,7 +704,7 @@ DEPENDENCIES
   rubocop-rspec (~> 1.31.0)
   ruby-prof
   rubyzip
-  sdr-client (= 0.24.0)
+  sdr-client (~> 0.27)
   selenium-webdriver
   simplecov (~> 0.17.1)
   spring


### PR DESCRIPTION


## Why was this change made?

This will allow argo to get the new versions of cocina-models as they are released and thus automatically be kept in synch with dor-services-app

## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?
n/a


