### PR TITLE
remove no-op rake task

### DIFF
--- a/lib/tasks/argo_testing.rake
+++ b/lib/tasks/argo_testing.rake
@@ -36,11 +36,6 @@ end
 if %w[test development].include? Rails.env
   require 'rspec/core/rake_task'
 
-  desc 'Larger integration/acceptance style tests (take several minutes to complete)'
-  RSpec::Core::RakeTask.new(:integration_tests) do |spec|
-    spec.pattern = 'spec/integration/**/*_spec.rb'
-  end
-
   fedora_files = File.foreach(File.join(File.expand_path('../../fedora_conf/data', __dir__), 'load_order')).to_a
 
   namespace :argo do


### PR DESCRIPTION
## Why was this change made?

There is no `spec/integrations` folder, and there is no reference to the `integration_tests` rake task anywhere.

## How was this change tested?

test suite

## Which documentation and/or configurations were updated?

it was self documenting.   :-D

