### PR TITLE
Fix the sameSite warnings about cookies

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -2,4 +2,4 @@
 
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_argo_session'
+Rails.application.config.session_store :cookie_store, key: '_argo_session', same_site: :lax


### PR DESCRIPTION


## Why was this change made?

In the browser console on Firefox:

```
Cookie “_argo_session” will be soon rejected because it has the “sameSite” attribute set to “none” or an invalid value, without the “secure” attribute. To know more about the “sameSite“ attribute, read https://developer.mozilla.org/docs/Web/HTTP/Cookies
```

This change removes that warning

## How was this change tested?

locally


## Which documentation and/or configurations were updated?
n/a


