### PR TITLE
README gets dedicated testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,30 +91,6 @@ CI runs a series of steps;  this the sequence to do it locally, along with some 
 
     Note that `RAILS_ENV=test` should not be necessary when running `bundle exec rake spec` on its own.
 
-7. **Problem test that fails locally but passes on CI**
-
-    spec/helpers/items_helper_spec.rb:40
-
-    ```
-    ItemsHelper
-      schema_validate
-        validates a document (FAILED - 1)
-
-    Failures:
-
-      1) ItemsHelper schema_validate validates a document
-         Failure/Error: expect(schema_validate(doc).length).to eq(3)
-
-           expected: 3
-                got: 2
-
-           (compared using ==)
-         # ./spec/helpers/items_helper_spec.rb:49:in `block (3 levels) in <top (required)>'
-
-    Finished in 0.80643 seconds (files took 3.43 seconds to load)
-    1 example, 1 failure
-    ```
-
 ## Run the servers
 
 ```
@@ -186,24 +162,6 @@ docker-compose run --rm web bin/rake argo:repo:load
 
 
 ## Common tasks
-
-### Run the tests
-
-To run the test suite, invoke `rspec` from the Argo app root.  Note that the docker containers need to be running already for this work.
-```bash
-# docker-compose up -d # (if not already running)
-rspec
-```
-
-### Run the continuous integration build
-
-_Important Note: Running `rake ci` will reload fixtures for the `test` environment only._
-
-The continuous integration build can be run by:
-
-```bash
-RAILS_ENV=test bundle exec rake ci
-```
 
 ### Delete records
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,92 @@ bundle install
 
 Note that `bundle install` may complain if MySQL isn't installed.  You can either comment out the `mysql2` inclusion in `Gemfile` and come back to it later (you can develop using `sqlite3`), or you can install MySQL.
 
+
+## Run the tests locally
+
+CI runs a series of steps;  this the sequence to do it locally, along with some helpful info.
+
+1. **Pull down the latest docker containers**
+
+    ```
+    docker-compose pull
+    ```
+
+2. **Start up the docker services needed for testing**
+
+    Once everything has been successfully pulled, start up the docker services needed for testing
+
+    ```
+    docker-compose up -d dor-services-app dor-indexing-app techmd
+    ```
+
+    You should do the following to make sure all the services are up:
+
+    ```
+    docker-compose ps
+    ```
+
+3. **Install Chrome**
+
+    You will need to have Google Chrome browser installed, as the tests use chrome for a headless browser.
+
+4. **Update javascript dependencies**
+
+    ```
+    yarn install
+    ```
+
+5. **Compile javascript**
+
+    ```
+    RAILS_ENV=test bin/rails webpacker:compile
+    ```
+
+    If you run into trouble with the docker containers complaining about webpacker, then ... figure out what to do to fix it and please update this document.  (There's a way to do it, something like `docker-compose run --container command`)
+
+6. **Run the tests (without rubocop)**
+
+    Note that
+
+    ```
+    RAILS_ENV=test bundle exec rake ci
+    ```
+
+    is a shortcut for running the following 2 steps:
+
+    ```
+    RAILS_ENV=test bundle exec rake argo:repo:load
+    RAILS_ENV=test bundle exec rake spec
+    ```
+
+    `rake argo:repo:load` loads test fixture objects into fedora/solr.   You will NOT be able to re-run this task successfully unless fixtures are no longer in the docker containers (e.g. if you `docker-compose down`).  That is because they are already loaded.  The error messages in your terminal output do not surface this cause, but that is likely at play if you see `"Rubydora::FedoraInvalidRequest: See logger for details"`, esp with `"Caused by: RestClient::InternalServerError: 500 Internal Server Error"` in there. In this case, run only `bundle exec rake spec` instead.
+
+    Note that `RAILS_ENV=test` should not be necessary when running `bundle exec rake spec` on its own.
+
+7. **Problem test that fails locally but passes on CI**
+
+    spec/helpers/items_helper_spec.rb:40
+
+    ```
+    ItemsHelper
+      schema_validate
+        validates a document (FAILED - 1)
+
+    Failures:
+
+      1) ItemsHelper schema_validate validates a document
+         Failure/Error: expect(schema_validate(doc).length).to eq(3)
+
+           expected: 3
+                got: 2
+
+           (compared using ==)
+         # ./spec/helpers/items_helper_spec.rb:49:in `block (3 levels) in <top (required)>'
+
+    Finished in 0.80643 seconds (files took 3.43 seconds to load)
+    1 example, 1 failure
+    ```
+
 ## Run the servers
 
 ```


### PR DESCRIPTION
## Why was this change made?

To help developers be able to consistently get tests to pass* locally.  (*all but one).

This PR is not "let's reorganize the README and improve it", but is meant as a surgical strike for "here's how to get tests running locally" which has been troubling for a number of developers.  I would ask that *this* PR be reviewed and approved if you think it accomplishes the goal, and additional README updates be ticketed separately (or just make a PR after this one is merged.)

If you want to see the updates formatted, visit https://github.com/sul-dlss/argo/tree/readme-testing

## How was this change tested?

3 of us "clumped" and ran through the steps manually

## Which documentation and/or configurations were updated?

README

