### PR TITLE
Use the bundled Nokogiri instead of underlying libxml version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ after_script:
 
 env:
   global:
-    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up bundle install
     - CC_TEST_REPORTER_ID=266992849463aa465e0884ad7d582306656214e31ac9245258f93190868cbc9a
 
 cache:

--- a/spec/helpers/items_helper_spec.rb
+++ b/spec/helpers/items_helper_spec.rb
@@ -44,9 +44,14 @@ RSpec.describe ItemsHelper, type: :helper do
       # the expected length is the number of error statements from validation
       # here's what the array looks like:
       # ["Element '{http://www.loc.gov/mods/v3}titleInfo', attribute 'type': [facet 'enumeration'] The value 'main' is not an element of the set {'abbreviated', 'translated', 'alternative', 'uniform'}.",
-      # "Element '{http://www.loc.gov/mods/v3}titleInfo', attribute 'type': 'main' is not a valid value of the atomic type '{http://www.loc.gov/mods/v3}titleInfoTypeAttributeDefinition'.",
       # "Element '{http://www.loc.gov/mods/v3}typeOfResource': This element is not expected."]
-      expect(schema_validate(doc).length).to eq(3)
+      #
+      # NOTE: if this test fails due to a third validation error being reported,
+      # it is likely due to a difference in the underlying libxml version. that
+      # error would look like:
+      #
+      # "Element '{http://www.loc.gov/mods/v3}titleInfo', attribute 'type': 'main' is not a valid value of the atomic type '{http://www.loc.gov/mods/v3}titleInfoTypeAttributeDefinition'.",
+      expect(schema_validate(doc).length).to eq(2)
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

This change means the behavior of the ItemsHelper spec should no longer vary based on system libxml.

## How was this change tested?

Unit tests. (Change should not affect the application otherwise.)

## Which documentation and/or configurations were updated?

None.

