### PR TITLE
Use standard rails logger for dor-workflow-client

### DIFF
--- a/app/services/workflow_client_factory.rb
+++ b/app/services/workflow_client_factory.rb
@@ -3,7 +3,7 @@
 # This initializes the workflow client with values from settings
 class WorkflowClientFactory
   def self.build
-    logger = Logger.new(Settings.workflow.logfile, Settings.workflow.shift_age)
+    logger = Rails.logger
     Dor::Workflow::Client.new(url: Settings.workflow_url, logger: logger, timeout: Settings.workflow.timeout)
   end
 end


### PR DESCRIPTION
## Why was this change made?

https://app.honeybadger.io/projects/49894/faults/62649217

There is a production bug that is very intermittent, but becoming more persistent with larger jobs. This passes the standard logger (i.e. log/production.log) instead of creating a one off.

## How was this change tested?

Local unit tests.


## Which documentation and/or configurations were updated?

N/A

