### PR TITLE
Set the correct attribute for data confirmation

### DIFF
--- a/app/views/catalog/_contents_default.html.erb
+++ b/app/views/catalog/_contents_default.html.erb
@@ -1,7 +1,7 @@
 <h3 id="document-contents-head" class="section-head collapsible-section">
   Contents
   <small style="margin-top: 5px" class="pull-right">
-    <% opts = document.preservation_size && document.preservation_size > 1_000_000_000 ? { confirm: 'This will be a large download. Are you sure?' } : {} %>
+    <% opts = document.preservation_size && document.preservation_size > 1_000_000_000 ? { data: { confirm: 'This will be a large download. Are you sure?' } } : {} %>
     <%= link_to 'Download all files', download_item_files_path(document), opts %>
   </small>
 </h3>


### PR DESCRIPTION
## Why was this change made?
currently we have the `confirm` attribute set, but we want this to be `data-confirm`


## How was this change tested?

Locally.

## Which documentation and/or configurations were updated?

n/a

