### PR TITLE
[Refactor] Stop passing output directory

### DIFF
--- a/app/jobs/checksum_report_job.rb
+++ b/app/jobs/checksum_report_job.rb
@@ -12,10 +12,9 @@ class ChecksumReportJob < GenericJob
   # @option params [Array]  :pids required list of pids
   # @option params [Array]  :groups the groups the user belonged to when the started the job. Required for because groups are not persisted with the user.
   # @option params [Array]  :user the user
-  # @option params [String] :output_directory the output directory to write the CSV checksum report to
   def perform(bulk_action_id, params)
     super
-    report_filename = generate_report_filename(params[:output_directory])
+    report_filename = generate_report_filename(bulk_action.output_directory)
 
     with_bulk_action_log do |log|
       log.puts("#{Time.current} Starting #{self.class} for BulkAction #{bulk_action_id}")

--- a/app/jobs/descmetadata_download_job.rb
+++ b/app/jobs/descmetadata_download_job.rb
@@ -10,10 +10,9 @@ class DescmetadataDownloadJob < GenericJob
 
   # @param [Integer] bulk_action_id ActiveRecord identifier of the BulkAction object that originated this job.
   # @param [Hash] params Custom params for this job
-  # requires `:pids` (an Array of pids) and output_directory
+  # requires `:pids` (an Array of pids)
   def perform(bulk_action_id, params)
     super
-    zip_filename = generate_zip_filename(params[:output_directory])
     with_bulk_action_log do |log|
       #  Fail with an error message if the calling BulkAction doesn't exist
       if bulk_action.nil?
@@ -105,8 +104,8 @@ class DescmetadataDownloadJob < GenericJob
   # Generate a filename for the job's zip output file.
   # @param  [String] output_dir Where to store the zip file.
   # @return [String] A filename for the zip file.
-  def generate_zip_filename(output_dir)
-    FileUtils.mkdir_p(output_dir) unless File.directory?(output_dir)
-    File.join(output_dir, Settings.bulk_metadata.zip)
+  def zip_filename
+    FileUtils.mkdir_p(bulk_action.output_directory) unless File.directory?(bulk_action.output_directory)
+    File.join(bulk_action.output_directory, Settings.bulk_metadata.zip)
   end
 end

--- a/app/services/bulk_action_persister.rb
+++ b/app/services/bulk_action_persister.rb
@@ -51,7 +51,6 @@ class BulkActionPersister
   def job_params
     {
       pids: pids.split,
-      output_directory: output_directory,
       manage_release: manage_release,
       set_governing_apo: set_governing_apo,
       manage_catkeys: manage_catkeys,

--- a/spec/jobs/checksum_report_job_spec.rb
+++ b/spec/jobs/checksum_report_job_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe ChecksumReportJob, type: :job do
   let(:pids) { ['druid:123', 'druid:456'] }
   let(:groups) { [] }
   let(:user) { instance_double(User, to_s: 'jcoyne85') }
-  let(:output_directory) { 'tmp/checksum_report_job_success' }
-  # so 'fail' tests don't fail due to CSV from 'success' tests
-  let(:output_directory_fail) { 'tmp/checksum_report_job_fail' }
+  let(:output_directory) { bulk_action.output_directory }
   let(:bulk_action) do
     create(
       :bulk_action,
@@ -24,6 +22,10 @@ RSpec.describe ChecksumReportJob, type: :job do
     allow(Ability).to receive(:new).and_return(ability)
   end
 
+  after do
+    FileUtils.rm_rf(output_directory) if Dir.exist?(output_directory)
+  end
+
   describe '#perform_now' do
     context 'with authorization' do
       let(:ability) { instance_double(Ability, can?: true) }
@@ -35,7 +37,6 @@ RSpec.describe ChecksumReportJob, type: :job do
 
         it 'calls the presevation_catalog API, writes a CSV file, and records success counts' do
           subject.perform(bulk_action.id,
-                          output_directory: output_directory,
                           pids: pids,
                           groups: groups,
                           user: user)
@@ -59,13 +60,12 @@ RSpec.describe ChecksumReportJob, type: :job do
           exp_msg_regex = /ChecksumReportJob got error from Preservation Catalog API\ \(Preservation::Client::UnexpectedResponseError\): ruh roh/
           expect do
             subject.perform(bulk_action.id,
-                            output_directory: output_directory_fail,
                             pids: pids,
                             groups: groups,
                             user: user)
           end.not_to raise_error
           expect(Preservation::Client.objects).to have_received(:checksums).with(druids: pids)
-          expect(File).not_to exist(File.join(output_directory_fail, Settings.checksum_report_job.csv_filename))
+          expect(File).not_to exist(File.join(output_directory, Settings.checksum_report_job.csv_filename))
           expect(Rails.logger).to have_received(:error).with(exp_msg_regex).once
           expect(Honeybadger).to have_received(:context).with(bulk_action_id: bulk_action.id, params: hash_including(pids: pids)).once
           expect(Honeybadger).to have_received(:notify).with(exp_msg_regex).once
@@ -90,13 +90,12 @@ RSpec.describe ChecksumReportJob, type: :job do
         exp_msg_regex = /ChecksumReportJob not authorized to view all content/
         expect do
           subject.perform(bulk_action.id,
-                          output_directory: output_directory_fail,
                           pids: pids,
                           groups: groups,
                           user: user)
         end.not_to raise_error
         expect(Preservation::Client.objects).not_to have_received(:checksums)
-        expect(File).not_to exist(File.join(output_directory_fail, Settings.checksum_report_job.csv_filename))
+        expect(File).not_to exist(File.join(output_directory, Settings.checksum_report_job.csv_filename))
         expect(Rails.logger).to have_received(:error).with(exp_msg_regex).once
         expect(Honeybadger).to have_received(:context).with(bulk_action_id: bulk_action.id, params: hash_including(pids: pids)).once
         expect(Honeybadger).to have_received(:notify).with(exp_msg_regex).once

--- a/spec/services/bulk_action_persister_spec.rb
+++ b/spec/services/bulk_action_persister_spec.rb
@@ -17,8 +17,6 @@ RSpec.describe BulkActionPersister do
         bulk_action.id,
         hash_including(
           pids: %w[a b c],
-          output_directory: Settings.bulk_metadata.directory +
-            "#{bulk_action.action_type}_#{bulk_action.id}",
           manage_release: {}
         )
       )


### PR DESCRIPTION
No functional changes.

## Why was this change made?

This is a simplification. There's no need to pass the output directory to the background job because it's a method on the BatchAction, which the background job is aware of.

## How was this change tested?
Test suite


## Which documentation and/or configurations were updated?

n/a

