### PR TITLE
Enable browser to download files streamed from preservation

### DIFF
--- a/spec/controllers/files_controller_spec.rb
+++ b/spec/controllers/files_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe FilesController, type: :controller do
         expect(response.headers['Last-Modified']).to be <= Time.now.utc.rfc2822
         expect(response.headers['Last-Modified']).to be >= last_modified_lower_bound
         expect(response.headers['Content-Type']).to eq('application/octet-stream')
-        expect(response.headers['Content-Disposition']).to eq("attachment; filename=#{CGI.escape(mock_file_name)}")
+        expect(response.headers['Content-Disposition']).to eq("attachment; filename=\"#{CGI.escape(mock_file_name)}\"")
         expect(response.code).to eq('200')
         expect(Preservation::Client.objects).to have_received(:content)
           .with(druid: pid, filepath: mock_file_name, version: mock_version, on_data: Proc)
@@ -50,7 +50,7 @@ RSpec.describe FilesController, type: :controller do
 
         it 'returns 404 with error information' do
           get :preserved, params: { id: 'not_there.txt', version: mock_version, item_id: pid }
-          expect(response.headers['Content-Type']).to eq('text/plain; charset=utf-8')
+          expect(response.headers['Content-Type']).to eq('application/octet-stream')
           expect(response.headers['Last-Modified']).to eq nil
           expect(response.headers['Content-Disposition']).to eq nil
           expect(response.code).to eq('404')


### PR DESCRIPTION
## Why was this change made?

To fix a bug reported by @oceanofsound and confirmed by @andrewjbtw. The bug has two angles:

1. Argo's files controller begins writing to the response stream before sending the headers, which results in the browser not interpreting the request as a download (but as an inline request, which will render the file in the browser instead of prompting for download location).
2. Once the request has nearly finished, the response stream is not properly closed (possibly because of writing to the response after streaming has begun) and a 500 error is raised.

This branch fixes both bugs by sending headers before writing to the response stream and ensuring the response stream is closed.

Note to @sul-dlss/infrastructure-team reviewers: I'm not sure how to test this in a way that is both resilient and useful. Happy to get feedback on this, but I would like to fix this production bug ASAP so I am not inclined to sink a bunch of time into unit tests.

## How was this change tested?

Tested in stage.

## Which documentation and/or configurations were updated?

None.

