### PR TITLE
Add a clarifying comment on the use of the spreadsheet library

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -19,7 +19,7 @@ import 'jquery-ui'
 import 'jquery-validation'
 import "bootstrap/dist/js/bootstrap"
 
-import 'spreadsheet'
+import 'spreadsheet' // Note: this library is used to read/write spreadsheet documents, not display
 
 import 'modules/apo_form'
 import 'modules/button_checker'


### PR DESCRIPTION
## Why was this change made?

To avoid confusion on the use of the spreadsheet library when working on the reports (spreadsheet-like) view as this particular library is only used to read/write XSL files.

## How was this change tested?

N/A

## Which documentation and/or configurations were updated?

Inline comment.
