### PR TITLE
[Refactor] Create a BulkActionForm

### DIFF
--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -11,7 +11,7 @@ class BaseForm
   # @param [Dor::Item] the object to update.
   def initialize(model)
     @model = model
-    @errors = [] # assume no errors yet
+    @errors = model.errors
   end
 
   # @param [HashWithIndifferentAccess] params the parameters from the form
@@ -30,5 +30,5 @@ class BaseForm
     model.attributes = params
   end
 
-  delegate :new_record?, to: :model
+  delegate :model_name, :to_key, :to_model, :new_record?, to: :model
 end

--- a/app/forms/bulk_action_form.rb
+++ b/app/forms/bulk_action_form.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# This models the values set from the bulk action form
+class BulkActionForm < BaseForm
+  def initialize(model, groups:)
+    super(model)
+    @groups = groups
+  end
+
+  def save
+    sync
+    BulkActionPersister.persist(self)
+  end
+
+  def sync
+    model.attributes = params.except(:pids, :groups, :manage_release, :set_governing_apo, :manage_catkeys, :prepare, :create_virtual_objects)
+    @pids = pids_with_prefix
+    @create_virtual_objects = params[:create_virtual_objects]
+    @manage_catkeys = params[:manage_catkeys]
+    @manage_release = params[:manage_release]
+    @prepare = params[:prepare]
+    @set_governing_apo = params[:set_governing_apo]
+  end
+
+  attr_reader :groups, :pids, :create_virtual_objects, :manage_catkeys, :manage_release, :prepare, :set_governing_apo
+
+  delegate :action_type, :description, to: :model
+
+  private
+
+  # add druid: prefix to list of pids if it doesn't have it yet
+  def pids_with_prefix
+    pids = params[:pids]
+    return pids if pids.blank?
+
+    pids.split.flatten.map { |pid| pid.start_with?('druid:') ? pid : "druid:#{pid}" }.join("\n")
+  end
+end

--- a/app/models/bulk_action.rb
+++ b/app/models/bulk_action.rb
@@ -22,10 +22,6 @@ class BulkAction < ApplicationRecord
 
   before_destroy :remove_output_directory
 
-  # A virtual attribute used for job creation but not persisted
-  attr_accessor :pids, :manage_release, :set_governing_apo, :manage_catkeys, :prepare, :create_virtual_objects
-  attr_accessor :groups # the groups the user was a member of when they launched the job
-
   def file(filename)
     File.join(output_directory, filename)
   end

--- a/app/services/bulk_action_persister.rb
+++ b/app/services/bulk_action_persister.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class BulkActionPersister
-  def self.persist(bulk_action)
-    new(bulk_action).persist
+  def self.persist(bulk_action_form)
+    new(bulk_action_form).persist
   end
 
-  def initialize(bulk_action)
-    @bulk_action = bulk_action
+  def initialize(bulk_action_form)
+    @bulk_action_form = bulk_action_form
   end
 
   def persist
@@ -20,10 +20,16 @@ class BulkActionPersister
 
   private
 
-  attr_reader :bulk_action
+  attr_reader :bulk_action_form
 
-  delegate :id, :file, :pids, :output_directory, :manage_release, :set_governing_apo,
-           :manage_catkeys, :groups, :prepare, :create_virtual_objects, to: :bulk_action
+  delegate :pids, :manage_release, :set_governing_apo,
+           :manage_catkeys, :groups, :prepare, :create_virtual_objects, to: :bulk_action_form
+
+  delegate :id, :file, :output_directory, to: :bulk_action
+
+  def bulk_action
+    bulk_action_form.model
+  end
 
   def create_log_file
     log_filename = file(Settings.bulk_metadata.log)

--- a/app/views/bulk_actions/new.html.erb
+++ b/app/views/bulk_actions/new.html.erb
@@ -1,13 +1,13 @@
 <div class='container'>
   <h1>New Bulk Action</h1>
 
-  <%= form_for(@bulk_action, html: { 'data-controller' => 'bulk_actions' }) do |f| %>
-    <% if @bulk_action.errors.any? %>
+  <%= form_for(@form, html: { 'data-controller' => 'bulk_actions' }) do |f| %>
+    <% if @form.errors.any? %>
       <div id="error_explanation">
-        <h2><%= pluralize(@bulk_action.errors.count, 'error') %> prohibited this bulk_action from being saved:</h2>
+        <h2><%= pluralize(@form.errors.count, 'error') %> prohibited this bulk_action from being saved:</h2>
 
         <ul>
-        <% @bulk_action.errors.full_messages.each do |message| %>
+        <% @form.errors.full_messages.each do |message| %>
           <li><%= message %></li>
         <% end %>
         </ul>

--- a/spec/factories/bulk_action.rb
+++ b/spec/factories/bulk_action.rb
@@ -5,6 +5,5 @@ FactoryBot.define do
     action_type { 'GenericJob' }
     association :user
     log_name { 'tmp/log.txt' }
-    pids { '' }
   end
 end

--- a/spec/jobs/descmetadata_download_job_spec.rb
+++ b/spec/jobs/descmetadata_download_job_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe DescmetadataDownloadJob, type: :job do
   describe 'perform' do
     let(:ability) { instance_double(Ability) }
     let(:bulk_action) do
-      create(:bulk_action, action_type: 'DescmetadataDownloadJob', pids: pid_list, log_name: 'foo.txt')
+      create(:bulk_action, action_type: 'DescmetadataDownloadJob', log_name: 'foo.txt')
     end
 
     before do

--- a/spec/models/bulk_action_spec.rb
+++ b/spec/models/bulk_action_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe BulkAction do
 
   describe '#file' do
     it 'returns the filename with path' do
-      @bulk_action = described_class.create(action_type: 'GenericJob', pids: '')
+      @bulk_action = described_class.create(action_type: 'GenericJob')
       expect(@bulk_action.file('hello_world.txt'))
         .to eq "#{Settings.bulk_metadata.directory}GenericJob_#{@bulk_action.id}/hello_world.txt"
     end
@@ -22,7 +22,7 @@ RSpec.describe BulkAction do
 
   describe 'before_destroy callbacks' do
     it 'calls #remove_output_directory' do
-      @bulk_action = described_class.create(action_type: 'GenericJob', pids: '')
+      @bulk_action = described_class.create(action_type: 'GenericJob')
       expect(@bulk_action).to receive(:remove_output_directory)
       @bulk_action.run_callbacks(:destroy) { true }
     end
@@ -35,7 +35,7 @@ RSpec.describe BulkAction do
         "#{bulk_action.action_type}_#{bulk_action.id}"
       )
     end
-    let(:bulk_action) { described_class.create(action_type: 'GenericJob', pids: '') }
+    let(:bulk_action) { described_class.create(action_type: 'GenericJob') }
 
     before do
       FileUtils.mkdir_p(directory)

--- a/spec/views/bulk_actions/new.html.erb_spec.rb
+++ b/spec/views/bulk_actions/new.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'bulk_actions/new.html.erb' do
   let(:apo_list) { [['APO 1', 'druid:123'], ['APO 2', 'druid:234']] }
 
   before do
-    @bulk_action = assign(:bulk_actions, create(:bulk_action))
+    @form = BulkActionForm.new(create(:bulk_action), groups: user_groups)
     allow(view).to receive(:current_user).and_return(double(sunetid: 'esnowden', groups: user_groups))
     allow(view).to receive(:apo_list).with(user_groups).and_return(apo_list)
 


### PR DESCRIPTION
No functional changes

## Why was this change made?

This separates responsibility for the form rendering from the model.  This means the model no longer needs to have virtual properties, and can be responsible solely for persistence.

## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?

n/a

