### PR TITLE
Drop ruby 2.6.4 from the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ language: ruby
 addons:
   chrome: stable
 rvm:
-  - 2.6.4 # deployed
-  - 2.7.1
+  - 2.7.1 # deployed
 
 before_install:
   # Get bundler 2.0 for ruby 2.6.4


### PR DESCRIPTION


## Why was this change made?

We are now deployed on ruby 2.7.1

## How was this change tested?

Travis

## Which documentation and/or configurations were updated?

n/a

