### PR TITLE
Move the Download All button to the right

### DIFF
--- a/app/components/download_all_button_component.html.erb
+++ b/app/components/download_all_button_component.html.erb
@@ -1,0 +1,5 @@
+<span class="section-head-link">
+  <small>
+    <%= link_to 'Download all files', download_item_files_path(document), link_options %>
+  </small>
+</span>

--- a/app/components/download_all_button_component.rb
+++ b/app/components/download_all_button_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class DownloadAllButtonComponent < ViewComponent::Base
+  # @param [SolrDocument] document
+  def initialize(document:)
+    @document = document
+  end
+
+  def link_options
+    # This onclick handler prevents the accordion which contains this element from folding.
+    options = { onclick: 'event.stopPropagation()' }
+    return options if !document.preservation_size || document.preservation_size < 1_000_000_000
+
+    options.merge(data: { confirm: 'This will be a large download. Are you sure?' })
+  end
+
+  attr_reader :document
+end

--- a/app/views/catalog/_contents_default.html.erb
+++ b/app/views/catalog/_contents_default.html.erb
@@ -1,9 +1,6 @@
 <h3 id="document-contents-head" class="section-head collapsible-section">
   Contents
-  <small style="margin-top: 5px" class="pull-right">
-    <% opts = document.preservation_size && document.preservation_size > 1_000_000_000 ? { data: { confirm: 'This will be a large download. Are you sure?' } } : {} %>
-    <%= link_to 'Download all files', download_item_files_path(document), opts %>
-  </small>
+  <%= render DownloadAllButtonComponent.new(document: document) %>
 </h3>
 <div id="document-contents-section" class="document-section contents-section">
   <% if object.datastreams.keys.include?('contentMetadata') &&

--- a/spec/components/download_all_button_component_spec.rb
+++ b/spec/components/download_all_button_component_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DownloadAllButtonComponent, type: :component do
+  include Rails.application.routes.url_helpers
+  subject { page }
+
+  let(:document) { instance_double(SolrDocument, preservation_size: 0) }
+  let(:component) { described_class.new(document: document) }
+
+  before do
+    render_inline(component)
+  end
+
+  it { is_expected.to have_link 'Download all files', href: download_item_files_path(document) }
+  it { is_expected.to have_selector 'a[onclick="event.stopPropagation()"]' }
+
+  context 'with a large file' do
+    let(:document) { instance_double(SolrDocument, preservation_size: 1_000_000_000) }
+
+    it { is_expected.to have_selector 'a[data-confirm="This will be a large download. Are you sure?"]' }
+  end
+end


### PR DESCRIPTION
And prevent the accordion from collapsing.

Now looks like this:
<img width="924" alt="Screen Shot 2020-06-25 at 10 19 18 AM" src="https://user-images.githubusercontent.com/92044/85748008-5e029580-b6cd-11ea-91ea-354f7bf697bc.png">


## Why was this change made?
Fixes #2134


## How was this change tested?

Tested locally

## Which documentation and/or configurations were updated?
n/a


