### PR TITLE
Docker-compose will pull whatever it needs when you do docker-compose up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ before_install:
   # Get bundler 2.0 for ruby 2.6.4
   - gem install bundler
   # Pull latest & start up needed underlying services
-  - docker-compose pull
   - docker-compose up -d dor-services-app dor-indexing-app techmd
   - docker-compose ps
   - google-chrome-stable --headless --disable-gpu --no-sandbox --remote-debugging-port=9222 http://localhost &


### PR DESCRIPTION
## Why was this change made?

Avoid pulling things we don't need.

## How was this change tested?

Travis

## Which documentation and/or configurations were updated?

n/a

