### PR TITLE
Remove test of obsolete option

### DIFF
--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -74,16 +74,6 @@ RSpec.describe ReportController, type: :controller do
         expect(data[1].first).to eq('br481xz7820') # first data row starts with pid
       end
 
-      it 'downloads valid CSV data when not on the first page' do
-        get :download, params: { fields: ' ', page: 3 }
-        expect(response).to have_http_status(:ok)
-        expect(response.header['Content-Disposition']).to eq('attachment; filename=report.csv')
-        data = CSV.parse(response.body)
-        expect(data.first.length).to eq(26)
-        expect(data.length).to be > 1
-        expect(data[1].first).to eq('br481xz7820') # first data row starts with pid
-      end
-
       it 'downloads valid CSV data for specific fields' do
         get :download, params: { fields: 'druid,purl,source_id_ssim,tag_ssim' }
         expect(response).to have_http_status(:ok)


### PR DESCRIPTION

## Why was this change made?

Reports no longer have pages.  The page is always set to `1`: https://github.com/sul-dlss/argo/blob/master/app/controllers/report_controller.rb#L53

## How was this change tested?
test suite


## Which documentation and/or configurations were updated?
n/a


