### PR TITLE
Extract report date formatter from helpers

### DIFF
--- a/app/helpers/dor_object_helper.rb
+++ b/app/helpers/dor_object_helper.rb
@@ -34,20 +34,6 @@ module DorObjectHelper
     result.html_safe
   end
 
-  def render_datetime(datetime)
-    return '' if datetime.nil? || datetime == ''
-
-    # this needs to use the timezone set in config.time_zone
-    begin
-      zone = ActiveSupport::TimeZone.new('Pacific Time (US & Canada)')
-      d = datetime.is_a?(Time) ? datetime : DateTime.parse(datetime).in_time_zone(zone)
-      I18n.l(d)
-    rescue StandardError
-      d = datetime.is_a?(Time) ? datetime : Time.zone.parse(datetime.to_s)
-      d.strftime('%Y-%m-%d %I:%M%p')
-    end
-  end
-
   def render_workflows(doc)
     workflows = {}
     Array(doc[ActiveFedora::SolrService.solr_name('workflow_status', :symbol)]).each do |line|

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -70,7 +70,7 @@ class Report
     },
     {
       field: :registered_earliest_dttsi, label: 'Registered',
-      proc: ->(doc) { render_datetime(doc[:registered_earliest_dttsi]) },
+      proc: ->(doc) { DatePresenter.render(doc[:registered_earliest_dttsi]) },
       sort: true, default: false, width: 100, download_default: false
     },
     {
@@ -99,12 +99,12 @@ class Report
     },
     {
       field: :accessioned_dttsim, label: 'Accession. Datetime',
-      proc: ->(doc) { render_datetime(doc[:accessioned_dttsim]) },
+      proc: ->(doc) { DatePresenter.render(doc[:accessioned_dttsim]) },
       sort: true, default: false, width: 100, download_default: false
     },
     {
       field: :published_dttsim, label: 'Pub. Date',
-      proc: ->(doc) { render_datetime(doc[:published_dttsim]) },
+      proc: ->(doc) { DatePresenter.render(doc[:published_dttsim]) },
       sort: true, default: true, width: 100, download_default: false
     },
     {

--- a/app/presenters/date_presenter.rb
+++ b/app/presenters/date_presenter.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class DatePresenter
+  def self.render(datetime)
+    return '' if datetime.nil? || datetime == ''
+
+    # this needs to use the timezone set in config.time_zone
+    begin
+      zone = ActiveSupport::TimeZone.new('Pacific Time (US & Canada)')
+      d = datetime.is_a?(Time) ? datetime : DateTime.parse(datetime).in_time_zone(zone)
+      I18n.l(d)
+    rescue StandardError
+      d = datetime.is_a?(Time) ? datetime : Time.zone.parse(datetime.to_s)
+      d.strftime('%Y-%m-%d %I:%M%p')
+    end
+  end
+end


### PR DESCRIPTION
No functional changes

## Why was this change made?

Helpers are modules that interface with the view context, but this was used by a model, so moving it elsewhere.

## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?
n/a


