### PR TITLE
Remove override of upstream methods

### DIFF
--- a/app/helpers/dor_object_helper.rb
+++ b/app/helpers/dor_object_helper.rb
@@ -48,13 +48,6 @@ module DorObjectHelper
     end
   end
 
-  def render_qfacet_value(facet_solr_field, item, options = {})
-    params = add_facet_params(facet_solr_field, item.qvalue)
-    Rails.cache.fetch('route_for' + params.to_s, expires_in: 1.hour) do
-      (link_to_unless(options[:suppress_link], item.value, params, class: 'facet_select') + ' ' + render_facet_count(item.hits)).html_safe
-    end
-  end
-
   def render_workflows(doc)
     workflows = {}
     Array(doc[ActiveFedora::SolrService.solr_name('workflow_status', :symbol)]).each do |line|


### PR DESCRIPTION


## Why was this change made?

Because upstream has made accessibility improvements and the caching from https://github.com/sul-dlss/argo/commit/4a78027fa4da36002666d39aaddf8950a0264c75 is no longer required

## How was this change tested?

Test suite


## Which documentation and/or configurations were updated?

n/a

