### PR TITLE
Avoid using deprecated path_for_facet method

### DIFF
--- a/app/helpers/value_helper.rb
+++ b/app/helpers/value_helper.rb
@@ -60,7 +60,9 @@ module ValueHelper
   # @return [String]
   def link_to_admin_policy_with_objs(args)
     policy_link = link_to_admin_policy(args)
-    objs_link = link_to('All objects with this APO', path_for_facet('is_governed_by_ssim', "info:fedora/#{args[:document].apo_pid}"))
+    facet_config = facet_configuration_for_field('is_governed_by_ssim')
+    path_for_facet = facet_item_presenter(facet_config, "info:fedora/#{args[:document].apo_pid}", 'is_governed_by_ssim').href
+    objs_link = link_to 'All objects with this APO', path_for_facet
     "#{policy_link} (#{objs_link})".html_safe
   end
 
@@ -79,12 +81,16 @@ module ValueHelper
   # @see #link_to_admin_policy
   # @return [String]
   def links_to_collections_with_objs(args, with_objs: true)
+    facet_config = facet_configuration_for_field('is_member_of_collection_ssim')
+
     args[:value].map.with_index do |val, i|
       collection_link = link_to(
         args[:document].collection_titles[i],
         solr_document_path(val.gsub('info:fedora/', ''))
       )
-      objs_link = link_to('All objects in this collection', path_for_facet('is_member_of_collection_ssim', val))
+      path_for_facet = facet_item_presenter(facet_config, val, 'is_member_of_collection_ssim').href
+
+      objs_link = link_to 'All objects in this collection', path_for_facet
       with_objs ? "#{collection_link} (#{objs_link})" : collection_link
     end.join('<br>').html_safe
   end


### PR DESCRIPTION
## Why was this change made?

To avoid deprecation warnings

## How was this change tested?

Test suite


## Which documentation and/or configurations were updated?

 n/a

