### PR TITLE
Allow actiondispatch to handle 404 errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,6 @@ class ApplicationController < ActionController::Base
 
   before_action :authenticate_user!
 
-  rescue_from ActiveFedora::ObjectNotFoundError, with: -> { render plain: 'Object Not Found', status: :not_found }
   rescue_from CanCan::AccessDenied, with: -> { render status: :forbidden, plain: 'forbidden' }
 
   layout :determine_layout

--- a/app/controllers/bulk_actions_controller.rb
+++ b/app/controllers/bulk_actions_controller.rb
@@ -5,8 +5,6 @@ class BulkActionsController < ApplicationController
 
   before_action :set_bulk_action, only: %i[destroy file]
 
-  rescue_from ActiveRecord::RecordNotFound, with: -> { render plain: 'Record Not Found', status: :not_found }
-
   # GET /bulk_actions
   def index
     @bulk_actions = BulkAction.where(user: current_user).order('created_at DESC')
@@ -47,6 +45,8 @@ class BulkActionsController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_bulk_action
     @bulk_action = current_user.bulk_actions.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render plain: 'Object Not Found', status: :not_found
   end
 
   # Only accept trusted parameters.

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,9 @@ module Argo
     initializer :after_append_asset_paths, group: :all, after: :append_assets_path do
       config.assets.paths.unshift Rails.root.join('app', 'assets', 'stylesheets', 'jquery-ui', 'custom-theme').to_s
     end
+
+    # Configure action_dispatch to handle not found errors
+    config.action_dispatch.rescue_responses['ActiveFedora::ObjectNotFoundError'] = :not_found
   end
 
   ARGO_VERSION = File.read(File.join(Rails.root, 'VERSION'))

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -69,19 +69,6 @@ RSpec.describe CatalogController, type: :controller do
           expect(response).to be_successful
         end
       end
-
-      context 'when not found' do
-        before do
-          allow(Dor).to receive(:find).with(druid).and_raise(ActiveFedora::ObjectNotFoundError)
-        end
-
-        let(:druid) { 'druid:zz999zz9999' }
-
-        it 'returns not found' do
-          get 'show', params: { id: druid }
-          expect(response).to be_not_found
-        end
-      end
     end
   end
 

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -224,11 +224,6 @@ RSpec.describe RegistrationsController, type: :controller do
       expect { get 'collection_list' }.to raise_error(ArgumentError)
     end
 
-    it 'handles a bogus APO' do
-      get 'collection_list', params: { apo_id: 'druid:aa111bb2222' }
-      expect(response).to have_http_status(:not_found)
-    end
-
     it 'handles an APO with no collections' do
       get 'collection_list', params: { apo_id: 'druid:zt570tx3016', format: :json }
       data = JSON.parse(response.body)

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -100,12 +100,6 @@ RSpec.describe WorkflowsController, type: :controller do
         expect(WorkflowPresenter).to have_received(:new).with(view: Object, workflow_status: workflow_status)
         expect(assigns[:presenter]).to eq presenter
       end
-
-      it 'returns 404 on missing item' do
-        expect(Dor).to receive(:find).with(pid).and_raise(ActiveFedora::ObjectNotFoundError)
-        get :show, params: { item_id: pid, id: 'accessionWF', repo: 'dor', format: :html }
-        expect(response).to have_http_status(:not_found)
-      end
     end
 
     context 'when the user wants to see the xml' do
@@ -137,12 +131,6 @@ RSpec.describe WorkflowsController, type: :controller do
       get :history, params: { item_id: pid, format: :html }
       expect(response).to have_http_status(:ok)
       expect(assigns[:history_xml]).to eq xml
-    end
-
-    it 'returns 404 on missing item' do
-      expect(Dor).to receive(:find).with(pid).and_raise(ActiveFedora::ObjectNotFoundError)
-      get :show, params: { item_id: pid, id: 'accessionWF', repo: 'dor', format: :html }
-      expect(response).to have_http_status(:not_found)
     end
   end
 

--- a/spec/support/feature_errors.rb
+++ b/spec/support/feature_errors.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# See https://github.com/eliotsykes/rspec-rails-examples#testing-production-errors
+
+module ErrorResponses
+  # See: https://github.com/rails/rails/pull/11289#issuecomment-118612393
+  def respond_without_detailed_exceptions
+    env_config = Rails.application.env_config
+    original_show_exceptions = env_config['action_dispatch.show_exceptions']
+    original_show_detailed_exceptions = env_config['action_dispatch.show_detailed_exceptions']
+    env_config['action_dispatch.show_exceptions'] = true
+    env_config['action_dispatch.show_detailed_exceptions'] = false
+    yield
+  ensure
+    env_config['action_dispatch.show_exceptions'] = original_show_exceptions
+    env_config['action_dispatch.show_detailed_exceptions'] = original_show_detailed_exceptions
+  end
+end
+
+RSpec.configure do |config|
+  config.include ErrorResponses, type: :feature
+  config.around :each, type: :feature do |example|
+    respond_without_detailed_exceptions do
+      example.run
+    end
+  end
+end


### PR DESCRIPTION


## Why was this change made?

This draws the user-friendly public/404.html.  This is the default behavior in later versions of ActiveFedora.

## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?

n/a

