### PR TITLE
Logger#warning is not a method

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -54,7 +54,7 @@ class RegistrationsController < ApplicationController
         rescue ActiveFedora::ObjectNotFoundError
           Honeybadger.notify("Unable to find the collection #{col_id} in Fedora, but it's listed in the administrativeMetadata datastream for #{params[:apo_id]}")
           col_not_found_warning = "#{params[:apo_id]} lists collection #{col_id} for registration, but it wasn't found in Fedora."
-          Rails.logger.warning col_not_found_warning
+          logger.warn col_not_found_warning
         end
       end
     end

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe RegistrationsController, type: :controller do
         missing_registration_collections.each do |col_id|
           col_not_found_warning = "druid:fg464dn8891 lists collection #{col_id} for registration, but it wasn't found in Fedora."
           allow(Dor).to receive(:find).with(col_id).and_raise(ActiveFedora::ObjectNotFoundError)
-          expect(Rails.logger).to receive(:warning).with(col_not_found_warning)
+          expect(Rails.logger).to receive(:warn).with(col_not_found_warning)
         end
         mock_collection_b = instance_double(Dor::Collection, label: 'Annual report of the State Corporation Commission showing a bunch of stuff')
 


### PR DESCRIPTION


## Why was this change made?
Replace with Logger#warn


## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?
n/a


