### PR TITLE
Generate the correct access subschema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ coverage/
 db/*.sqlite3
 dpg_pool
 gem_graph.png
+examples.txt
 
 /public/assets
 public/images/.dpg_pool

--- a/app/forms/collection_form.rb
+++ b/app/forms/collection_form.rb
@@ -59,7 +59,7 @@ class CollectionForm < BaseForm
     reg_params[:description] = build_description if params[:collection_title].present? && params[:collection_abstract].present?
 
     raw_rights = params[:collection_catkey].present? ? params[:collection_rights_catkey] : params[:collection_rights]
-    reg_params[:access] = access(raw_rights) || {}
+    reg_params.merge! CocinaAccess.from_form_value(raw_rights)
 
     if params[:collection_catkey].present?
       reg_params[:identification] = {
@@ -68,21 +68,6 @@ class CollectionForm < BaseForm
     end
 
     Cocina::Models::RequestCollection.new(reg_params)
-  end
-
-  # @param [String] the rights representation from the form
-  # @return [Hash<Symbol,String>] a hash representing the Access subschema of the Cocina model
-  def access(rights)
-    if rights.start_with?('loc:')
-      {
-        access: 'location-based',
-        readLocation: rights.delete_prefix('loc:')
-      }
-    else
-      {
-        access: rights
-      }
-    end
   end
 
   def build_description

--- a/app/forms/registration_form.rb
+++ b/app/forms/registration_form.rb
@@ -26,7 +26,8 @@ class RegistrationForm
         catalogLinks: catalog_links
       }
     }
-    model_params[:access] = access(params[:rights]) if params[:rights] != 'default'
+
+    model_params.merge!(CocinaAccess.from_form_value(params[:rights]))
 
     structural = {}
     structural[:isMemberOf] = params[:collection] if params[:collection].present?
@@ -76,27 +77,5 @@ class RegistrationForm
   def content_type_tag
     content_tag = params[:tag].find { |tag| tag.start_with?('Process : Content Type') }
     content_tag.split(':').last.strip
-  end
-
-  # @param [String] the rights representation from the form
-  # @return [Hash<Symbol,String>] a hash representing the Access subschema of the Cocina model
-  def access(rights)
-    if rights.end_with?('-nd') || %w[dark citation-only].include?(rights)
-      {
-        access: rights.delete_suffix('-nd'),
-        download: 'none'
-      }
-    elsif rights.start_with?('loc:')
-      {
-        access: 'location-based',
-        readLocation: rights.delete_prefix('loc:'),
-        download: 'location-based'
-      }
-    else
-      {
-        access: rights,
-        download: rights
-      }
-    end
   end
 end

--- a/app/services/cocina_access.rb
+++ b/app/services/cocina_access.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class CocinaAccess
+  # @param [String] the rights representation from the form (must be one of the keys in Dor::RightsMetadataDS::RIGHTS_TYPE_CODES, or 'default')
+  # @return [Hash<Symbol,String>] a hash representing the Access subschema of the Cocina model
+  def self.from_form_value(rights)
+    return {} if rights == 'default'
+
+    model_params = if rights.end_with?('-nd') || %w[dark citation-only].include?(rights)
+                     {
+                       access: rights.delete_suffix('-nd'),
+                       download: 'none'
+                     }
+                   elsif rights.start_with?('loc:')
+                     {
+                       access: 'location-based',
+                       readLocation: rights.delete_prefix('loc:'),
+                       download: 'location-based'
+                     }
+                   else
+                     {
+                       access: rights,
+                       download: rights
+                     }
+                   end
+
+    { access: model_params }
+  end
+end

--- a/spec/forms/apo_form_spec.rb
+++ b/spec/forms/apo_form_spec.rb
@@ -326,7 +326,7 @@ RSpec.describe ApoForm do
           type: 'http://cocina.sul.stanford.edu/models/collection.jsonld',
           label: coll_title,
           version: 1,
-          access: { access: 'world', download: 'none' },
+          access: { access: 'world', download: 'world' },
           administrative: { hasAdminPolicy: 'druid:zt570tx3016' }
         }
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,4 +5,5 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
 
   config.default_formatter = 'doc' if config.files_to_run.one?
+  config.example_status_persistence_file_path = 'examples.txt'
 end


### PR DESCRIPTION
When registering a collection from the APO page and selecting a no-download access type

## Why was this change made?

Fixes #2177 


## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?

n/a

