### PR TITLE
clean up remaining cruft from delayed_job

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -14,7 +14,7 @@ class UploadsController < ApplicationController
     output_directory = File.join(Settings.bulk_metadata.directory, params[:apo_id], directory_name)
     temp_spreadsheet_filename = params[:spreadsheet_file].original_filename + '.' + directory_name
 
-    # Temporary files are sometimes garbage collected before the Delayed Job is run, so make a copy and let the job delete it when it's done.
+    # Temporary files are sometimes garbage collected before the job is run, so make a copy and let the job delete it when it's done.
     temp_filename = make_tmp_filename(temp_spreadsheet_filename)
     FileUtils.copy(params[:spreadsheet_file].path, temp_filename)
     ModsulatorJob.perform_later(params[:apo_id],

--- a/db/migrate/20200709002946_drop_table_delayed_jobs.rb
+++ b/db/migrate/20200709002946_drop_table_delayed_jobs.rb
@@ -1,0 +1,5 @@
+class DropTableDelayedJobs < ActiveRecord::Migration[5.2]
+  def change
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_10_050959) do
+ActiveRecord::Schema.define(version: 2020_07_09_002946) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -35,21 +35,6 @@ ActiveRecord::Schema.define(version: 2018_05_10_050959) do
     t.datetime "updated_at", null: false
     t.integer "user_id"
     t.index ["user_id"], name: "index_bulk_actions_on_user_id"
-  end
-
-  create_table "delayed_jobs", force: :cascade do |t|
-    t.integer "priority", default: 0, null: false
-    t.integer "attempts", default: 0, null: false
-    t.text "handler", limit: 4294967295, null: false
-    t.text "last_error"
-    t.datetime "run_at"
-    t.datetime "locked_at"
-    t.datetime "failed_at"
-    t.string "locked_by"
-    t.string "queue"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
   create_table "indexing_exceptions", force: :cascade do |t|


### PR DESCRIPTION
* drop supporting database table
* clean up stray references in code and comments
* a couple opportunistic touchups on `ModsulatorClient` (better constructor param comment, DRY up logging a bit)

## Why was this change made?

happened to look at the schema and notice the `delayed_jobs` table, which seemed like cruft in light of the switch to sidekiq.

## How was this change tested?

unit tests (i wasn't able to get the unit tests working locally just now, would like to pair on that if someone has time, but this change seemed safe and limited enough that i figured i'd throw up a PR and see if CI passed)

## Which documentation and/or configurations were updated?

none