### PR TITLE
Hide the workflows datastream

### DIFF
--- a/app/views/catalog/_datastreams_default.html.erb
+++ b/app/views/catalog/_datastreams_default.html.erb
@@ -4,6 +4,12 @@
 </h3>
 <div id="document-datastreams-section" class="document-section">
   <table class="detail">
-    <%= render DatastreamRow.with_collection(object.datastreams.values.reject(&:new?)) %>
+    <%=
+      render DatastreamRow.with_collection(
+        object.datastreams.reject do |name, instance|
+          instance.new? || Settings.hidden_datastreams.include?(name)
+        end.values
+      )
+    %>
   </table>
 </div>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,6 +21,9 @@ checksum_report_job:
 export_tags_job:
   csv_filename: 'tags.csv'
 
+hidden_datastreams:
+  - 'workflows'
+
 # Newrelic
 newrelic:
   enabled: false


### PR DESCRIPTION
## Why was this change made?

It does not provide useful information and it is causing clicks to hit lyberservices boxes which we want to get rid of. Requested/approved by @andrewjbtw.

## How was this change tested?

I deployed to stage and confirmed an object that used to show the workflows datastream was no longer shown. https://argo-stage.stanford.edu/view/druid:bb181jh4180 (note: this branch may NOT be on stage when you click the link).

I'm not sure how best to otherwise test this change. View specs are a mess. Tests weren't added or changed when we moved to this component-based approach so :man_shrugging:. @sul-dlss/infrastructure-team  good enough?

## Which documentation and/or configurations were updated?

New configuration added locally, does not require shared_configs changes.

