### PR TITLE
show error message for malformed XML instead of raising an exception

### DIFF
--- a/spec/requests/update_datastream_spec.rb
+++ b/spec/requests/update_datastream_spec.rb
@@ -46,8 +46,11 @@ RSpec.describe 'Update a datastream' do
       expect { patch "/items/#{pid}/datastreams/contentMetadata", params: { content: ' ' } }.to raise_error(ArgumentError)
     end
 
-    it 'errors on malformed xml' do
-      expect { patch "/items/#{pid}/datastreams/contentMetadata", params: { content: '<this>isnt well formed.' } }.to raise_error(ArgumentError)
+    it 'does not update the datastream with malformed xml' do
+      patch "/items/#{pid}/datastreams/contentMetadata", params: { content: '<this>isnt well formed.' }
+      expect(item).not_to receive(:save)
+      expect(Argo::Indexer).not_to receive(:reindex_pid_remotely)
+      expect(response).to redirect_to "/view/#{pid}"
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Fixes #2183 

Show error message on invalid XML when saving a datastream instead of of raising an exception.


## How was this change tested?

Unit test updated.  Tested in browser in localhost.

## Which documentation and/or configurations were updated?



