### PR TITLE
restore ability to edit admin metadata

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -108,5 +108,6 @@ editable_datastreams:
   - contentMetadata
   - versionMetadata
   - rightsMetadata
+  - administrativeMetadata
 
 redis_url: 'redis://localhost:6379/'


### PR DESCRIPTION
## Why was this change made?

Fixes #2196 

## How was this change tested?

In localhost browser


## Which documentation and/or configurations were updated?

Only a config change


