### PR TITLE
restore datastream info shown to user

### DIFF
--- a/app/views/datastreams/show.html.erb
+++ b/app/views/datastreams/show.html.erb
@@ -9,10 +9,10 @@
 
     <% unless params[:id] == 'full_dc' %>
       <div class="CodeRay">
-        <pre>
+        <textarea id="content" class="form-control" rows=3 disabled>
           <foxml:datastream ID="<%= @ds.dsid %>" STATE="<%= @ds.state %>" CONTROL_GROUP="<%= @ds.controlGroup %>" VERSIONABLE="<%= @ds.versionable %>">
           <foxml:datastreamVersion ID="<%= @ds.dsVersionID %>" LABEL="<%= @ds.label %>" CREATED="<%= @ds.createDate&.xmlschema %>" MIMETYPE="<%= @ds.mimeType %>">
-        </pre>
+        </textarea>
       </div>
     <% end %>
     <%= CodeRay::Duo[:xml, :div].highlight(@content).html_safe %>


### PR DESCRIPTION
## Why was this change made?

Fixes #2197.  The datastream info coming from Fedora looks like HTML and the browser is not rendering it.  Adding the `<pre>` tags is not working (it just doesn't render in the browser).  Using a disabled textarea shows the content as is without letting the user change it.

## How was this change tested?

In localhost browser.


## Which documentation and/or configurations were updated?

None.


