### PR TITLE
Set access using cocina data model

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -213,8 +213,11 @@ class ItemsController < ApplicationController
 
   # This is called from the item page and from the bulk (synchronous) update page
   def set_rights
-    @object.read_rights = params[:access_form][:rights]
-    save_and_reindex
+    object_client = Dor::Services::Client.object(@object.pid)
+    dro = object_client.find
+    json = JSON.parse(dro.to_json)
+               .merge(CocinaAccess.from_form_value(params[:access_form][:rights]).deep_stringify_keys)
+    object_client.update(params: json)
 
     respond_to do |format|
       if params[:bulk]

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -213,13 +213,6 @@ RSpec.describe ItemsController, type: :controller do
     end
   end
 
-  describe '#set_rights' do
-    it 'sets an item to dark' do
-      expect(item).to receive(:read_rights=).with('dark')
-      get 'set_rights', params: { id: pid, access_form: { rights: 'dark' } }
-    end
-  end
-
   describe '#add_collection' do
     context 'when they have manage access' do
       before do

--- a/spec/requests/set_rights_spec.rb
+++ b/spec/requests/set_rights_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Set rights for an object' do
+  context 'when they have manage access' do
+    let(:user) { create(:user) }
+    let(:pid) { 'druid:cc243mg0841' }
+    let(:fedora_obj) { instance_double(Dor::Item, pid: pid, current_version: 1, admin_policy_object: nil) }
+    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, update: true) }
+    let(:cocina_model) do
+      Cocina::Models.build(
+        'label' => 'My ETD',
+        'version' => 1,
+        'type' => Cocina::Models::Vocab.object,
+        'externalIdentifier' => pid,
+        'access' => { 'access' => 'world' },
+        'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+        'structural' => {},
+        'identification' => {}
+      )
+    end
+
+    before do
+      allow(Dor).to receive(:find).and_return(fedora_obj)
+      allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+
+      sign_in user, groups: ['sdr:administrator-role']
+    end
+
+    it 'sets the access' do
+      post "/items/#{pid}/set_rights", params: { access_form: { rights: 'dark' } }
+      expect(response).to redirect_to(solr_document_path(pid))
+      expect(object_client).to have_received(:update)
+        .with(
+          params: {
+            'access' => { 'access' => 'dark', 'download' => 'none' },
+            'administrative' => { 'hasAdminPolicy' => 'druid:cg532dg5405' },
+            'externalIdentifier' => 'druid:cc243mg0841',
+            'identification' => {},
+            'label' => 'My ETD',
+            'structural' => {},
+            'type' => 'http://cocina.sul.stanford.edu/models/object.jsonld',
+            'version' => 1
+          }
+        )
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

This allows us to set to citation-only and it eliminates one place where we depend on the legacy ActiveFedora API. Fixes #2190

## How was this change tested?

Tested on staging.

## Which documentation and/or configurations were updated?



