### PR TITLE
Display cocina by default

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -225,7 +225,7 @@ class CatalogController < ApplicationController
       object: @obj
     )
 
-    @techmd = TechmdService.techmd_for(druid: params[:id]) if params[:beta]
+    @techmd = TechmdService.techmd_for(druid: params[:id])
 
     respond_to do |format|
       format.html { setup_next_and_previous_documents }

--- a/app/javascript/style/document.scss
+++ b/app/javascript/style/document.scss
@@ -126,5 +126,6 @@ table.detail {
     text-align: left;
     padding: 0em 2em 0.25em 0em;
     border: none;
+    vertical-align: top;
   }
 }

--- a/app/views/catalog/_cocina_default.html.erb
+++ b/app/views/catalog/_cocina_default.html.erb
@@ -1,10 +1,8 @@
-<% if params[:beta] %>
-  <h3 id="document-cocina-head" class="section-head collapsible-section">
-    Cocina Model
-  </h3>
-  <div id="document-cocina-section" class="document-section">
-    <table class="detail">
-      <pre><%= JSON.pretty_generate(@cocina.as_json) %></pre>
-    </table>
-  </div>
-<% end %>
+<h3 id="document-cocina-head" class="section-head collapsible-section collapsed">
+  Cocina Model
+</h3>
+<div id="document-cocina-section" class="document-section" style="display:none">
+  <table class="detail">
+    <pre><%= JSON.pretty_generate(@cocina.as_json) %></pre>
+  </table>
+</div>

--- a/app/views/catalog/_events_default.html.erb
+++ b/app/views/catalog/_events_default.html.erb
@@ -1,17 +1,15 @@
-<% if params[:beta] %>
-  <h3 id="document-events-head" class="section-head collapsible-section">
-    Events
-  </h3>
-  <div id="document-events-section" class="document-section">
-    <table class="detail">
-      <thead>
-        <tr><th>When</th><th>Event type</th><th>Data</th></tr>
-      </thead>
-      <tbody>
-      <% @events.each do |event| %>
-        <tr><td><time-ago datetime="<%= event.timestamp %>"><%= event.timestamp %></time-ago></td><td><%= event.event_type %></td><td><%= event.data %></td></tr>
-      <% end %>
-      </tbody>
-    </table>
-  </div>
-<% end %>
+<h3 id="document-events-head" class="section-head collapsible-section collapsed">
+  Events
+</h3>
+<div id="document-events-section" class="document-section"  style="display:none">
+  <table class="detail">
+    <thead>
+      <tr><th>When</th><th>Event type</th><th>Data</th></tr>
+    </thead>
+    <tbody>
+    <% @events.each do |event| %>
+      <tr><td><time-ago datetime="<%= event.timestamp %>"><%= event.timestamp %></time-ago></td><td><%= event.event_type %></td><td><pre><%= JSON.pretty_generate(event.data) %></pre></td></tr>
+    <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/catalog/_techmd_default.html.erb
+++ b/app/views/catalog/_techmd_default.html.erb
@@ -1,8 +1,8 @@
 <% unless @techmd.blank? %>
-  <h3 id="document-techmd-head" class="section-head collapsible-section">
+  <h3 id="document-techmd-head" class="section-head collapsible-section collapsed">
     Technical metadata
   </h3>
-  <div id="document-techmd-section" class="document-section techmd-section">
+  <div id="document-techmd-section" class="document-section techmd-section" style="display:none">
     <ul class="file-list">
       <% @techmd.each do | file_techmd | %>
         <li class="file">


### PR DESCRIPTION

But keep it collapsed

## Why was this change made?

Allow users to begin seeing the new data model.

## How was this change tested?

Tested on staging.


<img width="575" alt="Screen Shot 2020-08-19 at 2 41 56 PM" src="https://user-images.githubusercontent.com/92044/90682150-2b3ad080-e22a-11ea-8e80-9408b291caa1.png">

## Which documentation and/or configurations were updated?



