### PR TITLE
Updating access should not overwrite the entire access subschema

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -215,7 +215,9 @@ class ItemsController < ApplicationController
   def set_rights
     object_client = Dor::Services::Client.object(@object.pid)
     dro = object_client.find
-    updated = dro.new(CocinaAccess.from_form_value(params[:access_form][:rights]))
+    access_additions = CocinaAccess.from_form_value(params[:access_form][:rights])
+    updated_access = dro.access.new(access_additions.value!)
+    updated = dro.new(access: updated_access)
     object_client.update(params: updated)
     Argo::Indexer.reindex_pid_remotely(@object.pid)
 

--- a/app/forms/collection_form.rb
+++ b/app/forms/collection_form.rb
@@ -59,7 +59,8 @@ class CollectionForm < BaseForm
     reg_params[:description] = build_description if params[:collection_title].present? && params[:collection_abstract].present?
 
     raw_rights = params[:collection_catkey].present? ? params[:collection_rights_catkey] : params[:collection_rights]
-    reg_params.merge! CocinaAccess.from_form_value(raw_rights)
+    access = CocinaAccess.from_form_value(raw_rights)
+    reg_params.merge!(access: access.value!) unless access.none?
 
     if params[:collection_catkey].present?
       reg_params[:identification] = {

--- a/app/forms/registration_form.rb
+++ b/app/forms/registration_form.rb
@@ -27,7 +27,8 @@ class RegistrationForm
       }
     }
 
-    model_params.merge!(CocinaAccess.from_form_value(params[:rights]))
+    access = CocinaAccess.from_form_value(params[:rights])
+    model_params.merge!(access: access.value!) unless access.none?
 
     structural = {}
     structural[:isMemberOf] = params[:collection] if params[:collection].present?

--- a/app/services/cocina_access.rb
+++ b/app/services/cocina_access.rb
@@ -1,29 +1,30 @@
 # frozen_string_literal: true
 
 class CocinaAccess
+  extend Dry::Monads[:maybe]
+
   # @param [String] the rights representation from the form (must be one of the keys in Dor::RightsMetadataDS::RIGHTS_TYPE_CODES, or 'default')
-  # @return [Hash<Symbol,String>] a hash representing the Access subschema of the Cocina model
+  # @return [Maybe<Hash<Symbol,String>>] a hash representing a subset of the Access subschema of the Cocina model
   def self.from_form_value(rights)
-    return {} if rights == 'default'
+    return None() if rights == 'default'
 
-    model_params = if rights.end_with?('-nd') || %w[dark citation-only].include?(rights)
-                     {
-                       access: rights.delete_suffix('-nd'),
-                       download: 'none'
-                     }
-                   elsif rights.start_with?('loc:')
-                     {
-                       access: 'location-based',
-                       readLocation: rights.delete_prefix('loc:'),
-                       download: 'location-based'
-                     }
-                   else
-                     {
-                       access: rights,
-                       download: rights
-                     }
-                   end
-
-    { access: model_params }
+    data = if rights.end_with?('-nd') || %w[dark citation-only].include?(rights)
+             {
+               access: rights.delete_suffix('-nd'),
+               download: 'none'
+             }
+           elsif rights.start_with?('loc:')
+             {
+               access: 'location-based',
+               readLocation: rights.delete_prefix('loc:'),
+               download: 'location-based'
+             }
+           else
+             {
+               access: rights,
+               download: rights
+             }
+           end
+    Some(data)
   end
 end

--- a/spec/requests/set_rights_spec.rb
+++ b/spec/requests/set_rights_spec.rb
@@ -14,7 +14,13 @@ RSpec.describe 'Set rights for an object' do
         'version' => 1,
         'type' => Cocina::Models::Vocab.object,
         'externalIdentifier' => pid,
-        'access' => { 'access' => 'world' },
+        'access' => {
+          'access' => 'world',
+          "embargo": {
+            "releaseDate": '2021-02-11T00:00:00.000+00:00',
+            "access": 'world'
+          }
+        },
         'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
         'structural' => {},
         'identification' => {}
@@ -22,7 +28,13 @@ RSpec.describe 'Set rights for an object' do
     end
 
     let(:updated_model) do
-      cocina_model.new('access' => { 'access' => 'dark', 'download' => 'none' })
+      cocina_model.new('access' => {
+                         'access' => 'dark', 'download' => 'none',
+                         "embargo": {
+                           "releaseDate": '2021-02-11T00:00:00.000+00:00',
+                           "access": 'world'
+                         }
+                       })
     end
 
     before do


### PR DESCRIPTION
Just the properties that the form sets.


## Why was this change made?
Fixes #2215


## How was this change tested?



## Which documentation and/or configurations were updated?



