### PR TITLE
Disable publish/shelve in content metadata when setting rights to dark

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -214,7 +214,9 @@ class ItemsController < ApplicationController
     dro = object_client.find
     access_additions = CocinaAccess.from_form_value(params[:access_form][:rights])
     updated_access = dro.access.new(access_additions.value!)
-    updated = dro.new(access: updated_access)
+    structural_additions = CocinaStructural.from_form_value(params[:access_form][:rights], dro.structural)
+    updated_structural = dro.structural.new(structural_additions)
+    updated = dro.new(access: updated_access, structural: updated_structural)
     object_client.update(params: updated)
     reindex
 

--- a/app/services/cocina_structural.rb
+++ b/app/services/cocina_structural.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CocinaStructural
+  # @param structural [Cocina::Models::DROStructural] the DRO structural metadata to modify
+  # @param rights [String] the rights representation from the form (must be one of the keys in Dor::RightsMetadataDS::RIGHTS_TYPE_CODES, or 'default')
+  # @return [Hash<Symbol,String>] a hash representing a subset of the Structural subschema of the Cocina model
+  def self.from_form_value(rights, structural)
+    # Convert to hash so we can mutate it
+    structural.to_h.tap do |structure_hash|
+      if rights == 'dark' && structural&.contains&.any?
+        structure_hash[:contains].each do |fileset|
+          fileset[:structural][:contains].each do |file|
+            # Ensure files attached to dark objects are neither published nor shelved
+            file[:access].merge!(access: 'dark')
+            file[:administrative].merge!(shelve: false)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #2220

## Why was this change made?

See #2220.

## How was this change tested?

CI

## Which documentation and/or configurations were updated?

None.

