### PR TITLE
Fix importing of tags

### DIFF
--- a/app/forms/bulk_action_form.rb
+++ b/app/forms/bulk_action_form.rb
@@ -29,7 +29,10 @@ class BulkActionForm < BaseForm
   delegate :action_type, :description, to: :model
 
   def csv_as_string
-    csv_file = create_virtual_objects&.fetch(:csv_file) || register_druids&.fetch(:csv_file)
+    csv_file = create_virtual_objects&.fetch(:csv_file) ||
+               register_druids&.fetch(:csv_file) ||
+               import_tags&.fetch(:csv_file)
+
     # Short-circuit if request is not related to creating virtual objects
     return unless csv_file
 

--- a/spec/forms/bulk_action_form_spec.rb
+++ b/spec/forms/bulk_action_form_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BulkActionForm do
+  let(:csv_file) { instance_double(File, path: nil) }
+  let(:form) { described_class.new(BulkAction.new, groups: ['sdr:administrator-role']) }
+  let(:params) do
+    {
+      import_tags: { csv_file: csv_file }
+    }
+  end
+
+  describe '#csv_as_string' do
+    before do
+      allow(File).to receive(:read)
+      allow(BulkActionPersister).to receive(:persist)
+    end
+
+    it 'works in import_tags context' do
+      form.validate(params)
+      form.save
+      form.csv_as_string
+      expect(File).to have_received(:read).once
+      expect(BulkActionPersister).to have_received(:persist).once
+    end
+  end
+end


### PR DESCRIPTION

## Why was this change made?

This was broken in the bulk registration PR that omitted the import tags use case. I do not love the spec coverage I added, but it covers the bug this is fixing and beginning to add coverage of the bulk action form which was not covered and allowed this bug to go unnoticed.


## How was this change tested?

CI and local browser testing

## Which documentation and/or configurations were updated?



None