### PR TITLE
Add documentation of which forms have the None case

### DIFF
--- a/app/services/cocina_access.rb
+++ b/app/services/cocina_access.rb
@@ -6,6 +6,7 @@ class CocinaAccess
   # @param [String] the rights representation from the form (must be one of the keys in Dor::RightsMetadataDS::RIGHTS_TYPE_CODES, or 'default')
   # @return [Maybe<Hash<Symbol,String>>] a hash representing a subset of the Access subschema of the Cocina model
   def self.from_form_value(rights)
+    # Default only appears on the registration form, not the update form.
     return None() if rights == 'default'
 
     data = if rights.end_with?('-nd') || %w[dark citation-only].include?(rights)


### PR DESCRIPTION
## Why was this change made?
It was not clear which cases can return `None`


## How was this change tested?



## Which documentation and/or configurations were updated?



