### PR TITLE
Update openapi parser to avoid warnings about URI.escape

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -357,7 +357,7 @@ GEM
     openapi3_parser (0.8.2)
       commonmarker (~> 0.17)
       psych (~> 3.1)
-    openapi_parser (0.11.2)
+    openapi_parser (0.12.1)
     orm_adapter (0.5.0)
     parallel (1.19.2)
     parser (2.7.1.4)


### PR DESCRIPTION
## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



