### PR TITLE
Avoid deprecation warning about kwargs

### DIFF
--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -3,16 +3,16 @@
 FactoryBot.define do
   factory :collection, class: Cocina::Models::RequestDRO do
     initialize_with do
-      Cocina::Models.build_request(
-        'type' => type,
-        'label' => 'test object',
-        'version' => 1,
-        'access' => {
-        },
-        'administrative' => {
-          'hasAdminPolicy' => apo.pid
-        }
-      )
+      Cocina::Models.build_request({
+                                     'type' => type,
+                                     'label' => 'test object',
+                                     'version' => 1,
+                                     'access' => {
+                                     },
+                                     'administrative' => {
+                                       'hasAdminPolicy' => apo.pid
+                                     }
+                                   })
     end
 
     to_create do |cocina_model|


### PR DESCRIPTION


## Why was this change made?

Get's rid of this warning:
```
Using the last argument as keyword parameters is deprecated
```
## How was this change tested?

test suite

## Which documentation and/or configurations were updated?



