### PR TITLE
Use route helpers

### DIFF
--- a/app/views/items/_catkey_ui.html.erb
+++ b/app/views/items/_catkey_ui.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag url_for(controller: :items, action: :catkey, id: @object.pid) do %>
+<%= form_tag catkey_item_path(@object) do %>
   <div class="form-group">
     <input class="form-control" name="new_catkey" id="new_catkey" type="text" value="<%= @object.catkey %>">
     <p class='help-block'>

--- a/app/views/items/_collection_ui.html.erb
+++ b/app/views/items/_collection_ui.html.erb
@@ -17,7 +17,7 @@
     <h3 class="panel-title">Add a collection</h3>
   </div>
   <div class='panel-body'>
-    <%= form_tag url_for(controller: :items, action: :add_collection, id: @object.pid), id: 'add_collection_form' do %>
+    <%= form_tag add_collection_item_path(id: @object.pid), id: 'add_collection_form' do %>
       <div class='form-group'>
         <%= select_tag :collection, options_for_select(current_user.permitted_collections), class: 'form-control' %>
       </div>

--- a/app/views/items/_collection_ui_line_item.html.erb
+++ b/app/views/items/_collection_ui_line_item.html.erb
@@ -1,6 +1,6 @@
 <li id='collection_<%= col.pid.gsub('druid:', '') %>' class='list-group-item'>
   <%= object_title(col) %>
-  <%= link_to url_for(controller: :items, action: :remove_collection, id: @object.pid, collection: col.pid) do %>
+  <%= link_to remove_collection_item_path(id: @object.pid, collection: col.pid) do %>
     <span id='remove_collection' data-pid='<%= @object.pid %>' class='icon-remove-sign text-danger'></span>
   <% end %>
 </li>

--- a/app/views/items/_embargo_form.html.erb
+++ b/app/views/items/_embargo_form.html.erb
@@ -4,7 +4,7 @@
   });
 </script>
 <div id='embargo_update'>
-  <%= form_tag url_for(controller: :items, action: :embargo_update), method: :POST do %>
+  <%= form_tag embargo_update_item_path(id: @object.pid), method: :POST do %>
     <div class='form-group'>
       <label for='embargo_date'>New date</label>
       <input name="embargo_date" id="embargo_date" type="text">

--- a/app/views/items/_rights.html.erb
+++ b/app/views/items/_rights.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @form, url: url_for(controller: :items, action: :set_rights, id: @object.pid) do |f| %>
+<%= form_with model: @form, url: set_rights_item_path(@object) do |f| %>
   <div class='form-group'>
     <%= f.select :rights, f.object.rights_list, {}, class: 'form-control' %>
   </div>

--- a/app/views/items/_source_id_ui.html.erb
+++ b/app/views/items/_source_id_ui.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag url_for(controller: :items, action: :source_id, id: @object.pid) do %>
+<%= form_tag source_id_item_path(@object) do %>
   <div class="form-group">
     <input class="form-control" name="new_id" id="new_id" type="text" value="<%= @object.identityMetadata.sourceId %>">
     <p class='help-block'>

--- a/app/views/report/bulk.html.erb
+++ b/app/views/report/bulk.html.erb
@@ -8,18 +8,18 @@ report_model = {
 cons=[];
 function catalog_url(element)
 {
-  url='<%= link_to 'druid:xxxxxxxxx', url_for(controller: :catalog, action: :show, id: 'druid:xxxxxxxxx', bulk: 'true'), target: '_blank', rel: 'noopener' %>'
+  url='<%= link_to 'druid:xxxxxxxxx', solr_document_path(id: 'druid:xxxxxxxxx', bulk: 'true'), target: '_blank', rel: 'noopener' %>'
   url=url.replace(/xxxxxxxxx/g,element);
   return url;
 }
 set_content_type_url='<%= item_content_type_url(item_id: 'druid:xxxxxxxxx', bulk: 'true') %>'
-set_rights_url='<%= url_for controller: :items, action: :set_rights, id: 'druid:xxxxxxxxx', bulk: 'true' %>'
-set_collection_url='<%= url_for controller: :items, action: :set_collection, id: 'druid:xxxxxxxxx', bulk: 'true' %>'
-apo_apply_defaults_url='<%= url_for controller: :items, action: :apply_apo_defaults, id: 'druid:xxxxxxxxx', bulk: 'true' %>'
-add_workflow_url = '<%= item_workflows_path 'druid:xxxxxxxxx', bulk: 'true' %>'
+set_rights_url='<%= set_rights_item_path(id: 'druid:xxxxxxxxx', bulk: 'true') %>'
+set_collection_url='<%= set_collection_item_path(id: 'druid:xxxxxxxxx', bulk: 'true') %>'
+apo_apply_defaults_url='<%= apply_apo_defaults_item_path(id: 'druid:xxxxxxxxx', bulk: 'true') %>'
+add_workflow_url = '<%= item_workflows_path('druid:xxxxxxxxx', bulk: 'true') %>'
 refresh_metadata_url='<%= refresh_metadata_item_path(id: 'druid:xxxxxxxxx', bulk: 'true') %>'
-source_id_url='<%= url_for controller: :items, action: :source_id, id: 'druid:xxxxxxxxx', bulk: 'true' %>'
-tags_url='<%= url_for controller: :items, action: :tags_bulk, id: 'druid:xxxxxxxxx', bulk: 'true' %>'
+source_id_url='<%=  source_id_item_path(id: 'druid:xxxxxxxxx', bulk: 'true') %>'
+tags_url='<%= tags_bulk_item_path(id: 'druid:xxxxxxxxx', bulk: 'true') %>'
 </script>
 
 <style>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,14 +142,9 @@ Rails.application.routes.draw do
       get 'set_governing_apo_ui'
       post 'set_governing_apo'
       post :apply_apo_defaults
+      post 'source_id'
+      post 'catkey'
     end
-  end
-
-  namespace :items do
-    post 'source_id'
-    post 'catkey'
-    post 'add_collection'
-    post 'set_collection'
   end
 
   resource :registration, only: :show do

--- a/spec/features/apo_displays_spec.rb
+++ b/spec/features/apo_displays_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'Viewing an Admin policy' do
   before do
     Argo::Indexer.reindex_pid_remotely 'druid:zt570tx3016'
     sign_in current_user, groups: ['sdr:administrator-role']
+    allow(object).to receive(:persisted?).and_return(true) # This allows to_param to function
     allow(Dor).to receive(:find).and_return(object)
   end
 

--- a/spec/views/items/_embargo_form.html.erb_spec.rb
+++ b/spec/views/items/_embargo_form.html.erb_spec.rb
@@ -8,11 +8,10 @@ RSpec.describe 'items/_embargo_form.html.erb' do
   before do
     allow(view).to receive(:current_user).and_return(current_user)
     allow(controller).to receive(:current_user).and_return(current_user)
+    @object = instance_double(Dor::Item, pid: 'druid:abc123')
   end
 
-  # let(:object) { double('object', pid: 'druid:abc123')}
   it 'renders the partial content' do
-    controller.request.path_parameters[:id] = 'test'
     render
     expect(rendered).to have_css 'form .form-group label', text: 'New date'
     expect(rendered).to have_css 'input#embargo_date'


### PR DESCRIPTION
## Why was this change made?
Route helpers are the idiomatic rails way of specifying a route.  This is easier to grep for too.


## How was this change tested?



## Which documentation and/or configurations were updated?



