### PR TITLE
Update catkey using the cocina api 

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -160,8 +160,14 @@ class ItemsController < ApplicationController
   end
 
   def catkey
-    @object.catkey = params[:new_catkey].strip
-    save_and_reindex
+    object_client = Dor::Services::Client.object(@object.pid)
+    dro = object_client.find
+    updated_identification = dro.identification.new(
+      catalogLinks: [{ catalog: 'symphony', catalogRecordId: params[:new_catkey].strip }]
+    )
+    updated = dro.new(identification: updated_identification)
+    object_client.update(params: updated)
+    reindex
 
     respond_to do |format|
       if params[:bulk]

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -160,7 +160,9 @@ class ItemsController < ApplicationController
   end
 
   def catkey
-    CatkeyService.update(@object.pid, params[:new_catkey].strip)
+    object_client = Dor::Services::Client.object(params[:id])
+    dro = object_client.find
+    CatkeyService.update(dro, object_client, params[:new_catkey].strip)
     reindex
 
     respond_to do |format|

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -160,13 +160,7 @@ class ItemsController < ApplicationController
   end
 
   def catkey
-    object_client = Dor::Services::Client.object(@object.pid)
-    dro = object_client.find
-    updated_identification = dro.identification.new(
-      catalogLinks: [{ catalog: 'symphony', catalogRecordId: params[:new_catkey].strip }]
-    )
-    updated = dro.new(identification: updated_identification)
-    object_client.update(params: updated)
+    CatkeyService.update(@object.pid, params[:new_catkey].strip)
     reindex
 
     respond_to do |format|

--- a/app/jobs/generic_job.rb
+++ b/app/jobs/generic_job.rb
@@ -72,11 +72,11 @@ class GenericJob < ActiveJob::Base
     bulk_action.update(druid_count_total: count)
   end
 
-  def open_new_version(object, description)
-    wf_status = DorObjectWorkflowStatus.new(object.pid, version: object.current_version)
-    raise "#{Time.current} Unable to open new version for #{object.pid} (bulk_action.id=#{bulk_action.id})" unless wf_status.can_open_version?
+  def open_new_version(druid, version, description)
+    wf_status = DorObjectWorkflowStatus.new(druid, version: version)
+    raise "#{Time.current} Unable to open new version for #{druid} (bulk_action.id=#{bulk_action.id})" unless wf_status.can_open_version?
 
-    VersionService.open(identifier: object.pid,
+    VersionService.open(identifier: druid,
                         significance: 'minor',
                         description: description,
                         opening_user_name: bulk_action.user.to_s)

--- a/app/jobs/manage_catkey_job.rb
+++ b/app/jobs/manage_catkey_job.rb
@@ -39,8 +39,7 @@ class ManageCatkeyJob < GenericJob
     begin
       state_service = StateService.new(current_druid, version: current_obj.current_version)
       open_new_version(current_obj, "Catkey updated to #{new_catkey}") unless state_service.allows_modification?
-      current_obj.catkey = new_catkey
-      current_obj.save
+      CatkeyService.update(current_druid, new_catkey)
       bulk_action.increment(:druid_count_success).save
       log.puts("#{Time.current} Catkey added/updated/removed successfully")
     rescue StandardError => e

--- a/app/jobs/manage_catkey_job.rb
+++ b/app/jobs/manage_catkey_job.rb
@@ -28,7 +28,6 @@ class ManageCatkeyJob < GenericJob
 
   def update_catkey(current_druid, new_catkey, log)
     log.puts("#{Time.current} Beginning ManageCatkeyJob for #{current_druid}")
-    current_obj = Dor.find(current_druid)
     cocina = Dor::Services::Client.object(current_druid).find
 
     unless ability.can?(:manage_item, cocina)
@@ -37,9 +36,12 @@ class ManageCatkeyJob < GenericJob
     end
     log.puts("#{Time.current} Adding catkey of #{new_catkey}")
     begin
-      state_service = StateService.new(current_druid, version: current_obj.current_version)
-      open_new_version(current_obj, "Catkey updated to #{new_catkey}") unless state_service.allows_modification?
-      CatkeyService.update(current_druid, new_catkey)
+      object_client = Dor::Services::Client.object(current_druid)
+      dro = object_client.find
+      state_service = StateService.new(current_druid, version: dro.version)
+      open_new_version(dro.externalIdentifier, dro.version, "Catkey updated to #{new_catkey}") unless state_service.allows_modification?
+
+      CatkeyService.update(dro, object_client, new_catkey)
       bulk_action.increment(:druid_count_success).save
       log.puts("#{Time.current} Catkey added/updated/removed successfully")
     rescue StandardError => e

--- a/app/jobs/set_governing_apo_job.rb
+++ b/app/jobs/set_governing_apo_job.rb
@@ -37,7 +37,8 @@ class SetGoverningApoJob < GenericJob
     check_can_set_governing_apo!(cocina, state_service)
 
     current_obj = Dor.find(current_druid)
-    open_new_version(current_obj, 'Set new governing APO') unless state_service.allows_modification?
+
+    open_new_version(current_druid, current_obj.current_version, 'Set new governing APO') unless state_service.allows_modification?
 
     current_obj.admin_policy_object = Dor.find(new_apo_id)
     current_obj.identityMetadata.adminPolicy = nil if current_obj.identityMetadata.adminPolicy # no longer supported, erase if present as a bit of remediation

--- a/app/services/catkey_service.rb
+++ b/app/services/catkey_service.rb
@@ -2,13 +2,11 @@
 
 # Updates the catkey on an object by calling the dor-services-app api
 class CatkeyService
-  def self.update(druid, new_catkey)
-    object_client = Dor::Services::Client.object(druid)
-    dro = object_client.find
-    updated_identification = dro.identification.new(
+  def self.update(cocina_model, object_client, new_catkey)
+    updated_identification = cocina_model.identification.new(
       catalogLinks: [{ catalog: 'symphony', catalogRecordId: new_catkey }]
     )
-    updated = dro.new(identification: updated_identification)
+    updated = cocina_model.new(identification: updated_identification)
     object_client.update(params: updated)
   end
 end

--- a/app/services/catkey_service.rb
+++ b/app/services/catkey_service.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Updates the catkey on an object by calling the dor-services-app api
+class CatkeyService
+  def self.update(druid, new_catkey)
+    object_client = Dor::Services::Client.object(druid)
+    dro = object_client.find
+    updated_identification = dro.identification.new(
+      catalogLinks: [{ catalog: 'symphony', catalogRecordId: new_catkey }]
+    )
+    updated = dro.new(identification: updated_identification)
+    object_client.update(params: updated)
+  end
+end

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -158,12 +158,41 @@ RSpec.describe ItemsController, type: :controller do
     context 'when they have manage access' do
       before do
         allow(controller).to receive(:authorize!).and_return(true)
+        allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+      end
+
+      let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, update: true) }
+
+      let(:cocina_model) do
+        Cocina::Models.build({
+                               'label' => 'My ETD',
+                               'version' => 1,
+                               'type' => Cocina::Models::Vocab.object,
+                               'externalIdentifier' => pid,
+                               'access' => {
+                                 'access' => 'world'
+                               },
+                               'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+                               'structural' => {},
+                               'identification' => {}
+                             })
+      end
+
+      let(:updated_model) do
+        cocina_model.new(
+          {
+            'identification' => {
+              'catalogLinks' => [{ catalog: 'symphony', catalogRecordId: '12345' }]
+            }
+          }
+        )
       end
 
       it 'updates the catkey, trimming whitespace' do
-        expect(item).to receive(:catkey=).with('12345')
         expect(Argo::Indexer).to receive(:reindex_pid_remotely)
         post 'catkey', params: { id: pid, new_catkey: '   12345 ' }
+        expect(object_client).to have_received(:update)
+          .with(params: updated_model)
       end
     end
   end

--- a/spec/features/item_catkey_change_spec.rb
+++ b/spec/features/item_catkey_change_spec.rb
@@ -21,14 +21,28 @@ RSpec.describe 'Item catkey change' do
   end
 
   describe 'when modification is allowed' do
+    let(:pid) { 'druid:kv840rx2720' }
     let(:state_service) { instance_double(StateService, allows_modification?: true) }
     let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
-    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, events: events_client) }
-    let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
+    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, events: events_client, update: true) }
     let(:administrative) { instance_double(Cocina::Models::Administrative, releaseTags: []) }
     let(:workflows_response) { instance_double(Dor::Workflow::Response::Workflows, workflows: []) }
     let(:workflow_routes) { instance_double(Dor::Workflow::Client::WorkflowRoutes, all_workflows: workflows_response) }
     let(:workflow_client) { instance_double(Dor::Workflow::Client, milestones: [], workflow_routes: workflow_routes) }
+    let(:cocina_model) do
+      Cocina::Models.build({
+                             'label' => 'My ETD',
+                             'version' => 1,
+                             'type' => Cocina::Models::Vocab.object,
+                             'externalIdentifier' => pid,
+                             'access' => {
+                               'access' => 'world'
+                             },
+                             'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+                             'structural' => {},
+                             'identification' => {}
+                           })
+    end
 
     before do
       # The indexer calls to the workflow service, so stub that out as it's unimportant to this test.
@@ -37,7 +51,7 @@ RSpec.describe 'Item catkey change' do
     end
 
     it 'changes the catkey' do
-      visit catkey_ui_item_path 'druid:kv840rx2720'
+      visit catkey_ui_item_path pid
       fill_in 'new_catkey', with: '12345'
       click_button 'Update'
       expect(page).to have_css '.alert.alert-info', text: 'Catkey for ' \

--- a/spec/jobs/generic_job_spec.rb
+++ b/spec/jobs/generic_job_spec.rb
@@ -55,7 +55,8 @@ RSpec.describe GenericJob do
       instance_double(User,
                       admin?: true)
     end
-    let(:dor_object) { instance_double(Dor::Item, pid: 'druid:123abc', current_version: 1) }
+    let(:pid) { 'druid:123abc' }
+    let(:version) { 1 }
     let(:workflow) { double('workflow') }
     let(:log) { double('log') }
     let(:webauth) { OpenStruct.new('privgroup' => 'dorstuff', 'login' => 'someuser') }
@@ -68,10 +69,10 @@ RSpec.describe GenericJob do
 
     it 'opens a new version if the workflow status allows' do
       expect(DorObjectWorkflowStatus).to receive(:new)
-        .with(dor_object.pid, version: dor_object.current_version).and_return(workflow)
+        .with(pid, version: version).and_return(workflow)
       expect(workflow).to receive(:can_open_version?).and_return(true)
 
-      subject.send(:open_new_version, dor_object, 'Set new governing APO')
+      subject.send(:open_new_version, pid, version, 'Set new governing APO')
 
       expect(version_client).to have_received(:open).with(
         significance: 'minor',
@@ -82,9 +83,9 @@ RSpec.describe GenericJob do
 
     it 'does not open a new version if rejected by the workflow status' do
       expect(DorObjectWorkflowStatus).to receive(:new)
-        .with(dor_object.pid, version: dor_object.current_version).and_return(workflow)
+        .with(pid, version: version).and_return(workflow)
       expect(workflow).to receive(:can_open_version?).and_return(false)
-      expect { subject.send(:open_new_version, dor_object, 'Message') }.to raise_error(/Unable to open new version/)
+      expect { subject.send(:open_new_version, pid, version, 'Message') }.to raise_error(/Unable to open new version/)
 
       expect(version_client).not_to have_received(:open)
     end
@@ -96,10 +97,10 @@ RSpec.describe GenericJob do
 
       it 'fails with an exception' do
         expect(DorObjectWorkflowStatus).to receive(:new)
-          .with(dor_object.pid, version: dor_object.current_version).and_return(workflow)
+          .with(pid, version: version).and_return(workflow)
         expect(workflow).to receive(:can_open_version?).and_return(true)
         allow(subject).to receive(:current_user).and_return(current_user)
-        expect { subject.send(:open_new_version, dor_object, 'Set new governing APO') }.to raise_error(Dor::Exception)
+        expect { subject.send(:open_new_version, pid, version, 'Set new governing APO') }.to raise_error(Dor::Exception)
       end
     end
   end

--- a/spec/requests/set_catkey_spec.rb
+++ b/spec/requests/set_catkey_spec.rb
@@ -6,8 +6,11 @@ RSpec.describe 'Set catkey for an object' do
   let(:user) { create(:user) }
   let(:pid) { 'druid:dc243mg0841' }
   let(:fedora_obj) { instance_double(Dor::Item, pid: pid, current_version: 1, admin_policy_object: nil) }
+  let(:cocina) { instance_double(Cocina::Models::DRO) }
+  let(:object_service) { instance_double(Dor::Services::Client::Object, find: cocina) }
 
   before do
+    allow(Dor::Services::Client).to receive(:object).with(pid).and_return(object_service)
     allow(Dor).to receive(:find).and_return(fedora_obj)
   end
 

--- a/spec/requests/set_catkey_spec.rb
+++ b/spec/requests/set_catkey_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Set catkey for an object' do
+  let(:user) { create(:user) }
+  let(:pid) { 'druid:dc243mg0841' }
+  let(:fedora_obj) { instance_double(Dor::Item, pid: pid, current_version: 1, admin_policy_object: nil) }
+
+  before do
+    allow(Dor).to receive(:find).and_return(fedora_obj)
+  end
+
+  context 'without manage content access' do
+    before do
+      sign_in user
+    end
+
+    it 'returns a 403' do
+      post "/items/#{pid}/catkey", params: { new_catkey: '12345' }
+
+      expect(response.code).to eq('403')
+    end
+  end
+
+  context 'when they have manage access' do
+    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, update: true) }
+
+    let(:cocina_model) do
+      Cocina::Models.build({
+                             'label' => 'My ETD',
+                             'version' => 1,
+                             'type' => Cocina::Models::Vocab.object,
+                             'externalIdentifier' => pid,
+                             'access' => {
+                               'access' => 'world'
+                             },
+                             'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+                             'structural' => {},
+                             'identification' => {}
+                           })
+    end
+
+    let(:updated_model) do
+      cocina_model.new(
+        {
+          'identification' => {
+            'catalogLinks' => [{ catalog: 'symphony', catalogRecordId: '12345' }]
+          }
+        }
+      )
+    end
+
+    before do
+      allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+      allow(Argo::Indexer).to receive(:reindex_pid_remotely)
+      sign_in user, groups: ['sdr:administrator-role']
+    end
+
+    it 'updates the catkey, trimming whitespace' do
+      post "/items/#{pid}/catkey", params: { new_catkey: '   12345 ' }
+
+      expect(object_client).to have_received(:update)
+        .with(params: updated_model)
+      expect(Argo::Indexer).to have_received(:reindex_pid_remotely).with(pid)
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?
To move us away from Fedora 3


## How was this change tested?



## Which documentation and/or configurations were updated?



