### PR TITLE
Allow capistrano to manage sidekiq workers in QA

### DIFF
--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-server 'argo-qa-a.stanford.edu', user: 'lyberadmin', roles: %w[web db app]
-server 'argo-qa-b.stanford.edu', user: 'lyberadmin', roles: %w[web db app]
+server 'argo-qa-a.stanford.edu', user: 'lyberadmin', roles: %w[web db app worker]
+server 'argo-qa-b.stanford.edu', user: 'lyberadmin', roles: %w[web db app worker]
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'


### PR DESCRIPTION
## Why was this change made?

Sidekiq is running stale workers in QA.

## How was this change tested?

Deployment.

## Which documentation and/or configurations were updated?

None
