### PR TITLE
BulkActionPersister now handles catkeys

### DIFF
--- a/app/services/bulk_action_persister.rb
+++ b/app/services/bulk_action_persister.rb
@@ -59,6 +59,7 @@ class BulkActionPersister
     {
       pids: pids.split,
       manage_release: manage_release,
+      manage_catkeys: manage_catkeys,
       set_governing_apo: set_governing_apo,
       prepare: prepare,
       csv_file: bulk_action_form.csv_as_string,

--- a/app/views/bulk_actions/forms/_manage_catkey_form.html.erb
+++ b/app/views/bulk_actions/forms/_manage_catkey_form.html.erb
@@ -1,6 +1,7 @@
-<div class='form-group'>
-  <label>List of catkeys*</label>
-  <textarea id='bulk_action_manage_catkeys_catkeys' name='bulk_action[manage_catkeys][catkeys]' class='form-control' rows='10'>
-  </textarea>
-  <span class='help-block'>* must be same length as list of druids and in same order to update ... add a blank line to delete existing catkey</span>
-</div>
+<%= f.fields_for :manage_catkeys do |manage_catkeys_fields| %>
+  <div class='form-group'>
+    <%= manage_catkeys_fields.label :catkeys, 'List of catkeys*' %>
+    <%= manage_catkeys_fields.text_area :catkeys, class: 'form-control', rows: 10 %>
+    <span class='help-block'>* must be same length as list of druids and in same order to update ... add a blank line to delete existing catkey</span>
+  </div>
+<% end %>

--- a/app/views/bulk_actions/forms/_set_governing_apo_form.html.erb
+++ b/app/views/bulk_actions/forms/_set_governing_apo_form.html.erb
@@ -1,12 +1,6 @@
-<div>
-  <%= f.fields_for :set_governing_apo do |set_governing_apo_fields| %>
-    <div class='form-group'>
-      <div class='text'>
-        <label for='bulk_action_set_governing_apo_new_apo_id' class='control-label'>
-          New governing APO
-        </label>
-        <%= set_governing_apo_fields.select(:new_apo_id, apo_list(current_user.groups), {}, class: 'form-control') %>
-      </div>
-    </div>
-  <% end %>
-</div>
+<%= f.fields_for :set_governing_apo do |set_governing_apo_fields| %>
+  <div class='form-group'>
+    <%= set_governing_apo_fields.label :new_apo_id, 'New governing APO' %>
+    <%= set_governing_apo_fields.select(:new_apo_id, apo_list(current_user.groups), {}, class: 'form-control') %>
+  </div>
+<% end %>

--- a/app/views/bulk_actions/new.html.erb
+++ b/app/views/bulk_actions/new.html.erb
@@ -71,7 +71,7 @@
           <span class='help-block'>
             Adds or updates catkeys associated with objects.  You need two lists: druids and catkeys, and they need to correspond 1:1 in the correct order.
           </span>
-          <%= render 'bulk_actions/forms/manage_catkey_form' %>
+          <%= render 'bulk_actions/forms/manage_catkey_form', f: f %>
         </div>
 
         <div role='tabpanel' class='tab-pane' id='PrepareJob'>

--- a/spec/services/bulk_action_persister_spec.rb
+++ b/spec/services/bulk_action_persister_spec.rb
@@ -91,6 +91,18 @@ RSpec.describe BulkActionPersister do
       it { is_expected.to include(prepare: { 'description' => 'change the data', 'significance' => 'minor' }) }
     end
 
+    context 'for a manage_catkeys job' do
+      let(:bulk_action) do
+        BulkAction.create(action_type: 'ManageCatkeyJob')
+      end
+
+      let(:params) do
+        { pids: %w[a b c], manage_catkeys: { 'catkeys' => "one\ntwo\nthree" } }
+      end
+
+      it { is_expected.to include(manage_catkeys: { 'catkeys' => "one\ntwo\nthree" }) }
+    end
+
     context 'for a create virtual objects job' do
       let(:bulk_action) do
         BulkAction.create(action_type: 'CreateVirtualObjectsJob')


### PR DESCRIPTION


## Why was this change made?

This fixes a regression where bulk manage catkeys was broken.
Fixes #2257

## How was this change tested?



## Which documentation and/or configurations were updated?



