### PR TITLE
Restore url to dor-services for dor-indexing-app in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
     environment:
       SOLR_URL: http://solr:8983/solr/argo
       SETTINGS__SOLR__URL: http://solr:8983/solr/argo
+      SETTINGS__DOR_SERVICES__URL: http://dor-services-app:3000/
       # To generate the token: docker-compose run dor-services-app rake generate_token
       SETTINGS__DOR_SERVICES__TOKEN: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJGb28ifQ.-BVfLTW9Q1_ZQEsGv4tuzGLs5rESN7LgdtEwUltnKv4
       SETTINGS__FEDORA_URL: http://fedoraAdmin:fedoraAdmin@fcrepo:8080/fedora


### PR DESCRIPTION


## Why was this change made?

This was a regression in 9a4df0ab86e7995962379ce6db6cc0819bf511dd that made it impossible to run the tests locally

## How was this change tested?



## Which documentation and/or configurations were updated?



