### PR TITLE
Authorize managing items using the Cocina data model

### DIFF
--- a/app/controllers/apo_controller.rb
+++ b/app/controllers/apo_controller.rb
@@ -41,7 +41,7 @@ class ApoController < ApplicationController
   end
 
   def update
-    authorize! :manage_item, @object
+    authorize! :manage_item, @cocina
     @form = ApoForm.new(@object)
     unless @form.validate(params)
       respond_to do |format|
@@ -56,7 +56,7 @@ class ApoController < ApplicationController
   end
 
   def delete_collection
-    authorize! :manage_item, @object
+    authorize! :manage_item, @cocina
     @object.remove_default_collection(params[:collection])
     @object.save # indexing happens automatically
 
@@ -78,5 +78,6 @@ class ApoController < ApplicationController
     raise 'missing druid' unless params[:id]
 
     @object = Dor.find params[:id]
+    @cocina = Dor::Services::Client.object(params[:id]).find
   end
 end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -3,17 +3,20 @@
 # Manages HTTP interactions for creating collections
 class CollectionsController < ApplicationController
   def new
+    cocina = Dor::Services::Client.object(params[:apo_id]).find
+    authorize! :manage_item, cocina
+
     @apo = Dor.find params[:apo_id]
-    authorize! :manage_item, @apo
     respond_to do |format|
       format.html { render layout: !request.xhr? }
     end
   end
 
   def create
-    @apo = Dor.find params[:apo_id]
-    authorize! :manage_item, @apo
+    cocina = Dor::Services::Client.object(params[:apo_id]).find
+    authorize! :manage_item, cocina
 
+    @apo = Dor.find params[:apo_id]
     form = CollectionForm.new(Dor::Collection.new)
     return render 'new' unless form.validate(params.merge(apo_pid: params[:apo_id]))
 

--- a/app/controllers/content_types_controller.rb
+++ b/app/controllers/content_types_controller.rb
@@ -11,10 +11,11 @@ class ContentTypesController < ApplicationController
 
   # set the content type in the content metadata
   def update
-    authorize! :manage_item, @object
+    cocina = Dor::Services::Client.object(params[:item_id]).find
+    authorize! :manage_item, cocina
 
     # if this object has been submitted and doesnt have an open version, they cannot change it.
-    state_service = StateService.new(@object.pid, version: @object.current_version)
+    state_service = StateService.new(cocina.externalIdentifier, version: cocina.version)
     return render_error('Object cannot be modified in its current state.') unless state_service.allows_modification?
     return render_error('Invalid new content type.') unless valid_content_type?
     return render_error('Object doesnt have a content metadata datastream to update.') unless has_content?

--- a/app/controllers/datastreams_controller.rb
+++ b/app/controllers/datastreams_controller.rb
@@ -42,13 +42,14 @@ class DatastreamsController < ApplicationController
   # @option params [String] `:id` the identifier for the datastream, e.g., `identityMetadata`
   # @option params [String] `:item_id` the druid to modify
   def update
-    @object = Dor.find params[:item_id]
-    authorize! :manage_item, @object
+    cocina = Dor::Services::Client.object(params[:item_id]).find
+    authorize! :manage_item, cocina
 
     raise ArgumentError, 'Missing content' if params[:content].blank?
 
     begin
       Nokogiri::XML(params[:content], &:strict)
+      @object = Dor.find params[:item_id]
       @object.datastreams[params[:id]].content = params[:content] # set the XML to be verbatim as posted
       @object.save
       Argo::Indexer.reindex_pid_remotely(@object.pid)

--- a/app/controllers/manage_releases_controller.rb
+++ b/app/controllers/manage_releases_controller.rb
@@ -5,7 +5,8 @@ class ManageReleasesController < ApplicationController
   include Blacklight::Searchable
 
   def show
-    authorize! :manage_item, Dor.find(params[:item_id])
+    cocina = Dor::Services::Client.object(params[:item_id]).find
+    authorize! :manage_item, cocina
     _, @document = search_service.fetch params[:item_id]
     @bulk_action = BulkAction.new
 

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -68,7 +68,8 @@ class ReportController < CatalogController
     @ids = Report.new(params, current_user: current_user).pids
     @ids.each do |pid|
       druid = "druid:#{pid}"
-      next unless current_ability.can_update_workflow?('waiting', Dor.find(druid))
+      cocina = Dor::Services::Client.object(druid).find
+      next unless current_ability.can_update_workflow?('waiting', cocina)
 
       WorkflowClientFactory.build.update_status(
         druid: druid,

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -10,8 +10,8 @@ class TagsController < ApplicationController
   end
 
   def update
-    @object = Dor.find params[:item_id]
-    authorize! :manage_item, @object
+    cocina = Dor::Services::Client.object(params[:item_id]).find
+    authorize! :manage_item, cocina
 
     current_tags = tags_client.list
 

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -34,7 +34,9 @@ class WorkflowsController < ApplicationController
   # @option params [String] `:status` The status to which we want to reset the workflow.
   def update
     params.require %i[process status]
-    return render status: :forbidden, plain: 'Unauthorized' unless can_update_workflow?(params[:status], @object)
+    cocina = Dor::Services::Client.object(params[:item_id]).find
+
+    return render status: :forbidden, plain: 'Unauthorized' unless can_update_workflow?(params[:status], cocina)
 
     # this will raise an exception if the item doesn't have that workflow step
     WorkflowClientFactory.build.workflow_status(druid: params[:item_id],

--- a/app/jobs/close_version_job.rb
+++ b/app/jobs/close_version_job.rb
@@ -26,9 +26,9 @@ class CloseVersionJob < GenericJob
   private
 
   def close_object(pid, log)
-    object = Dor.find(pid)
+    cocina = Dor::Services::Client.object(pid).find
 
-    unless ability.can?(:manage_item, object)
+    unless ability.can?(:manage_item, cocina)
       log.puts("#{Time.current} Not authorized for #{pid}")
       return
     end

--- a/app/jobs/manage_catkey_job.rb
+++ b/app/jobs/manage_catkey_job.rb
@@ -29,7 +29,9 @@ class ManageCatkeyJob < GenericJob
   def update_catkey(current_druid, new_catkey, log)
     log.puts("#{Time.current} Beginning ManageCatkeyJob for #{current_druid}")
     current_obj = Dor.find(current_druid)
-    unless ability.can?(:manage_item, current_obj)
+    cocina = Dor::Services::Client.object(current_druid).find
+
+    unless ability.can?(:manage_item, cocina)
       log.puts("#{Time.current} Not authorized for #{current_druid}")
       return
     end

--- a/app/jobs/prepare_job.rb
+++ b/app/jobs/prepare_job.rb
@@ -31,11 +31,11 @@ class PrepareJob < GenericJob
   private
 
   def open_object(pid, significance, description, user_name, log)
-    object = Dor.find(pid)
+    cocina = Dor::Services::Client.object(pid).find
 
-    return log.puts("#{Time.current} #{pid} is not openable") unless openable?(pid, version: object.current_version)
+    return log.puts("#{Time.current} #{pid} is not openable") unless openable?(pid, version: cocina.version)
 
-    return log.puts("#{Time.current} Not authorized for #{pid}") unless ability.can?(:manage_item, object)
+    return log.puts("#{Time.current} Not authorized for #{pid}") unless ability.can?(:manage_item, cocina)
 
     VersionService.open(identifier: pid,
                         significance: significance,

--- a/app/jobs/purge_job.rb
+++ b/app/jobs/purge_job.rb
@@ -22,9 +22,8 @@ class PurgeJob < GenericJob
   private
 
   def purge(current_druid, log_buffer)
-    object = Dor.find(current_druid)
-
-    unless ability.can?(:manage_item, object)
+    cocina = Dor::Services::Client.object(current_druid).find
+    unless ability.can?(:manage_item, cocina)
       log.puts("#{Time.current} Not authorized to purge #{current_druid}")
       return
     end
@@ -35,7 +34,7 @@ class PurgeJob < GenericJob
       bulk_action.increment(:druid_count_fail).save
       return
     end
-
+    object = Dor.find(current_druid)
     object.delete
     workflow_client.delete_all_workflows(pid: current_druid)
     ActiveFedora.solr.conn.delete_by_id(current_druid)

--- a/app/jobs/release_object_job.rb
+++ b/app/jobs/release_object_job.rb
@@ -33,9 +33,9 @@ class ReleaseObjectJob < GenericJob
 
   def release_object(current_druid, log)
     log.puts("#{Time.current} Beginning ReleaseObjectJob for #{current_druid}")
+    cocina = Dor::Services::Client.object(current_druid).find
 
-    object = Dor.find(current_druid)
-    unless ability.can?(:manage_item, object)
+    unless ability.can?(:manage_item, cocina)
       log.puts("#{Time.current} Not authorized for #{current_druid}")
       return
     end
@@ -56,7 +56,7 @@ class ReleaseObjectJob < GenericJob
     end
     log.puts("#{Time.current} Trying to start release workflow")
     begin
-      WorkflowClientFactory.build.create_workflow_by_name(current_druid, 'releaseWF', version: object.current_version)
+      WorkflowClientFactory.build.create_workflow_by_name(current_druid, 'releaseWF', version: cocina.version)
       log.puts("#{Time.current} Workflow creation successful")
       bulk_action.increment(:druid_count_success).save
     rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Dor::WorkflowException => e

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -39,12 +39,12 @@ class Ability
 
     can %i[view_metadata view_content], [ActiveFedora::Base, Cocina::Models::DRO] if current_user.viewer?
 
-    can :manage_item, Dor::AdminPolicyObject do |dor_item|
-      can_manage_items? current_user.roles(dor_item.pid)
+    can :manage_item, Cocina::Models::AdminPolicy do |cocina|
+      can_manage_items? current_user.roles(cocina.externalIdentifier)
     end
 
-    can :manage_item, ActiveFedora::Base do |dor_item|
-      can_manage_items? current_user.roles(dor_item.admin_policy_object.pid) if dor_item.admin_policy_object
+    can :manage_item, [Cocina::Models::Collection, Cocina::Models::DRO] do |cocina|
+      can_manage_items? current_user.roles(cocina.administrative.hasAdminPolicy)
     end
 
     can :manage_desc_metadata, Dor::AdminPolicyObject do |dor_item|
@@ -55,7 +55,7 @@ class Ability
       can_edit_desc_metadata? current_user.roles(dor_item.admin_policy_object.pid) if dor_item.admin_policy_object
     end
 
-    can :manage_governing_apo, ActiveFedora::Base do |dor_item, new_apo_id|
+    can :manage_governing_apo, [Cocina::Models::Collection, Cocina::Models::DRO] do |dor_item, new_apo_id|
       # user must have management privileges on both the target APO and the APO currently governing the item
       can_manage_items?(current_user.roles(new_apo_id)) && can?(:manage_item, dor_item)
     end
@@ -69,7 +69,7 @@ class Ability
     end
 
     can :view_content, Cocina::Models::DRO do |dro|
-      can_view? current_user.roles(dro.administrative.hasAdminPolicy) if dro&.administrative&.hasAdminPolicy
+      can_view? current_user.roles(dro.administrative.hasAdminPolicy)
     end
 
     can :view_metadata, ActiveFedora::Base do |dor_item|

--- a/spec/controllers/apo_controller_spec.rb
+++ b/spec/controllers/apo_controller_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 RSpec.describe ApoController, type: :controller do
   before do
+    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+
     allow(Dor).to receive(:find).with(apo.pid).and_return(apo)
     allow(apo).to receive(:save)
 
@@ -11,12 +13,22 @@ RSpec.describe ApoController, type: :controller do
     allow(collection).to receive(:save)
 
     sign_in user
-    allow(controller).to receive(:authorize!).with(:manage_item, Dor::AdminPolicyObject).and_return(true)
+    allow(controller).to receive(:authorize!).with(:manage_item, Cocina::Models::AdminPolicy).and_return(true)
   end
 
   let(:user) { create(:user) }
-
   let(:apo) { instantiate_fixture('zt570tx3016', Dor::AdminPolicyObject) }
+  let(:pid) { 'druid:zt570tx3016' }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+  let(:cocina_model) do
+    Cocina::Models.build(
+      'label' => 'The APO',
+      'version' => 1,
+      'type' => Cocina::Models::Vocab.admin_policy,
+      'externalIdentifier' => pid,
+      'administrative' => { hasAdminPolicy: 'druid:hv992ry2431' }
+    )
+  end
   let(:collection) { FactoryBot.create_for_repository(:collection) }
 
   describe '#create' do

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe CollectionsController do
   before do
     allow(Dor).to receive(:find).with(apo.pid).and_return(apo)
-    allow(controller).to receive(:authorize!).with(:manage_item, Dor::AdminPolicyObject).and_return(true)
+    allow(controller).to receive(:authorize!).with(:manage_item, Cocina::Models::AdminPolicy).and_return(true)
     sign_in user
   end
 
@@ -14,6 +14,22 @@ RSpec.describe CollectionsController do
   let(:collection) { FactoryBot.create_for_repository(:collection) }
 
   describe '#new' do
+    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+    let(:cocina_model) do
+      Cocina::Models.build(
+        'label' => 'The APO',
+        'version' => 1,
+        'type' => Cocina::Models::Vocab.admin_policy,
+        'externalIdentifier' => pid,
+        'administrative' => { hasAdminPolicy: 'druid:hv992ry2431' }
+      )
+    end
+    let(:pid) { 'druid:zt570tx3016' }
+
+    before do
+      allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+    end
+
     it 'is successful' do
       get :new, params: { apo_id: apo.pid }
       expect(assigns[:apo]).to eq apo
@@ -23,8 +39,20 @@ RSpec.describe CollectionsController do
 
   describe '#create' do
     let(:form) { instance_double(CollectionForm, validate: true, save: true, model: Dor::Collection.find(collection.externalIdentifier)) }
+    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+    let(:cocina_model) do
+      Cocina::Models.build(
+        'label' => 'The APO',
+        'version' => 1,
+        'type' => Cocina::Models::Vocab.admin_policy,
+        'externalIdentifier' => pid,
+        'administrative' => { hasAdminPolicy: 'druid:hv992ry2431' }
+      )
+    end
+    let(:pid) { 'druid:zt570tx3016' }
 
     before do
+      allow(Dor::Services::Client).to receive(:object).and_return(object_client)
       allow(CollectionForm).to receive(:new).and_return(form)
     end
 

--- a/spec/controllers/content_types_controller_spec.rb
+++ b/spec/controllers/content_types_controller_spec.rb
@@ -5,12 +5,28 @@ require 'rails_helper'
 RSpec.describe ContentTypesController, type: :controller do
   before do
     allow(Dor).to receive(:find).with(pid).and_return(item)
+    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
     sign_in(user)
   end
 
   let(:pid) { 'druid:bc123df4567' }
   let(:item) { Dor::Item.new pid: pid }
   let(:user) { create :user }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+  let(:cocina_model) do
+    Cocina::Models.build(
+      'label' => 'My Item',
+      'version' => 1,
+      'type' => Cocina::Models::Vocab.object,
+      'externalIdentifier' => pid,
+      'access' => {
+        'access' => 'world'
+      },
+      'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+      'structural' => {},
+      'identification' => {}
+    )
+  end
 
   describe 'show' do
     it 'is successful' do

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -35,11 +35,25 @@ RSpec.describe TagsController, type: :controller do
 
   describe '#update' do
     let(:pid) { 'druid:bc123df4567' }
-    let(:item) { Dor::Item.new pid: pid }
+    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+    let(:cocina_model) do
+      Cocina::Models.build(
+        'label' => 'My Item',
+        'version' => 1,
+        'type' => Cocina::Models::Vocab.object,
+        'externalIdentifier' => pid,
+        'access' => {
+          'access' => 'world'
+        },
+        'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+        'structural' => {},
+        'identification' => {}
+      )
+    end
 
     before do
       sign_in user
-      allow(Dor).to receive(:find).with(pid).and_return(item)
+      allow(Dor::Services::Client).to receive(:object).and_return(object_client)
       allow(Argo::Indexer).to receive(:reindex_pid_remotely)
     end
 

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -140,6 +140,26 @@ RSpec.describe WorkflowsController, type: :controller do
                       workflow_status: nil,
                       update_status: nil)
     end
+    let(:cocina) do
+      Cocina::Models.build(
+        'label' => 'My Item',
+        'version' => 2,
+        'type' => Cocina::Models::Vocab.object,
+        'externalIdentifier' => pid,
+        'access' => {
+          'access' => 'world'
+        },
+        'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+        'structural' => {},
+        'identification' => {}
+      )
+    end
+
+    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina) }
+
+    before do
+      allow(Dor::Services::Client).to receive(:object).with(pid).and_return(object_client)
+    end
 
     it 'requires various workflow parameters' do
       expect { post :update, params: { item_id: pid, repo: 'dor', id: 'accessionWF' } }.to raise_error(ActionController::ParameterMissing)

--- a/spec/features/create_collection_spec.rb
+++ b/spec/features/create_collection_spec.rb
@@ -5,12 +5,19 @@ require 'rails_helper'
 RSpec.describe 'Add collection' do
   before do
     allow(Dor::Collection).to receive(:where).and_return([1])
+    allow(Dor).to receive(:find).with(apo_id).and_return(apo)
+    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
     sign_in create(:user), groups: ['sdr:administrator-role']
   end
 
+  let(:apo_id) { 'druid:vt333hq2222' }
+  let(:apo) { instance_double(Dor::AdminPolicyObject, label: 'hey', pid: apo_id) }
+  let(:cocina_model) { instance_double(Cocina::Models::AdminPolicy) }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+
   describe 'when collection catkey is provided', js: true do
     it 'warns if catkey exists' do
-      visit new_apo_collection_path 'druid:zt570tx3016'
+      visit new_apo_collection_path apo_id
       choose 'Create a Collection from Symphony'
       expect(page).to have_text('Collection Catkey')
       expect(page).not_to have_text('already exists')
@@ -21,7 +28,7 @@ RSpec.describe 'Add collection' do
 
   describe 'when collection title is provided', js: true do
     it 'warns if title exists' do
-      visit new_apo_collection_path 'druid:zt570tx3016'
+      visit new_apo_collection_path apo_id
       expect(page).to have_text('Collection Title')
       expect(page).not_to have_text('already exists')
       fill_in 'collection_title', with: 'foo'

--- a/spec/jobs/close_version_job_spec.rb
+++ b/spec/jobs/close_version_job_spec.rb
@@ -3,23 +3,49 @@
 require 'rails_helper'
 
 RSpec.describe CloseVersionJob, type: :job do
-  let(:pids) { ['druid:123', 'druid:456'] }
+  let(:pids) { ['druid:bc123df4567', 'druid:bc123df4598'] }
   let(:groups) { [] }
   let(:user) { instance_double(User, to_s: 'jcoyne85') }
-  let(:client) { instance_double(Dor::Services::Client::Object, version: version_client) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, close: true) }
   let(:bulk_action) do
     create(:bulk_action,
            log_name: 'foo.txt')
   end
-  let(:item1) { Dor::Item.new }
-  let(:item2) { Dor::Item.new }
+  let(:item1) do
+    Cocina::Models.build(
+      'label' => 'My Item',
+      'version' => 1,
+      'type' => Cocina::Models::Vocab.object,
+      'externalIdentifier' => pids[0],
+      'access' => {
+        'access' => 'world'
+      },
+      'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+      'structural' => {},
+      'identification' => {}
+    )
+  end
+  let(:item2) do
+    Cocina::Models.build(
+      'label' => 'My Item',
+      'version' => 1,
+      'type' => Cocina::Models::Vocab.object,
+      'externalIdentifier' => pids[1],
+      'access' => {
+        'access' => 'world'
+      },
+      'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+      'structural' => {},
+      'identification' => {}
+    )
+  end
+  let(:object_client1) { instance_double(Dor::Services::Client::Object, find: item1, version: version_client) }
+  let(:object_client2) { instance_double(Dor::Services::Client::Object, find: item2, version: version_client) }
 
   before do
-    allow(Dor::Services::Client).to receive(:object).and_return(client)
     allow(Ability).to receive(:new).and_return(ability)
-    allow(Dor).to receive(:find).with(pids[0]).and_return(item1)
-    allow(Dor).to receive(:find).with(pids[1]).and_return(item2)
+    allow(Dor::Services::Client).to receive(:object).with(pids[0]).and_return(object_client1)
+    allow(Dor::Services::Client).to receive(:object).with(pids[1]).and_return(object_client2)
   end
 
   after do

--- a/spec/jobs/manage_catkey_job_spec.rb
+++ b/spec/jobs/manage_catkey_job_spec.rb
@@ -17,9 +17,57 @@ RSpec.describe ManageCatkeyJob do
   let(:pids) { %w[druid:bb111cc2222 druid:cc111dd2222 druid:dd111ee2222] }
   let(:catkeys) { %w[12345 6789 44444] }
   let(:buffer) { StringIO.new }
+  let(:item1) do
+    Cocina::Models.build(
+      'label' => 'My Item',
+      'version' => 2,
+      'type' => Cocina::Models::Vocab.object,
+      'externalIdentifier' => pids[0],
+      'access' => {
+        'access' => 'world'
+      },
+      'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+      'structural' => {},
+      'identification' => {}
+    )
+  end
+  let(:item2) do
+    Cocina::Models.build(
+      'label' => 'My Item',
+      'version' => 3,
+      'type' => Cocina::Models::Vocab.object,
+      'externalIdentifier' => pids[1],
+      'access' => {
+        'access' => 'world'
+      },
+      'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+      'structural' => {},
+      'identification' => {}
+    )
+  end
+  let(:item3) do
+    Cocina::Models.build(
+      'label' => 'My Item',
+      'version' => 3,
+      'type' => Cocina::Models::Vocab.object,
+      'externalIdentifier' => pids[1],
+      'access' => {
+        'access' => 'world'
+      },
+      'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+      'structural' => {},
+      'identification' => {}
+    )
+  end
+  let(:object_client1) { instance_double(Dor::Services::Client::Object, find: item1) }
+  let(:object_client2) { instance_double(Dor::Services::Client::Object, find: item2) }
+  let(:object_client3) { instance_double(Dor::Services::Client::Object, find: item3) }
 
   before do
     allow(subject).to receive(:bulk_action).and_return(bulk_action_no_process_callback)
+    allow(Dor::Services::Client).to receive(:object).with(pids[0]).and_return(object_client1)
+    allow(Dor::Services::Client).to receive(:object).with(pids[1]).and_return(object_client2)
+    allow(Dor::Services::Client).to receive(:object).with(pids[2]).and_return(object_client3)
   end
 
   describe '#perform' do

--- a/spec/jobs/prepare_job_spec.rb
+++ b/spec/jobs/prepare_job_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe PrepareJob, type: :job do
-  let(:pids) { ['druid:123', 'druid:456'] }
+  let(:pids) { ['druid:bb111cc2222', 'druid:cc111dd2222'] }
   let(:groups) { [] }
   let(:workflow_status) { instance_double(DorObjectWorkflowStatus, can_open_version?: true) }
   let(:bulk_action) do
@@ -11,15 +11,45 @@ RSpec.describe PrepareJob, type: :job do
            log_name: 'foo.txt')
   end
   let(:user) { bulk_action.user }
-  let(:item1) { Dor::Item.new }
-  let(:item2) { Dor::Item.new }
+
+  let(:cocina1) do
+    Cocina::Models.build(
+      'label' => 'My Item',
+      'version' => 2,
+      'type' => Cocina::Models::Vocab.object,
+      'externalIdentifier' => pids[0],
+      'access' => {
+        'access' => 'world'
+      },
+      'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+      'structural' => {},
+      'identification' => {}
+    )
+  end
+  let(:cocina2) do
+    Cocina::Models.build(
+      'label' => 'My Item',
+      'version' => 3,
+      'type' => Cocina::Models::Vocab.object,
+      'externalIdentifier' => pids[1],
+      'access' => {
+        'access' => 'world'
+      },
+      'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+      'structural' => {},
+      'identification' => {}
+    )
+  end
+
+  let(:object_client1) { instance_double(Dor::Services::Client::Object, find: cocina1) }
+  let(:object_client2) { instance_double(Dor::Services::Client::Object, find: cocina2) }
 
   before do
     allow(Ability).to receive(:new).and_return(ability)
     allow(VersionService).to receive(:open)
     allow(DorObjectWorkflowStatus).to receive(:new).and_return(workflow_status)
-    allow(Dor).to receive(:find).with(pids[0]).and_return(item1)
-    allow(Dor).to receive(:find).with(pids[1]).and_return(item2)
+    allow(Dor::Services::Client).to receive(:object).with(pids[0]).and_return(object_client1)
+    allow(Dor::Services::Client).to receive(:object).with(pids[1]).and_return(object_client2)
   end
 
   after do

--- a/spec/jobs/purge_job_spec.rb
+++ b/spec/jobs/purge_job_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe PurgeJob, type: :job do
-  let(:pids) { ['druid:123', 'druid:456'] }
+  let(:pids) { ['druid:bb111cc2222', 'druid:cc111dd2222'] }
   let(:groups) { [] }
   let(:user) { instance_double(User, to_s: 'jcoyne85') }
   let(:client) { instance_double(Dor::Workflow::Client, lifecycle: submitted, delete_all_workflows: true) }
@@ -15,11 +15,45 @@ RSpec.describe PurgeJob, type: :job do
   let(:item1) { instance_double(Dor::Item, delete: true) }
   let(:item2) { instance_double(Dor::Item, delete: true) }
 
+  let(:cocina1) do
+    Cocina::Models.build(
+      'label' => 'My Item',
+      'version' => 2,
+      'type' => Cocina::Models::Vocab.object,
+      'externalIdentifier' => pids[0],
+      'access' => {
+        'access' => 'world'
+      },
+      'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+      'structural' => {},
+      'identification' => {}
+    )
+  end
+  let(:cocina2) do
+    Cocina::Models.build(
+      'label' => 'My Item',
+      'version' => 3,
+      'type' => Cocina::Models::Vocab.object,
+      'externalIdentifier' => pids[1],
+      'access' => {
+        'access' => 'world'
+      },
+      'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+      'structural' => {},
+      'identification' => {}
+    )
+  end
+
+  let(:object_client1) { instance_double(Dor::Services::Client::Object, find: cocina1) }
+  let(:object_client2) { instance_double(Dor::Services::Client::Object, find: cocina2) }
+
   before do
     allow(WorkflowClientFactory).to receive(:build).and_return(client)
     allow(Ability).to receive(:new).and_return(ability)
     allow(Dor).to receive(:find).with(pids[0]).and_return(item1)
     allow(Dor).to receive(:find).with(pids[1]).and_return(item2)
+    allow(Dor::Services::Client).to receive(:object).with(pids[0]).and_return(object_client1)
+    allow(Dor::Services::Client).to receive(:object).with(pids[1]).and_return(object_client2)
 
     described_class.perform_now(bulk_action.id,
                                 pids: pids,

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -45,9 +45,9 @@ RSpec.describe Ability do
     let(:admin) { true }
 
     it { is_expected.to be_able_to(:manage, :everything) }
-    it { is_expected.to be_able_to(:manage_item, item) }
+    it { is_expected.to be_able_to(:manage_item, dro) }
     it { is_expected.to be_able_to(:manage_desc_metadata, item) }
-    it { is_expected.to be_able_to(:manage_governing_apo, item, new_apo_id) }
+    it { is_expected.to be_able_to(:manage_governing_apo, dro, new_apo_id) }
     it { is_expected.to be_able_to(:create, Dor::AdminPolicyObject) }
     it { is_expected.to be_able_to(:view_metadata, item) }
     it { is_expected.to be_able_to(:view_content, item) }
@@ -59,9 +59,9 @@ RSpec.describe Ability do
     let(:manager) { true }
 
     it { is_expected.not_to be_able_to(:manage, :everything) }
-    it { is_expected.to be_able_to(:manage_item, item) }
+    it { is_expected.to be_able_to(:manage_item, dro) }
     it { is_expected.to be_able_to(:manage_desc_metadata, item) }
-    it { is_expected.to be_able_to(:manage_governing_apo, item, new_apo_id) }
+    it { is_expected.to be_able_to(:manage_governing_apo, dro, new_apo_id) }
     it { is_expected.to be_able_to(:create, Dor::AdminPolicyObject) }
     it { is_expected.to be_able_to(:view_metadata, item) }
     it { is_expected.to be_able_to(:view_content, item) }
@@ -72,10 +72,10 @@ RSpec.describe Ability do
   context 'as a viewer' do
     let(:viewer) { true }
 
-    it { is_expected.not_to be_able_to(:manage_item, item) }
+    it { is_expected.not_to be_able_to(:manage_item, dro) }
     it { is_expected.not_to be_able_to(:manage_desc_metadata, item) }
     it { is_expected.not_to be_able_to(:create, Dor::AdminPolicyObject) }
-    it { is_expected.not_to be_able_to(:manage_governing_apo, item, new_apo_id) }
+    it { is_expected.not_to be_able_to(:manage_governing_apo, dro, new_apo_id) }
     it { is_expected.to be_able_to(:view_metadata, item) }
     it { is_expected.to be_able_to(:view_content, item) }
     it { is_expected.to be_able_to(:view_content, dro) }
@@ -83,9 +83,9 @@ RSpec.describe Ability do
   end
 
   context 'for items without an APO' do
-    it { is_expected.not_to be_able_to(:manage_item, item) }
+    it { is_expected.not_to be_able_to(:manage_item, dro) }
     it { is_expected.not_to be_able_to(:manage_desc_metadata, item) }
-    it { is_expected.not_to be_able_to(:manage_governing_apo, item, new_apo_id) }
+    it { is_expected.not_to be_able_to(:manage_governing_apo, dro, new_apo_id) }
     it { is_expected.not_to be_able_to(:view_content, item) }
     it { is_expected.not_to be_able_to(:view_content, dro) }
     it { is_expected.not_to be_able_to(:view_metadata, item) }
@@ -95,9 +95,8 @@ RSpec.describe Ability do
     let(:roles) { ['dor-administrator'] }
 
     it { is_expected.not_to be_able_to(:manage, :everything) }
-    it { is_expected.not_to be_able_to(:manage_item, item) }
-    it { is_expected.to be_able_to(:manage_item, item_with_apo) }
-    it { is_expected.not_to be_able_to(:manage_governing_apo, item, new_apo_id) }
+    it { is_expected.to be_able_to(:manage_item, dro) }
+    it { is_expected.to be_able_to(:manage_governing_apo, dro, new_apo_id) }
     it { is_expected.not_to be_able_to(:manage_desc_metadata, item) }
     it { is_expected.to be_able_to(:manage_desc_metadata, item_with_apo) }
     it { is_expected.not_to be_able_to(:create, Dor::AdminPolicyObject) }
@@ -112,9 +111,8 @@ RSpec.describe Ability do
     let(:roles) { ['dor-apo-metadata'] }
 
     it { is_expected.not_to be_able_to(:manage, :everything) }
-    it { is_expected.not_to be_able_to(:manage_item, item) }
-    it { is_expected.not_to be_able_to(:manage_item, item_with_apo) }
-    it { is_expected.not_to be_able_to(:manage_governing_apo, item, new_apo_id) }
+    it { is_expected.not_to be_able_to(:manage_item, dro) }
+    it { is_expected.not_to be_able_to(:manage_governing_apo, dro, new_apo_id) }
     it { is_expected.not_to be_able_to(:manage_desc_metadata, item) }
     it { is_expected.to be_able_to(:manage_desc_metadata, item_with_apo) }
     it { is_expected.not_to be_able_to(:create, Dor::AdminPolicyObject) }
@@ -129,10 +127,9 @@ RSpec.describe Ability do
     let(:roles) { ['dor-viewer'] }
 
     it { is_expected.not_to be_able_to(:manage, :everything) }
-    it { is_expected.not_to be_able_to(:manage_item, item) }
-    it { is_expected.not_to be_able_to(:manage_item, item_with_apo) }
+    it { is_expected.not_to be_able_to(:manage_item, dro) }
     it { is_expected.not_to be_able_to(:manage_desc_metadata, item) }
-    it { is_expected.not_to be_able_to(:manage_governing_apo, item, new_apo_id) }
+    it { is_expected.not_to be_able_to(:manage_governing_apo, dro, new_apo_id) }
     it { is_expected.not_to be_able_to(:manage_desc_metadata, item_with_apo) }
     it { is_expected.not_to be_able_to(:create, Dor::AdminPolicyObject) }
     it { is_expected.not_to be_able_to(:view_metadata, item) }

--- a/spec/requests/apply_apo_defaults_spec.rb
+++ b/spec/requests/apply_apo_defaults_spec.rb
@@ -8,21 +8,38 @@ RSpec.describe 'Apply APO defaults' do
                     admin_policy_object: apo,
                     reapply_admin_policy_object_defaults: nil,
                     save: true,
-                    pid: 'druid:888')
+                    pid: pid)
   end
+  let(:pid) { 'druid:bc123df4567' }
   let(:apo) { instance_double(Dor::AdminPolicyObject, pid: 'druid:999') }
   let(:user) { create(:user) }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+  let(:cocina_model) do
+    Cocina::Models.build(
+      'label' => 'The item',
+      'version' => 1,
+      'type' => Cocina::Models::Vocab.object,
+      'externalIdentifier' => pid,
+      'access' => {
+        'access' => 'world'
+      },
+      'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+      'structural' => {},
+      'identification' => {}
+    )
+  end
 
   before do
     sign_in user
     allow(Dor).to receive(:find).and_return(item)
     allow(Argo::Indexer).to receive(:reindex_pid_remotely)
+    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
   end
 
   it 'applies the defaults' do
     post '/items/druid:123/apply_apo_defaults'
     expect(item).to have_received(:reapply_admin_policy_object_defaults)
-    expect(Argo::Indexer).to have_received(:reindex_pid_remotely).with('druid:888')
+    expect(Argo::Indexer).to have_received(:reindex_pid_remotely).with(pid)
     expect(response).to be_successful
   end
 end

--- a/spec/requests/manage_release_spec.rb
+++ b/spec/requests/manage_release_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe 'Draw the manage release form' do
-  let(:item) do
-    instance_double(Dor::Item, pid: 'druid:bc123df4567')
-  end
+  # let(:item) do
+  #   instance_double(Dor::Item, pid: 'druid:bc123df4567')
+  # end
   let(:document) do
     instance_double(SolrDocument,
                     id: 'druid:bc123df4567',
@@ -15,9 +15,26 @@ RSpec.describe 'Draw the manage release form' do
   end
 
   let(:user) { create(:user) }
+  let(:pid) { 'druid:bc123df4567' }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+  let(:cocina_model) do
+    Cocina::Models.build(
+      'label' => 'The item',
+      'version' => 1,
+      'type' => Cocina::Models::Vocab.object,
+      'externalIdentifier' => pid,
+      'access' => {
+        'access' => 'world'
+      },
+      'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+      'structural' => {},
+      'identification' => {}
+    )
+  end
 
   before do
-    allow(Dor).to receive(:find).with('druid:bc123df4567').and_return(item)
+    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+    # allow(Dor).to receive(:find).with('druid:bc123df4567').and_return(item)
   end
 
   context 'for content managers' do

--- a/spec/requests/set_governing_apo_spec.rb
+++ b/spec/requests/set_governing_apo_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'Set APO for an object' do
 
       before do
         allow(Ability).to receive(:new).and_return(ability)
-        allow(ability).to receive(:authorize!).with(:manage_governing_apo, fedora_obj, new_apo_id).and_raise(CanCan::AccessDenied)
+        allow(ability).to receive(:authorize!).with(:manage_governing_apo, cocina_model, new_apo_id).and_raise(CanCan::AccessDenied)
       end
 
       it 'returns a 403' do

--- a/spec/requests/show_rights_spec.rb
+++ b/spec/requests/show_rights_spec.rb
@@ -104,12 +104,13 @@ RSpec.describe 'Show rights for an object' do
       end
 
       before do
-        allow(object_client).to receive(:find).and_raise(Dor::Services::Client::UnexpectedResponse)
+        allow(object_client).to receive(:find)
+          .and_raise(Dor::Services::Client::UnexpectedResponse, 'Error: ({"errors":[{"detail":"Invalid date"}]})')
       end
 
-      it 'draws the page' do
+      it 'shows the error' do
         get "/items/#{pid}/rights"
-        expect(response).to be_successful
+        expect(flash[:error]).to eq 'Unable to retrieve the cocina model: Invalid date'
       end
     end
   end

--- a/spec/requests/update_datastream_spec.rb
+++ b/spec/requests/update_datastream_spec.rb
@@ -7,8 +7,24 @@ RSpec.describe 'Update a datastream' do
     allow(Dor).to receive(:find).with(pid).and_return(item)
     allow(item).to receive_messages(save: nil)
     allow(Argo::Indexer).to receive(:reindex_pid_remotely)
+    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
   end
 
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+  let(:cocina_model) do
+    Cocina::Models.build(
+      'label' => 'My Item',
+      'version' => 1,
+      'type' => Cocina::Models::Vocab.object,
+      'externalIdentifier' => pid,
+      'access' => {
+        'access' => 'world'
+      },
+      'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+      'structural' => {},
+      'identification' => {}
+    )
+  end
   let(:pid) { 'druid:bc123df4567' }
   let(:item) { Dor::Item.new pid: pid }
   let(:user) { create(:user) }


### PR DESCRIPTION
## Why was this change made?
This helps us decouple from Fedora 3.


## How was this change tested?



## Which documentation and/or configurations were updated?



