### PR TITLE
add techmd url in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       SETTINGS__REDIS_URL: redis://redis:6379/
       SETTINGS__SOLRIZER_URL: http://solr:8983/solr/argo
       SETTINGS__WORKFLOW_URL: http://workflow:3000
+      SETTINGS__TECH_MD_SERVICE__URL: http://techmd:3000
       SOLR_URL: http://solr:8983/solr/argo
     depends_on:
       - dor-indexing-app


### PR DESCRIPTION
## Why was this change made?

Argo will not show an item page in the browser without a techmd URL configured -- else it tries to use localhost:3005, which is not accessible from the web container.

## How was this change tested?



## Which documentation and/or configurations were updated?



