### PR TITLE
Adds additional facet field configuration.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -160,6 +160,11 @@ class CatalogController < ApplicationController
     config.add_facet_field 'sw_genre_ssim',              label: 'SW Genre',             component: true, limit: 10, home: false
     config.add_facet_field 'sw_language_ssim',           label: 'SW Language',          component: true, limit: 10, home: false
     config.add_facet_field 'mods_typeOfResource_ssim',   label: 'MODS Resource Type',   component: true, limit: 10, home: false
+    # Adding the facet field allows it to be queried (e.g., from value_helper)
+    config.add_facet_field 'is_governed_by_ssim', if: false
+    config.add_facet_field 'is_member_of_collection_ssim', if: false
+    config.add_facet_field 'tag_ssim', if: false
+    config.add_facet_field 'project_tag_ssim', if: false
 
     config.add_facet_fields_to_solr_request! # deprecated in newer Blacklights
 


### PR DESCRIPTION
closes #2297

## Why was this change made?
Blacklight was changed to disallow filtering on non-configured fields. This adds the necessary config.


## How was this change tested?
Stage


## Which documentation and/or configurations were updated?
NA


