### PR TITLE
Align with current blacklight.

### DIFF
--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,31 +1,8 @@
 <% @page_title = t('blacklight.search.show.title', document_title: truncate(strip_tags(document_show_html_title).html_safe, length: 50), application_name: application_name).html_safe %>
 <% content_for(:head) { render_link_rel_alternates } %>
+
+<%= render_document_main_content_partial %>
+
 <% content_for(:sidebar) do %>
   <%= render_document_sidebar_partial @document %>
-<% end %>
-
-<%= render 'constraints', localized_params: session[:search] %>
-
-<div class="pageEntriesInfo">
-  <%= item_page_entry_info %>
-</div>
-
-<%= render 'previous_next_doc' if @search_context %>
-
-<%# this should be in a partial -%>
-<div id="document" class="<%= render_document_class %>">
-  <div id="doc_<%= @document.id.to_s.parameterize %>">
-    <div class="document">
-      <%= render_document_partials @document, blacklight_config.view_config(:show).partials, object: @obj, document_counter: 0 %>
-    </div>
-  </div>
-</div>
-
-<% if @document.respond_to?(:export_as_openurl_ctx_kev) %>
-  <!--
-       // COinS, for Zotero among others.
-       // This document_partial_name(@document) business is not quite right,
-       // but has been there for a while.
-  -->
-  <span class="Z3988" title="<%= @document.export_as_openurl_ctx_kev(document_partial_name(@document)) %>"></span>
 <% end %>

--- a/spec/views/catalog/show.html.erb_spec.rb
+++ b/spec/views/catalog/show.html.erb_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe 'catalog/show.html.erb' do
   it 'assigns page title, truncating it' do
     expect(view).to receive(:document_show_html_title).and_return(title)
     expect(view).to receive(:render_document_sidebar_partial)
-    expect(view).to receive(:item_page_entry_info)
     expect(view).to receive(:render_document_partials)
     render
     expect(view.instance_variable_get(:@page_title))


### PR DESCRIPTION
## Why was this change made?
These are some differences between current Blacklight and Argo that @jcoyne and I discovered. This cleans them up.


## How was this change tested?
Locally.


## Which documentation and/or configurations were updated?
NA


