### PR TITLE
Override Blacklight default error handler to give a more useful error…

### DIFF
--- a/app/javascript/modules/blacklight-override.js
+++ b/app/javascript/modules/blacklight-override.js
@@ -1,0 +1,15 @@
+// Override Blacklights default error handler to give a more useful error message
+// Ported upstream as https://github.com/projectblacklight/blacklight/pull/2386
+Blacklight.modal.onFailure = function(jqXHR, textStatus, errorThrown) {
+  console.error('Server error:', this.url, jqXHR.status, errorThrown)
+  var contents =  `<div class="modal-header">
+            <div class="h5 modal-title">There was a problem with your request.</div>
+            <button type="button" class="blacklight-modal-close close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button></div>
+            <div class="modal-body"><p>Expected a successful response from the server, but got an error</p>
+            <pre>${this.type} ${this.url}` +
+            `\n${jqXHR.status}: ${errorThrown}</pre><div>`
+  $(Blacklight.modal.modalSelector).find('.modal-content').html(contents);
+  $(Blacklight.modal.modalSelector).modal('show');
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -34,9 +34,11 @@ import 'modules/permission_list'
 import 'modules/populate_druids'
 import 'modules/sharing'
 import TagsAutocomplete from 'modules/tags_autocomplete'
-import Argo from  'argo'
+import Argo from 'argo'
 
 import 'blacklight-frontend/app/assets/javascripts/blacklight/blacklight'
+import 'modules/blacklight-override'
+
 import 'blacklight-hierarchy/app/assets/javascripts/blacklight/hierarchy/hierarchy'
 
 // The Blacklight onLoad event works better than the regular onLoad event if


### PR DESCRIPTION
… message

Upstream port at https://github.com/projectblacklight/blacklight/pull/2386

### Before

(smaller box with "Network Error" as the only information)

### After

![image](https://user-images.githubusercontent.com/96775/100661769-d4549500-3308-11eb-86fc-28e256c7a33d.png)


## Why was this change made?

Ref #2306  (this is prerequisite for a fix)



## How was this change tested?

Tested on staging on https://argo-stage.stanford.edu/view/druid:qv217cy9963 (try to set rights)


## Which documentation and/or configurations were updated?



