### PR TITLE
Update blacklight-hierarchy to 4.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ gem 'zip_tricks', '~> 5.3'
 
 # Stanford related gems
 gem 'blacklight', '~> 7.13'
-gem 'blacklight-hierarchy', '~> 4.2'
+gem 'blacklight-hierarchy', '~> 4.3'
 gem 'dor-services', '~> 9.6'
 gem 'dor-services-client', '~> 6.15'
 gem 'dor-workflow-client', '~> 3.19'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,8 +81,8 @@ GEM
       kaminari (>= 0.15)
       rails (>= 5.1, < 7)
       view_component
-    blacklight-hierarchy (4.2.1)
-      blacklight (~> 7.9)
+    blacklight-hierarchy (4.3.0)
+      blacklight (~> 7.13)
       deprecation
       rails (>= 5.1, < 7)
     bootsnap (1.5.1)
@@ -609,7 +609,7 @@ PLATFORMS
 DEPENDENCIES
   barby
   blacklight (~> 7.13)
-  blacklight-hierarchy (~> 4.2)
+  blacklight-hierarchy (~> 4.3)
   bootsnap (>= 1.1.0)
   byebug
   cancancan


### PR DESCRIPTION

## Why was this change made?

We hit this deprecation warning for each tag (approximately 10,500 times on the index page). So it's imperative that we avoid it for performance.


## How was this change tested?



## Which documentation and/or configurations were updated?



