### PR TITLE
Display an error when there is a bad cocina fetch

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,6 +24,13 @@ class ItemsController < ApplicationController
     set_governing_apo
   ]
 
+  rescue_from Dor::Services::Client::UnexpectedResponse do |exception|
+    md = /\((.*)\)/.match exception.message
+    detail = JSON.parse(md[1])['errors'].first['detail']
+    redirect_to solr_document_path(params[:id]),
+                flash: { error: "Unable to retrieve the cocina model: #{detail.truncate(200)}" }
+  end
+
   def purl_preview
     xml = Dor::Services::Client.object(params[:id]).metadata.descriptive
     @mods_display = ModsDisplayObject.new(xml)

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -135,11 +135,12 @@ RSpec.describe ItemsController, type: :controller do
 
       context 'when the date is malformed' do
         before do
-          allow(embargo_service).to receive(:update).and_raise(Dor::Services::Client::UnexpectedResponse)
+          allow(embargo_service).to receive(:update).and_raise(Dor::Services::Client::UnexpectedResponse, 'Error: ({"errors":[{"detail":"Invalid date"}]})')
         end
 
-        it 'dies' do
-          expect { post :embargo_update, params: { id: pid, embargo_date: 'not-a-date' } }.to raise_error(Dor::Services::Client::UnexpectedResponse)
+        it 'shows the error' do
+          post :embargo_update, params: { id: pid, embargo_date: 'not-a-date' }
+          expect(flash[:error]).to eq 'Unable to retrieve the cocina model: Invalid date'
         end
       end
     end


### PR DESCRIPTION
## Why was this change made?

Fixes #2306

## How was this change tested?
Tested on stage
<img width="1097" alt="Screen Shot 2020-12-03 at 4 40 19 PM" src="https://user-images.githubusercontent.com/92044/101097145-4ab1fb00-3586-11eb-877d-fa7d71f53f53.png">


## Which documentation and/or configurations were updated?



