### PR TITLE
Copy deprecated methods out of blacklight-hierarchy

### DIFF
--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -3,7 +3,4 @@
 class ApplicationComponent < ViewComponent::Base
   delegate :can?, to: :controller
   delegate :search_state, to: :view_context
-
-  # rotate_facet_params and facet_order is from blacklight-hierarchy
-  delegate :rotate_facet_params, :facet_order, to: :view_context
 end

--- a/app/components/workflow_table_process_component.rb
+++ b/app/components/workflow_table_process_component.rb
@@ -25,6 +25,39 @@ class WorkflowTableProcessComponent < ApplicationComponent
     link_to(item_count, new_params)
   end
 
+  # rubocop:disable Naming/MethodParameterName
+  def rotate_facet_params(prefix, from, to, p = params.dup)
+    return p if from == to
+
+    from_field = "#{prefix}_#{from}"
+    to_field = "#{prefix}_#{to}"
+    p[:f] = (p[:f] || {}).dup # the command above is not deep in rails3, !@#$!@#$
+    p[:f][from_field] = (p[:f][from_field] || []).dup
+    p[:f][to_field] = (p[:f][to_field] || []).dup
+    # rubocop:disable Style/Semicolon
+    p[:f][from_field].reject! { |v| p[:f][to_field] << rotate_facet_value(v, from, to); true }
+    # rubocop:enable Style/Semicolon
+    p[:f].delete(from_field)
+    p[:f][to_field].compact!
+    p[:f].delete(to_field) if p[:f][to_field].empty?
+    p
+  end
+  # rubocop:enable Naming/MethodParameterName
+
+  def rotate_facet_value(val, from, to)
+    components = Hash[from.split(//).zip(val.split(/:/))]
+    new_values = components.values_at(*to.split(//))
+    new_values.pop while new_values.last.nil?
+    return nil if new_values.include?(nil)
+
+    new_values.compact.join(':')
+  end
+
+  def facet_order(prefix)
+    param_name = "#{prefix}_facet_order".to_sym
+    params[param_name] || blacklight_config.facet_display[:hierarchy][prefix].first
+  end
+
   def workflow_reset_link(status = 'error')
     return unless data[process] && data[process][status] && data[process][status][:_]
 
@@ -40,4 +73,6 @@ class WorkflowTableProcessComponent < ApplicationComponent
     raw ' | ' + link_to('reset', report_reset_path(new_params), remote: true, method: :post)
     # rubocop:enable Rails/OutputSafety
   end
+
+  delegate :blacklight_config, to: :search_state
 end

--- a/spec/components/workflow_table_process_component_spec.rb
+++ b/spec/components/workflow_table_process_component_spec.rb
@@ -11,12 +11,22 @@ RSpec.describe WorkflowTableProcessComponent, type: :component do
     let(:name) { 'accessionWF' }
     let(:process) { 'descriptive-metadata' }
     let(:status) { 'error' }
-    let(:blacklight_config) { Blacklight::Configuration.new }
+    let(:blacklight_config) do
+      Blacklight::Configuration.new.configure do |config|
+        config.facet_display = {
+          hierarchy: {
+            'wf_wps' => [['ssim'], ':'],
+            'wf_wsp' => [['ssim'], ':'],
+            'wf_swp' => [['ssim'], ':'],
+            'exploded_tag' => [['ssim'], ':']
+          }
+        }
+      end
+    end
     let(:query_params) { { controller: 'report', action: 'workflow_grid' } }
     let(:search_state) { Blacklight::SearchState.new(query_params, blacklight_config) }
 
     before do
-      #    allow(component.view_context).to receive(:blacklight_config).and_return blacklight_config
       allow(component).to receive(:search_state).and_return search_state
       allow(component).to receive(:report_reset_path).and_return('/foo')
     end


### PR DESCRIPTION
Put them locally in the WorkflowTableProcessComponent

## Why was this change made?
So we stop seeing the deprecation methods.


## How was this change tested?



## Which documentation and/or configurations were updated?



