### PR TITLE
Avoid deprecated method add_facet_params

### DIFF
--- a/app/components/workflow_table_component.rb
+++ b/app/components/workflow_table_component.rb
@@ -9,7 +9,7 @@ class WorkflowTableComponent < ApplicationComponent
   attr_reader :name, :data
 
   def workflow_name
-    new_params = search_state.add_facet_params('wf_wps_ssim', name).merge(controller: 'catalog', action: 'index')
+    new_params = search_state.filter('wf_wps_ssim').add(name).params.merge(controller: 'catalog', action: 'index')
     link_to(name, new_params)
   end
 

--- a/app/components/workflow_table_process_component.rb
+++ b/app/components/workflow_table_process_component.rb
@@ -10,12 +10,12 @@ class WorkflowTableProcessComponent < ApplicationComponent
   attr_reader :name, :data, :process, :description
 
   def workflow_process_name
-    new_params = search_state.add_facet_params('wf_wps_ssim', [name, process].compact.join(':')).merge(controller: 'catalog', action: 'index')
+    new_params = search_state.filter('wf_wps_ssim').add([name, process].compact.join(':')).params.merge(controller: 'catalog', action: 'index')
     link_to(process, new_params)
   end
 
   def workflow_item_count(status)
-    new_params = search_state.add_facet_params('wf_wps_ssim', [name, process, status].compact.join(':')).merge(controller: 'catalog', action: 'index')
+    new_params = search_state.filter('wf_wps_ssim').add([name, process, status].compact.join(':')).params.merge(controller: 'catalog', action: 'index')
     rotate_facet_params('wf_wps', 'wps', facet_order('wf_wps'), new_params)
     item_count = 0
     if data[process] && data[process][status] && item = data[process][status][:_] # rubocop:disable Lint/AssignmentInCondition


### PR DESCRIPTION
Put them locally in the WorkflowTableProcessComponent

## Why was this change made?
So we stop seeing the deprecation methods.


## How was this change tested?



## Which documentation and/or configurations were updated?



