### PR TITLE
Avoid using the deprecated method document_show_html_title

### DIFF
--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,4 +1,5 @@
-<% @page_title = t('blacklight.search.show.title', document_title: truncate(strip_tags(document_show_html_title).html_safe, length: 50), application_name: application_name).html_safe %>
+<% @page_title = t('blacklight.search.show.title',
+  document_title: truncate(strip_tags(document_presenter(@document).html_title).html_safe, length: 50), application_name: application_name).html_safe %>
 <% content_for(:head) { render_link_rel_alternates } %>
 
 <%= render_document_main_content_partial %>

--- a/spec/views/catalog/show.html.erb_spec.rb
+++ b/spec/views/catalog/show.html.erb_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'catalog/show.html.erb' do
   let(:document) { SolrDocument.new id: 'xyz', content_type_ssim: 'a' }
   let(:title) { 'Long title that should be truncated at 50 characters' }
   let(:blacklight_config) { CatalogController.blacklight_config }
+  let(:document_presenter) { instance_double(Blacklight::ShowPresenter, html_title: title) }
 
   before do
     assign :document, document
@@ -20,7 +21,7 @@ RSpec.describe 'catalog/show.html.erb' do
   end
 
   it 'assigns page title, truncating it' do
-    expect(view).to receive(:document_show_html_title).and_return(title)
+    expect(view).to receive(:document_presenter).and_return(document_presenter)
     expect(view).to receive(:render_document_sidebar_partial)
     expect(view).to receive(:render_document_partials)
     render


### PR DESCRIPTION
## Why was this change made?

So we can upgrade blacklight at some time.

## How was this change tested?



## Which documentation and/or configurations were updated?



