### PR TITLE
Avoid using the deprecated method show_presenter

### DIFF
--- a/app/views/bulk_jobs/index.html.erb
+++ b/app/views/bulk_jobs/index.html.erb
@@ -1,5 +1,5 @@
 <% @page_title = "Bulk Uploads for APO #{@obj.id}" %>
-<% content_for(:head) { show_presenter(@document).link_rel_alternates } -%>
+<% content_for(:head) { document_presenter(@document).link_rel_alternates } -%>
 <% content_for(:sidebar) do %>
   <%= render_document_sidebar_partial @document %>
 <% end %>


### PR DESCRIPTION
## Why was this change made?

So we can upgrade blacklight at some time.

## How was this change tested?



## Which documentation and/or configurations were updated?



