### PR TITLE
Decouple ButtonsPresenter from datastreams

### DIFF
--- a/app/controllers/bulk_jobs_controller.rb
+++ b/app/controllers/bulk_jobs_controller.rb
@@ -11,10 +11,11 @@ class BulkJobsController < ApplicationController
     authorize! :view_metadata, @obj
     @document = find(params[:apo_id])
     @bulk_jobs = load_bulk_jobs(params[:apo_id])
+    @cocina =  Dor::Services::Client.object(params[:apo_id]).find
+
     @buttons_presenter = ButtonsPresenter.new(
-      ability: current_ability,
-      solr_document: @document,
-      object: @obj
+      manager: can?(:manage_item, @cocina),
+      solr_document: @document
     )
   end
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -227,9 +227,8 @@ class CatalogController < ApplicationController
     @milestones_presenter = MilestonesPresenter.new(milestones: milestones, versions: versions)
 
     @buttons_presenter = ButtonsPresenter.new(
-      ability: current_ability,
-      solr_document: @document,
-      object: @obj
+      manager: can?(:manage_item, @cocina),
+      solr_document: @document
     )
 
     @techmd = TechmdService.techmd_for(druid: params[:id])

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -60,33 +60,33 @@ class CatalogController < ApplicationController
     # exploded_tag_ssim indexes all tag prefixes (see IdentityMetadataDS#to_solr for a more exact
     # description), whereas tag_ssim only indexes whole tags.  we want to facet on exploded_tag_ssim
     # to get the hierarchy.
-    config.add_facet_field 'exploded_tag_ssim',               label: 'Tag',                 limit: 9999,
-                                                              component: Blacklight::Hierarchy::FacetFieldListComponent,
-                                                              unless: ->(controller, _config, _response) { controller.params[:no_tags] }
-    config.add_facet_field 'objectType_ssim',                 label: 'Object Type',         component: true, limit: 10
-    config.add_facet_field 'content_type_ssim',               label: 'Content Type',        component: true, limit: 10
-    config.add_facet_field 'content_file_mimetypes_ssim',     label: 'MIME Types',          component: true, limit: 10, home: false
-    config.add_facet_field 'content_file_roles_ssim',         label: 'File Role',           component: true, limit: 10, home: false
-    config.add_facet_field 'rights_descriptions_ssim',        label: 'Access Rights',       component: true, limit: 1000, sort: 'index', home: false
-    config.add_facet_field 'use_license_machine_ssi',         label: 'License',             component: true, limit: 10, home: false
-    config.add_facet_field 'nonhydrus_collection_title_ssim', label: 'Collection',          component: true, limit: 10, more_limit: 9999, sort: 'index'
-    config.add_facet_field 'hydrus_collection_title_ssim',    label: 'Hydrus Collection',   component: true, limit: 10, more_limit: 9999, sort: 'index', home: false
-    config.add_facet_field 'nonhydrus_apo_title_ssim',        label: 'Admin Policy',        component: true, limit: 10, more_limit: 9999, sort: 'index'
-    config.add_facet_field 'hydrus_apo_title_ssim',           label: 'Hydrus Admin Policy', component: true, limit: 10, more_limit: 9999, sort: 'index', home: false
-    config.add_facet_field 'current_version_isi',             label: 'Version',             component: true, limit: 10, home: false
-    config.add_facet_field 'processing_status_text_ssi',      label: 'Processing Status',   component: true, limit: 10, home: false
-    config.add_facet_field SolrDocument::FIELD_RELEASED_TO,   label: 'Released To',         component: true, limit: 10
-    config.add_facet_field 'wf_wps_ssim', label: 'Workflows (WPS)',
-                                          component: Blacklight::Hierarchy::FacetFieldListComponent,
-                                          limit: 9999
-    config.add_facet_field 'wf_wsp_ssim', label: 'Workflows (WSP)',
-                                          component: Blacklight::Hierarchy::FacetFieldListComponent,
-                                          limit: 9999,
-                                          home: false
-    config.add_facet_field 'wf_swp_ssim', label: 'Workflows (SWP)',
-                                          component: Blacklight::Hierarchy::FacetFieldListComponent,
-                                          limit: 9999,
-                                          home: false
+    config.add_facet_field 'exploded_tag_ssim',                 label: 'Tag',                 limit: 9999,
+                                                                component: Blacklight::Hierarchy::FacetFieldListComponent,
+                                                                unless: ->(controller, _config, _response) { controller.params[:no_tags] }
+    config.add_facet_field 'objectType_ssim',                   label: 'Object Type',         component: true, limit: 10
+    config.add_facet_field 'content_type_ssim',                 label: 'Content Type',        component: true, limit: 10
+    config.add_facet_field 'content_file_mimetypes_ssim',       label: 'MIME Types',          component: true, limit: 10, home: false
+    config.add_facet_field 'content_file_roles_ssim',           label: 'File Role',           component: true, limit: 10, home: false
+    config.add_facet_field 'rights_descriptions_ssim',          label: 'Access Rights',       component: true, limit: 1000, sort: 'index', home: false
+    config.add_facet_field 'use_license_machine_ssi',           label: 'License',             component: true, limit: 10, home: false
+    config.add_facet_field 'nonhydrus_collection_title_ssim',   label: 'Collection',          component: true, limit: 10, more_limit: 9999, sort: 'index'
+    config.add_facet_field 'hydrus_collection_title_ssim',      label: 'Hydrus Collection',   component: true, limit: 10, more_limit: 9999, sort: 'index', home: false
+    config.add_facet_field 'nonhydrus_apo_title_ssim',          label: 'Admin Policy',        component: true, limit: 10, more_limit: 9999, sort: 'index'
+    config.add_facet_field 'hydrus_apo_title_ssim',             label: 'Hydrus Admin Policy', component: true, limit: 10, more_limit: 9999, sort: 'index', home: false
+    config.add_facet_field SolrDocument::FIELD_CURRENT_VERSION, label: 'Version',             component: true, limit: 10, home: false
+    config.add_facet_field 'processing_status_text_ssi',        label: 'Processing Status',   component: true, limit: 10, home: false
+    config.add_facet_field SolrDocument::FIELD_RELEASED_TO,     label: 'Released To',         component: true, limit: 10
+    config.add_facet_field 'wf_wps_ssim',    label: 'Workflows (WPS)',
+                                             component: Blacklight::Hierarchy::FacetFieldListComponent,
+                                             limit: 9999
+    config.add_facet_field 'wf_wsp_ssim',    label: 'Workflows (WSP)',
+                                             component: Blacklight::Hierarchy::FacetFieldListComponent,
+                                             limit: 9999,
+                                             home: false
+    config.add_facet_field 'wf_swp_ssim',    label: 'Workflows (SWP)',
+                                             component: Blacklight::Hierarchy::FacetFieldListComponent,
+                                             limit: 9999,
+                                             home: false
     config.add_facet_field 'has_model_ssim', label: 'Object Model',
                                              component: true,
                                              limit: 10,

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -25,9 +25,11 @@ class SolrDocument
   FIELD_PLACE                     = 'originInfo_place_placeTerm_tesim'
   FIELD_PUBLISHER                 = 'originInfo_publisher_tesim'
   FIELD_CREATED_DATE              = 'originInfo_date_created_tesim'
+  FIELD_CURRENT_VERSION           = 'current_version_isi'
 
   attribute :object_type, Blacklight::Types::String, FIELD_OBJECT_TYPE
   attribute :catkey, Blacklight::Types::String, FIELD_CATKEY_ID
+  attribute :current_version, Blacklight::Types::String, FIELD_CURRENT_VERSION
   attribute :embargo_status, Blacklight::Types::String, FIELD_EMBARGO_STATUS
   attribute :embargo_release_date, Blacklight::Types::String, FIELD_EMBARGO_RELEASE_DATE
   attribute :dor_services_version, Blacklight::Types::String, :dor_services_version_ssi
@@ -77,6 +79,14 @@ class SolrDocument
 
   def admin_policy?
     object_type == 'adminPolicy'
+  end
+
+  def item?
+    object_type == 'item'
+  end
+
+  def collection?
+    object_type == 'collection'
   end
 
   def thumbnail_url

--- a/app/presenters/buttons_presenter.rb
+++ b/app/presenters/buttons_presenter.rb
@@ -2,16 +2,14 @@
 
 # determines which links display in the sidebar
 class ButtonsPresenter
-  # @param [Ability] ability
+  # @param [Boolean] manager
   # @param [SolrDocument] solr_document
-  # @param [Dor::Item] object
-  def initialize(ability:, solr_document:, object:)
-    @ability = ability
+  def initialize(manager:, solr_document:)
+    @manager = manager
     @doc = solr_document
-    @object = object
   end
 
-  attr_reader :ability, :doc, :object
+  attr_reader :manager, :doc
 
   delegate :close_ui_item_versions_path,
            :workflow_service_closeable_path,
@@ -57,7 +55,7 @@ class ButtonsPresenter
   #
   # @return [Array]
   def buttons
-    return [] unless ability.can?(:manage_item, object)
+    return [] unless manager
 
     buttons = [close_button, open_button]
 

--- a/app/presenters/buttons_presenter.rb
+++ b/app/presenters/buttons_presenter.rb
@@ -78,10 +78,10 @@ class ButtonsPresenter
       buttons << { url: collection_ui_item_path(id: pid), label: 'Edit collections' }
     end
 
-    buttons << { url: item_content_type_path(item_id: pid), label: 'Set content type' } if object.datastreams.include? 'contentMetadata'
+    buttons << { url: item_content_type_path(item_id: pid), label: 'Set content type' } if object.is_a?(Dor::Item)
     buttons << { url: rights_item_path(id: pid), label: 'Set rights' } unless object.is_a?(Dor::AdminPolicyObject)
 
-    if object.datastreams.include?('identityMetadata') && object.identityMetadata.otherId('catkey').present?
+    if object.catkey
       # a catkey indicates there's a symphony record
       buttons << refresh_metadata_button
     end

--- a/spec/features/apo_spec.rb
+++ b/spec/features/apo_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'apo', js: true do
     allow(apo).to receive(:save!)
     allow(apo).to receive(:new_record?).and_return(false)
     allow(Argo::Indexer).to receive(:reindex_pid_remotely).and_call_original # for the collection
-    allow(Argo::Indexer).to receive(:reindex_pid_remotely).with(new_apo_druid) do |key|
+    allow(Argo::Indexer).to receive(:reindex_pid_remotely).with(new_apo_druid) do |_key|
       # Since the register was mocked, this wouldn't build the correct solr document.
       # This will make one truer to what we need:
       ActiveFedora::SolrService.add(id: new_apo_druid,

--- a/spec/features/apo_spec.rb
+++ b/spec/features/apo_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe 'apo', js: true do
   end
 
   after do
-    Dor::AdminPolicyObject.find(new_apo_druid).destroy # clean up after ourselves
     Dor::Collection.find(new_collection_druid).destroy # clean up after ourselves
   end
 
@@ -63,6 +62,16 @@ RSpec.describe 'apo', js: true do
 
     # Stubbing this out, because it's the dor-services-app that would have actually created it.
     allow(Dor).to receive(:find).with(new_apo_druid).and_return(apo)
+    allow(apo).to receive(:save!)
+    allow(apo).to receive(:new_record?).and_return(false)
+    allow(Argo::Indexer).to receive(:reindex_pid_remotely).and_call_original # for the collection
+    allow(Argo::Indexer).to receive(:reindex_pid_remotely).with(new_apo_druid) do |key|
+      # Since the register was mocked, this wouldn't build the correct solr document.
+      # This will make one truer to what we need:
+      ActiveFedora::SolrService.add(id: new_apo_druid,
+                                    SolrDocument::FIELD_OBJECT_TYPE => 'adminPolicy')
+      ActiveFedora::SolrService.commit
+    end
     allow(Dor).to receive(:find).with(new_collection_druid).and_return(collection)
     allow(Dor).to receive(:find).with('druid:dd327rv8888', cast: true).and_call_original # The agreement
     sign_in user, groups: ['sdr:administrator-role']

--- a/spec/features/bulk_jobs_spec.rb
+++ b/spec/features/bulk_jobs_spec.rb
@@ -9,15 +9,11 @@ RSpec.describe 'Bulk jobs view' do
     ActiveFedora::SolrService.commit
     sign_in create(:user), groups: ['sdr:administrator-role']
     allow(Dor).to receive(:find).with(apo_id).and_return(apo)
-    apo.datastreams['DC'].content = <<~XML
-      <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
-        <dc:title>Default Admin Policy</dc:title>
-        <dc:identifier>druid:hv992yv2222</dc:identifier>
-        <dc:language>eng</dc:language>
-      </oai_dc:dc>
-    XML
+    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
   end
 
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+  let(:cocina_model) { instance_double(Cocina::Models::DRO) }
   let(:apo_id) { 'druid:hv992yv2222' }
   let(:apo) { Dor::AdminPolicyObject.new(pid: apo_id) }
 

--- a/spec/features/item_catkey_change_spec.rb
+++ b/spec/features/item_catkey_change_spec.rb
@@ -56,7 +56,8 @@ RSpec.describe 'Item catkey change' do
       allow(Dor::Workflow::Client).to receive(:new).and_return(workflow_client)
       allow(Dor::Services::Client).to receive(:object).and_return(object_client)
       allow(Argo::Indexer).to receive(:reindex_pid_remotely)
-      ActiveFedora::SolrService.add(id: druid, objectType_ssim: 'item')
+      ActiveFedora::SolrService.add(id: druid, objectType_ssim: 'item',
+                                    SolrDocument::FIELD_CATKEY_ID => 'catkey:99999')
       ActiveFedora::SolrService.commit
     end
 

--- a/spec/features/item_source_id_change_spec.rb
+++ b/spec/features/item_source_id_change_spec.rb
@@ -56,7 +56,8 @@ RSpec.describe 'Item source id change' do
       allow(Dor::Workflow::Client).to receive(:new).and_return(workflow_client)
       allow(Dor::Services::Client).to receive(:object).and_return(object_client)
       allow(Argo::Indexer).to receive(:reindex_pid_remotely)
-      ActiveFedora::SolrService.add(id: druid, objectType_ssim: 'item')
+      ActiveFedora::SolrService.add(id: druid, objectType_ssim: 'item',
+                                    SolrDocument::FIELD_CATKEY_ID => 'catkey:99999')
       ActiveFedora::SolrService.commit
     end
 

--- a/spec/presenters/buttons_presenter_spec.rb
+++ b/spec/presenters/buttons_presenter_spec.rb
@@ -21,11 +21,6 @@ RSpec.describe ButtonsPresenter, type: :presenter do
   end
 
   let(:governing_apo_id) { 'druid:hv992yv2222' }
-  let(:doc) do
-    SolrDocument.new('id' => item_id,
-                     'processing_status_text_ssi' => 'not registered',
-                     SolrDocument::FIELD_APO_ID => [governing_apo_id])
-  end
 
   describe '#buttons' do
     let(:state_service) { instance_double(StateService, allows_modification?: true) }
@@ -44,6 +39,13 @@ RSpec.describe ButtonsPresenter, type: :presenter do
                                    admin_policy_object: governing_apo,
                                    embargoed?: false,
                                    catkey: catkey)
+      end
+      let(:doc) do
+        SolrDocument.new('id' => item_id,
+                         'processing_status_text_ssi' => 'not registered',
+                         SolrDocument::FIELD_OBJECT_TYPE => 'item',
+                         SolrDocument::FIELD_CATKEY_ID => catkey,
+                         SolrDocument::FIELD_APO_ID => [governing_apo_id])
       end
       let(:catkey) { nil }
 
@@ -118,11 +120,6 @@ RSpec.describe ButtonsPresenter, type: :presenter do
         ]
       end
 
-      before do
-        allow(object).to receive(:is_a?).and_return(false)
-        allow(object).to receive(:is_a?).with(Dor::Item).and_return(true)
-      end
-
       it 'creates a hash with the needed button info for an admin' do
         default_buttons.each do |button|
           expect(buttons).to include(button)
@@ -140,7 +137,7 @@ RSpec.describe ButtonsPresenter, type: :presenter do
       end
 
       it 'only includes the embargo update button if the user is an admin and the object is embargoed' do
-        allow(object).to receive(:embargoed?).and_return(true)
+        allow(doc).to receive(:embargoed?).and_return(true)
         default_buttons.push(
           label: 'Update embargo',
           url: "/items/#{item_id}/embargo_form"
@@ -160,7 +157,7 @@ RSpec.describe ButtonsPresenter, type: :presenter do
       end
 
       context 'when the item has a catkey' do
-        let(:catkey) { '1234567' }
+        let(:catkey) { 'catkey:1234567' }
 
         it 'includes the refresh descMetadata button' do
           default_buttons.push(
@@ -188,6 +185,7 @@ RSpec.describe ButtonsPresenter, type: :presenter do
       let(:doc) do
         SolrDocument.new('id' => view_apo_id,
                          'processing_status_text_ssi' => 'not registered',
+                         SolrDocument::FIELD_OBJECT_TYPE => 'adminPolicy',
                          SolrDocument::FIELD_APO_ID => [governing_apo_id])
       end
 
@@ -253,11 +251,6 @@ RSpec.describe ButtonsPresenter, type: :presenter do
             url: "/items/#{view_apo_id}/manage_release"
           }
         ]
-      end
-
-      before do
-        allow(object).to receive(:is_a?).and_return(false)
-        allow(object).to receive(:is_a?).with(Dor::AdminPolicyObject).and_return(true)
       end
 
       it 'renders the appropriate default buttons for an apo' do

--- a/spec/requests/set_rights_spec.rb
+++ b/spec/requests/set_rights_spec.rb
@@ -6,7 +6,13 @@ RSpec.describe 'Set rights for an object' do
   context 'when they have manage access' do
     let(:user) { create(:user) }
     let(:pid) { 'druid:cc243mg0841' }
-    let(:fedora_obj) { instance_double(Dor::Item, pid: pid, current_version: 1, admin_policy_object: nil) }
+    let(:fedora_obj) do
+      instance_double(Dor::Item,
+                      pid: pid,
+                      current_version: 1,
+                      admin_policy_object: nil,
+                      catkey: nil)
+    end
     let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, update: true) }
 
     before do


### PR DESCRIPTION


## Why was this change made?
This helps decouple Argo from Fedora 3


## How was this change tested?



## Which documentation and/or configurations were updated?



