### PR TITLE
Create a show thumbnail partial

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -195,7 +195,7 @@ class CatalogController < ApplicationController
     # Configure document actions framework
     config.index.document_actions.delete(:bookmark)
 
-    config.show.partials = %w[show_header full_view_links thumbnail show datastreams events cocina history contents techmd]
+    config.show.partials = %w[show_header full_view_links show_thumbnail show datastreams events cocina history contents techmd]
   end
 
   def index

--- a/app/views/catalog/_show_thumbnail.html.erb
+++ b/app/views/catalog/_show_thumbnail.html.erb
@@ -1,0 +1,4 @@
+<% # The thumbnail partial provided by blacklight 7 is only suitable for the index
+   # as it depends on the deprecated @response ivar. Furthermore we don't need a link
+   # that goes to the very same page that we are on. %>
+<%= document_presenter(document).thumbnail.render %>


### PR DESCRIPTION

## Why was this change made?

The thumbnail partial provided by blacklight was only suitable for the index context as it depends on the @response ivar that is deprecated in the show method


## How was this change tested?



## Which documentation and/or configurations were updated?



