### PR TITLE
Use Blacklight::HiddenSearchStateComponent to avoid deprecations

### DIFF
--- a/app/components/date_choice_facet_component.html.erb
+++ b/app/components/date_choice_facet_component.html.erb
@@ -16,7 +16,7 @@
       </div>
       <div>
         <%= form_tag search_catalog_path, method: :get do %>
-          <%= render_hash_as_hidden_fields(search_params) %>
+          <%= render Blacklight::HiddenSearchStateComponent.new(params: search_params) %>
           <%= hidden_field_tag "f[#{solr_field_name}][]", '[* TO *]', data: { range_value: '' } %>
           <%= submit_tag('submit', class: 'btn btn-primary') %>
         <% end %>


### PR DESCRIPTION
## Why was this change made?

render_hash_as_hidden_fields is deprecated in Blacklight. This provides a way to avoid the deprecation.

## How was this change tested?



## Which documentation and/or configurations were updated?



