### PR TITLE
Support removing catKeys with manage catKey bulk action.

### DIFF
--- a/app/jobs/manage_catkey_job.rb
+++ b/app/jobs/manage_catkey_job.rb
@@ -34,12 +34,17 @@ class ManageCatkeyJob < GenericJob
       log.puts("#{Time.current} Not authorized for #{current_druid}")
       return
     end
-    log.puts("#{Time.current} Adding catkey of #{new_catkey}")
+    if new_catkey
+      log.puts("#{Time.current} Adding catkey of #{new_catkey}")
+    else
+      log.puts("#{Time.current} Removing catkey")
+    end
     begin
       object_client = Dor::Services::Client.object(current_druid)
       dro = object_client.find
       state_service = StateService.new(current_druid, version: dro.version)
-      open_new_version(dro.externalIdentifier, dro.version, "Catkey updated to #{new_catkey}") unless state_service.allows_modification?
+      msg = new_catkey ? "Catkey updated to #{new_catkey}" : 'Catkey removed'
+      open_new_version(dro.externalIdentifier, dro.version, msg) unless state_service.allows_modification?
 
       CatkeyService.update(dro, object_client, new_catkey)
       bulk_action.increment(:druid_count_success).save

--- a/app/services/catkey_service.rb
+++ b/app/services/catkey_service.rb
@@ -3,9 +3,9 @@
 # Updates the catkey on an object by calling the dor-services-app api
 class CatkeyService
   def self.update(cocina_model, object_client, new_catkey)
-    updated_identification = cocina_model.identification.new(
-      catalogLinks: [{ catalog: 'symphony', catalogRecordId: new_catkey }]
-    )
+    catalog_links = []
+    catalog_links << { catalog: 'symphony', catalogRecordId: new_catkey } unless new_catkey.nil?
+    updated_identification = cocina_model.identification.new(catalogLinks: catalog_links)
     updated = cocina_model.new(identification: updated_identification)
     object_client.update(params: updated)
   end


### PR DESCRIPTION
closes #2358

## Why was this change made?
Manage catKey bulk action was not supporting blank lines, which are used to remove catKeys.


## How was this change tested?
Unit, stage


## Which documentation and/or configurations were updated?
NA


