### PR TITLE
Allow administrators to edit objects even if they can't be loaded 

### DIFF
--- a/app/controllers/apo_controller.rb
+++ b/app/controllers/apo_controller.rb
@@ -78,6 +78,6 @@ class ApoController < ApplicationController
     raise 'missing druid' unless params[:id]
 
     @object = Dor.find params[:id]
-    @cocina = Dor::Services::Client.object(params[:id]).find
+    @cocina = maybe_load_cocina(params[:id])
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,16 @@ class ApplicationController < ActionController::Base
 
   layout :determine_layout
 
+  # Currently we know that not all objects are Cocina compliant, this ensures that we can at least
+  # receive some object and so, at least administrators can be authorized to operate on it.
+  # @return [Cocina::Models::DRO,NilModel]
+  def maybe_load_cocina(druid)
+    object_client = Dor::Services::Client.object(druid)
+    object_client.find
+  rescue Dor::Services::Client::UnexpectedResponse
+    NilModel.new(druid)
+  end
+
   def current_user
     super.tap do |cur_user|
       break unless cur_user

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -210,14 +210,9 @@ class CatalogController < ApplicationController
     deprecated_response, @document = search_service.fetch(params[:id])
     @response = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(deprecated_response, 'The @response instance variable is deprecated; use @document.response instead.')
 
+    @cocina = maybe_load_cocina(params[:id])
     object_client = Dor::Services::Client.object(params[:id])
 
-    # Used for drawing releaseTags in the history section
-    begin
-      @cocina = object_client.find
-    rescue Dor::Services::Client::UnexpectedResponse
-      @cocina = NilModel.new(params[:id])
-    end
     @events = object_client.events.list
 
     @workflows = WorkflowService.workflows_for(druid: params[:id])

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -3,7 +3,7 @@
 # Manages HTTP interactions for creating collections
 class CollectionsController < ApplicationController
   def new
-    @cocina = Dor::Services::Client.object(params[:apo_id]).find
+    @cocina = maybe_load_cocina(params[:apo_id])
     authorize! :manage_item, @cocina
 
     respond_to do |format|
@@ -12,7 +12,7 @@ class CollectionsController < ApplicationController
   end
 
   def create
-    cocina = Dor::Services::Client.object(params[:apo_id]).find
+    cocina = maybe_load_cocina(params[:apo_id])
     authorize! :manage_item, cocina
 
     @apo = Dor.find params[:apo_id]

--- a/app/controllers/content_types_controller.rb
+++ b/app/controllers/content_types_controller.rb
@@ -11,7 +11,7 @@ class ContentTypesController < ApplicationController
 
   # set the content type in the content metadata
   def update
-    cocina = Dor::Services::Client.object(params[:item_id]).find
+    cocina = maybe_load_cocina(params[:item_id])
     authorize! :manage_item, cocina
 
     # if this object has been submitted and doesnt have an open version, they cannot change it.

--- a/app/controllers/datastreams_controller.rb
+++ b/app/controllers/datastreams_controller.rb
@@ -42,7 +42,7 @@ class DatastreamsController < ApplicationController
   # @option params [String] `:id` the identifier for the datastream, e.g., `identityMetadata`
   # @option params [String] `:item_id` the druid to modify
   def update
-    cocina = Dor::Services::Client.object(params[:item_id]).find
+    cocina = maybe_load_cocina(params[:item_id])
     authorize! :manage_item, cocina
 
     raise ArgumentError, 'Missing content' if params[:content].blank?
@@ -68,8 +68,8 @@ class DatastreamsController < ApplicationController
 
   def show_aspect
     pid = params[:item_id].include?('druid') ? params[:item_id] : "druid:#{params[:item_id]}"
-    @obj = Dor.find(pid)
-    @cocina = Dor::Services::Client.object(pid).find
     @response, @document = search_service.fetch pid # this does the authorization
+    @obj = Dor.find(pid)
+    @cocina = maybe_load_cocina(pid)
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -38,7 +38,7 @@ class Ability
       Honeybadger.notify('Deprecated call to ability with an ActiveFedora object')
       current_user.manager?
     end
-    can %i[manage_item manage_desc_metadata manage_governing_apo view_content view_metadata], Cocina::Models::DRO if current_user.manager?
+    can %i[manage_item manage_desc_metadata manage_governing_apo view_content view_metadata], [NilModel, Cocina::Models::DRO] if current_user.manager?
     can :create, Dor::AdminPolicyObject if current_user.manager?
 
     can %i[view_metadata view_content], [ActiveFedora::Base, Cocina::Models::DRO] if current_user.viewer?

--- a/app/models/nil_model.rb
+++ b/app/models/nil_model.rb
@@ -6,6 +6,12 @@ class NilModel
     @pid = pid
   end
 
+  # rubocop:disable Naming/MethodName
+  def externalIdentifier
+    @pid
+  end
+  # rubocop:enable Naming/MethodName
+
   def administrative
     NilAdministrative.new
   end


### PR DESCRIPTION


## Why was this change made?
Presently a problem getting the object from DSA prevents authorizing the object, even though we don't actually need the object if the user is an administrator.  This gives administrators to edit these broken objects.

fixes #2356 

## How was this change tested?



## Which documentation and/or configurations were updated?



