### PR TITLE
Direct datastream updates through the legacy API where possible

### DIFF
--- a/app/controllers/datastreams_controller.rb
+++ b/app/controllers/datastreams_controller.rb
@@ -49,10 +49,7 @@ class DatastreamsController < ApplicationController
 
     begin
       Nokogiri::XML(params[:content], &:strict)
-      @object = Dor.find params[:item_id]
-      @object.datastreams[params[:id]].content = params[:content] # set the XML to be verbatim as posted
-      @object.save
-      Argo::Indexer.reindex_pid_remotely(@object.pid)
+      store_xml(druid: params[:item_id], datastream: params[:id], content: params[:content])
       msg = 'Datastream was successfully updated'
     rescue Nokogiri::XML::SyntaxError
       # if the content is not well-formed xml, inform the user rather than raising an exception
@@ -65,6 +62,43 @@ class DatastreamsController < ApplicationController
   end
 
   private
+
+  LEGACY_API = %w[
+    administrative
+    descriptive
+    content
+    geo
+    identity
+    provenance
+    relationships
+    rights
+    technical
+    version
+  ].freeze
+
+  def store_xml(druid:, datastream:, content:)
+    endpoint = datastream == 'RELS-EXT' ? 'relationships' : datastream.delete_suffix('Metadata')
+    return update_directly(druid: druid, datastream: datastream, content: content) unless LEGACY_API.include? endpoint
+
+    object_client = Dor::Services::Client.object(druid)
+    object_client.metadata.legacy_update(
+      endpoint.to_sym => {
+        updated: Time.zone.now,
+        content: content
+      }
+    )
+    Argo::Indexer.reindex_pid_remotely(druid)
+  end
+
+  # This is the deprecated path where we write directly to Fedora 3
+  def update_directly(druid:, datastream:, content:)
+    Honeybadger.notify("Deprecated call to update_directly for #{druid}, #{datastream}")
+
+    @object = Dor.find druid
+    @object.datastreams[datastream].content = content # set the XML to be verbatim as posted
+    @object.save
+    Argo::Indexer.reindex_pid_remotely(druid)
+  end
 
   def show_aspect
     pid = params[:item_id].include?('druid') ? params[:item_id] : "druid:#{params[:item_id]}"


### PR DESCRIPTION


## Why was this change made?
This allows the legacy API to validate the correctness before saving and it makes Argo consistent with how common-accessioning updates metadata.


## How was this change tested?



## Which documentation and/or configurations were updated?



