### PR TITLE
Allow admins to operate on items when the data is bad

### DIFF
--- a/spec/requests/set_rights_spec.rb
+++ b/spec/requests/set_rights_spec.rb
@@ -349,9 +349,7 @@ RSpec.describe 'Set rights for an object' do
         post "/items/#{pid}/set_rights", params: { dro_rights_form: { rights: 'dark' } }
         expect(response).to redirect_to(solr_document_path(pid))
         follow_redirect!
-        expect(response.body).to include 'Unable to retrieve the cocina model: ' \
-          '#/components/schemas/SourceId pattern ^.+:.+$ does not match value: ' \
-          'bad_source_id:, example: sul:PC0170_s3_Fiesta_Bowl_2012-01-02_210609_2026'
+        expect(response.body).to include 'Can&#39;t set rights on an invalid model'
       end
     end
   end

--- a/spec/requests/show_rights_spec.rb
+++ b/spec/requests/show_rights_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe 'Show rights for an object' do
 
       it 'shows the error' do
         get "/items/#{pid}/rights"
-        expect(flash[:error]).to eq 'Unable to retrieve the cocina model: Invalid date'
+        expect(flash[:error]).to eq 'Unable to retrieve the cocina model'
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?
So that you can purge an invalid object.



## How was this change tested?



## Which documentation and/or configurations were updated?



