### PR TITLE
Pin zip_tricks to 5.3.1 in order to avoid breaking download all...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ gem 'rake'
 gem 'retries'
 gem 'ruby-prof'
 gem 'rubyzip'
-gem 'zip_tricks', '~> 5.3'
+gem 'zip_tricks', '5.3.1' # 5.3.1 is required as 5.4+ breaks the download all feature
 
 # Stanford related gems
 gem 'blacklight', '~> 7.13'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -609,7 +609,7 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.4.2)
-    zip_tricks (5.5.0)
+    zip_tricks (5.3.1)
 
 PLATFORMS
   ruby
@@ -681,7 +681,7 @@ DEPENDENCIES
   webdrivers
   webmock
   webpacker (~> 5.0)
-  zip_tricks (~> 5.3)
+  zip_tricks (= 5.3.1)
 
 BUNDLED WITH
    2.2.7


### PR DESCRIPTION
## Why was this change made?

Fixes #2320 

## How was this change tested?

Manually on prod


## Which documentation and/or configurations were updated?



