### PR TITLE
use correct options when setting rights in bulk page

### DIFF
--- a/app/forms/access_form.rb
+++ b/app/forms/access_form.rb
@@ -44,8 +44,6 @@ class AccessForm
   def derive_rights_from_cocina
     rights = if @model.access.readLocation
                "loc:#{@model.access.readLocation}"
-             elsif @model.access.access == 'citation-only'
-               'none' # TODO: we could remove this if we switch to REGISTRATION_RIGHTS_OPTIONS from DEFAULT_RIGHTS_OPTIONS
              else
                @model.access.access
              end

--- a/app/views/report/bulk.html.erb
+++ b/app/views/report/bulk.html.erb
@@ -171,7 +171,7 @@ ul li{
 
 <div class="bulk_operation" id="rights" name="rights">
   <h1>Set object rights</h1>
-  <%= select_tag :rights_select, options_for_select(Constants::DEFAULT_RIGHTS_OPTIONS) %>
+  <%= select_tag :rights_select, options_for_select(Constants::REGISTRATION_RIGHTS_OPTIONS) %>
   <button class="btn btn-primary" id="rights_button" name="rights_button">Set rights</button>
 </div>
 <button class="btn btn-primary stop_button" id="stop" style="display:none" name="stop">Stop</button>

--- a/spec/forms/dro_rights_form_spec.rb
+++ b/spec/forms/dro_rights_form_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe DRORightsForm do
       let(:access) { 'citation-only' }
       let(:download) { 'none' }
 
-      it { is_expected.to eq 'none' }
+      it { is_expected.to eq 'citation-only' }
     end
 
     context 'with dark' do


### PR DESCRIPTION
## Why was this change made?

Fixes #2390 - bulk update for set rights to citation-only not working correctly.

Testing shows this works on stage, but I'm not sure I fully understand why we have two sets of options and why we still use `DEFAULT_RIGHTS_OPTIONS` for the APO (https://github.com/sul-dlss/argo/blob/main/app/views/apo/_form.html.erb#L84) and Collection (https://github.com/sul-dlss/argo/blob/main/app/views/collections/new.html.erb#L39).

But seeing as `REGISTRATION_RIGHTS_OPTIONS` is used for the items in all other spots in Argo right now (including in item registration), I think this bug fix change makes sense.

## How was this change tested?

Unit tests and manually on stage

## Which documentation and/or configurations were updated?



