### PR TITLE
use cocina based rights options for collections and apos

### DIFF
--- a/app/forms/access_form.rb
+++ b/app/forms/access_form.rb
@@ -5,14 +5,14 @@
 class AccessForm
   extend ActiveModel::Naming
   # @param [Cocina::Models::DRO, Cocina::Models::Collection] model
-  # @param [String] the default rights to assign to the object, from Constants::REGISTRATION_RIGHTS_OPTIONS (which is defined as RIGHTS_TYPE_CODES in dor-services)
+  # @param [String] the default rights to assign to the object, from Constants::REGISTRATION_RIGHTS_OPTIONS
   def initialize(model, default_rights: nil)
     @model = model
     @default_rights = default_rights || 'citation-only'
   end
 
   # @param [HashWithIndifferentAccess] params the values from the form
-  # @option params [String] :rights the rights representation from the form (must be one of the keys in Dor::RightsMetadataDS::RIGHTS_TYPE_CODES, or 'default')
+  # @option params [String] :rights the rights representation from the form (must be one of the keys in Constants::REGISTRATION_RIGHTS_OPTIONS, or 'default')
   def validate(params)
     rights = params[:rights]
     # valid_rights_options is implemented by concrete class.

--- a/app/forms/collection_rights_form.rb
+++ b/app/forms/collection_rights_form.rb
@@ -26,8 +26,6 @@ class CollectionRightsForm < AccessForm
   def derive_rights_from_cocina
     if @model.access.readLocation
       "loc:#{@model.access.readLocation}"
-    elsif @model.access.access == 'citation-only'
-      'none' # TODO: we could remove this if we switch to REGISTRATION_RIGHTS_OPTIONS from DEFAULT_RIGHTS_OPTIONS
     else
       @model.access.access
     end

--- a/app/services/cocina_access.rb
+++ b/app/services/cocina_access.rb
@@ -4,7 +4,7 @@
 class CocinaAccess
   extend Dry::Monads[:maybe]
 
-  # @param [String] the rights representation from the form (must be one of the keys in Dor::RightsMetadataDS::RIGHTS_TYPE_CODES, or 'default')
+  # @param [String] the rights representation from the form (must be one of the keys in Constants::COLLECTION_RIGHTS_OPTIONS, or 'default')
   # @return [Maybe<Hash<Symbol,String>>] a hash representing a subset of the Access subschema of the Cocina model
   def self.from_form_value(rights)
     # Default only appears on the registration form, not the update form.

--- a/app/services/cocina_dro_access.rb
+++ b/app/services/cocina_dro_access.rb
@@ -4,7 +4,7 @@
 class CocinaDROAccess
   extend Dry::Monads[:maybe]
 
-  # @param [String] rights the rights representation from the form (must be one of the keys in Dor::RightsMetadataDS::RIGHTS_TYPE_CODES, or 'default')
+  # @param [String] rights the rights representation from the form (must be one of the keys in Constants::REGISTRATION_RIGHTS_OPTIONS, or 'default')
   # @return [Maybe<Hash<Symbol,String>>] a hash representing a subset of the Access subschema of the Cocina model
   def self.from_form_value(rights)
     # Default only appears on the registration form, not the update form.

--- a/app/views/apo/_form.html.erb
+++ b/app/views/apo/_form.html.erb
@@ -81,7 +81,7 @@
     <div class="form-group">
       <label for="collection_rights" class="col-sm-2 control-label">Collection Rights</label>
       <div class="col-sm-10">
-        <%= select_tag :collection_rights, options_for_select(Constants::DEFAULT_RIGHTS_OPTIONS, 'world'), class: 'form-control' %>
+        <%= select_tag :collection_rights, options_for_select(Constants::COLLECTION_RIGHTS_OPTIONS, 'world'), class: 'form-control' %>
       </div>
     </div>
   </div>
@@ -96,7 +96,7 @@
     <div class="form-group">
       <label for="collection_rights_catkey" class="col-sm-2 control-label">Collection Rights</label>
       <div class="col-sm-10">
-        <%= select_tag :collection_rights_catkey, options_for_select(Constants::DEFAULT_RIGHTS_OPTIONS, 'world'), class: 'form-control' %>
+        <%= select_tag :collection_rights_catkey, options_for_select(Constants::COLLECTION_RIGHTS_OPTIONS, 'world'), class: 'form-control' %>
       </div>
     </div>
   </div>
@@ -108,7 +108,7 @@
 
   <div class="form-group">
     <label>Default Object Rights</label>
-      <%= select_tag :default_object_rights, options_for_select(Constants::DEFAULT_RIGHTS_OPTIONS, @form.default_rights), class: 'form-control' %>
+      <%= select_tag :default_object_rights, options_for_select(Constants::REGISTRATION_RIGHTS_OPTIONS, @form.default_rights), class: 'form-control' %>
   </div>
   <div class="form-group">
     <label for="use">Default Use and Reproduction statement</label><br>

--- a/app/views/collections/new.html.erb
+++ b/app/views/collections/new.html.erb
@@ -36,7 +36,7 @@
         <label for="collection_rights">
           Collection Object Visibility
         </label>
-        <%= select_tag :collection_rights, options_for_select(Constants::DEFAULT_RIGHTS_OPTIONS, 'world'), class: 'form-control' %>
+        <%= select_tag :collection_rights, options_for_select(Constants::COLLECTION_RIGHTS_OPTIONS, 'world'), class: 'form-control' %>
       </div>
     </div>
     <div id="create-collection-catkey" class="collection_div" style="display:none">
@@ -51,7 +51,7 @@
         <label for="collection_rights_catkey">
           Collection Object Visibility
         </label>
-        <%= select_tag :collection_rights_catkey, options_for_select(Constants::DEFAULT_RIGHTS_OPTIONS, 'world'), class: 'form-control' %>
+        <%= select_tag :collection_rights_catkey, options_for_select(Constants::COLLECTION_RIGHTS_OPTIONS, 'world'), class: 'form-control' %>
       </div>
     </div>
     <div class="form-group">

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -3,23 +3,6 @@
 ##
 # A module for including constants throughout the Argo application
 module Constants
-  # From https://github.com/sul-dlss/dor-services/blob/main/lib/dor/datastreams/rights_metadata_ds.rb
-  DEFAULT_RIGHTS_OPTIONS = [
-    %w[World world],
-    ['World (no-download)', 'world-nd'],
-    %w[Stanford stanford],
-    ['Stanford (no-download)', 'stanford-nd'],
-    ['Controlled Digital Lending (no-download)', 'cdl-stanford-nd'],
-    ['Location: Special Collections', 'loc:spec'],
-    ['Location: Music Library', 'loc:music'],
-    ['Location: Archive of Recorded Sound', 'loc:ars'],
-    ['Location: Art Library', 'loc:art'],
-    ['Location: Hoover Library', 'loc:hoover'],
-    ['Location: Media & Microtext', 'loc:m&m'],
-    ['Dark (Preserve Only)', 'dark'],
-    ['Citation Only', 'none']
-  ].freeze
-
   REGISTRATION_RIGHTS_OPTIONS = [
     %w[World world],
     ['World (no-download)', 'world-nd'],

--- a/spec/forms/collection_rights_form_spec.rb
+++ b/spec/forms/collection_rights_form_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe CollectionRightsForm do
       let(:access) { 'citation-only' }
       let(:download) { 'none' }
 
-      it { is_expected.to eq 'none' }
+      it { is_expected.to eq 'citation-only' }
     end
 
     context 'with dark' do


### PR DESCRIPTION
## Why was this change made?

The analog to changes made to fix a bug with setting the rights of an item in #2394 

This is the attempt to normalize the usage of default object rights and collection rights in all locations and stop using options that exist in the datastream.  We already do this for items, so expect it should be possible for collections and default object rights in APOs as well (and perhaps necessary).  

What is not clear is why we have not not done this yet (i.e. why/if we still need to use the `DEFAULT_RIGHTS_OPTIONS` in these locations in order to match the allowed values in the datastream at https://github.com/sul-dlss/dor-services/blob/main/lib/dor/datastreams/rights_metadata_ds.rb) or if it will work using the cocina based `REGISTRATION_RIGHTS_OPTIONS` for items and `COLLECTION_RIGHTS_OPTIONS` for collections.  
This PR makes the changes assuming it will.

## How was this change tested?



## Which documentation and/or configurations were updated?



