### PR TITLE
Get registration workflow from cocina

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -14,16 +14,12 @@ class RegistrationsController < ApplicationController
     render plain: pdf.render, content_type: :pdf
   end
 
-  def workflows_for_apo(apo_id)
-    docs = Dor::SearchService.query(%(id:"#{apo_id}"))['response']['docs']
-    result = docs.collect { |doc| doc['registration_workflow_id_ssim'] }.compact
-    # always put default workflow option first, then alpha sort the rest
-    result.flatten.sort.unshift(Settings.apo.default_workflow_option).uniq
-  end
-
   def workflow_list
+    cocina =  Dor::Services::Client.object(params[:apo_id]).find
+    workflows = ([Settings.apo.default_workflow_option] + Array(cocina.administrative.registrationWorkflow)).uniq
+
     respond_to do |format|
-      format.any(:json, :xml) { render request.format.to_sym => workflows_for_apo(params[:apo_id]) }
+      format.any(:json, :xml) { render request.format.to_sym => workflows }
     end
   end
 

--- a/spec/features/item_registration_spec.rb
+++ b/spec/features/item_registration_spec.rb
@@ -14,12 +14,26 @@ RSpec.describe 'Item registration page', js: true do
     }
   end
 
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+  let(:cocina_model) do
+    Cocina::Models.build(
+      'label' => 'The APO',
+      'version' => 1,
+      'type' => Cocina::Models::Vocab.admin_policy,
+      'externalIdentifier' => ur_apo_id,
+      'administrative' => {
+        hasAdminPolicy: ur_apo_id,
+        registrationWorkflow: %w[dpgImageWF goobiWF]
+      }
+    )
+  end
+
   before do
+    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+
     ActiveFedora::SolrService.add(solr_doc)
     ActiveFedora::SolrService.commit
     sign_in user, groups: ['sdr:administrator-role', 'dlss:developers']
-    allow_any_instance_of(RegistrationsController).to receive(:workflows_for_apo).and_return([])
-    allow_any_instance_of(RegistrationsController).to receive(:workflows_for_apo).with(ur_apo_id).and_return(%w[dpgImageWF goobiWF])
   end
 
   it 'invokes item registration method with the expected values and relays errors properly' do


### PR DESCRIPTION
Blocked by https://github.com/sul-dlss/cocina-models/pull/213
## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



