### PR TITLE
Decouple authorization of APO creation from ActiveFedora

### DIFF
--- a/app/controllers/apo_controller.rb
+++ b/app/controllers/apo_controller.rb
@@ -8,19 +8,19 @@ class ApoController < ApplicationController
   ]
 
   def edit
-    authorize! :create, Dor::AdminPolicyObject
+    authorize! :create, Cocina::Models::AdminPolicy
     @form = ApoForm.new(@object)
     render layout: 'one_column'
   end
 
   def new
-    authorize! :create, Dor::AdminPolicyObject
+    authorize! :create, Cocina::Models::AdminPolicy
     @form = ApoForm.new(Dor::AdminPolicyObject.new)
     render layout: 'one_column'
   end
 
   def create
-    authorize! :create, Dor::AdminPolicyObject
+    authorize! :create, Cocina::Models::AdminPolicy
 
     @form = ApoForm.new(Dor::AdminPolicyObject.new)
     unless @form.validate(params.merge(tag: "Registered By : #{current_user.login}"))

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -12,8 +12,8 @@
 #
 # Argo specific notes:
 #   * permissions granted by an APO apply to objects governed by the APO, as well as to the APO itself; hence, the fallthrough
-#   check to the APO's own ID for Dor::AdminPolicyObject types in addition to the checks for ActiveFedora::Base types (e.g. the
-#   "can :manage_item, Dor::AdminPolicyObject" and "can :manage_item, ActiveFedora::Base" definitions, with the latter being checked
+#   check to the APO's own ID for Cocina::Models::AdminPolicy types in addition to the checks for ActiveFedora::Base types (e.g. the
+#   "can :manage_item, Cocina::Models::AdminPolicy" and "can :manage_item, ActiveFedora::Base" definitions, with the latter being checked
 #   first).  see https://github.com/sul-dlss/argo/issues/76
 #
 # note about confusing dor-services method declarations:
@@ -39,7 +39,7 @@ class Ability
       current_user.manager?
     end
     can %i[manage_item manage_desc_metadata manage_governing_apo view_content view_metadata], [NilModel, Cocina::Models::DRO] if current_user.manager?
-    can :create, Dor::AdminPolicyObject if current_user.manager?
+    can :create, Cocina::Models::AdminPolicy if current_user.manager?
 
     can %i[view_metadata view_content], [ActiveFedora::Base, Cocina::Models::DRO] if current_user.viewer?
 

--- a/spec/controllers/apo_controller_spec.rb
+++ b/spec/controllers/apo_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe ApoController, type: :controller do
 
     before do
       allow(ApoForm).to receive(:new).and_return(form)
-      allow(controller).to receive(:authorize!).with(:create, Dor::AdminPolicyObject).and_return(true)
+      allow(controller).to receive(:authorize!).with(:create, Cocina::Models::AdminPolicy).and_return(true)
     end
 
     context 'when the form is valid' do
@@ -85,7 +85,7 @@ RSpec.describe ApoController, type: :controller do
 
     before do
       allow(ApoForm).to receive(:new).and_return(form)
-      allow(controller).to receive(:authorize!).with(:create, Dor::AdminPolicyObject).and_return(true)
+      allow(controller).to receive(:authorize!).with(:create, Cocina::Models::AdminPolicy).and_return(true)
     end
 
     context 'when the form is valid' do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Ability do
     it { is_expected.to be_able_to(:manage_item, dro) }
     it { is_expected.to be_able_to(:manage_desc_metadata, item) }
     it { is_expected.to be_able_to(:manage_governing_apo, dro, new_apo_id) }
-    it { is_expected.to be_able_to(:create, Dor::AdminPolicyObject) }
+    it { is_expected.to be_able_to(:create, Cocina::Models::AdminPolicy) }
     it { is_expected.to be_able_to(:view_metadata, item) }
     it { is_expected.to be_able_to(:view_content, item) }
     it { is_expected.to be_able_to(:view_content, dro) }
@@ -62,7 +62,7 @@ RSpec.describe Ability do
     it { is_expected.to be_able_to(:manage_item, dro) }
     it { is_expected.to be_able_to(:manage_desc_metadata, item) }
     it { is_expected.to be_able_to(:manage_governing_apo, dro, new_apo_id) }
-    it { is_expected.to be_able_to(:create, Dor::AdminPolicyObject) }
+    it { is_expected.to be_able_to(:create, Cocina::Models::AdminPolicy) }
     it { is_expected.to be_able_to(:view_metadata, item) }
     it { is_expected.to be_able_to(:view_content, item) }
     it { is_expected.to be_able_to(:view_content, dro) }
@@ -74,7 +74,7 @@ RSpec.describe Ability do
 
     it { is_expected.not_to be_able_to(:manage_item, dro) }
     it { is_expected.not_to be_able_to(:manage_desc_metadata, item) }
-    it { is_expected.not_to be_able_to(:create, Dor::AdminPolicyObject) }
+    it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, new_apo_id) }
     it { is_expected.to be_able_to(:view_metadata, item) }
     it { is_expected.to be_able_to(:view_content, item) }
@@ -99,7 +99,7 @@ RSpec.describe Ability do
     it { is_expected.to be_able_to(:manage_governing_apo, dro, new_apo_id) }
     it { is_expected.not_to be_able_to(:manage_desc_metadata, item) }
     it { is_expected.to be_able_to(:manage_desc_metadata, item_with_apo) }
-    it { is_expected.not_to be_able_to(:create, Dor::AdminPolicyObject) }
+    it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
     it { is_expected.not_to be_able_to(:view_metadata, item) }
     it { is_expected.to be_able_to(:view_metadata, item_with_apo) }
     it { is_expected.not_to be_able_to(:view_content, item) }
@@ -115,7 +115,7 @@ RSpec.describe Ability do
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, new_apo_id) }
     it { is_expected.not_to be_able_to(:manage_desc_metadata, item) }
     it { is_expected.to be_able_to(:manage_desc_metadata, item_with_apo) }
-    it { is_expected.not_to be_able_to(:create, Dor::AdminPolicyObject) }
+    it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
     it { is_expected.not_to be_able_to(:view_metadata, item) }
     it { is_expected.not_to be_able_to(:view_metadata, item_with_apo) }
     it { is_expected.not_to be_able_to(:view_content, item) }
@@ -131,7 +131,7 @@ RSpec.describe Ability do
     it { is_expected.not_to be_able_to(:manage_desc_metadata, item) }
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, new_apo_id) }
     it { is_expected.not_to be_able_to(:manage_desc_metadata, item_with_apo) }
-    it { is_expected.not_to be_able_to(:create, Dor::AdminPolicyObject) }
+    it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
     it { is_expected.not_to be_able_to(:view_metadata, item) }
     it { is_expected.to be_able_to(:view_metadata, item_with_apo) }
     it { is_expected.not_to be_able_to(:view_content, item) }


### PR DESCRIPTION
## Why was this change made?

Ref #2387



## How was this change tested?



## Which documentation and/or configurations were updated?



