### PR TITLE
Updating descMetadata should use legacy API

### DIFF
--- a/app/controllers/datastreams_controller.rb
+++ b/app/controllers/datastreams_controller.rb
@@ -61,6 +61,17 @@ class DatastreamsController < ApplicationController
     end
   end
 
+  def self.endpoint_for_datastream(datastream)
+    case datastream
+    when 'RELS-EXT'
+      'relationships'
+    when 'descMetadata'
+      'descriptive'
+    else
+      datastream.delete_suffix('Metadata')
+    end
+  end
+
   private
 
   LEGACY_API = %w[
@@ -77,7 +88,7 @@ class DatastreamsController < ApplicationController
   ].freeze
 
   def store_xml(druid:, datastream:, content:)
-    endpoint = datastream == 'RELS-EXT' ? 'relationships' : datastream.delete_suffix('Metadata')
+    endpoint = self.class.endpoint_for_datastream datastream
     return update_directly(druid: druid, datastream: datastream, content: content) unless LEGACY_API.include? endpoint
 
     object_client = Dor::Services::Client.object(druid)

--- a/spec/requests/update_datastream_spec.rb
+++ b/spec/requests/update_datastream_spec.rb
@@ -90,4 +90,12 @@ RSpec.describe 'Update a datastream' do
       expect(response).to redirect_to "/view/#{pid}"
     end
   end
+
+  describe 'DatastreamsController.endpoint_for_datastream' do
+    subject { DatastreamsController.endpoint_for_datastream(datastream) }
+
+    let(:datastream) { 'descMetadata' }
+
+    it { is_expected.to eq 'descriptive' }
+  end
 end


### PR DESCRIPTION
## Why was this change made?
Fixes #2429


## How was this change tested?



## Which documentation and/or configurations were updated?



