### PR TITLE
Decouple SetGoverningApoJob from Fedora 3

### DIFF
--- a/spec/requests/manage_release_spec.rb
+++ b/spec/requests/manage_release_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe 'Draw the manage release form' do
 
   before do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
-    # allow(Dor).to receive(:find).with('druid:bc123df4567').and_return(item)
   end
 
   context 'for content managers' do


### PR DESCRIPTION
## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



