### PR TITLE
Update to use latest cocina-models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,14 +63,14 @@ gem 'zip_tricks', '5.3.1' # 5.3.1 is required as 5.4+ breaks the download all fe
 gem 'blacklight', '~> 7.13'
 gem 'blacklight-hierarchy', '~> 5.0'
 gem 'dor-services', '~> 9.6'
-gem 'dor-services-client', '~> 6.20'
+gem 'dor-services-client', '~> 6.24'
 gem 'dor-workflow-client', '~> 3.19'
 gem 'mods_display'
 gem 'okcomputer' # monitors application and its dependencies
 gem 'preservation-client', '~> 3.2'
 gem 'responders', '~> 2.0'
 gem 'rsolr'
-gem 'sdr-client', '~> 0.44'
+gem 'sdr-client', '~> 0.49'
 
 gem 'devise'
 gem 'devise-remote-user', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (3.0.0)
-    cocina-models (0.49.0)
+    cocina-models (0.52.0)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -180,9 +180,9 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-services-client (6.21.0)
+    dor-services-client (6.24.0)
       activesupport (>= 4.2, < 7)
-      cocina-models (~> 0.49.0)
+      cocina-models (~> 0.52.0)
       deprecation
       faraday (>= 0.15, < 2)
       moab-versioning (~> 4.0)
@@ -521,9 +521,9 @@ GEM
       nokogiri
       rest-client
     rubyzip (2.3.0)
-    sdr-client (0.46.0)
+    sdr-client (0.49.0)
       activesupport
-      cocina-models (~> 0.49.0)
+      cocina-models (~> 0.52.0)
       dry-monads
       faraday (>= 0.16)
     selenium-webdriver (3.142.7)
@@ -632,7 +632,7 @@ DEPENDENCIES
   devise-remote-user (~> 1.0)
   dlss-capistrano (~> 3.1)
   dor-services (~> 9.6)
-  dor-services-client (~> 6.20)
+  dor-services-client (~> 6.24)
   dor-workflow-client (~> 3.19)
   dry-monads
   equivalent-xml (>= 0.6.0)
@@ -669,7 +669,7 @@ DEPENDENCIES
   rubocop-rspec (~> 2.1.0)
   ruby-prof
   rubyzip
-  sdr-client (~> 0.44)
+  sdr-client (~> 0.49)
   selenium-webdriver
   sidekiq (~> 6.0)
   simplecov (~> 0.17.1)


### PR DESCRIPTION
## Why was this change made?

So that we can use some of the latest cocina-models features to decouple from Fedora 3.

## How was this change tested?



## Which documentation and/or configurations were updated?



