### PR TITLE
Remove unused solr field from qf

### DIFF
--- a/app/helpers/blacklight_config_helper.rb
+++ b/app/helpers/blacklight_config_helper.rb
@@ -7,7 +7,6 @@ module BlacklightConfigHelper
       defType: 'dismax',
       qf: %(
         collection_title_tesim
-        creator_tesim
         dor_id_tesim
         extent_ssim
         identifier_tesim


### PR DESCRIPTION

## Why was this change made?

No documents index this field: https://sul-solr-prod-a.stanford.edu/solr/argo3_prod/select?fl=scale_ssim&q=creator_tesim%3A*


## How was this change tested?



## Which documentation and/or configurations were updated?



