### PR TITLE
bundle with latest version of bundler to match docker

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -684,4 +684,4 @@ DEPENDENCIES
   zip_tricks (= 5.3.1)
 
 BUNDLED WITH
-   2.2.13
+   2.2.14


### PR DESCRIPTION
## Why was this change made?

You can't spin up the docker web container unless the Gemfile.lock uses the latest version of bundler that the container is using.  You may need to update your laptop bundler gem to match.

i.e. if you run `bundle version` you should see `Bundler version 2.2.14`.  if not:

```
gem install --default bundler -v '2.2.14'
```


## How was this change tested?

My laptop


## Which documentation and/or configurations were updated?



