### PR TITLE
Remove unused solr filter query

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,9 +61,6 @@ class User < ApplicationRecord
     return [] if obj_doc.empty?
 
     pid_roles = Set.new
-    # Determine whether user has 'dor-apo-manager' role
-    solr_apo_roles = %w[apo_role_group_manager_ssim apo_role_person_manager_ssim]
-    pid_roles << 'dor-apo-manager' if solr_apo_roles.any? { |r| solr_role_allowed?(obj_doc, r) }
     # Check additional known roles
     KNOWN_ROLES.each do |role|
       solr_apo_roles = ["apo_role_#{role}_ssim", "apo_role_person_#{role}_ssim"]

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -209,8 +209,7 @@ RSpec.describe User, type: :model do
         'apo_role_sdr-administrator_ssim' => %w[workgroup:dlss:groupA workgroup:dlss:groupB],
         'apo_role_sdr-viewer_ssim' => %w[workgroup:dlss:groupE workgroup:dlss:groupF],
         'apo_role_dor-apo-manager_ssim' => %w[workgroup:dlss:groupC workgroup:dlss:groupD],
-        'apo_role_person_sdr-viewer_ssim' => %w[sunetid:tcramer],
-        'apo_role_group_manager_ssim' => %w[workgroup:dlss:groupR]
+        'apo_role_person_sdr-viewer_ssim' => %w[sunetid:tcramer]
       }
     end
 
@@ -235,11 +234,6 @@ RSpec.describe User, type: :model do
       user_roles = %w[sdr-administrator sdr-viewer]
       expect(subject).to receive(:groups).and_return(user_groups).at_least(:once)
       expect(subject.roles(druid)).to eq(user_roles)
-    end
-
-    it 'translates the old "manager" role into dor-apo-manager' do
-      expect(subject).to receive(:groups).and_return(['workgroup:dlss:groupR']).at_least(:once)
-      expect(subject.roles(druid)).to eq(['dor-apo-manager'])
     end
 
     it 'returns an empty set of roles if the DRUID solr search fails' do


### PR DESCRIPTION

## Why was this change made?
These fields do not exist in the solr index:

https://sul-solr-prod-a.stanford.edu/solr/argo3_prod/select?q=apo_role_group_manager_ssim%3A*
https://sul-solr-prod-a.stanford.edu/solr/argo3_prod/select?q=apo_role_person_manager_ssim%3A*



## How was this change tested?



## Which documentation and/or configurations were updated?



