### PR TITLE
guard against republushing objects that have not been published

### DIFF
--- a/app/jobs/release_object_job.rb
+++ b/app/jobs/release_object_job.rb
@@ -33,6 +33,12 @@ class ReleaseObjectJob < GenericJob
 
   def release_object(current_druid, log)
     log.puts("#{Time.current} Beginning ReleaseObjectJob for #{current_druid}")
+
+    unless WorkflowService.published?(druid: current_druid)
+      log.puts("#{Time.current} Object has never been published and cannot be released for #{current_druid}")
+      return
+    end
+
     cocina = Dor::Services::Client.object(current_druid).find
 
     unless ability.can?(:manage_item, cocina)

--- a/app/jobs/republish_job.rb
+++ b/app/jobs/republish_job.rb
@@ -22,10 +22,14 @@ class RepublishJob < GenericJob
   private
 
   def republish(current_druid, log_buffer)
-    Dor::Services::Client.object(current_druid).publish
-
-    log_buffer.puts("#{Time.current} #{self.class}: Successfully published #{current_druid} (bulk_action.id=#{bulk_action.id})")
-    bulk_action.increment(:druid_count_success).save
+    if WorkflowService.published?(druid: current_druid)
+      Dor::Services::Client.object(current_druid).publish
+      log_buffer.puts("#{Time.current} #{self.class}: Successfully published #{current_druid} (bulk_action.id=#{bulk_action.id})")
+      bulk_action.increment(:druid_count_success).save
+    else
+      log_buffer.puts("#{Time.current} #{self.class}: Did not republish #{current_druid} because it is never been published (bulk_action.id=#{bulk_action.id})")
+      bulk_action.increment(:druid_count_fail).save
+    end
   rescue StandardError => e
     log_buffer.puts("#{Time.current} #{self.class}: Unexpected error for #{current_druid} (bulk_action.id=#{bulk_action.id}): #{e}")
     bulk_action.increment(:druid_count_fail).save

--- a/app/presenters/buttons_presenter.rb
+++ b/app/presenters/buttons_presenter.rb
@@ -31,7 +31,7 @@ class ButtonsPresenter
            :refresh_metadata_item_path,
            :item_manage_release_path,
            :embargo_form_item_path,
-           :dor_path,
+           :dor_republish_path,
            to: :url_helpers
 
   def url_helpers
@@ -134,7 +134,7 @@ class ButtonsPresenter
 
   def republish_button
     {
-      url: dor_path(pid: pid),
+      url: dor_republish_path(pid: pid),
       label: 'Republish',
       check_url: workflow_service_published_path(pid),
       new_page: true

--- a/app/services/workflow_service.rb
+++ b/app/services/workflow_service.rb
@@ -17,6 +17,13 @@ class WorkflowService
     end
   end
 
+  # @return [Boolean] if the object has been published or not before
+  def self.published?(druid:)
+    return true if workflow_client.lifecycle(druid: druid, milestone_name: 'published')
+
+    false
+  end
+
   # Get the workflow definition from the server so we know which processes should be present
   # TODO: This could be cached for better performance
   def self.definition_process_names(workflow_name)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -174,7 +174,7 @@ Rails.application.routes.draw do
   end
 
   namespace :dor do
-    match 'republish/:pid', action: :republish, via: %i[get post]
+    match 'republish/:pid', action: :republish, as: 'republish', via: %i[get post]
     match 'reindex/:pid',   action: :reindex, as: 'reindex', via: %i[get post]
     resources :objects, only: :create # we only implement create for object registration
   end

--- a/spec/jobs/release_object_job_spec.rb
+++ b/spec/jobs/release_object_job_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe ReleaseObjectJob do
-  let(:client) { instance_double(Dor::Workflow::Client, create_workflow_by_name: nil) }
   let(:buffer) { StringIO.new }
 
   let(:item1) do
@@ -61,133 +60,159 @@ RSpec.describe ReleaseObjectJob do
       }
     end
 
-    before do
-      allow(Dor::Services::Client).to receive(:object).with(pids[0]).and_return(object_client1)
-      allow(Dor::Services::Client).to receive(:object).with(pids[1]).and_return(object_client2)
+    context 'with already published objects' do
+      let(:client) { instance_double(Dor::Workflow::Client, create_workflow_by_name: nil, lifecycle: Time.zone.now) }
+
+      before do
+        allow(Dor::Services::Client).to receive(:object).with(pids[0]).and_return(object_client1)
+        allow(Dor::Services::Client).to receive(:object).with(pids[1]).and_return(object_client2)
+      end
+
+      context 'in a happy world' do
+        before do
+          expect(subject).to receive(:bulk_action).and_return(bulk_action).at_least(:once)
+          expect(subject.ability).to receive(:can?).and_return(true).exactly(pids.length).times
+        end
+
+        it 'updates the total druid count' do
+          subject.perform(bulk_action.id, params)
+          expect(bulk_action.druid_count_total).to eq pids.length
+          expect(client).to have_received(:create_workflow_by_name).with(pids[0], 'releaseWF', version: 2)
+          expect(client).to have_received(:create_workflow_by_name).with(pids[1], 'releaseWF', version: 3)
+        end
+
+        it 'increments the bulk_actions druid count success' do
+          expect do
+            subject.perform(bulk_action.id, params)
+          end.to change(bulk_action, :druid_count_success).from(0).to(pids.length)
+        end
+
+        it 'logs information to the logfile' do
+          subject.perform(bulk_action.id, params)
+          expect(buffer.string).to include 'Starting ReleaseObjectJob for BulkAction'
+          pids.each do |pid|
+            expect(buffer.string).to include "Beginning ReleaseObjectJob for #{pid}"
+          end
+          expect(buffer.string).to include 'Adding release tag for SEARCHWORKS'
+          expect(buffer.string).to include 'Release tag added successfully'
+          expect(buffer.string).to include 'Trying to start release workflow'
+          expect(buffer.string).to include 'Workflow creation successful'
+          expect(buffer.string).to include 'Finished ReleaseObjectJob for BulkAction'
+        end
+      end
+
+      context 'when a release tag fails' do
+        before do
+          expect(subject).to receive(:bulk_action).and_return(bulk_action).at_least(:once)
+          expect(subject.ability).to receive(:can?).and_return(true).exactly(pids.length).times
+          # no stubbed release wf calls (they should never get called)
+          allow(release_tags_client).to receive(:create).and_raise Dor::Services::Client::UnexpectedResponse, ': 500 (Response from dor-services-app did not contain a body.'
+        end
+
+        it 'updates the total druid count' do
+          subject.perform(bulk_action.id, params)
+          expect(bulk_action.druid_count_total).to eq pids.length
+        end
+
+        it 'increments the bulk_actions druid count fail' do
+          expect do
+            subject.perform(bulk_action.id, params)
+          end.to change(bulk_action, :druid_count_fail).from(0).to(pids.length)
+        end
+
+        it 'logs information to the logfile' do
+          # Stub out the file, and send it to a string buffer instead
+          buffer = StringIO.new
+          expect(subject).to receive(:with_bulk_action_log).and_yield(buffer)
+          subject.perform(bulk_action.id, params)
+          pids.each do |pid|
+            expect(buffer.string).to include "Beginning ReleaseObjectJob for #{pid}"
+            expect(buffer.string).to include 'Release tag failed POST Dor::Services::Client::UnexpectedResponse : 500 (Response from dor-services-app did not contain a body.'
+          end
+          expect(buffer.string).to include 'Adding release tag for SEARCHWORKS'
+          expect(buffer.string).not_to include 'Release tag added successfully'
+          expect(buffer.string).not_to include 'Trying to start release workflow'
+        end
+      end
+
+      context 'when a release wf fails' do
+        before do
+          expect(subject).to receive(:bulk_action).and_return(bulk_action).at_least(:once)
+          expect(subject.ability).to receive(:can?).and_return(true).exactly(pids.length).times
+          allow(client).to receive(:create_workflow_by_name).and_raise(Dor::WorkflowException)
+        end
+
+        it 'updates the total druid count' do
+          subject.perform(bulk_action.id, params)
+          expect(bulk_action.druid_count_total).to eq pids.length
+        end
+
+        it 'increments the bulk_actions druid count fail' do
+          expect do
+            subject.perform(bulk_action.id, params)
+          end.to change(bulk_action, :druid_count_fail).from(0).to(pids.length)
+        end
+
+        it 'logs information to the logfile' do
+          # Stub out the file, and send it to a string buffer instead
+          buffer = StringIO.new
+          expect(subject).to receive(:with_bulk_action_log).and_yield(buffer)
+          subject.perform(bulk_action.id, params)
+          pids.each do |pid|
+            expect(buffer.string).to include "Beginning ReleaseObjectJob for #{pid}"
+            expect(buffer.string).to include 'Workflow creation failed POST Dor::WorkflowException Dor::WorkflowException'
+          end
+          expect(buffer.string).to include 'Adding release tag for SEARCHWORKS'
+          expect(buffer.string).to include 'Release tag added successfully'
+          expect(buffer.string).to include 'Trying to start release workflow'
+        end
+      end
+
+      context 'when not authorized' do
+        before do
+          expect(subject).to receive(:bulk_action).and_return(bulk_action).at_least(:once)
+          expect(subject.ability).to receive(:can?).and_return(false).exactly(pids.length).times
+        end
+
+        it 'updates the total druid count' do
+          subject.perform(bulk_action.id, params)
+          expect(bulk_action.druid_count_total).to eq pids.length
+        end
+
+        it 'logs druid info to logfile' do
+          buffer = StringIO.new
+          expect(subject).to receive(:with_bulk_action_log).and_yield(buffer)
+          subject.perform(bulk_action.id, params)
+          expect(buffer.string).to include 'Starting ReleaseObjectJob for BulkAction'
+          pids.each do |pid|
+            expect(buffer.string).to include "Beginning ReleaseObjectJob for #{pid}"
+            expect(buffer.string).to include "Not authorized for #{pid}"
+            expect(buffer.string).not_to include 'Adding release tag for'
+          end
+          expect(buffer.string).to include 'Finished ReleaseObjectJob for BulkAction'
+        end
+      end
     end
 
-    context 'in a happy world' do
+    context 'when objects have never been published' do
+      let(:client) { instance_double(Dor::Workflow::Client, create_workflow_by_name: nil, lifecycle: nil) }
+
       before do
         expect(subject).to receive(:bulk_action).and_return(bulk_action).at_least(:once)
-        expect(subject.ability).to receive(:can?).and_return(true).exactly(pids.length).times
+        expect(subject.ability).not_to receive(:can?)
       end
 
-      it 'updates the total druid count' do
+      it 'does not create workflows' do
         subject.perform(bulk_action.id, params)
         expect(bulk_action.druid_count_total).to eq pids.length
-        expect(client).to have_received(:create_workflow_by_name).with(pids[0], 'releaseWF', version: 2)
-        expect(client).to have_received(:create_workflow_by_name).with(pids[1], 'releaseWF', version: 3)
+        expect(client).not_to have_received(:create_workflow_by_name).with(pids[0], 'releaseWF', version: 2)
+        expect(client).not_to have_received(:create_workflow_by_name).with(pids[1], 'releaseWF', version: 3)
       end
 
-      it 'increments the bulk_actions druid count success' do
+      it 'does not increments the bulk_actions druid count success' do
         expect do
           subject.perform(bulk_action.id, params)
-        end.to change(bulk_action, :druid_count_success).from(0).to(pids.length)
-      end
-
-      it 'logs information to the logfile' do
-        subject.perform(bulk_action.id, params)
-        expect(buffer.string).to include 'Starting ReleaseObjectJob for BulkAction'
-        pids.each do |pid|
-          expect(buffer.string).to include "Beginning ReleaseObjectJob for #{pid}"
-        end
-        expect(buffer.string).to include 'Adding release tag for SEARCHWORKS'
-        expect(buffer.string).to include 'Release tag added successfully'
-        expect(buffer.string).to include 'Trying to start release workflow'
-        expect(buffer.string).to include 'Workflow creation successful'
-        expect(buffer.string).to include 'Finished ReleaseObjectJob for BulkAction'
-      end
-    end
-
-    context 'when a release tag fails' do
-      before do
-        expect(subject).to receive(:bulk_action).and_return(bulk_action).at_least(:once)
-        expect(subject.ability).to receive(:can?).and_return(true).exactly(pids.length).times
-        # no stubbed release wf calls (they should never get called)
-        allow(release_tags_client).to receive(:create).and_raise Dor::Services::Client::UnexpectedResponse, ': 500 (Response from dor-services-app did not contain a body.'
-      end
-
-      it 'updates the total druid count' do
-        subject.perform(bulk_action.id, params)
-        expect(bulk_action.druid_count_total).to eq pids.length
-      end
-
-      it 'increments the bulk_actions druid count fail' do
-        expect do
-          subject.perform(bulk_action.id, params)
-        end.to change(bulk_action, :druid_count_fail).from(0).to(pids.length)
-      end
-
-      it 'logs information to the logfile' do
-        # Stub out the file, and send it to a string buffer instead
-        buffer = StringIO.new
-        expect(subject).to receive(:with_bulk_action_log).and_yield(buffer)
-        subject.perform(bulk_action.id, params)
-        pids.each do |pid|
-          expect(buffer.string).to include "Beginning ReleaseObjectJob for #{pid}"
-          expect(buffer.string).to include 'Release tag failed POST Dor::Services::Client::UnexpectedResponse : 500 (Response from dor-services-app did not contain a body.'
-        end
-        expect(buffer.string).to include 'Adding release tag for SEARCHWORKS'
-        expect(buffer.string).not_to include 'Release tag added successfully'
-        expect(buffer.string).not_to include 'Trying to start release workflow'
-      end
-    end
-
-    context 'when a release wf fails' do
-      before do
-        expect(subject).to receive(:bulk_action).and_return(bulk_action).at_least(:once)
-        expect(subject.ability).to receive(:can?).and_return(true).exactly(pids.length).times
-        allow(client).to receive(:create_workflow_by_name).and_raise(Dor::WorkflowException)
-      end
-
-      it 'updates the total druid count' do
-        subject.perform(bulk_action.id, params)
-        expect(bulk_action.druid_count_total).to eq pids.length
-      end
-
-      it 'increments the bulk_actions druid count fail' do
-        expect do
-          subject.perform(bulk_action.id, params)
-        end.to change(bulk_action, :druid_count_fail).from(0).to(pids.length)
-      end
-
-      it 'logs information to the logfile' do
-        # Stub out the file, and send it to a string buffer instead
-        buffer = StringIO.new
-        expect(subject).to receive(:with_bulk_action_log).and_yield(buffer)
-        subject.perform(bulk_action.id, params)
-        pids.each do |pid|
-          expect(buffer.string).to include "Beginning ReleaseObjectJob for #{pid}"
-          expect(buffer.string).to include 'Workflow creation failed POST Dor::WorkflowException Dor::WorkflowException'
-        end
-        expect(buffer.string).to include 'Adding release tag for SEARCHWORKS'
-        expect(buffer.string).to include 'Release tag added successfully'
-        expect(buffer.string).to include 'Trying to start release workflow'
-      end
-    end
-
-    context 'when not authorized' do
-      before do
-        expect(subject).to receive(:bulk_action).and_return(bulk_action).at_least(:once)
-        expect(subject.ability).to receive(:can?).and_return(false).exactly(pids.length).times
-      end
-
-      it 'updates the total druid count' do
-        subject.perform(bulk_action.id, params)
-        expect(bulk_action.druid_count_total).to eq pids.length
-      end
-
-      it 'logs druid info to logfile' do
-        buffer = StringIO.new
-        expect(subject).to receive(:with_bulk_action_log).and_yield(buffer)
-        subject.perform(bulk_action.id, params)
-        expect(buffer.string).to include 'Starting ReleaseObjectJob for BulkAction'
-        pids.each do |pid|
-          expect(buffer.string).to include "Beginning ReleaseObjectJob for #{pid}"
-          expect(buffer.string).to include "Not authorized for #{pid}"
-          expect(buffer.string).not_to include 'Adding release tag for'
-        end
-        expect(buffer.string).to include 'Finished ReleaseObjectJob for BulkAction'
+        end.not_to change(bulk_action, :druid_count_success)
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?

Fixes #2384 

- before allowing a bulk action that republishes or releases object (which also would result in a publish), confirm that the object has actually been published before and abort if not
- rename the publish check route used by the "Republish" blue button to match what it does

## How was this change tested?

- updated tests


## Which documentation and/or configurations were updated?



