### PR TITLE
Handle datastream validation errors when updating via legacy metadata…

### DIFF
--- a/app/controllers/datastreams_controller.rb
+++ b/app/controllers/datastreams_controller.rb
@@ -54,6 +54,8 @@ class DatastreamsController < ApplicationController
     rescue Nokogiri::XML::SyntaxError
       # if the content is not well-formed xml, inform the user rather than raising an exception
       error_msg = 'The datastream could not be saved due to malformed XML.'
+    rescue Dor::Services::Client::UnexpectedResponse => e
+      error_msg = e.message
     end
 
     respond_to do |format|

--- a/spec/requests/update_datastream_spec.rb
+++ b/spec/requests/update_datastream_spec.rb
@@ -89,6 +89,25 @@ RSpec.describe 'Update a datastream' do
       expect(Argo::Indexer).not_to have_received(:reindex_pid_remotely)
       expect(response).to redirect_to "/view/#{pid}"
     end
+
+    context 'for a datastream that fails validation' do
+      let(:object_client) do
+        instance_double(Dor::Services::Client::Object, find: cocina_model, metadata: metadata_client)
+      end
+      let(:metadata_client) do
+        instance_double(Dor::Services::Client::Metadata, legacy_update: true)
+      end
+
+      before do
+        allow(metadata_client).to receive(:legacy_update).and_raise(Dor::Services::Client::UnexpectedResponse)
+      end
+
+      it 'does not update the datastream' do
+        patch "/items/#{pid}/datastreams/contentMetadata", params: { content: xml }
+        expect(response).to redirect_to "/view/#{pid}"
+        expect(Argo::Indexer).not_to have_received(:reindex_pid_remotely)
+      end
+    end
   end
 
   describe 'DatastreamsController.endpoint_for_datastream' do


### PR DESCRIPTION
… endpoint.

refs #2438

## Why was this change made?
Notify a user when she attempts to update a descMetadata datastream with invalid MODS.


## How was this change tested?
Unit, QA


## Which documentation and/or configurations were updated?
NA


