### PR TITLE
Revert "Decouple BulkJobsController from Fedora 3"

### DIFF
--- a/app/controllers/bulk_jobs_controller.rb
+++ b/app/controllers/bulk_jobs_controller.rb
@@ -6,12 +6,12 @@ class BulkJobsController < ApplicationController
   # Generates the index page for a given DRUID's past bulk metadata upload jobs.
   def index
     params[:apo_id] = 'druid:' + params[:apo_id] unless params[:apo_id].include? 'druid'
+    @obj = Dor.find params[:apo_id]
 
-    @cocina =  Dor::Services::Client.object(params[:apo_id]).find
-    authorize! :view_metadata, @cocina
-
+    authorize! :view_metadata, @obj
     @document = find(params[:apo_id])
     @bulk_jobs = load_bulk_jobs(params[:apo_id])
+    @cocina =  Dor::Services::Client.object(params[:apo_id]).find
 
     @buttons_presenter = ButtonsPresenter.new(
       manager: can?(:manage_item, @cocina),

--- a/app/views/bulk_jobs/index.html.erb
+++ b/app/views/bulk_jobs/index.html.erb
@@ -1,4 +1,4 @@
-<% @page_title = "Bulk Uploads for APO #{@document.id}" %>
+<% @page_title = "Bulk Uploads for APO #{@obj.id}" %>
 <% content_for(:head) { document_presenter(@document).link_rel_alternates } -%>
 <% content_for(:sidebar) do %>
   <%= render_document_sidebar_partial @document %>

--- a/spec/features/bulk_jobs_spec.rb
+++ b/spec/features/bulk_jobs_spec.rb
@@ -8,12 +8,14 @@ RSpec.describe 'Bulk jobs view' do
     ActiveFedora::SolrService.add(id: apo_id, objectType_ssim: 'adminPolicy')
     ActiveFedora::SolrService.commit
     sign_in create(:user), groups: ['sdr:administrator-role']
+    allow(Dor).to receive(:find).with(apo_id).and_return(apo)
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
   end
 
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
-  let(:cocina_model) { instance_double(Cocina::Models::AdminPolicy) }
+  let(:cocina_model) { instance_double(Cocina::Models::DRO) }
   let(:apo_id) { 'druid:hv992yv2222' }
+  let(:apo) { Dor::AdminPolicyObject.new(pid: apo_id) }
 
   context 'on the page with the list of bulk jobs' do
     let(:workflow_client) { instance_double(Dor::Workflow::Client, lifecycle: [], active_lifecycle: []) }


### PR DESCRIPTION
This reverts commit e086dc6f34d40ef6f42741f144e4481a6ad9d49f.

## Why was this change made?

Ryan Lieu reports:
> objects now visible, but when I click on "MODS bulk loads" from an APO, I'm getting the "forbidden" page now

## How was this change tested?



## Which documentation and/or configurations were updated?



