### PR TITLE
Grant view metadata ability to cocina objects

### DIFF
--- a/app/controllers/bulk_jobs_controller.rb
+++ b/app/controllers/bulk_jobs_controller.rb
@@ -6,12 +6,12 @@ class BulkJobsController < ApplicationController
   # Generates the index page for a given DRUID's past bulk metadata upload jobs.
   def index
     params[:apo_id] = 'druid:' + params[:apo_id] unless params[:apo_id].include? 'druid'
-    @obj = Dor.find params[:apo_id]
 
-    authorize! :view_metadata, @obj
+    @cocina =  Dor::Services::Client.object(params[:apo_id]).find
+    authorize! :view_metadata, @cocina
+
     @document = find(params[:apo_id])
     @bulk_jobs = load_bulk_jobs(params[:apo_id])
-    @cocina =  Dor::Services::Client.object(params[:apo_id]).find
 
     @buttons_presenter = ButtonsPresenter.new(
       manager: can?(:manage_item, @cocina),

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -205,17 +205,18 @@ class CatalogController < ApplicationController
 
   def show
     params[:id] = 'druid:' + params[:id] unless params[:id].include? 'druid'
-    @obj = Dor.find params[:id]
-    authorize! :view_metadata, @obj
     _deprecated_response, @document = search_service.fetch(params[:id])
 
     @cocina = maybe_load_cocina(params[:id])
-    object_client = Dor::Services::Client.object(params[:id])
+    authorize! :view_metadata, @cocina
 
+    object_client = Dor::Services::Client.object(params[:id])
     @events = object_client.events.list
 
     @workflows = WorkflowService.workflows_for(druid: params[:id])
     milestones = MilestoneService.milestones_for(druid: params[:id])
+
+    @obj = Dor.find params[:id]
     versions = VersionService.list(resource: @obj)
 
     @milestones_presenter = MilestonesPresenter.new(milestones: milestones, versions: versions)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -76,6 +76,10 @@ class Ability
       can_view? current_user.roles(dro.administrative.hasAdminPolicy)
     end
 
+    can :view_metadata, [Cocina::Models::Collection, Cocina::Models::DRO, Cocina::Models::AdminPolicy] do |dro|
+      can_view? current_user.roles(dro.administrative.hasAdminPolicy)
+    end
+
     can :view_metadata, ActiveFedora::Base do |dor_item|
       can_view? current_user.roles(dor_item.admin_policy_object.pid) if dor_item.admin_policy_object
     end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -41,7 +41,7 @@ class Ability
     can %i[manage_item manage_desc_metadata manage_governing_apo view_content view_metadata], [NilModel, Cocina::Models::DRO] if current_user.manager?
     can :create, Cocina::Models::AdminPolicy if current_user.manager?
 
-    can %i[view_metadata view_content], [ActiveFedora::Base, Cocina::Models::DRO] if current_user.viewer?
+    can %i[view_metadata view_content], [ActiveFedora::Base, Cocina::Models::DRO, Cocina::Models::Collection, Cocina::Models::AdminPolicy] if current_user.viewer?
 
     can :manage_item, Cocina::Models::AdminPolicy do |cocina|
       can_manage_items? current_user.roles(cocina.externalIdentifier)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,13 +10,6 @@ class User < ApplicationRecord
   MANAGER_GROUPS = %w[workgroup:sdr:manager-role].freeze
   VIEWER_GROUPS = %w[workgroup:sdr:viewer-role].freeze
 
-  # TODO: redefine `KNOWN_ROLES` using Dor::Governable.
-  # The KNOWN_ROLES should be consistent with Dor::Governable so that the
-  # set intersections can work as required.
-  # This depends on changes in dor-services, e.g.
-  # https://github.com/sul-dlss/dor-services/pull/150
-  # Dor::Governable::KNOWN_ROLES
-
   # @return [Array<String>] list of roles the user can adopt
   KNOWN_ROLES = %w[
     dor-apo-creator

--- a/app/views/bulk_jobs/index.html.erb
+++ b/app/views/bulk_jobs/index.html.erb
@@ -1,4 +1,4 @@
-<% @page_title = "Bulk Uploads for APO #{@obj.id}" %>
+<% @page_title = "Bulk Uploads for APO #{@document.id}" %>
 <% content_for(:head) { document_presenter(@document).link_rel_alternates } -%>
 <% content_for(:sidebar) do %>
   <%= render_document_sidebar_partial @document %>

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -41,12 +41,16 @@ RSpec.describe CatalogController, type: :controller do
     describe 'with user' do
       before do
         sign_in user
+        allow(Dor::Services::Client).to receive(:object).and_return(object_client)
       end
 
       context 'when unauthorized' do
         before do
-          allow(controller).to receive(:authorize!).with(:view_metadata, item).and_raise(CanCan::AccessDenied)
+          allow(controller).to receive(:authorize!).with(:view_metadata, cocina_model).and_raise(CanCan::AccessDenied)
         end
+
+        let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+        let(:cocina_model) { instance_double(Cocina::Models::DRO) }
 
         it 'is forbidden' do
           get 'show', params: { id: druid }
@@ -56,8 +60,7 @@ RSpec.describe CatalogController, type: :controller do
 
       context 'when authorized' do
         before do
-          allow(controller).to receive(:authorize!).with(:view_metadata, item)
-          allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+          allow(controller).to receive(:authorize!).with(:view_metadata, cocina_model)
         end
 
         let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }

--- a/spec/features/bulk_jobs_spec.rb
+++ b/spec/features/bulk_jobs_spec.rb
@@ -8,14 +8,12 @@ RSpec.describe 'Bulk jobs view' do
     ActiveFedora::SolrService.add(id: apo_id, objectType_ssim: 'adminPolicy')
     ActiveFedora::SolrService.commit
     sign_in create(:user), groups: ['sdr:administrator-role']
-    allow(Dor).to receive(:find).with(apo_id).and_return(apo)
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
   end
 
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
-  let(:cocina_model) { instance_double(Cocina::Models::DRO) }
+  let(:cocina_model) { instance_double(Cocina::Models::AdminPolicy) }
   let(:apo_id) { 'druid:hv992yv2222' }
-  let(:apo) { Dor::AdminPolicyObject.new(pid: apo_id) }
 
   context 'on the page with the list of bulk jobs' do
     let(:workflow_client) { instance_double(Dor::Workflow::Client, lifecycle: [], active_lifecycle: []) }

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Ability do
   end
 
   context 'with the manage role' do
-    let(:roles) { ['dor-administrator'] }
+    let(:roles) { ['dor-apo-manager'] }
 
     it { is_expected.not_to be_able_to(:manage, :everything) }
     it { is_expected.to be_able_to(:manage_item, dro) }
@@ -126,8 +126,13 @@ RSpec.describe Ability do
     it { is_expected.not_to be_able_to(:manage_desc_metadata, item) }
     it { is_expected.to be_able_to(:manage_desc_metadata, item_with_apo) }
     it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
+
     it { is_expected.not_to be_able_to(:view_metadata, item) }
     it { is_expected.to be_able_to(:view_metadata, item_with_apo) }
+    it { is_expected.to be_able_to(:view_metadata, dro) }
+    it { is_expected.to be_able_to(:view_metadata, collection) }
+    it { is_expected.to be_able_to(:view_metadata, admin_policy) }
+
     it { is_expected.not_to be_able_to(:view_content, item) }
     it { is_expected.to be_able_to(:view_content, item_with_apo) }
     it { is_expected.to be_able_to(:view_content, dro) }

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -18,6 +18,27 @@ RSpec.describe Ability do
                             })
   end
 
+  let(:admin_policy) do
+    Cocina::Models::AdminPolicy.new(externalIdentifier: new_apo_id,
+                                    label: 'test',
+                                    type: Cocina::Models::Vocab.admin_policy,
+                                    version: 1,
+                                    administrative: {
+                                      hasAdminPolicy: new_apo_id
+                                    })
+  end
+
+  let(:collection) do
+    Cocina::Models::Collection.new(externalIdentifier: 'druid:bc123df4567',
+                                   label: 'test',
+                                   type: Cocina::Models::Vocab.collection,
+                                   version: 1,
+                                   access: {},
+                                   administrative: {
+                                     hasAdminPolicy: new_apo_id
+                                   })
+  end
+
   let(:user) do
     instance_double(User,
                     admin?: admin,
@@ -78,7 +99,12 @@ RSpec.describe Ability do
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, new_apo_id) }
     it { is_expected.to be_able_to(:view_metadata, item) }
     it { is_expected.to be_able_to(:view_content, item) }
+    it { is_expected.to be_able_to(:view_metadata, dro) }
     it { is_expected.to be_able_to(:view_content, dro) }
+    it { is_expected.to be_able_to(:view_metadata, admin_policy) }
+    it { is_expected.to be_able_to(:view_content, admin_policy) }
+    it { is_expected.to be_able_to(:view_metadata, collection) }
+    it { is_expected.to be_able_to(:view_content, collection) }
     it { is_expected.not_to be_able_to(:update, :workflow) }
   end
 


### PR DESCRIPTION
## Why was this change made?

Earlier we had to revert this in two places because we hadn't appropriately issued these abilities to users who were members of workgroups that had the manage role on the APO.

## How was this change tested?



## Which documentation and/or configurations were updated?



