### PR TITLE
Decouple view_metadata and view_content abilities from Fedora

### DIFF
--- a/app/jobs/checksum_report_job.rb
+++ b/app/jobs/checksum_report_job.rb
@@ -18,7 +18,7 @@ class ChecksumReportJob < GenericJob
       log.puts("#{Time.current} Starting #{self.class} for BulkAction #{bulk_action_id}")
       update_druid_count
       begin
-        raise "#{Time.current} ChecksumReportJob not authorized to view all content}" unless ability.can?(:view_content, ActiveFedora::Base)
+        raise "#{Time.current} ChecksumReportJob not authorized to view all content}" unless ability.can?(:view_content, Cocina::Models::DRO)
 
         csv_report = Preservation::Client.objects.checksums(druids: pids)
         File.open(report_filename, 'w') { |file| file.write(csv_report) }

--- a/app/jobs/descmetadata_download_job.rb
+++ b/app/jobs/descmetadata_download_job.rb
@@ -38,8 +38,8 @@ class DescmetadataDownloadJob < GenericJob
       bulk_action.increment(:druid_count_fail).save
       return
     end
-
-    unless ability.can?(:view_metadata, dor_object)
+    cocina_object = Dor::Services::Client.object(current_druid).find
+    unless ability.can?(:view_metadata, cocina_object)
       log.puts("#{Time.current} Not authorized for #{current_druid}")
       return
     end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -34,14 +34,14 @@ class Ability
     can :manage, :all if current_user.admin?
     cannot :impersonate, User unless current_user.webauth_admin?
 
-    can %i[manage_item manage_desc_metadata manage_governing_apo view_content view_metadata], ActiveFedora::Base do
+    can %i[manage_item manage_desc_metadata manage_governing_apo], ActiveFedora::Base do
       Honeybadger.notify('Deprecated call to ability with an ActiveFedora object')
       current_user.manager?
     end
     can %i[manage_item manage_desc_metadata manage_governing_apo view_content view_metadata], [NilModel, Cocina::Models::DRO] if current_user.manager?
     can :create, Cocina::Models::AdminPolicy if current_user.manager?
 
-    can %i[view_metadata view_content], [ActiveFedora::Base, Cocina::Models::DRO, Cocina::Models::Collection, Cocina::Models::AdminPolicy] if current_user.viewer?
+    can %i[view_metadata view_content], [Cocina::Models::DRO, Cocina::Models::Collection, Cocina::Models::AdminPolicy] if current_user.viewer?
 
     can :manage_item, Cocina::Models::AdminPolicy do |cocina|
       can_manage_items? current_user.roles(cocina.externalIdentifier)
@@ -64,24 +64,12 @@ class Ability
       can_manage_items?(current_user.roles(new_apo_id)) && can?(:manage_item, dor_item)
     end
 
-    can [:view_content, :view_metadata], Dor::AdminPolicyObject do |dor_item|
-      can_view? current_user.roles(dor_item.pid)
-    end
-
-    can :view_content, ActiveFedora::Base do |dor_item|
-      can_view? current_user.roles(dor_item.admin_policy_object.pid) if dor_item.admin_policy_object
-    end
-
     can :view_content, Cocina::Models::DRO do |dro|
       can_view? current_user.roles(dro.administrative.hasAdminPolicy)
     end
 
     can :view_metadata, [Cocina::Models::Collection, Cocina::Models::DRO, Cocina::Models::AdminPolicy] do |dro|
       can_view? current_user.roles(dro.administrative.hasAdminPolicy)
-    end
-
-    can :view_metadata, ActiveFedora::Base do |dor_item|
-      can_view? current_user.roles(dor_item.admin_policy_object.pid) if dor_item.admin_policy_object
     end
   end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -70,8 +70,6 @@ RSpec.describe Ability do
     it { is_expected.to be_able_to(:manage_desc_metadata, item) }
     it { is_expected.to be_able_to(:manage_governing_apo, dro, new_apo_id) }
     it { is_expected.to be_able_to(:create, Cocina::Models::AdminPolicy) }
-    it { is_expected.to be_able_to(:view_metadata, item) }
-    it { is_expected.to be_able_to(:view_content, item) }
     it { is_expected.to be_able_to(:view_content, dro) }
     it { is_expected.to be_able_to(:update, :workflow) }
   end
@@ -84,8 +82,6 @@ RSpec.describe Ability do
     it { is_expected.to be_able_to(:manage_desc_metadata, item) }
     it { is_expected.to be_able_to(:manage_governing_apo, dro, new_apo_id) }
     it { is_expected.to be_able_to(:create, Cocina::Models::AdminPolicy) }
-    it { is_expected.to be_able_to(:view_metadata, item) }
-    it { is_expected.to be_able_to(:view_content, item) }
     it { is_expected.to be_able_to(:view_content, dro) }
     it { is_expected.not_to be_able_to(:update, :workflow) }
   end
@@ -97,14 +93,10 @@ RSpec.describe Ability do
     it { is_expected.not_to be_able_to(:manage_desc_metadata, item) }
     it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, new_apo_id) }
-    it { is_expected.to be_able_to(:view_metadata, item) }
-    it { is_expected.to be_able_to(:view_content, item) }
     it { is_expected.to be_able_to(:view_metadata, dro) }
     it { is_expected.to be_able_to(:view_content, dro) }
     it { is_expected.to be_able_to(:view_metadata, admin_policy) }
-    it { is_expected.to be_able_to(:view_content, admin_policy) }
     it { is_expected.to be_able_to(:view_metadata, collection) }
-    it { is_expected.to be_able_to(:view_content, collection) }
     it { is_expected.not_to be_able_to(:update, :workflow) }
   end
 
@@ -112,9 +104,7 @@ RSpec.describe Ability do
     it { is_expected.not_to be_able_to(:manage_item, dro) }
     it { is_expected.not_to be_able_to(:manage_desc_metadata, item) }
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, new_apo_id) }
-    it { is_expected.not_to be_able_to(:view_content, item) }
     it { is_expected.not_to be_able_to(:view_content, dro) }
-    it { is_expected.not_to be_able_to(:view_metadata, item) }
   end
 
   context 'with the manage role' do
@@ -127,14 +117,9 @@ RSpec.describe Ability do
     it { is_expected.to be_able_to(:manage_desc_metadata, item_with_apo) }
     it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
 
-    it { is_expected.not_to be_able_to(:view_metadata, item) }
-    it { is_expected.to be_able_to(:view_metadata, item_with_apo) }
     it { is_expected.to be_able_to(:view_metadata, dro) }
     it { is_expected.to be_able_to(:view_metadata, collection) }
     it { is_expected.to be_able_to(:view_metadata, admin_policy) }
-
-    it { is_expected.not_to be_able_to(:view_content, item) }
-    it { is_expected.to be_able_to(:view_content, item_with_apo) }
     it { is_expected.to be_able_to(:view_content, dro) }
   end
 
@@ -147,10 +132,6 @@ RSpec.describe Ability do
     it { is_expected.not_to be_able_to(:manage_desc_metadata, item) }
     it { is_expected.to be_able_to(:manage_desc_metadata, item_with_apo) }
     it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
-    it { is_expected.not_to be_able_to(:view_metadata, item) }
-    it { is_expected.not_to be_able_to(:view_metadata, item_with_apo) }
-    it { is_expected.not_to be_able_to(:view_content, item) }
-    it { is_expected.not_to be_able_to(:view_content, item_with_apo) }
     it { is_expected.not_to be_able_to(:view_content, dro) }
   end
 
@@ -163,10 +144,6 @@ RSpec.describe Ability do
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, new_apo_id) }
     it { is_expected.not_to be_able_to(:manage_desc_metadata, item_with_apo) }
     it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
-    it { is_expected.not_to be_able_to(:view_metadata, item) }
-    it { is_expected.to be_able_to(:view_metadata, item_with_apo) }
-    it { is_expected.not_to be_able_to(:view_content, item) }
-    it { is_expected.to be_able_to(:view_content, item_with_apo) }
     it { is_expected.to be_able_to(:view_content, dro) }
   end
 end


### PR DESCRIPTION
## Why was this change made?

Decouple from Fedora 3

## How was this change tested?



## Which documentation and/or configurations were updated?



