### PR TITLE
Decouple manage-desc-metadata from Fedora 3

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -213,20 +213,21 @@ class ItemsController < ApplicationController
   end
 
   def refresh_metadata
-    authorize! :manage_desc_metadata, @object
+    authorize! :manage_desc_metadata, @cocina
 
-    if @object.catkey.blank?
+    catkey = @cocina.identification&.catalogLinks&.find { |link| link.catalog == 'symphony' }&.catalogRecordId
+    if catkey.blank?
       render status: :bad_request, plain: 'object must have catkey to refresh descMetadata'
       return
     end
 
-    Dor::Services::Client.object(@object.pid).refresh_metadata
+    Dor::Services::Client.object(@cocina.externalIdentifier).refresh_metadata
 
     respond_to do |format|
       if params[:bulk]
         format.html { render status: :ok, plain: 'Refreshed.' }
       else
-        format.any { redirect_to solr_document_path(params[:id]), notice: "Metadata for #{@object.pid} successfully refreshed from catkey: #{@object.catkey}" }
+        format.any { redirect_to solr_document_path(params[:id]), notice: "Metadata for #{@cocina.externalIdentifier} successfully refreshed from catkey: #{catkey}" }
       end
     end
   rescue Dor::Services::Client::UnexpectedResponse => e

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -34,7 +34,7 @@ class Ability
     can :manage, :all if current_user.admin?
     cannot :impersonate, User unless current_user.webauth_admin?
 
-    can %i[manage_item manage_desc_metadata manage_governing_apo], ActiveFedora::Base do
+    can %i[manage_item manage_governing_apo], ActiveFedora::Base do
       Honeybadger.notify('Deprecated call to ability with an ActiveFedora object')
       current_user.manager?
     end
@@ -51,12 +51,12 @@ class Ability
       can_manage_items? current_user.roles(cocina.administrative.hasAdminPolicy)
     end
 
-    can :manage_desc_metadata, Dor::AdminPolicyObject do |dor_item|
-      can_edit_desc_metadata? current_user.roles(dor_item.pid)
+    can :manage_desc_metadata, Cocina::Models::AdminPolicy do |admin_policy|
+      can_edit_desc_metadata? current_user.roles(admin_policy.externalIdentifier)
     end
 
-    can :manage_desc_metadata, ActiveFedora::Base do |dor_item|
-      can_edit_desc_metadata? current_user.roles(dor_item.admin_policy_object.pid) if dor_item.admin_policy_object
+    can :manage_desc_metadata, [Cocina::Models::Collection, Cocina::Models::DRO] do |cocina_object|
+      can_edit_desc_metadata? current_user.roles(cocina_object.administrative.hasAdminPolicy)
     end
 
     can :manage_governing_apo, [Cocina::Models::Collection, Cocina::Models::DRO] do |dor_item, new_apo_id|

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Ability do
 
     it { is_expected.to be_able_to(:manage, :everything) }
     it { is_expected.to be_able_to(:manage_item, dro) }
-    it { is_expected.to be_able_to(:manage_desc_metadata, item) }
+    it { is_expected.to be_able_to(:manage_desc_metadata, dro) }
     it { is_expected.to be_able_to(:manage_governing_apo, dro, new_apo_id) }
     it { is_expected.to be_able_to(:create, Cocina::Models::AdminPolicy) }
     it { is_expected.to be_able_to(:view_content, dro) }
@@ -79,7 +79,8 @@ RSpec.describe Ability do
 
     it { is_expected.not_to be_able_to(:manage, :everything) }
     it { is_expected.to be_able_to(:manage_item, dro) }
-    it { is_expected.to be_able_to(:manage_desc_metadata, item) }
+    it { is_expected.to be_able_to(:manage_desc_metadata, dro) }
+
     it { is_expected.to be_able_to(:manage_governing_apo, dro, new_apo_id) }
     it { is_expected.to be_able_to(:create, Cocina::Models::AdminPolicy) }
     it { is_expected.to be_able_to(:view_content, dro) }
@@ -90,7 +91,7 @@ RSpec.describe Ability do
     let(:viewer) { true }
 
     it { is_expected.not_to be_able_to(:manage_item, dro) }
-    it { is_expected.not_to be_able_to(:manage_desc_metadata, item) }
+    it { is_expected.not_to be_able_to(:manage_desc_metadata, dro) }
     it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, new_apo_id) }
     it { is_expected.to be_able_to(:view_metadata, dro) }
@@ -102,7 +103,7 @@ RSpec.describe Ability do
 
   context 'for items without an APO' do
     it { is_expected.not_to be_able_to(:manage_item, dro) }
-    it { is_expected.not_to be_able_to(:manage_desc_metadata, item) }
+    it { is_expected.not_to be_able_to(:manage_desc_metadata, dro) }
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, new_apo_id) }
     it { is_expected.not_to be_able_to(:view_content, dro) }
   end
@@ -113,8 +114,7 @@ RSpec.describe Ability do
     it { is_expected.not_to be_able_to(:manage, :everything) }
     it { is_expected.to be_able_to(:manage_item, dro) }
     it { is_expected.to be_able_to(:manage_governing_apo, dro, new_apo_id) }
-    it { is_expected.not_to be_able_to(:manage_desc_metadata, item) }
-    it { is_expected.to be_able_to(:manage_desc_metadata, item_with_apo) }
+    it { is_expected.to be_able_to(:manage_desc_metadata, dro) }
     it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
 
     it { is_expected.to be_able_to(:view_metadata, dro) }
@@ -129,8 +129,7 @@ RSpec.describe Ability do
     it { is_expected.not_to be_able_to(:manage, :everything) }
     it { is_expected.not_to be_able_to(:manage_item, dro) }
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, new_apo_id) }
-    it { is_expected.not_to be_able_to(:manage_desc_metadata, item) }
-    it { is_expected.to be_able_to(:manage_desc_metadata, item_with_apo) }
+    it { is_expected.to be_able_to(:manage_desc_metadata, dro) }
     it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
     it { is_expected.not_to be_able_to(:view_content, dro) }
   end
@@ -140,9 +139,8 @@ RSpec.describe Ability do
 
     it { is_expected.not_to be_able_to(:manage, :everything) }
     it { is_expected.not_to be_able_to(:manage_item, dro) }
-    it { is_expected.not_to be_able_to(:manage_desc_metadata, item) }
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, new_apo_id) }
-    it { is_expected.not_to be_able_to(:manage_desc_metadata, item_with_apo) }
+    it { is_expected.not_to be_able_to(:manage_desc_metadata, dro) }
     it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
     it { is_expected.to be_able_to(:view_content, dro) }
   end


### PR DESCRIPTION
## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



