### PR TITLE
Remove rights errors facet

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -151,7 +151,6 @@ class CatalogController < ApplicationController
                                         no_use_statement: { label: 'No Use & Reproduction Statement', fq: '-use_statement_ssim:*' }
                                       }
 
-    config.add_facet_field 'rights_errors_ssim',         label: 'Access Rights Errors', component: true, limit: 10, home: false
     config.add_facet_field 'sw_format_ssim',             label: 'SW Resource Type',     component: true, limit: 10, home: false
     config.add_facet_field 'sw_pub_date_facet_ssi',      label: 'SW Date',              component: true, limit: 10, home: false
     config.add_facet_field 'topic_ssim',                 label: 'SW Topic',             component: true, limit: 10, home: false


### PR DESCRIPTION

## Why was this change made?
We now prevent invalid rights from being entered via the legacy api. This enables dor-indexing-app to decouple from ActiveFedora.


Fixes #2448 

## How was this change tested?



## Which documentation and/or configurations were updated?



