### PR TITLE
adjust content types shown in registration form to match latest allowed values

### DIFF
--- a/app/forms/registration_form.rb
+++ b/app/forms/registration_form.rb
@@ -69,6 +69,10 @@ class RegistrationForm
       Cocina::Models::Vocab.manuscript
     when 'Book (ltr)', 'Book (rtl)'
       Cocina::Models::Vocab.book
+    when 'Webarchive-seed'
+      Cocina::Models::Vocab.webarchive_seed
+    when 'Geo'
+      Cocina::Models::Vocab.geo
     else
       Cocina::Models::Vocab.object
     end

--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -32,9 +32,10 @@ module RegistrationHelper
       'Image',
       'Map',
       'Media',
-      'Software',
       '3D',
-      'Document'
+      'Document',
+      'Geo',
+      'Webarchive-seed'
     ]
   end
 end

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -49,7 +49,7 @@ module Constants
     ['Citation Only', 'citation-only']
   ].freeze
 
-  CONTENT_TYPES = %w[image book file map media document 3d].freeze
+  CONTENT_TYPES = %w[image book file map media document 3d geo webarchive-seed].freeze
 
   RESOURCE_TYPES = %w[image page file audio video document 3d object].freeze
 


### PR DESCRIPTION
## Why was this change made?

(part of) fixing #2427 -- adjusts available content types in argo registration, item detail page (blue button) and bulk updates to match the current correct list

## How was this change tested?

Localhost browser and existing unit tests


## Which documentation and/or configurations were updated?



