### PR TITLE
Update the display of resource types for cocina-models 0.55.0

### DIFF
--- a/app/components/contents/resource_component.html.erb
+++ b/app/components/contents/resource_component.html.erb
@@ -1,7 +1,7 @@
 <li class="resource">
-  <span class="label">Resource (<%= resource_counter + 1 %>)</span> <%= type %>
+  <span class="label">Resource (<%= resource_counter %>)</span> <%= type %>
   <% if label %>
-    <span class="label">Label</span> <%= label %>
+    <br><span class="label">Label</span> <%= label %>
   <% end %>
   <ul class="child-list">
     <%= render Contents::FileComponent.with_collection(files, viewable: viewable?) %>

--- a/app/components/contents/resource_component.rb
+++ b/app/components/contents/resource_component.rb
@@ -15,8 +15,7 @@ module Contents
     end
 
     def type
-      # TODO: resource type will be in the metadata
-      resource.type.delete_prefix('http://cocina.sul.stanford.edu/models/').delete_suffix('.jsonld')
+      resource.type.delete_prefix('http://cocina.sul.stanford.edu/models/resources/').delete_suffix('.jsonld')
     end
 
     delegate :label, to: :resource


### PR DESCRIPTION
## Why was this change made?

Integration tests fail, and the resource types are no longer correct after cocina-models 0.55.0>



## How was this change tested?

Before
<img width="493" alt="Screen Shot 2021-03-15 at 4 02 00 PM" src="https://user-images.githubusercontent.com/92044/111221029-fa483180-85a7-11eb-8918-dac172b63c23.png">

After
<img width="440" alt="Screen Shot 2021-03-15 at 4 05 00 PM" src="https://user-images.githubusercontent.com/92044/111221227-354a6500-85a8-11eb-820d-b5b621d9074c.png">




## Which documentation and/or configurations were updated?



