### PR TITLE
Remove unnecessary check from Argo

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -39,20 +39,7 @@ class RegistrationsController < ApplicationController
       solr_doc = Dor::SearchService.query("id:\"#{col_id}\"",
                                           rows: 1,
                                           fl: col_title_field)['response']['docs'].first
-      if solr_doc.present? && solr_doc[col_title_field].present?
-        collections[col_id] = "#{short_label(solr_doc[col_title_field].first, truncate_limit)} (#{col_druid})"
-      else
-        Honeybadger.notify("Unable to find title of the collection #{col_id} in Solr. Checking Fedora, but this is slow.")
-        begin
-          # Title not found in Solr, so check DOR
-          collection = Dor.find(col_id)
-          collections[col_id] = "#{short_label(collection.label, truncate_limit)} (#{col_druid})"
-        rescue ActiveFedora::ObjectNotFoundError
-          Honeybadger.notify("Unable to find the collection #{col_id} in Fedora, but it's listed in the administrativeMetadata datastream for #{params[:apo_id]}")
-          col_not_found_warning = "#{params[:apo_id]} lists collection #{col_id} for registration, but it wasn't found in Fedora."
-          logger.warn col_not_found_warning
-        end
-      end
+      collections[col_id] = "#{short_label(solr_doc[col_title_field].first, truncate_limit)} (#{col_druid})"
     end
 
     # before returning the list, sort by collection name, and add a "None" option at the top


### PR DESCRIPTION


## Why was this change made?

We haven't seen such a case in Argo production in over a year and it appears to be bad data that was resolved:
https://app.honeybadger.io/projects/49894/faults/54082399

## How was this change tested?



## Which documentation and/or configurations were updated?



