### PR TITLE
Remove unused APO properties metadata_source and desc_metadata_format

### DIFF
--- a/app/forms/apo_form.rb
+++ b/app/forms/apo_form.rb
@@ -37,8 +37,6 @@ class ApoForm < BaseForm
   # Copies the values to the model
   def sync
     model.mods_title           = params[:title]
-    model.desc_metadata_format = params[:desc_md]
-    model.metadata_source      = params[:metadata_source]
     model.agreement_object_id  = params[:agreement]
 
     model.default_workflow     = params[:workflow]
@@ -67,16 +65,6 @@ class ApoForm < BaseForm
 
   delegate :use_license, :agreement_object_id, :use_statement, :copyright_statement,
            :default_rights, :mods_title, to: :model
-
-  def desc_metadata_format
-    model.desc_metadata_format || 'MODS'
-  end
-
-  def metadata_source
-    return 'DOR' if new_record?
-
-    model.metadata_source
-  end
 
   def default_collection_objects
     @default_collection_objects ||= begin

--- a/app/helpers/apo_helper.rb
+++ b/app/helpers/apo_helper.rb
@@ -1,16 +1,6 @@
 # frozen_string_literal: true
 
 module ApoHelper
-  def options_for_desc_md
-    [
-      ['MODS']
-    ]
-  end
-
-  def apo_metadata_sources
-    [['Symphony'], ['DOR']]
-  end
-
   # Retrieve a list of workflow templates from  the workflow service and return
   # an array suitable for select_tag options
   def workflow_options

--- a/app/views/apo/_form.html.erb
+++ b/app/views/apo/_form.html.erb
@@ -10,16 +10,6 @@
     <%= select_tag :agreement, options_for_select(agreement_options, @form.agreement_object_id), class: 'form-control' %>
   </div>
 
-  <div class="form-group">
-    <label>Descriptive Metadata format</label>
-      <%= select_tag :desc_md, options_for_select(options_for_desc_md, @form.desc_metadata_format), class: 'form-control' %>
-  </div>
-
-  <div class="form-group">
-    <label>Metadata source</label>
-    <%= select_tag :metadata_source, options_for_select(apo_metadata_sources, @form.metadata_source), class: 'form-control' %>
-  </div>
-
   <sharing data-permissions="<%= @form.permissions.to_json %>">
 
   <% if @form.default_collection_objects.present? %>

--- a/spec/features/apo_spec.rb
+++ b/spec/features/apo_spec.rb
@@ -95,7 +95,6 @@ RSpec.describe 'apo', js: true do
     select 'View', from: 'permissionRole'
     click_button 'Add'
 
-    page.select('MODS', from: 'desc_md')
     page.select('Attribution Share Alike 3.0 Unported', from: 'use_license')
 
     choose 'Create a Collection'
@@ -110,7 +109,6 @@ RSpec.describe 'apo', js: true do
     expect(find_field('use').value).to eq('Use statement')
     expect(page).to have_selector('.permissionName', text: 'developers')
     expect(page).to have_selector('.permissionName', text: 'someone')
-    expect(find_field('desc_md').value).to eq('MODS')
     expect(find_field('use_license').value).to eq('by-sa')
     expect(page).to have_link('New Testing Collection')
 
@@ -126,7 +124,6 @@ RSpec.describe 'apo', js: true do
     fill_in 'Default Copyright statement', with: 'New copyright statement'
     fill_in 'Default Use and Reproduction statement', with: 'New use statement'
     page.select('Attribution No Derivatives 3.0 Unported', from: 'use_license')
-    page.select('MODS', from: 'desc_md')
     click_button 'Update APO'
 
     click_on 'Edit APO'
@@ -137,7 +134,6 @@ RSpec.describe 'apo', js: true do
     expect(page).to have_selector('.permissionName', text: 'dpg-staff')
     expect(page).to have_selector('.permissionName', text: 'anyone')
 
-    expect(find_field('desc_md').value).to eq('MODS')
     expect(find_field('use_license').value).to eq('by-nd')
   end
 end

--- a/spec/forms/apo_form_spec.rb
+++ b/spec/forms/apo_form_spec.rb
@@ -20,8 +20,6 @@ RSpec.describe ApoForm do
         copyright: 'My copyright statement',
         use: 'My use and reproduction statement',
         title: +'My title',
-        desc_md: 'MODS',
-        metadata_source: 'DOR',
         agreement: agreement.pid,
         workflow: 'registrationWF',
         default_object_rights: 'world',
@@ -41,8 +39,6 @@ RSpec.describe ApoForm do
         instance.sync
 
         expect(apo.mods_title).to           eq(md_info[:title])
-        expect(apo.desc_metadata_format).to eq(md_info[:desc_md])
-        expect(apo.metadata_source).to      eq(md_info[:metadata_source])
         expect(apo.agreement_object_id).to  eq(md_info[:agreement])
         expect(apo.default_workflows).to    eq([md_info[:workflow]])
         expect(apo.default_rights).to       eq(md_info[:default_object_rights])
@@ -157,18 +153,6 @@ RSpec.describe ApoForm do
       it { is_expected.to eq 'world' }
     end
 
-    describe '#desc_metadata_format' do
-      subject { instance.desc_metadata_format }
-
-      it { is_expected.to eq 'MODS' }
-    end
-
-    describe '#metadata_source' do
-      subject { instance.metadata_source }
-
-      it { is_expected.to be_nil }
-    end
-
     describe '#use_statement' do
       subject { instance.use_statement }
 
@@ -255,18 +239,6 @@ RSpec.describe ApoForm do
       it { is_expected.to eq 'world' }
     end
 
-    describe '#desc_metadata_format' do
-      subject { instance.desc_metadata_format }
-
-      it { is_expected.to eq 'MODS' }
-    end
-
-    describe '#metadata_source' do
-      subject { instance.metadata_source }
-
-      it { is_expected.to eq 'DOR' }
-    end
-
     describe '#use_statement' do
       subject { instance.use_statement }
 
@@ -321,8 +293,6 @@ RSpec.describe ApoForm do
         { # These data mimic the APO registration form
           'title' => +'New APO Title',
           'agreement' => agreement.pid,
-          'desc_md' => 'MODS',
-          'metadata_source' => 'DOR',
           permissions: {
             '0' => { access: 'manage', name: 'developers', type: 'group' },
             '1' => { access: 'manage', name: 'dpg-staff', type: 'group' },


### PR DESCRIPTION
## Why was this change made?

This removes properties that are unneeded. Ref https://github.com/sul-dlss/cocina-models/issues/230

## How was this change tested?



## Which documentation and/or configurations were updated?



