### PR TITLE
Decouple default_collection_objects on ApoForm from Fedora

### DIFF
--- a/app/controllers/apo_controller.rb
+++ b/app/controllers/apo_controller.rb
@@ -9,20 +9,20 @@ class ApoController < ApplicationController
 
   def edit
     authorize! :create, Cocina::Models::AdminPolicy
-    @form = ApoForm.new(@object)
+    @form = ApoForm.new(@object, search_service: search_service)
     render layout: 'one_column'
   end
 
   def new
     authorize! :create, Cocina::Models::AdminPolicy
-    @form = ApoForm.new(Dor::AdminPolicyObject.new)
+    @form = ApoForm.new(Dor::AdminPolicyObject.new, search_service: search_service)
     render layout: 'one_column'
   end
 
   def create
     authorize! :create, Cocina::Models::AdminPolicy
 
-    @form = ApoForm.new(Dor::AdminPolicyObject.new)
+    @form = ApoForm.new(Dor::AdminPolicyObject.new, search_service: search_service)
     unless @form.validate(params.merge(tag: "Registered By : #{current_user.login}"))
       respond_to do |format|
         format.json { render status: :bad_request, json: { errors: form.errors } }
@@ -42,7 +42,7 @@ class ApoController < ApplicationController
 
   def update
     authorize! :manage_item, @cocina
-    @form = ApoForm.new(@object)
+    @form = ApoForm.new(@object, search_service: search_service)
     unless @form.validate(params)
       respond_to do |format|
         format.json { render status: :bad_request, json: { errors: @form.errors } }
@@ -73,6 +73,11 @@ class ApoController < ApplicationController
   end
 
   private
+
+  def search_service
+    @search_service ||= Blacklight::SearchService.new(config: CatalogController.blacklight_config,
+                                                      current_user: current_user)
+  end
 
   def create_obj
     raise 'missing druid' unless params[:id]

--- a/app/forms/apo_form.rb
+++ b/app/forms/apo_form.rb
@@ -6,7 +6,14 @@
 class ApoForm < BaseForm
   DEFAULT_MANAGER_WORKGROUPS = %w[developer service-manager metadata-staff].freeze
 
-  attr_reader :default_collection_pid
+  attr_reader :default_collection_pid, :search_service
+
+  # @param [Dor::Item] model the object to update.
+  # @param [Blacklight::SearchService] search_service a way to search solr
+  def initialize(model, search_service:)
+    super(model)
+    @search_service = search_service
+  end
 
   # @param [HashWithIndifferentAccess] params the parameters from the form
   # @return [Boolean] true if the parameters are valid
@@ -66,10 +73,9 @@ class ApoForm < BaseForm
   delegate :use_license, :agreement_object_id, :use_statement, :copyright_statement,
            :default_rights, :mods_title, to: :model
 
+  # @return [Array<SolrDocument>]
   def default_collection_objects
-    @default_collection_objects ||= begin
-      Array(model.default_collections).map { |pid| Dor.find(pid) }
-    end
+    @default_collection_objects ||= search_service.fetch(Array(model.default_collections)).last
   end
 
   def to_param

--- a/app/views/apo/_form.html.erb
+++ b/app/views/apo/_form.html.erb
@@ -14,8 +14,8 @@
 
   <% if @form.default_collection_objects.present? %>
     <label>Default Collections</label><br>
-    <% @form.default_collection_objects.each do |col| %>
-      <%= link_to col.label, solr_document_path(id: col.pid) %> <%= link_to('(remove)', delete_collection_apo_path(collection: col.pid, id: @form), confirm: 'You are about to leave the page, are you sure?') %><br>
+    <% @form.default_collection_objects.each do |solr_doc| %>
+      <%= link_to solr_doc.label, solr_doc %> <%= link_to('(remove)', delete_collection_apo_path(collection: solr_doc.id, id: @form), confirm: 'You are about to leave the page, are you sure?') %><br>
     <% end %>
   <% end %>
   <br>

--- a/spec/features/apo_spec.rb
+++ b/spec/features/apo_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'apo', js: true do
+RSpec.describe 'Create an apo', js: true do
   let(:user) { create(:user) }
   let(:new_apo_druid) { 'druid:zy987wv6543' }
   let(:new_collection_druid) { 'druid:zy333wv6543' }
@@ -64,7 +64,7 @@ RSpec.describe 'apo', js: true do
       .and_return(created_apo, created_collection)
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
 
-    # Stubbing this out, because it's the dor-services-app that would have actually created it.
+    # Stubbing out the registration process, because it's the dor-services-app that would have actually created it.
     allow(Dor).to receive(:find).with(new_apo_druid).and_return(apo)
     allow(apo).to receive(:save!)
     allow(apo).to receive(:new_record?).and_return(false)


### PR DESCRIPTION
Look in solr for these labels. It's faster.

## Why was this change made?

Ref #2418 



## How was this change tested?



## Which documentation and/or configurations were updated?



