### PR TITLE
Decouple content types controller from Fedora

### DIFF
--- a/app/views/content_types/_content_type.html.erb
+++ b/app/views/content_types/_content_type.html.erb
@@ -2,19 +2,19 @@
 <p><%= I18n.t('argo.content_type.suggeted_mappings').html_safe %></p>
 <p>More complex updates should be executed by hand on the datastream XML.</p>
 
-<%= form_tag item_content_type_path(item_id: @object.pid), id: 'content_type_form', method: :patch do %>
+<%= form_tag item_content_type_path(item_id: @cocina_object.externalIdentifier), id: 'content_type_form', method: :patch do %>
   <% old_content_type = begin
-                          @object.contentMetadata.contentType[0]
+                          Constants::CONTENT_TYPES.key(@cocina_object.type)
                         rescue StandardError
                           ''
                         end %>
   <% old_resource_type = begin
-                           @object.contentMetadata.ng_xml.xpath('/contentMetadata/resource')[0]['type']
+                           Constants::RESOURCE_TYPES.key(@cocina_object.structural.contains.first.type)
                          rescue StandardError
                            ''
                          end %>
-  <% display_content_types = [['none', '']] + Constants::CONTENT_TYPES %>
-  <% display_resource_types = [['none', '']] + Constants::RESOURCE_TYPES %>
+  <% display_content_types = [['none', '']] + Constants::CONTENT_TYPES.keys %>
+  <% display_resource_types = [['none', '']] + Constants::RESOURCE_TYPES.keys %>
   <div class='form-group'>
     <label>Old content type</label>
     <%= old_content_type %><%= hidden_field_tag :old_content_type, old_content_type %>

--- a/app/views/report/bulk.html.erb
+++ b/app/views/report/bulk.html.erb
@@ -110,9 +110,9 @@ ul li{
        current_content_types << k if idx.even?
      end
      current_content_types = [['none', '']] + current_content_types
-     current_resource_types = [['none', '']] + Constants::RESOURCE_TYPES
-     new_content_types = [['none', '']] + Constants::CONTENT_TYPES
-     new_resource_types = [['none', '']] + Constants::RESOURCE_TYPES %>
+     current_resource_types = [['none', '']] + Constants::RESOURCE_TYPES.keys
+     new_content_types = [['none', '']] + Constants::CONTENT_TYPES.keys
+     new_resource_types = [['none', '']] + Constants::RESOURCE_TYPES.keys %>
   <h1>Set content and resource types</h1>
   <p>
     Given the above list of druids, the following will be performed on each object:<br>

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -49,9 +49,28 @@ module Constants
     ['Citation Only', 'citation-only']
   ].freeze
 
-  CONTENT_TYPES = %w[image book file map media document 3d geo webarchive-seed].freeze
+  CONTENT_TYPES = {
+    'image' => Cocina::Models::Vocab.image,
+    'book' => Cocina::Models::Vocab.book,
+    'file' => Cocina::Models::Vocab.file,
+    'map' => Cocina::Models::Vocab.map,
+    'media' => Cocina::Models::Vocab.media,
+    'document' => Cocina::Models::Vocab.document,
+    '3d' => Cocina::Models::Vocab.three_dimensional,
+    'geo' => Cocina::Models::Vocab.geo,
+    'webarchive-seed' => Cocina::Models::Vocab.webarchive_seed
+  }.freeze
 
-  RESOURCE_TYPES = %w[image page file audio video document 3d object].freeze
+  RESOURCE_TYPES = {
+    'image' => Cocina::Models::Vocab::Resources.image,
+    'page' => Cocina::Models::Vocab::Resources.page,
+    'file' => Cocina::Models::Vocab::Resources.file,
+    'audio' => Cocina::Models::Vocab::Resources.audio,
+    'video' => Cocina::Models::Vocab::Resources.video,
+    'document' => Cocina::Models::Vocab::Resources.document,
+    '3d' => Cocina::Models::Vocab::Resources.three_dimensional,
+    'object' => Cocina::Models::Vocab::Resources.object
+  }.freeze
 
   RELEASE_TARGETS = [
     %w[Searchworks Searchworks],

--- a/spec/controllers/content_types_controller_spec.rb
+++ b/spec/controllers/content_types_controller_spec.rb
@@ -4,27 +4,66 @@ require 'rails_helper'
 
 RSpec.describe ContentTypesController, type: :controller do
   before do
-    allow(Dor).to receive(:find).with(pid).and_return(item)
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
     sign_in(user)
   end
 
   let(:pid) { 'druid:bc123df4567' }
-  let(:item) { Dor::Item.new pid: pid }
+  let(:item) { Dor::Item.new(pid: pid) }
   let(:user) { create :user }
-  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, update: true) }
   let(:cocina_model) do
     Cocina::Models.build(
       'label' => 'My Item',
       'version' => 1,
-      'type' => Cocina::Models::Vocab.object,
+      'type' => Cocina::Models::Vocab.image,
       'externalIdentifier' => pid,
       'access' => {
         'access' => 'world'
       },
       'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
-      'structural' => {},
+      'structural' => structural,
       'identification' => {}
+    )
+  end
+  let(:structural) do
+    Cocina::Models::DROStructural.new(
+      contains: [
+        Cocina::Models::FileSet.new(
+          externalIdentifier: 'bc123df4567_2',
+          type: Cocina::Models::Vocab::Resources.document,
+          label: 'document files',
+          version: 1,
+          structural: Cocina::Models::FileSetStructural.new(
+            contains: [
+              Cocina::Models::File.new(
+                externalIdentifier: 'bc123df4567.pdf',
+                type: Cocina::Models::Vocab.file,
+                label: 'the PDF',
+                filename: 'bc123df4567.pdf',
+                version: 1
+              )
+            ]
+          )
+        ),
+        Cocina::Models::FileSet.new(
+          externalIdentifier: 'bc123df4567_2',
+          type: Cocina::Models::Vocab::Resources.image,
+          label: 'image files',
+          version: 1,
+          structural: Cocina::Models::FileSetStructural.new(
+            contains: [
+              Cocina::Models::File.new(
+                externalIdentifier: 'bc123df4567.png',
+                type: Cocina::Models::Vocab.file,
+                label: 'the PNG',
+                filename: 'bc123df4567.png',
+                version: 1
+              )
+            ]
+          )
+        )
+      ]
     )
   end
 
@@ -37,40 +76,95 @@ RSpec.describe ContentTypesController, type: :controller do
 
   describe '#update' do
     before do
-      allow(controller).to receive(:current_ability).and_return(ability)
+      allow(controller).to receive(:authorize!).and_return(true)
       allow(StateService).to receive(:new).and_return(state_service)
+      allow(Argo::Indexer).to receive(:reindex_pid_remotely)
     end
 
     let(:state_service) { instance_double(StateService, allows_modification?: true) }
 
     context 'with access' do
-      let(:ability) { instance_double(Ability, authorize!: true) }
-
-      it 'is successful' do
-        expect(item.contentMetadata).to receive(:set_content_type)
-        expect(item).to receive(:save)
-        expect(Argo::Indexer).to receive(:reindex_pid_remotely)
-
-        patch :update, params: { item_id: pid, new_content_type: 'media' }
+      it 'is successful at changing the content type' do
+        patch :update, params: { item_id: pid, old_content_type: 'image', new_content_type: 'media' }
         expect(response).to redirect_to solr_document_path(pid)
+        expect(object_client).to have_received(:update).with(params: a_cocina_object_with_types(content_type: Cocina::Models::Vocab.media)).once
+        expect(Argo::Indexer).to have_received(:reindex_pid_remotely).once
       end
 
-      context 'and an invalid content_type' do
+      it 'is successful at changing the resource type' do
+        # patch :update, params: { item_id: pid, old_resource_type: 'document', new_resource_type: 'file', new_content_type: 'image' }
+        patch :update, params: { item_id: pid, old_content_type: 'media', old_resource_type: 'document', new_resource_type: 'file', new_content_type: 'image' }
+        expect(response).to redirect_to solr_document_path(pid)
+        expect(object_client).to have_received(:update)
+          .with(params: a_cocina_object_with_types(resource_types: [Cocina::Models::Vocab::Resources.file, Cocina::Models::Vocab::Resources.image]))
+          .once
+        expect(Argo::Indexer).to have_received(:reindex_pid_remotely).once
+      end
+
+      it 'is successful when effectively a no-op' do
+        patch :update, params: { item_id: pid, old_content_type: 'media', new_content_type: 'image', old_resource_type: 'file', new_resource_type: 'document' }
+        expect(response).to redirect_to solr_document_path(pid)
+        expect(object_client).to have_received(:update)
+          .with(
+            params: a_cocina_object_with_types(
+              content_type: Cocina::Models::Vocab.image,
+              resource_types: [Cocina::Models::Vocab::Resources.document, Cocina::Models::Vocab::Resources.image]
+            )
+          )
+          .once
+        expect(Argo::Indexer).to have_received(:reindex_pid_remotely).once
+      end
+
+      context 'when modification not allowed' do
+        let(:state_service) { instance_double(StateService, allows_modification?: false) }
+
+        it 'is forbidden' do
+          patch :update, params: { item_id: pid, new_content_type: 'media' }
+          expect(response).to be_forbidden
+          expect(response.body).to eq('Object cannot be modified in its current state.')
+          expect(Argo::Indexer).not_to have_received(:reindex_pid_remotely)
+        end
+      end
+
+      context 'without structural metadata' do
+        let(:structural) { Cocina::Models::DROStructural.new({}) }
+
+        it 'renders an error' do
+          patch :update, params: { item_id: pid, new_content_type: 'media' }
+          expect(response).to be_forbidden
+          expect(response.body).to eq("Object doesn't contain resources to update.")
+          expect(Argo::Indexer).not_to have_received(:reindex_pid_remotely)
+        end
+      end
+
+      context 'with an invalid content_type' do
         it 'is forbidden' do
           patch :update, params: { item_id: pid, new_content_type: 'frog' }
           expect(response).to be_forbidden
+          expect(response.body).to eq('Invalid new content type.')
+          expect(Argo::Indexer).not_to have_received(:reindex_pid_remotely)
         end
       end
 
-      context 'in a batch process' do
+      context 'when a batch process' do
         it 'is successful' do
-          expect(item.contentMetadata).to receive(:set_content_type)
-          expect(item).to receive(:save)
-          expect(Argo::Indexer).not_to receive(:reindex_pid_remotely)
-
           patch :update, params: { item_id: pid, new_content_type: 'media', bulk: true }
           expect(response).to be_successful
+          expect(Argo::Indexer).not_to have_received(:reindex_pid_remotely)
         end
+      end
+    end
+
+    context 'without access' do
+      before do
+        allow(controller).to receive(:authorize!).and_raise(CanCan::AccessDenied)
+      end
+
+      it 'is forbidden' do
+        patch :update, params: { item_id: pid, new_content_type: 'media' }
+        expect(response).to be_forbidden
+        expect(response.body).to eq('forbidden')
+        expect(Argo::Indexer).not_to have_received(:reindex_pid_remotely)
       end
     end
   end

--- a/spec/support/cocina_matchers.rb
+++ b/spec/support/cocina_matchers.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Provides RSpec matchers for Cocina models
+RSpec::Matchers.define :a_cocina_object_with_types do |expected|
+  match do |actual|
+    if expected[:content_type] && expected[:resource_types]
+      match_cocina_type?(actual, expected) && match_contained_cocina_types?(actual, expected)
+    elsif expected[:content_type]
+      match_cocina_type?(actual, expected)
+    elsif expected[:resource_types]
+      match_contained_cocina_types?(actual, expected)
+    else
+      raise ArgumentError, 'must provide content_type and/or resource_types keyword args'
+    end
+  end
+
+  def match_cocina_type?(actual, expected)
+    actual.type == expected[:content_type]
+  end
+
+  def match_contained_cocina_types?(actual, expected)
+    actual.structural.contains.map(&:type).all? { |type| type.in?(expected[:resource_types]) }
+  end
+end

--- a/spec/views/content_types/_content_type.html.erb_spec.rb
+++ b/spec/views/content_types/_content_type.html.erb_spec.rb
@@ -3,29 +3,29 @@
 require 'rails_helper'
 
 RSpec.describe 'content_types/_content_type.html.erb' do
-  let(:content_metadata) do
-    double('cm', contentType: [''], ng_xml: Nokogiri::XML('<xml></xml>'))
-  end
-  let(:object) do
-    double('object', pid: 'druid:abc123', contentMetadata: content_metadata)
+  let(:cocina_object) do
+    instance_double(Cocina::Models::DRO,
+                    externalIdentifier: 'druid:abc123',
+                    type: Cocina::Models::Vocab.book,
+                    structural: {})
   end
 
   it 'renders the partial content' do
-    assign(:object, object)
+    assign(:cocina_object, cocina_object)
     render
     expect(rendered).to have_css 'form .form-group label', text: 'Old content type'
     expect(rendered).to have_css 'input[type="hidden"]#old_content_type', visible: false
     expect(rendered).to have_css 'form .form-group label', text: 'Old resource type'
     expect(rendered).to have_css 'select.form-control#old_resource_type'
     expect(rendered).to have_css 'form .form-group label', text: 'New content type'
-    Constants::CONTENT_TYPES.each do |type|
+    Constants::CONTENT_TYPES.each_key do |type|
       expect(rendered).to have_css 'form select option', text: type
     end
     expect(rendered).to have_css 'form select option', text: 'none', count: 3
     expect(rendered).to have_css 'select.form-control#new_content_type'
     expect(rendered).to have_css 'form .form-group label', text: 'New resource type'
     expect(rendered).to have_css 'select.form-control#new_resource_type'
-    Constants::RESOURCE_TYPES.each do |type|
+    Constants::RESOURCE_TYPES.each_key do |type|
       expect(rendered).to have_css 'form select option', text: type
     end
     expect(rendered).to have_css 'form button.btn.btn-primary', text: 'Update'


### PR DESCRIPTION
Fixes #2431

## Why was this change made?

See subject.

As part of this work, increase the test coverage of the content types controller by testing previously untested branches, and add a new matcher that lets us sniff cocina objects and ensure they have expected content and resource types.

## How was this change tested?

CI

## Which documentation and/or configurations were updated?

None

