### PR TITLE
Decouples the ItemsController#purge method from Fedora 3

### DIFF
--- a/app/services/purge_service.rb
+++ b/app/services/purge_service.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Removes an object from dor-services-app, the workflow service and solr.
+class PurgeService
+  def self.purge(druid:)
+    Dor::Services::Client.object(druid).destroy
+    WorkflowClientFactory.build.delete_all_workflows(pid: druid)
+    solr_conn = ActiveFedora.solr.conn
+    solr_conn.delete_by_id(druid)
+    solr_conn.commit
+  end
+end

--- a/app/services/workflow_service.rb
+++ b/app/services/workflow_service.rb
@@ -17,6 +17,13 @@ class WorkflowService
     end
   end
 
+  # @return [Boolean] if the object has been submitted or not before
+  def self.submitted?(druid:)
+    return true if workflow_client.lifecycle(druid: druid, milestone_name: 'submitted')
+
+    false
+  end
+
   # @return [Boolean] if the object has been published or not before
   def self.published?(druid:)
     return true if workflow_client.lifecycle(druid: druid, milestone_name: 'published')

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -86,27 +86,21 @@ RSpec.describe ItemsController, type: :controller do
 
       context 'when the object has not been submitted' do
         before do
-          allow(controller).to receive(:dor_lifecycle).with(pid, 'submitted').and_return(false)
-          allow(item).to receive(:delete)
-          allow(ActiveFedora.solr.conn).to receive(:delete_by_id)
-          allow(ActiveFedora.solr.conn).to receive(:commit)
+          allow(WorkflowService).to receive(:submitted?).with(druid: pid).and_return(false)
+          allow(PurgeService).to receive(:purge)
         end
 
         it 'deletes the object' do
           delete 'purge_object', params: { id: pid }
           expect(response).to redirect_to root_path
           expect(flash[:notice]).to eq "#{pid} has been purged!"
-
-          expect(client).to have_received(:delete_all_workflows).with(pid: pid)
-          expect(item).to have_received(:delete)
-          expect(ActiveFedora.solr.conn).to have_received(:delete_by_id).with(pid)
-          expect(ActiveFedora.solr.conn).to have_received(:commit)
+          expect(PurgeService).to have_received(:purge)
         end
       end
 
       context 'when the object has been submitted' do
         before do
-          allow(controller).to receive(:dor_lifecycle).with(pid, 'submitted').and_return(true)
+          allow(WorkflowService).to receive(:submitted?).with(druid: pid).and_return(true)
         end
 
         it 'blocks purge' do

--- a/spec/services/purge_service_spec.rb
+++ b/spec/services/purge_service_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PurgeService do
+  describe '.purge' do
+    subject(:purge) { described_class.purge(druid: 'druid:ab123cd4567') }
+
+    let(:object_client) { instance_double(Dor::Services::Client::Object, destroy: true) }
+    let(:workflow_client) { instance_double(Dor::Workflow::Client, delete_all_workflows: true) }
+    let(:solr_client) { instance_double(RSolr::Client, delete_by_id: true, commit: true) }
+
+    before do
+      allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+      allow(WorkflowClientFactory).to receive(:build).and_return(workflow_client)
+      allow(ActiveFedora.solr).to receive(:conn).and_return(solr_client)
+    end
+
+    it 'removes the object' do
+      purge
+      expect(object_client).to have_received(:destroy)
+      expect(workflow_client).to have_received(:delete_all_workflows)
+      expect(solr_client).to have_received(:delete_by_id)
+      expect(solr_client).to have_received(:commit)
+    end
+  end
+end


### PR DESCRIPTION
and removes duplicate code

## Why was this change made?

Duplicate code is bad.

## How was this change tested?



## Which documentation and/or configurations were updated?



