### PR TITLE
use the API to apply admin policy defaults

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ gem 'zip_tricks', '5.3.1' # 5.3.1 is required as 5.4+ breaks the download all fe
 gem 'blacklight', '~> 7.13'
 gem 'blacklight-hierarchy', '~> 5.0'
 gem 'dor-services', '~> 9.6'
-gem 'dor-services-client', '~> 6.27.0'
+gem 'dor-services-client', '~> 6.28'
 gem 'dor-workflow-client', '~> 3.19'
 gem 'mods_display'
 gem 'okcomputer' # monitors application and its dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,7 +180,7 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-services-client (6.27.0)
+    dor-services-client (6.28.0)
       activesupport (>= 4.2, < 7)
       cocina-models (~> 0.55.0)
       deprecation
@@ -632,7 +632,7 @@ DEPENDENCIES
   devise-remote-user (~> 1.0)
   dlss-capistrano (~> 3.1)
   dor-services (~> 9.6)
-  dor-services-client (~> 6.27.0)
+  dor-services-client (~> 6.28)
   dor-workflow-client (~> 3.19)
   dry-monads
   equivalent-xml (>= 0.6.0)

--- a/spec/requests/apply_apo_defaults_spec.rb
+++ b/spec/requests/apply_apo_defaults_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe 'Apply APO defaults' do
   let(:pid) { 'druid:bc123df4567' }
   let(:apo) { instance_double(Dor::AdminPolicyObject, pid: 'druid:999') }
   let(:user) { create(:user) }
-  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+  let(:object_client) do
+    instance_double(Dor::Services::Client::Object, find: cocina_model, apply_admin_policy_defaults: true)
+  end
   let(:cocina_model) do
     Cocina::Models.build(
       'label' => 'The item',
@@ -38,7 +40,7 @@ RSpec.describe 'Apply APO defaults' do
 
   it 'applies the defaults' do
     post '/items/druid:123/apply_apo_defaults'
-    expect(item).to have_received(:reapply_admin_policy_object_defaults)
+    expect(object_client).to have_received(:apply_admin_policy_defaults)
     expect(Argo::Indexer).to have_received(:reindex_pid_remotely).with(pid)
     expect(response).to be_successful
   end


### PR DESCRIPTION

## Why was this change made?
This decouples from Fedora 3

Ref #2497



## How was this change tested?



## Which documentation and/or configurations were updated?



