### PR TITLE
Render Cocina model as collapsible JSON

### DIFF
--- a/app/javascript/argo.js
+++ b/app/javascript/argo.js
@@ -3,6 +3,7 @@ import CollectionEditor from 'controllers/collection_editor'
 import BulkActions from 'controllers/bulk_actions'
 import BulkUpload from 'controllers/bulk_upload'
 import FacetFilter from 'controllers/facet_filter'
+import JSONRenderer from 'controllers/json_renderer'
 import Tokens from 'controllers/tokens'
 import WorkflowGrid from 'controllers/workflow_grid_controller'
 import { Application } from 'stimulus'
@@ -44,6 +45,7 @@ export default class Argo {
         application.register("bulk_actions", BulkActions)
         application.register("bulk_upload", BulkUpload)
         application.register("facet-filter", FacetFilter)
+        application.register('json-renderer', JSONRenderer)
         application.register("workflow-grid", WorkflowGrid)
         application.register("collection-editor", CollectionEditor)
         application.register("tokens", Tokens)

--- a/app/javascript/controllers/json_renderer.js
+++ b/app/javascript/controllers/json_renderer.js
@@ -1,0 +1,11 @@
+import * as renderjson from 'renderjson'
+import { Controller } from 'stimulus'
+
+export default class extends Controller {
+  static targets = ['section']
+
+  connect() {
+    const cocina = JSON.parse(this.sectionTarget.dataset.cocina)
+    this.sectionTarget.appendChild(renderjson.set_show_to_level(1)(cocina))
+  }
+}

--- a/app/views/catalog/_cocina_default.html.erb
+++ b/app/views/catalog/_cocina_default.html.erb
@@ -1,8 +1,7 @@
 <h3 id="document-cocina-head" class="section-head collapsible-section collapsed">
   Cocina Model
 </h3>
-<div id="document-cocina-section" class="document-section" style="display:none">
-  <table class="detail">
-    <pre><%= JSON.pretty_generate(@cocina.as_json) %></pre>
+<div id="document-cocina-section" class="document-section" style="display:none" data-controller="json-renderer">
+  <table class="detail" data-target="json-renderer.section" data-cocina='<%= @cocina.to_json.html_safe %>'>
   </table>
 </div>

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "jquery-ui": "^1.12.1",
     "jquery-validation": "^1.19.1",
     "popper.js": "^1.15.0",
+    "renderjson": "^1.4.0",
     "stimulus": "^1.1.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6298,6 +6298,11 @@ remove-trailing-separator@^1.0.1:
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
   integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
 
+renderjson@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/renderjson/-/renderjson-1.4.0.tgz#d944644521ac5ef977ee524a6a05b76a2a945144"
+  integrity sha512-R0IZoxjWQP4XMJjLkPjNKSwjDyl20EiLohyu1Os7AvIvO4F4Vtar1N6IjJLPLjDN7OYOXTsqtIVJupQnQMvYQw==
+
 repeat-element@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"


### PR DESCRIPTION
Fixes #2381

![Peek 2021-03-17 18-49](https://user-images.githubusercontent.com/131982/111561385-982b3000-8751-11eb-9525-b3bacd66b3a3.gif)

## Why was this change made?

New feature request to help users make sense of the often verbose Cocina structure.

Use the `renderjson` library for this.

## How was this change tested?

CI? Not sure whether this is worth a feature spec or not, tbh.

## Which documentation and/or configurations were updated?

None.


