### PR TITLE
Load the datastream inventory using the API

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -199,7 +199,7 @@ RSpec/MessageSpies:
 # Offense count: 308
 # Configuration parameters: AllowSubject.
 RSpec/MultipleMemoizedHelpers:
-  Max: 16
+  Max: 17
 
 # Offense count: 191
 # Configuration parameters: IgnoreSharedExamples.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (3.0.0)
-    cocina-models (0.56.0)
+    cocina-models (0.56.1)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -180,7 +180,7 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-services-client (6.30.0)
+    dor-services-client (6.30.1)
       activesupport (>= 4.2, < 7)
       cocina-models (~> 0.56.0)
       deprecation

--- a/app/components/datastream_row.html.erb
+++ b/app/components/datastream_row.html.erb
@@ -1,8 +1,7 @@
 <tr>
   <td><%= link_to_identifier %></td>
-  <td><%= control_group %></td>
   <td><%= mime_type %></td>
-  <td><%= version %></td>
+  <td><%= versionId %></td>
   <td><%= size %></td>
   <td><%= label %></td>
 </tr>

--- a/app/components/datastream_row.rb
+++ b/app/components/datastream_row.rb
@@ -11,14 +11,7 @@ class DatastreamRow < ApplicationComponent
 
   attr_reader :datastream
 
-  delegate :label, :dsid, :pid, to: :datastream
-
-  # Datastream helpers
-  CONTROL_GROUP_TEXT = { 'X' => 'inline', 'M' => 'managed', 'R' => 'redirect', 'E' => 'external' }.freeze
-
-  def control_group
-    "#{datastream.controlGroup}/#{CONTROL_GROUP_TEXT[datastream.controlGroup]}"
-  end
+  delegate :label, :dsid, :pid, :versionId, to: :datastream
 
   def link_to_identifier
     link_to dsid, item_datastream_path(pid, dsid), title: dsid, data: { blacklight_modal: 'trigger' }
@@ -30,10 +23,5 @@ class DatastreamRow < ApplicationComponent
 
   def mime_type
     datastream.mimeType
-  end
-
-  def version
-    v = datastream.versionID.nil? ? '0' : datastream.versionID.to_s.split(/\./).last
-    "v#{v}"
   end
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -220,9 +220,7 @@ class CatalogController < ApplicationController
 
     @milestones_presenter = MilestonesPresenter.new(milestones: milestones, versions: versions)
 
-    @datastreams = obj.datastreams.reject do |name, instance|
-      instance.new? || Settings.hidden_datastreams.include?(name)
-    end.values
+    @datastreams = object_client.metadata.datastreams
 
     @buttons_presenter = ButtonsPresenter.new(
       manager: can?(:manage_item, @cocina),

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -20,62 +20,6 @@ RSpec.describe CatalogController, type: :controller do
     end
   end
 
-  describe '#show' do
-    let(:druid) { 'druid:fakepid' }
-    let(:item) { instance_double(Dor::Item, datastreams: {}) }
-
-    before do
-      ActiveFedora::SolrService.add(id: druid,
-                                    sw_display_title_tesim: 'Slides, IA 11, Geodesic Domes, Double Skin "Growth" House, N.C. State, 1953')
-      ActiveFedora::SolrService.commit
-      allow(Dor).to receive(:find).with(druid).and_return(item)
-    end
-
-    context 'without logging in' do
-      it 'redirects to login' do
-        get 'show', params: { id: druid }
-        expect(response).to redirect_to new_user_session_path
-      end
-    end
-
-    describe 'with user' do
-      before do
-        sign_in user
-        allow(Dor::Services::Client).to receive(:object).and_return(object_client)
-      end
-
-      context 'when unauthorized' do
-        before do
-          allow(controller).to receive(:authorize!).with(:view_metadata, cocina_model).and_raise(CanCan::AccessDenied)
-        end
-
-        let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
-        let(:cocina_model) { instance_double(Cocina::Models::DRO) }
-
-        it 'is forbidden' do
-          get 'show', params: { id: druid }
-          expect(response).to be_forbidden
-        end
-      end
-
-      context 'when authorized' do
-        before do
-          allow(controller).to receive(:authorize!).with(:view_metadata, cocina_model)
-        end
-
-        let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
-        let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, events: events_client) }
-        let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative) }
-        let(:administrative) { instance_double(Cocina::Models::Administrative, releaseTags: []) }
-
-        it 'is successful' do
-          get 'show', params: { id: druid }
-          expect(response).to be_successful
-        end
-      end
-    end
-  end
-
   describe 'blacklight config' do
     let(:config) { controller.blacklight_config }
 

--- a/spec/features/add_workflow_to_item_spec.rb
+++ b/spec/features/add_workflow_to_item_spec.rb
@@ -17,7 +17,13 @@ RSpec.describe 'Add a workflow to an item' do
                     active_lifecycle: [])
   end
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
-  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, events: events_client) }
+  let(:metadata_client) { instance_double(Dor::Services::Client::Metadata, datastreams: []) }
+  let(:object_client) do
+    instance_double(Dor::Services::Client::Object,
+                    find: cocina_model,
+                    events: events_client,
+                    metadata: metadata_client)
+  end
   let(:cocina_model) do
     instance_double(Cocina::Models::DRO,
                     externalIdentifier: item_id,

--- a/spec/features/apo_spec.rb
+++ b/spec/features/apo_spec.rb
@@ -11,12 +11,14 @@ RSpec.describe 'Create an apo', js: true do
   let(:tags_client) { instance_double(Dor::Services::Client::AdministrativeTags, create: true) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, current: 1) }
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
+  let(:metadata_client) { instance_double(Dor::Services::Client::Metadata, datastreams: []) }
   let(:object_client) do
     instance_double(Dor::Services::Client::Object,
                     find: cocina_model,
                     version: version_client,
                     events: events_client,
-                    administrative_tags: tags_client)
+                    administrative_tags: tags_client,
+                    metadata: metadata_client)
   end
   let(:cocina_model) do
     instance_double(Cocina::Models::AdminPolicy,

--- a/spec/features/consistent_titles_spec.rb
+++ b/spec/features/consistent_titles_spec.rb
@@ -36,7 +36,13 @@ RSpec.describe 'Consistent titles' do
                       milestones: {},
                       workflow_routes: workflow_routes)
     end
-    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, events: events_client) }
+    let(:metadata_client) { instance_double(Dor::Services::Client::Metadata, datastreams: []) }
+    let(:object_client) do
+      instance_double(Dor::Services::Client::Object,
+                      find: cocina_model,
+                      events: events_client,
+                      metadata: metadata_client)
+    end
     let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
     let(:administrative) { instance_double(Cocina::Models::Administrative, releaseTags: []) }
 

--- a/spec/features/enable_buttons_spec.rb
+++ b/spec/features/enable_buttons_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe 'Enable buttons' do
       Dor::Item,
       current_version: '1',
       admin_policy_object: nil,
-      datastreams: {},
       catkey: nil,
       identityMetadata: double(ng_xml: Nokogiri::XML(''))
     )
@@ -24,7 +23,13 @@ RSpec.describe 'Enable buttons' do
   let(:item_id) { 'druid:hj185xx2222' }
   let(:state_service) { instance_double(StateService, allows_modification?: true) }
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
-  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, events: events_client) }
+  let(:metadata_client) { instance_double(Dor::Services::Client::Metadata, datastreams: []) }
+  let(:object_client) do
+    instance_double(Dor::Services::Client::Object,
+                    find: cocina_model,
+                    events: events_client,
+                    metadata: metadata_client)
+  end
   let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
   let(:administrative) { instance_double(Cocina::Models::Administrative, releaseTags: []) }
 

--- a/spec/features/item_catkey_change_spec.rb
+++ b/spec/features/item_catkey_change_spec.rb
@@ -45,7 +45,14 @@ RSpec.describe 'Item catkey change' do
   describe 'when modification is allowed' do
     let(:state_service) { instance_double(StateService, allows_modification?: true) }
     let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
-    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, events: events_client, update: true) }
+    let(:metadata_client) { instance_double(Dor::Services::Client::Metadata, datastreams: []) }
+    let(:object_client) do
+      instance_double(Dor::Services::Client::Object,
+                      find: cocina_model,
+                      events: events_client,
+                      update: true,
+                      metadata: metadata_client)
+    end
     let(:administrative) { instance_double(Cocina::Models::Administrative, releaseTags: []) }
     let(:workflows_response) { instance_double(Dor::Workflow::Response::Workflows, workflows: []) }
     let(:workflow_routes) { instance_double(Dor::Workflow::Client::WorkflowRoutes, all_workflows: workflows_response) }

--- a/spec/features/item_source_id_change_spec.rb
+++ b/spec/features/item_source_id_change_spec.rb
@@ -45,10 +45,17 @@ RSpec.describe 'Item source id change' do
   describe 'when modification is allowed' do
     let(:state_service) { instance_double(StateService, allows_modification?: true) }
     let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
-    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, events: events_client, update: true) }
+    let(:object_client) do
+      instance_double(Dor::Services::Client::Object,
+                      find: cocina_model,
+                      events: events_client,
+                      metadata: metadata_client,
+                      update: true)
+    end
     let(:workflows_response) { instance_double(Dor::Workflow::Response::Workflows, workflows: []) }
     let(:workflow_routes) { instance_double(Dor::Workflow::Client::WorkflowRoutes, all_workflows: workflows_response) }
     let(:workflow_client) { instance_double(Dor::Workflow::Client, milestones: [], workflow_routes: workflow_routes) }
+    let(:metadata_client) { instance_double(Dor::Services::Client::Metadata, datastreams: []) }
 
     before do
       # The indexer calls to the workflow service, so stub that out as it's unimportant to this test.

--- a/spec/features/item_view_metadata_spec.rb
+++ b/spec/features/item_view_metadata_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe 'Item view', js: true do
   let(:obj) { Dor::Item.new(pid: item_id) }
   let(:item_id) { 'druid:hj185xx2222' }
   let(:event) { Dor::Services::Client::Events::Event.new(event_type: 'shelve_request_received', data: { 'host' => 'dor-services-stage.stanford.edu' }) }
+  let(:datastream) { Dor::Services::Client::Metadata::Datastream.new(dsid: 'descMetadata', pid: item_id) }
+  let(:metadata_client) { instance_double(Dor::Services::Client::Metadata, datastreams: [datastream]) }
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: [event]) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, current: 1) }
   let(:all_workflows) { instance_double(Dor::Workflow::Response::Workflows, workflows: []) }
@@ -47,7 +49,12 @@ RSpec.describe 'Item view', js: true do
   end
 
   context 'when there is an error retrieving the cocina_model' do
-    let(:object_client) { instance_double(Dor::Services::Client::Object, version: version_client, events: events_client) }
+    let(:object_client) do
+      instance_double(Dor::Services::Client::Object,
+                      version: version_client,
+                      events: events_client,
+                      metadata: metadata_client)
+    end
     let(:solr_doc) { { id: item_id } }
 
     before do
@@ -64,8 +71,13 @@ RSpec.describe 'Item view', js: true do
   end
 
   context 'when the cocina_model exists' do
-    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, version: version_client, events: events_client) }
-
+    let(:object_client) do
+      instance_double(Dor::Services::Client::Object,
+                      find: cocina_model,
+                      version: version_client,
+                      events: events_client,
+                      metadata: metadata_client)
+    end
     let(:attrs) do
       <<~JSON
         {

--- a/spec/features/release_history_spec.rb
+++ b/spec/features/release_history_spec.rb
@@ -10,7 +10,13 @@ RSpec.describe 'Release history' do
   end
 
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
-  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, events: events_client) }
+  let(:metadata_client) { instance_double(Dor::Services::Client::Metadata, datastreams: []) }
+  let(:object_client) do
+    instance_double(Dor::Services::Client::Object,
+                    find: cocina_model,
+                    events: events_client,
+                    metadata: metadata_client)
+  end
   let(:all_workflows) { instance_double(Dor::Workflow::Response::Workflows, workflows: []) }
   let(:workflow_routes) { instance_double(Dor::Workflow::Client::WorkflowRoutes, all_workflows: all_workflows) }
   let(:workflow_client) do

--- a/spec/requests/set_rights_spec.rb
+++ b/spec/requests/set_rights_spec.rb
@@ -331,7 +331,13 @@ RSpec.describe 'Set rights for an object' do
                                'identification' => {}
                              })
       end
-      let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, events: events_client) }
+      let(:metadata_client) { instance_double(Dor::Services::Client::Metadata, datastreams: []) }
+      let(:object_client) do
+        instance_double(Dor::Services::Client::Object,
+                        find: cocina_model,
+                        events: events_client,
+                        metadata: metadata_client)
+      end
       let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
       let(:service) { instance_double(Blacklight::SearchService, fetch: [nil, doc]) }
       let(:doc) { SolrDocument.new id: pid }


### PR DESCRIPTION
## Why was this change made?

Decouples CatalogController from Fedora

## How was this change tested?
Tested on stage.

Before:

<img width="1021" alt="Screen Shot 2021-03-18 at 2 36 59 PM" src="https://user-images.githubusercontent.com/92044/111686987-c2cfc400-87f7-11eb-99fd-3e2c52675b63.png">

After:

<img width="829" alt="Screen Shot 2021-03-18 at 2 39 14 PM" src="https://user-images.githubusercontent.com/92044/111687006-c7947800-87f7-11eb-9c27-9447bb41b237.png">



## Which documentation and/or configurations were updated?



