### PR TITLE
Decouple APO form from Fedora 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,7 @@ executors:
           SETTINGS__FEDORA_URL: http://fedoraAdmin:fedoraAdmin@fcrepo:8080/fedora
           SETTINGS__SURI__URL: http://suri:3000
           SETTINGS__WORKFLOW_URL: http://workflow:3000
+          SETTINGS__ENABLED_FEATURES__UPDATE_DESCRIPTIVE: 'true'
           REDIS_URL: redis://redis:6379/
       - image: suldlss/suri-rails:latest
         name: suri

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
   - rubocop-rails
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
   Exclude:
     - bin/**
     - db/migrate/**

--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ gem 'okcomputer' # monitors application and its dependencies
 gem 'preservation-client', '~> 3.2'
 gem 'responders', '~> 2.0'
 gem 'rsolr'
-gem 'sdr-client', '~> 0.55.0'
+gem 'sdr-client', '~> 0.55.1'
 
 gem 'devise'
 gem 'devise-remote-user', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ GEM
       parser (>= 2.4)
       smart_properties
     bindex (0.8.1)
-    blacklight (7.15.2)
+    blacklight (7.16.0)
       deprecation
       globalid
       i18n (>= 1.7.0)
@@ -669,7 +669,7 @@ DEPENDENCIES
   rubocop-rspec (~> 2.1.0)
   ruby-prof
   rubyzip
-  sdr-client (~> 0.55.0)
+  sdr-client (~> 0.55.1)
   selenium-webdriver
   sidekiq (~> 6.0)
   simplecov

--- a/app/controllers/apo_controller.rb
+++ b/app/controllers/apo_controller.rb
@@ -45,7 +45,7 @@ class ApoController < ApplicationController
 
   def update
     authorize! :manage_item, @cocina
-    change_set = AdminPolicyChangeSet.new
+    change_set = AdminPolicyChangeSet.new(model: @cocina)
     unless change_set.validate(params[:apo_form])
       @form = ApoForm.new(@cocina, search_service: search_service)
       respond_to do |format|

--- a/app/forms/apo_form.rb
+++ b/app/forms/apo_form.rb
@@ -3,100 +3,78 @@
 # Inspired by Reform, but not exactly reform, because of existing deficiencies
 # in dor-services:
 #  https://github.com/sul-dlss/dor-services/pull/360
-class ApoForm < BaseForm
+class ApoForm
+  include ActiveModel::Conversion
+  extend ActiveModel::Naming
+
   DEFAULT_MANAGER_WORKGROUPS = %w[developer service-manager metadata-staff].freeze
 
-  attr_reader :default_collection_pid, :search_service
+  attr_reader :model, :params, :default_collection_pid, :search_service
 
-  # @param [Dor::Item] model the object to update.
+  # needed so that the form routes to `/apo` rather than '/apo_form'
+  def self.model_name
+    Struct.new(:param_key, :route_key, :i18n_key, :name).new('apo_form', 'apo', 'apo', 'Apo')
+  end
+
+  # needed for generating the update route
+  def to_key
+    Array(@model&.externalIdentifier)
+  end
+
+  # @param [Cocina::Models::AdminPolicy,NilClass] model the object to update or nil for a new item
   # @param [Blacklight::SearchService] search_service a way to search solr
   def initialize(model, search_service:)
-    super(model)
+    @model = model
     @search_service = search_service
+    self.default_rights = 'world'
+    self.default_workflow = 'registrationWF'
+    populate_from_model if model
+    @errors = []
   end
 
-  # @param [HashWithIndifferentAccess] params the parameters from the form
-  # @return [Boolean] true if the parameters are valid
-  def validate(params)
-    @params = param_cleanup(params)
-
-    # error if title is empty
-    errors.push(:title) if @params[:title].blank?
-
-    @errors.push(:collection_radio) if @params[:collection_radio] == 'select' && new_record?
-
-    @errors.empty?
+  def populate_from_model
+    @default_collections = model.administrative.collectionsForRegistration
+    self.title = model.description.title.first.value
+    self.agreement_object_id = model.administrative.referencesAgreement
+    self.default_rights = model.administrative.defaultAccess&.access
+    self.use_statement = model.administrative.defaultAccess&.useAndReproductionStatement
+    self.copyright_statement = model.administrative.defaultAccess&.copyright
+    self.use_license = model.administrative.defaultAccess&.license
+    self.default_workflow = model.administrative.registrationWorkflow.first
   end
 
-  # Copies the values to the model, saves and indexes, and starts workflow.
-  def save
-    @needs_accession_workflow = false
-    find_or_register_model
-    sync
-    add_default_collection
-    add_administrative_tags!
-    model.save!
-    Argo::Indexer.reindex_pid_remotely(model.pid)
-    # Kick off the accessionWF after all updates are complete.
-    WorkflowClientFactory.build.create_workflow_by_name(model.pid, 'accessionWF', version: '1') if @needs_accession_workflow
-  end
+  attr_accessor :use_license, :agreement_object_id, :use_statement, :copyright_statement,
+                :default_rights, :title, :default_workflow
 
-  # Copies the values to the model
-  def sync
-    model.mods_title           = params[:title]
-    model.agreement_object_id  = params[:agreement]
-
-    model.default_workflow     = params[:workflow]
-    model.default_rights       = params[:default_object_rights]
-    # Set the Use License given a machine-readable code for a creative commons
-    # or open data commons license
-    model.use_license          = params[:use_license]
-    model.copyright_statement  = params[:copyright]
-    model.use_statement        = params[:use]
-
-    sync_roles
+  def persisted?
+    !model.nil?
   end
 
   # @return [Array<Hash>] the list of permissions (grants for users/groups) on this object
   def permissions
-    return default_permissions if new_record?
+    return default_permissions unless persisted?
 
     manage_permissions + view_permissions
   end
 
-  def default_workflow
-    return Settings.apo.default_workflow_option if new_record?
-
-    model.administrativeMetadata.ng_xml.xpath('//registration/workflow/@id').to_s
-  end
-
-  delegate :use_license, :agreement_object_id, :use_statement, :copyright_statement,
-           :default_rights, :mods_title, to: :model
-
   # @return [Array<SolrDocument>]
   def default_collection_objects
-    @default_collection_objects ||= search_service.fetch(Array(model.default_collections)).last
+    @default_collection_objects ||= search_service.fetch(Array(@default_collections)).last
   end
 
   def to_param
-    model.pid
+    model.externalIdentifier
   end
 
   def license_options
     [['-- none --', '']] + options_for_use_license_type(use_license)
   end
 
+  def collection_radio
+    'none'
+  end
+
   private
-
-  def add_administrative_tags!
-    return unless params[:tag]
-
-    tags_client.create(tags: Array(params[:tag]))
-  end
-
-  def tags_client
-    Dor::Services::Client.object(model.pid).administrative_tags
-  end
 
   LICENSES = {
     'pddl' => { label: 'Open Data Commons Public Domain Dedication and License 1.0',
@@ -131,19 +109,23 @@ class ApoForm < BaseForm
   def options_for_use_license_type(current_value)
     LICENSES.map do |key, attributes|
       if key == current_value && attributes.key?(:deprecation_warning)
-        ["#{attributes.fetch(:label)} (#{attributes.fetch(:deprecation_warning)})", key]
+        ["#{attributes.fetch(:label)} (#{attributes.fetch(:deprecation_warning)})", attributes.fetch(:uri)]
       elsif !attributes.key?(:deprecation_warning)
-        [attributes.fetch(:label), key]
+        [attributes.fetch(:label), attributes.fetch(:uri)]
       end
     end.compact # the options block will produce nils for unused deprecated entries, compact will get rid of them
   end
 
   def manage_permissions
-    build_permissions(Array(model.roles['dor-apo-manager']), 'manage')
+    manage_role = model.administrative.roles&.find { |role| role.name == 'dor-apo-manager' }
+    managers = manage_role ? manage_role.members.map { |member| "#{member.type}:#{member.identifier}" } : []
+    build_permissions(managers, 'manage')
   end
 
   def view_permissions
-    build_permissions(Array(model.roles['dor-apo-viewer']), 'view')
+    view_role = model.administrative.roles&.find { |role| role.name == 'dor-apo-viewer' }
+    viewers = view_role ? view_role.members.map { |member| "#{member.type}:#{member.identifier}" } : []
+    build_permissions(viewers, 'view')
   end
 
   def build_permissions(role_list, access)
@@ -160,75 +142,5 @@ class ApoForm < BaseForm
     DEFAULT_MANAGER_WORKGROUPS.map do |name|
       { name: name, type: 'group', access: 'manage' }
     end
-  end
-
-  def sync_roles
-    model.purge_roles
-    return unless params[:permissions]
-
-    # and populate it with the correct roleMetadata
-    attributes = params[:permissions].values
-    attributes.each do |perm|
-      if perm[:access] == 'manage'
-        model.add_roleplayer('dor-apo-manager', "sdr:#{perm[:name]}")
-      elsif perm[:access] == 'view'
-        model.add_roleplayer('dor-apo-viewer', "sdr:#{perm[:name]}")
-      end
-    end
-  end
-
-  # Adds a new or existing collection as the default collection for the APO
-  def add_default_collection
-    @default_collection_pid = if params[:collection_radio] == 'create'
-                                create_collection model.pid
-                              elsif params[:collection].present? # Guards against empty string
-                                params[:collection]
-                              end
-
-    model.add_default_collection(@default_collection_pid) if @default_collection_pid
-  end
-
-  def find_or_register_model
-    return model unless new_record?
-
-    @model = register_model
-  end
-
-  # @return [Dor::AdminPolicyObject] registers the APO
-  def register_model
-    response = Dor::Services::Client.objects.register(params: cocina_model)
-    @needs_accession_workflow = true
-    # Once it's been created we populate it with its metadata
-    Dor.find(response.externalIdentifier)
-  end
-
-  # @return [Hash] the parameters used to register an apo. Must be called after `validate`
-  def cocina_model
-    Cocina::Models::RequestAdminPolicy.new(
-      label: params[:title],
-      version: 1,
-      type: Cocina::Models::Vocab.admin_policy,
-      administrative: {
-        hasAdminPolicy: SolrDocument::UBER_APO_ID
-      }
-    )
-  end
-
-  def param_cleanup(params)
-    params[:title]&.strip!
-    %i[managers viewers].each do |role_param_sym|
-      params[role_param_sym] = params[role_param_sym].tr("\n,", ' ') if params[role_param_sym]
-    end
-    params
-  end
-
-  # Create a collection
-  # @param [String] apo_pid the identifier for this APO
-  # @return [String] the pid for the newly created collection
-  def create_collection(apo_pid)
-    form = CollectionForm.new
-    form.validate(params.merge(apo_pid: apo_pid))
-    form.save
-    form.model.externalIdentifier
   end
 end

--- a/app/forms/apo_form.rb
+++ b/app/forms/apo_form.rb
@@ -27,7 +27,7 @@ class ApoForm
     @model = model
     @search_service = search_service
     self.default_rights = 'world'
-    self.default_workflow = 'registrationWF'
+    self.default_workflows = ['registrationWF']
     populate_from_model if model
     @errors = []
   end
@@ -40,11 +40,11 @@ class ApoForm
     self.use_statement = model.administrative.defaultAccess&.useAndReproductionStatement
     self.copyright_statement = model.administrative.defaultAccess&.copyright
     self.use_license = model.administrative.defaultAccess&.license
-    self.default_workflow = model.administrative.registrationWorkflow.first
+    self.default_workflows = model.administrative.registrationWorkflow
   end
 
   attr_accessor :use_license, :agreement_object_id, :use_statement, :copyright_statement,
-                :default_rights, :title, :default_workflow
+                :default_rights, :title, :default_workflows
 
   def persisted?
     !model.nil?

--- a/app/helpers/apo_helper.rb
+++ b/app/helpers/apo_helper.rb
@@ -13,7 +13,7 @@ module ApoHelper
   end
 
   def agreement_options
-    q = 'objectType_ssim:agreement '
+    q = 'objectType_ssim:agreement'
     result = SearchService.query(q, rows: 99_999, fl: 'id,tag_ssim,sw_display_title_tesim')['response']['docs']
     result.sort! do |a, b|
       a['sw_display_title_tesim'].to_s <=> b['sw_display_title_tesim'].to_s

--- a/app/javascript/modules/apo_form.js
+++ b/app/javascript/modules/apo_form.js
@@ -26,7 +26,7 @@ export default class {
     }
 
     collection() {
-      $('[name="collection_radio"]').on('change', (event) => {
+      $('[name="apo_form[collection_radio]"]').on('change', (event) => {
         $('.collection_div').hide()
         var reveal
         if (reveal = $(event.target).data('reveal')) {

--- a/app/javascript/modules/permission_grant.js
+++ b/app/javascript/modules/permission_grant.js
@@ -34,9 +34,9 @@ export default class {
      * write out the row as a hidden html field
      */
     serialize(idx) {
-      return `<input type="hidden" name="permissions[${idx}][name]" value="${this.data.name}">` +
-      `<input type="hidden" name="permissions[${idx}][access]" value="${this.data.access}">` +
-      `<input type="hidden" name="permissions[${idx}][type]" value="group">`
+      return `<input type="hidden" name="apo_form[permissions][${idx}][name]" value="${this.data.name}">` +
+      `<input type="hidden" name="apo_form[permissions][${idx}][access]" value="${this.data.access}">` +
+      `<input type="hidden" name="apo_form[permissions][${idx}][type]" value="group">`
 
     }
 

--- a/app/models/admin_policy_change_set.rb
+++ b/app/models/admin_policy_change_set.rb
@@ -110,16 +110,16 @@ class AdminPolicyChangeSet # rubocop:disable Metrics/ClassLength
     @changes.key?(:title)
   end
 
-  def default_workflow=(workflow)
-    @changes[:default_workflow] = workflow
+  def default_workflows=(workflows)
+    @changes[:default_workflows] = workflows
   end
 
-  def default_workflow
-    @changes[:default_workflow]
+  def default_workflows
+    @changes[:default_workflows]
   end
 
-  def default_workflow_changed?
-    @changes.key?(:default_workflow)
+  def default_workflows_changed?
+    @changes.key?(:default_workflows)
   end
 
   def permissions=(permissions)

--- a/app/models/admin_policy_change_set.rb
+++ b/app/models/admin_policy_change_set.rb
@@ -11,7 +11,11 @@ class AdminPolicyChangeSet # rubocop:disable Metrics/ClassLength
   attr_reader :model
 
   def save
-    @model = AdminPolicyChangeSetPersister.update(model, self)
+    @model = if new_record?
+               AdminPolicyChangeSetPersister.create(self)
+             else
+               AdminPolicyChangeSetPersister.update(model, self)
+             end
   end
 
   def new_record?

--- a/app/models/admin_policy_change_set.rb
+++ b/app/models/admin_policy_change_set.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+# Represents a set of changes to an admin policy.
+class AdminPolicyChangeSet # rubocop:disable Metrics/ClassLength
+  def initialize(model: nil)
+    @model = model
+    @changes = {}
+    yield self if block_given?
+  end
+
+  attr_reader :model
+
+  def save
+    @model = AdminPolicyChangeSetPersister.update(model, self)
+  end
+
+  def new_record?
+    model.nil?
+  end
+
+  def validate(params)
+    params.each do |k, v|
+      public_send("#{k}=", v.presence)
+    end
+
+    title.present? && agreement_object_id.present?
+  end
+
+  def use_license=(license)
+    @changes[:use_license] = license
+  end
+
+  def use_license
+    @changes[:use_license]
+  end
+
+  def use_license_changed?
+    @changes.key?(:use_license)
+  end
+
+  def registered_by=(user)
+    @changes[:registered_by] = user
+  end
+
+  def registered_by
+    @changes[:registered_by]
+  end
+
+  def registered_by_changed?
+    @changes.key?(:registered_by)
+  end
+
+  def agreement_object_id=(id)
+    @changes[:agreement_object_id] = id
+  end
+
+  def agreement_object_id
+    @changes[:agreement_object_id]
+  end
+
+  def agreement_object_id_changed?
+    @changes.key?(:agreement_object_id)
+  end
+
+  def use_statement=(statement)
+    @changes[:use_statement] = statement
+  end
+
+  def use_statement
+    @changes[:use_statement]
+  end
+
+  def use_statement_changed?
+    @changes.key?(:use_statement)
+  end
+
+  def copyright_statement=(statement)
+    @changes[:copyright_statement] = statement
+  end
+
+  def copyright_statement
+    @changes[:copyright_statement]
+  end
+
+  def copyright_statement_changed?
+    @changes.key?(:copyright_statement)
+  end
+
+  def default_rights=(rights)
+    @changes[:default_rights] = rights
+  end
+
+  def default_rights
+    @changes[:default_rights]
+  end
+
+  def default_rights_changed?
+    @changes.key?(:default_rights)
+  end
+
+  def title=(title)
+    @changes[:title] = title&.strip
+  end
+
+  def title
+    @changes[:title]
+  end
+
+  def title_changed?
+    @changes.key?(:title)
+  end
+
+  def default_workflow=(workflow)
+    @changes[:default_workflow] = workflow
+  end
+
+  def default_workflow
+    @changes[:default_workflow]
+  end
+
+  def default_workflow_changed?
+    @changes.key?(:default_workflow)
+  end
+
+  def permissions=(permissions)
+    @changes[:permissions] = permissions
+  end
+
+  def permissions
+    @changes[:permissions]
+  end
+
+  def permissions_changed?
+    @changes.key?(:permissions)
+  end
+
+  # Does the user want to create a new default collection
+  def collection_radio=(val)
+    @changes[:collection_radio] = val
+  end
+
+  def collection_radio
+    @changes[:collection_radio]
+  end
+
+  def collections_for_registration=(val)
+    @changes[:collections_for_registration] = val
+  end
+
+  def collections_for_registration
+    @changes[:collections_for_registration] || {}
+  end
+
+  # These attributes get passed to the CollectionForm
+  def collection=(val)
+    @changes[:collection] = val
+  end
+
+  def collection
+    @changes[:collection]
+  end
+end

--- a/app/services/admin_policy_change_set_persister.rb
+++ b/app/services/admin_policy_change_set_persister.rb
@@ -88,7 +88,7 @@ class AdminPolicyChangeSetPersister # rubocop:disable Metrics/ClassLength
   end
 
   def updated_administrative(updated)
-    rights = CocinaAccess.from_form_value(default_rights)
+    rights = CocinaDROAccess.from_form_value(default_rights)
     administrative = {
       referencesAgreement: agreement_object_id,
       registrationWorkflow: registration_workflow,

--- a/app/services/admin_policy_change_set_persister.rb
+++ b/app/services/admin_policy_change_set_persister.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+# Writes updates Cocina Models
+class AdminPolicyChangeSetPersister
+  # @param [Cocina::Models::AdminPolicy] model the orignal state of the model
+  # @param [AdminPolicyChangeSet] change_set the values to update.
+  # @return [Cocina::Models::AdminPolicy] the model with updates applied
+  def self.update(model, change_set)
+    new(model, change_set).update
+  end
+
+  def initialize(model, change_set)
+    @change_set = change_set
+    @model = model || model_for_registration
+  end
+
+  def model_for_registration
+    Cocina::Models::RequestAdminPolicy.new(
+      label: title,
+      version: 1,
+      type: Cocina::Models::Vocab.admin_policy,
+      administrative: { hasAdminPolicy: SolrDocument::UBER_APO_ID }
+    )
+  end
+
+  def new_record?
+    model.is_a? Cocina::Models::RequestAdminPolicy
+  end
+
+  def update
+    needs_accession_workflow = false
+
+    # We are forced to register first, so that we have a AdminPolicy to put the default collection into.
+    if new_record?
+      @model = Dor::Services::Client.objects.register(params: model)
+      needs_accession_workflow = true
+    end
+
+    updated = sync
+
+    # TODO: If update went through sdr-api, we wouldn't have to start accessioning separately.
+    response = Dor::Services::Client.object(updated.externalIdentifier).update(params: updated)
+    tag_registered_by(response.externalIdentifier)
+
+    # Kick off the accessionWF after all updates are complete.
+    WorkflowClientFactory.build.create_workflow_by_name(response.externalIdentifier, 'accessionWF', version: '1') if needs_accession_workflow
+    response
+  end
+
+  def sync
+    updated = model
+    updated = updated.new(label: title)
+    updated = updated_administrative(updated)
+    updated_description(updated)
+  end
+
+  private
+
+  attr_reader :model, :change_set
+
+  delegate :use_license, :agreement_object_id, :use_statement, :copyright_statement,
+           :default_rights, :title, :default_workflow, :permissions,
+           :collection_radio, :collections_for_registration, :collection,
+           :registered_by, to: :change_set
+
+  def tag_registered_by(pid)
+    return unless registered_by
+
+    tags_client(pid).create(tags: ["Registered By : #{registered_by}"])
+  end
+
+  def tags_client(pid)
+    Dor::Services::Client.object(pid).administrative_tags
+  end
+
+  def updated_description(updated)
+    description = { title: [{ value: title }] }
+    updated_description = updated.description.new(description)
+    updated.new(description: updated_description)
+  end
+
+  def updated_administrative(updated)
+    rights = CocinaAccess.from_form_value(default_rights)
+    administrative = {
+      referencesAgreement: agreement_object_id,
+      registrationWorkflow: [default_workflow],
+      defaultAccess: rights.value!.merge(
+        license: use_license,
+        copyright: copyright_statement,
+        useAndReproductionStatement: use_statement
+      ),
+      roles: roles
+    }.compact
+
+    # Get the ids of the existing collections from the form.
+    collection_ids = collections_for_registration.values.map { |elem| elem.fetch(:id) }
+    if collection_radio == 'create'
+      collection_ids << create_collection(updated.externalIdentifier)
+    elsif collection[:collection].present? # guard against empty string
+      collection_ids << collection[:collection]
+    end
+    administrative[:collectionsForRegistration] = collection_ids
+    updated_administrative = updated.administrative.new(administrative)
+    updated.new(administrative: updated_administrative)
+  end
+
+  # Create a collection
+  # @param [String] apo_pid the identifier for this APO
+  # @return [String] the pid for the newly created collection
+  def create_collection(apo_pid)
+    form = CollectionForm.new
+    form.validate(collection.merge(apo_pid: apo_pid))
+    form.save
+    form.model.externalIdentifier
+  end
+
+  # Translate the value used on the form to the value used in Cocina
+  ROLE_NAME = {
+    'manage' => 'dor-apo-manager',
+    'view' => 'dor-apo-viewer'
+  }.freeze
+
+  def roles
+    return [] unless permissions
+
+    attributes = permissions.values
+    ungrouped_perms = attributes.each_with_object({}) do |perm, grouped|
+      role_name = ROLE_NAME.fetch(perm[:access])
+      grouped[role_name] ||= []
+      grouped[role_name] << { type: 'workgroup', identifier: "sdr:#{perm[:name]}" }
+    end
+
+    ungrouped_perms.map { |name, members| { name: name, members: members } }
+  end
+end

--- a/app/views/apo/_form.html.erb
+++ b/app/views/apo/_form.html.erb
@@ -103,7 +103,7 @@
 
   <div class="form-group">
     <%= f.label :default_rights, "Default Object Rights" %>
-    <%= f.select :default_rights, options_for_select(Constants::DEFAULT_RIGHTS_OPTIONS, @form.default_rights), {}, class: 'form-control' %>
+    <%= f.select :default_rights, options_for_select(Constants::REGISTRATION_RIGHTS_OPTIONS, @form.default_rights), {}, class: 'form-control' %>
   </div>
   <div class="form-group">
     <%= f.label :use_statement, "Default Use and Reproduction statement" %>

--- a/app/views/apo/_form.html.erb
+++ b/app/views/apo/_form.html.erb
@@ -1,95 +1,100 @@
-<%= form_tag url, method: method, data: { behavior: 'apo-form' } do %>
+<%= form_for @form, url: { action: @form.persisted? ? 'update' : 'create'}, data: { behavior: 'apo-form' } do |f| %>
   <div class="form-group">
-    <label for="title">Title</label>
-    <input type="text" class="form-control" id="title" name="title" value="<%= @form.mods_title %>">
+    <%= f.label :title %>
+    <%= f.text_field :title, class: 'form-control' %>
     <span id="title-err-msg-elt" class="apo-register-error"></span>
   </div>
 
   <div class="form-group">
     <label>Agreement</label>
-    <%= select_tag :agreement, options_for_select(agreement_options, @form.agreement_object_id), class: 'form-control' %>
+    <%= f.select :agreement_object_id, options_for_select(agreement_options, @form.agreement_object_id), {}, class: 'form-control' %>
   </div>
 
   <sharing data-permissions="<%= @form.permissions.to_json %>"></sharing>
 
   <% if @form.default_collection_objects.present? %>
-    <label>Default Collections</label><br>
-    <% @form.default_collection_objects.each do |solr_doc| %>
-      <%= link_to solr_doc.label, solr_doc %> <%= link_to('(remove)', delete_collection_apo_path(collection: solr_doc.id, id: @form), confirm: 'You are about to leave the page, are you sure?') %><br>
-    <% end %>
+    <fieldset>
+      <legend>Default Collections</legend>
+      <% @form.default_collection_objects.each_with_index do |solr_doc, index| %>
+        <%= hidden_field_tag "apo_form[collections_for_registration][#{index}][id]", solr_doc.id %>
+        <%= link_to solr_doc.label, solr_doc %> <%= link_to('(remove)', delete_collection_apo_path(collection: solr_doc.id, id: @form), confirm: 'You are about to leave the page, are you sure?') %><br>
+      <% end %>
+    </fieldset>
   <% end %>
   <br>
 
   <div class="radio">
     <label>
-      <input checked type="radio" name="collection_radio" value="none">
+      <%= f.radio_button :collection_radio, 'none', checked: true %>
       Don't add a Collection
     </label>
   </div>
 
-  <% if @form.new_record? %>
+  <% unless @form.persisted? %>
     <div class="radio">
       <label>
-        <input type="radio" name="collection_radio" value="create" data-reveal='create-collection'>
+        <%= f.radio_button :collection_radio, 'create', data: { reveal: 'create-collection' } %>
         Create a Collection
       </label>
     </div>
 
     <div class="radio">
       <label>
-        <input type="radio" name="collection_radio" value="create" data-reveal='create-collection-catkey'>
+        <%= f.radio_button :collection_radio, 'create', data: { reveal: 'create-collection-catkey' } %>
         Create a Collection from Symphony
       </label>
     </div>
   <% else %>
     <div class="radio">
       <label>
-        <input type="radio" name="collection_radio" value="select" data-reveal='select-collection'>
+        <%= f.radio_button :collection_radio, 'select', data: { reveal: 'select-collection' } %>
         Choose a Default Collection
       </label>
     </div>
   <% end %>
 
-  <div id="select-collection" class="collection_div form-group" style="display:none">
-    <%= select_tag :collection, options_for_select(current_user.permitted_collections), class: 'form-control' %>
-  </div>
-  <div id="create-collection" class="collection_div" style="display:none">
-    <div class="form-group">
-      <label for="collection_title" class="col-sm-2 control-label">Collection Title</label>
-      <div class="col-sm-10">
-        <input type="text" id="collection_title" class="form-control" name="collection_title" style="width:90%" value="">
+  <%= f.fields_for :collection do |collection| %>
+    <div id="select-collection" class="collection_div form-group" style="display:none">
+      <%= collection.select :collection, options_for_select(current_user.permitted_collections), {}, class: 'form-control' %>
+    </div>
+    <div id="create-collection" class="collection_div" style="display:none">
+      <div class="form-group">
+        <%= collection.label :collection_title, "Collection Title", class: "col-sm-2 control-label" %>
+        <div class="col-sm-10">
+          <%= collection.text_field :collection_title, class: 'form-control' %>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <%= collection.label :collection_abstract, "Collection Abstract", class: "col-sm-2 control-label" %>
+        <div class="col-sm-10">
+          <%= collection.text_area :collection_abstract, class: 'form-control' %>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <%= collection.label :collection_rights, "Collection Rights", class: "col-sm-2 control-label" %>
+        <div class="col-sm-10">
+          <%= collection.select :collection_rights, options_for_select(Constants::DEFAULT_RIGHTS_OPTIONS, 'world'), {}, class: 'form-control' %>
+        </div>
       </div>
     </div>
 
-    <div class="form-group">
-      <label for="collection_abstract" class="col-sm-2 control-label">Collection Abstract</label>
-      <div class="col-sm-10">
-        <textarea id="collection_abstract" class="form-control" name="collection_abstract" style="width:90%"></textarea>
+    <div id="create-collection-catkey" class="collection_div" style="display:none">
+      <div class="form-group">
+        <%= collection.label :collection_catkey, "Collection Catkey", class: "col-sm-2 control-label" %>
+        <div class="col-sm-10">
+          <%= collection.text_field :collection_catkey, class: 'form-control' %>
+        </div>
+      </div>
+      <div class="form-group">
+        <%= collection.label :collection_rights_catkey, "Collection Rights", class: "col-sm-2 control-label" %>
+        <div class="col-sm-10">
+          <%= collection.select :collection_rights_catkey, options_for_select(Constants::DEFAULT_RIGHTS_OPTIONS, 'world'), {}, class: 'form-control' %>
+        </div>
       </div>
     </div>
-
-    <div class="form-group">
-      <label for="collection_rights" class="col-sm-2 control-label">Collection Rights</label>
-      <div class="col-sm-10">
-        <%= select_tag :collection_rights, options_for_select(Constants::DEFAULT_RIGHTS_OPTIONS, 'world'), class: 'form-control' %>
-      </div>
-    </div>
-  </div>
-
-  <div id="create-collection-catkey" class="collection_div" style="display:none">
-    <div class="form-group">
-      <label for="collection_catkey" class="col-sm-2 control-label">Collection Catkey</label>
-      <div class="col-sm-10">
-        <input type="text" id="collection_catkey" name="collection_catkey" style="width:90%" value="" class="form-control">
-      </div>
-    </div>
-    <div class="form-group">
-      <label for="collection_rights_catkey" class="col-sm-2 control-label">Collection Rights</label>
-      <div class="col-sm-10">
-        <%= select_tag :collection_rights_catkey, options_for_select(Constants::DEFAULT_RIGHTS_OPTIONS, 'world'), class: 'form-control' %>
-      </div>
-    </div>
-  </div>
+  <% end %>
 
   <div class="form-group" style="clear: both; border-top: 1px solid #CCC;padding: 8px 0px 12px;margin-top: 10px;width:95%">
     <label style="font-size:1.2em">Object defaults</label>
@@ -97,31 +102,31 @@
   </div>
 
   <div class="form-group">
-    <label>Default Object Rights</label>
-      <%= select_tag :default_object_rights, options_for_select(Constants::DEFAULT_RIGHTS_OPTIONS, @form.default_rights), class: 'form-control' %>
+    <%= f.label :default_rights, "Default Object Rights" %>
+    <%= f.select :default_rights, options_for_select(Constants::DEFAULT_RIGHTS_OPTIONS, @form.default_rights), {}, class: 'form-control' %>
   </div>
   <div class="form-group">
-    <label for="use">Default Use and Reproduction statement</label><br>
+    <%= f.label :use_statement, "Default Use and Reproduction statement" %>
     <p>See <%= link_to 'here', 'https://consul.stanford.edu/display/APO/Sample+Access+Condition+statements', target: '_blank', rel: 'noopener' %> for sample Use and Reproduction statements.</p>
-    <textarea class="form-control" rows="2" name="use" id="use"><%= @form.use_statement %></textarea>
+    <%= f.text_area :use_statement, class: "form-control", rows:"2" %>
   </div>
 
   <div class="form-group">
-    <label for="copyright">Default Copyright statement</label><br>
+    <%= f.label :copyright_statement, "Default Copyright statement" %>
     <p>See <%= link_to 'here', 'https://consul.stanford.edu/display/APO/Sample+Access+Condition+statements', target: '_blank', rel: 'noopener' %> for sample Copyright statements.</p>
-    <textarea class="form-control" id='copyright' name="copyright"><%= @form.copyright_statement %></textarea>
+    <%= f.text_area :copyright_statement, class: "form-control", rows:"2" %>
   </div>
   <div class="form-group">
-    <label>Default use license</label>
-    <%= select_tag :use_license, options_for_select(@form.license_options, @form.use_license), class: 'form-control' %>
+    <%= f.label :use_license, "Default use license" %>
+    <%= f.select :use_license, options_for_select(@form.license_options, @form.use_license), {}, class: 'form-control' %>
   </div>
 
   <div class="form-group">
-    <label>Default workflow</label>
-    <%= select_tag :workflow, options_for_select(workflow_options, @form.default_workflow), class: 'form-control' %>
+    <%= f.label :default_workflow, "Default workflow" %>
+    <%= f.select :default_workflow, options_for_select(workflow_options, @form.default_workflow), {}, class: 'form-control' %>
   </div>
   <div class="form-group">
-    <% if @form.new_record? %>
+    <% unless @form.persisted? %>
       <%= submit_tag 'Register APO', class: 'btn btn-primary' %>
       <%= link_to 'Cancel', '/', class: 'btn btn-secondary' %>
     <% else %>

--- a/app/views/apo/_form.html.erb
+++ b/app/views/apo/_form.html.erb
@@ -122,8 +122,9 @@
   </div>
 
   <div class="form-group">
-    <%= f.label :default_workflow, "Default workflow" %>
-    <%= f.select :default_workflow, options_for_select(workflow_options, @form.default_workflow), {}, class: 'form-control' %>
+    <%= f.label :default_workflows %>
+    <%= f.select :default_workflows, options_for_select(workflow_options, @form.default_workflows),
+                                    {}, multiple: true, class: 'form-control' %>
   </div>
   <div class="form-group">
     <% unless @form.persisted? %>

--- a/app/views/apo/edit.html.erb
+++ b/app/views/apo/edit.html.erb
@@ -1,3 +1,3 @@
 <h1>Edit APO</h1>
 
-<%= render 'form', url: apo_path(@cocina.externalIdentifier), method: :patch %>
+<%= render 'form' %>

--- a/app/views/apo/new.html.erb
+++ b/app/views/apo/new.html.erb
@@ -1,3 +1,3 @@
 <h1>Register APO</h1>
 
-<%= render 'form', url: apo_index_path, method: :post %>
+<%= render 'form' %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,7 @@ services:
       SETTINGS__FEDORA_URL: http://fedoraAdmin:fedoraAdmin@fcrepo:8080/fedora
       SETTINGS__SURI__URL: http://suri:3000
       SETTINGS__WORKFLOW_URL: http://workflow:3000
+      SETTINGS__ENABLED_FEATURES__UPDATE_DESCRIPTIVE: 'true'
       REDIS_URL: redis://redis:6379/
     depends_on:
       - db

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -4,6 +4,7 @@
 # A module for including constants throughout the Argo application
 module Constants
   # From https://github.com/sul-dlss/dor-services/blob/main/lib/dor/datastreams/rights_metadata_ds.rb
+  # Currently these are only used by the CollectionForm
   DEFAULT_RIGHTS_OPTIONS = [
     %w[World world],
     ['World (no-download)', 'world-nd'],

--- a/spec/controllers/apo_controller_spec.rb
+++ b/spec/controllers/apo_controller_spec.rb
@@ -5,19 +5,11 @@ require 'rails_helper'
 RSpec.describe ApoController, type: :controller do
   before do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
-
-    allow(Dor).to receive(:find).with(apo.pid).and_return(apo)
-    allow(apo).to receive(:save)
-
-    allow(Dor).to receive(:find).with(collection.externalIdentifier).and_return(collection)
-    allow(collection).to receive(:save)
-
     sign_in user
     allow(controller).to receive(:authorize!).with(:manage_item, Cocina::Models::AdminPolicy).and_return(true)
   end
 
   let(:user) { create(:user) }
-  let(:apo) { instance_double(Dor::AdminPolicyObject, pid: pid) }
   let(:pid) { 'druid:zt570qh4444' }
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
   let(:cocina_model) do
@@ -37,77 +29,6 @@ RSpec.describe ApoController, type: :controller do
                                    label: '',
                                    version: 1,
                                    access: {})
-  end
-
-  describe '#create' do
-    let(:form) do
-      instance_double(ApoForm, validate: valid,
-                               save: true,
-                               model: apo,
-                               default_collection_pid: nil)
-    end
-
-    before do
-      allow(ApoForm).to receive(:new).and_return(form)
-      allow(controller).to receive(:authorize!).with(:create, Cocina::Models::AdminPolicy).and_return(true)
-    end
-
-    context 'when the form is valid' do
-      let(:valid) { true }
-
-      it 'is successful' do
-        post :create, params: {}
-        expect(form).to have_received(:validate).with(ActionController::Parameters)
-        expect(response).to be_redirect
-        expect(flash[:notice]).to eq 'APO druid:zt570qh4444 created.'
-      end
-    end
-
-    context 'when the form is invalid' do
-      let(:valid) { false }
-
-      it 'redraws the form' do
-        post :create, params: {}
-        expect(form).to have_received(:validate).with(ActionController::Parameters)
-        expect(response).to render_template 'new'
-        expect(assigns[:form]).to eq form
-      end
-    end
-  end
-
-  describe '#update' do
-    let(:form) do
-      instance_double(ApoForm, validate: valid,
-                               save: true,
-                               model: apo,
-                               default_collection_pid: nil)
-    end
-
-    before do
-      allow(ApoForm).to receive(:new).and_return(form)
-      allow(controller).to receive(:authorize!).with(:create, Cocina::Models::AdminPolicy).and_return(true)
-    end
-
-    context 'when the form is valid' do
-      let(:valid) { true }
-
-      it 'is successful' do
-        patch :update, params: { id: apo.pid }
-        expect(form).to have_received(:validate).with(ActionController::Parameters)
-        expect(response).to be_redirect
-      end
-    end
-
-    context 'when the form is invalid' do
-      let(:valid) { false }
-
-      it 'redraws the form' do
-        patch :update, params: { id: apo.pid }
-        expect(form).to have_received(:validate).with(ActionController::Parameters)
-        expect(response).to render_template 'edit'
-        expect(assigns[:form]).to eq form
-      end
-    end
   end
 
   describe '#delete_collection' do
@@ -139,7 +60,7 @@ RSpec.describe ApoController, type: :controller do
     end
 
     it 'calls remove_default_collection' do
-      post 'delete_collection', params: { id: apo.pid, collection: collection_id }
+      post 'delete_collection', params: { id: pid, collection: collection_id }
       expect(object_client).to have_received(:update)
         .with(params: expected)
     end

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -1,27 +1,26 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :collection, class: 'Cocina::Models::RequestDRO' do
-    initialize_with do
-      Cocina::Models.build_request({
-                                     'type' => type,
-                                     'label' => 'test object',
-                                     'version' => 1,
-                                     'access' => {
-                                     },
-                                     'administrative' => {
-                                       'hasAdminPolicy' => apo.pid
-                                     }
-                                   })
+  factory :collection, class: 'Cocina::Models::RequestCollection' do
+    initialize_with do |*_args|
+      CollectionMethodSender.new(
+        Cocina::Models.build_request(
+          'type' => type,
+          'label' => 'test collection',
+          'version' => 1,
+          'administrative' => {
+            'hasAdminPolicy' => admin_policy_id
+          },
+          'access' => {}
+        )
+      )
     end
 
-    to_create do |cocina_model|
-      Dor::Services::Client.objects.register(params: cocina_model)
+    to_create do |builder|
+      Dor::Services::Client.objects.register(params: builder.cocina_model)
     end
 
-    apo do
-      FactoryBot.create_for_repository(:ur_apo)
-    end
+    admin_policy_id { FactoryBot.create_for_repository(:ur_apo).pid }
 
     type { Cocina::Models::Vocab.collection }
   end

--- a/spec/features/apo_displays_spec.rb
+++ b/spec/features/apo_displays_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 RSpec.describe 'Viewing an Admin policy' do
   let(:apo_druid) { 'druid:zt570qh4444' }
-  let(:object) { Dor::AdminPolicyObject.new(pid: apo_druid) }
   let(:current_user) { create(:user) }
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, version: version_client) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: versions) }
@@ -32,8 +31,6 @@ RSpec.describe 'Viewing an Admin policy' do
     solr_conn.add(solr_doc)
     solr_conn.commit
     sign_in current_user, groups: ['sdr:administrator-role']
-    allow(object).to receive(:persisted?).and_return(true) # This allows to_param to function
-    allow(Dor).to receive(:find).and_return(object)
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
   end
 

--- a/spec/forms/apo_form_spec.rb
+++ b/spec/forms/apo_form_spec.rb
@@ -61,17 +61,17 @@ RSpec.describe ApoForm do
       end
     end
 
-    describe '#default_workflow' do
-      subject { instance.default_workflow }
+    describe '#default_workflows' do
+      subject { instance.default_workflows }
 
       let(:administrative) do
         {
           hasAdminPolicy: 'druid:xx666zz7777',
-          registrationWorkflow: ['digitizationWF']
+          registrationWorkflow: %w[digitizationWF goobiWF]
         }
       end
 
-      it { is_expected.to eq 'digitizationWF' }
+      it { is_expected.to eq %w[digitizationWF goobiWF] }
     end
 
     describe '#agreement_object_id' do
@@ -158,10 +158,10 @@ RSpec.describe ApoForm do
       end
     end
 
-    describe '#default_workflow' do
-      subject { instance.default_workflow }
+    describe '#default_workflows' do
+      subject { instance.default_workflows }
 
-      it { is_expected.to eq 'registrationWF' }
+      it { is_expected.to eq ['registrationWF'] }
     end
 
     describe '#use_license' do

--- a/spec/forms/apo_form_spec.rb
+++ b/spec/forms/apo_form_spec.rb
@@ -3,105 +3,51 @@
 require 'rails_helper'
 
 RSpec.describe ApoForm do
-  let(:fake_tags_client) { instance_double(Dor::Services::Client::AdministrativeTags, create: true) }
   let(:search_service) { instance_double(Blacklight::SearchService) }
   let(:instance) { described_class.new(apo, search_service: search_service) }
-
-  before do
-    allow(instance).to receive(:tags_client).and_return(fake_tags_client)
+  let(:apo) do
+    Cocina::Models::AdminPolicy.new(
+      type: Cocina::Models::Vocab.admin_policy,
+      externalIdentifier: 'druid:zt570qh4444',
+      version: 1,
+      administrative: administrative,
+      label: 'My title',
+      description: { title: [{ value: 'Stored title' }] }
+    )
   end
+
+  let(:administrative) do
+    {
+      hasAdminPolicy: 'druid:xx666zz7777',
+      registrationWorkflow: ['registrationWF'],
+      defaultAccess: default_access
+    }
+  end
+  let(:default_access) { {} }
 
   context 'with a persisted model (update)' do
     let(:agreement_id) { 'druid:dd327rv8888' }
-    let(:apo) do
-      Dor::AdminPolicyObject.new(pid: 'druid:zt570qh4444')
-    end
-    let(:md_info) do
-      {
-        copyright: 'My copyright statement',
-        use: 'My use and reproduction statement',
-        title: +'My title',
-        agreement: agreement_id,
-        workflow: 'registrationWF',
-        default_object_rights: 'world',
-        use_license: 'by-nc'
-      }
-    end
-
-    before do
-      allow(apo).to receive(:new_record?).and_return(false)
-    end
-
-    describe '#sync' do
-      it 'sets clean APO metadata for defaultObjectRights' do
-        instance.validate(md_info)
-        instance.sync
-
-        expect(apo.mods_title).to           eq(md_info[:title])
-        expect(apo.agreement_object_id).to  eq(md_info[:agreement])
-        expect(apo.default_workflows).to    eq([md_info[:workflow]])
-        expect(apo.default_rights).to       eq(md_info[:default_object_rights])
-        expect(apo.use_license).to          eq(md_info[:use_license])
-        expect(apo.use_license_uri).to      eq('https://creativecommons.org/licenses/by-nc/3.0/')
-        expect(apo.use_license_human).to    eq('Attribution Non-Commercial 3.0 Unported')
-        expect(apo.copyright_statement).to  eq(md_info[:copyright])
-        expect(apo.use_statement).to        eq(md_info[:use])
-        default = apo.defaultObjectRights.ng_xml
-        expect(default.xpath('//copyright/human').text).to eq 'My copyright statement'
-        expect(default.xpath('//use/machine').text).to eq 'by-nc'
-        expect(default.xpath('//use/human[@type="useAndReproduction"]').text).to eq 'My use and reproduction statement'
-        expect(default.xpath('//access[@type="read"]/machine/world')).to be_present
-      end
-
-      it 'handles no use license' do
-        md_info[:use_license] = ' '
-        instance.validate(md_info)
-        instance.sync
-        expect(apo.use_license).to          be_blank
-        expect(apo.use_license_uri).to      be_nil
-        expect(apo.use_license_human).to    be_blank
-      end
-
-      it 'handles no copyright statement' do
-        md_info[:copyright] = ' '
-        instance.validate(md_info)
-        instance.sync
-        expect(apo.copyright_statement).to be_nil
-      end
-
-      it 'handles UTF8 copyright statement' do
-        md_info[:copyright] = 'Copyright © All Rights Reserved.'
-        instance.validate(md_info)
-        instance.sync
-        expect(apo.copyright_statement).to eq(md_info[:copyright])
-      end
-
-      context 'when the user provides no statement' do
-        it 'updates it to nil' do
-          md_info[:use] = ' '
-          instance.validate(md_info)
-          instance.sync
-          expect(apo.use_statement).to be_nil
-        end
-      end
-    end
-
-    describe '#validate' do
-      it 'errors out if no workflow' do
-        md_info[:workflow] = ' '
-        instance.validate(md_info)
-
-        expect { instance.sync }.to raise_error(ArgumentError)
-      end
-    end
 
     describe '#permissions' do
       subject { instance.permissions }
 
-      before do
-        allow(apo).to receive(:roles).and_return('dor-apo-manager' =>
-          ['workgroup:dlss:developers', 'workgroup:dlss:pmag-staff', 'workgroup:dlss:smpl-staff',
-           'workgroup:dlss:dpg-staff', 'workgroup:dlss:argo-access-spec', 'lmcrae'])
+      let(:administrative) do
+        {
+          hasAdminPolicy: 'druid:xx666zz7777',
+          registrationWorkflow: ['registrationWF'],
+          roles: [
+            {
+              members: [
+                { identifier: 'dlss:developers', type: 'workgroup' },
+                { identifier: 'dlss:pmag-staff', type: 'workgroup' },
+                { identifier: 'dlss:smpl-staff', type: 'workgroup' },
+                { identifier: 'dlss:dpg-staff', type: 'workgroup' },
+                { identifier: 'dlss:argo-access-spec', type: 'workgroup' }
+              ],
+              name: 'dor-apo-manager'
+            }
+          ]
+        }
       end
 
       it 'has the defaults' do
@@ -110,8 +56,7 @@ RSpec.describe ApoForm do
           { name: 'pmag-staff', type: 'group', access: 'manage' },
           { name: 'smpl-staff', type: 'group', access: 'manage' },
           { name: 'dpg-staff', type: 'group', access: 'manage' },
-          { name: 'argo-access-spec', type: 'group', access: 'manage' },
-          { name: 'lmcrae', type: 'person', access: 'manage' }
+          { name: 'argo-access-spec', type: 'group', access: 'manage' }
         ]
       end
     end
@@ -119,8 +64,11 @@ RSpec.describe ApoForm do
     describe '#default_workflow' do
       subject { instance.default_workflow }
 
-      before do
-        apo.default_workflow = 'digitizationWF'
+      let(:administrative) do
+        {
+          hasAdminPolicy: 'druid:xx666zz7777',
+          registrationWorkflow: ['digitizationWF']
+        }
       end
 
       it { is_expected.to eq 'digitizationWF' }
@@ -129,8 +77,12 @@ RSpec.describe ApoForm do
     describe '#agreement_object_id' do
       subject { instance.agreement_object_id }
 
-      before do
-        apo.agreement_object_id = 'druid:dd327rv8888'
+      let(:administrative) do
+        {
+          hasAdminPolicy: 'druid:xx666zz7777',
+          registrationWorkflow: ['digitizationWF'],
+          referencesAgreement: 'druid:dd327rv8888'
+        }
       end
 
       it { is_expected.to eq agreement_id }
@@ -139,15 +91,15 @@ RSpec.describe ApoForm do
     describe '#use_license' do
       subject { instance.use_license }
 
-      before do
-        apo.use_license = 'by-nc-sa'
-      end
+      let(:default_access) { { license: 'https://creativecommons.org/licenses/by-nc-sa/3.0/' } }
 
-      it { is_expected.to eq 'by-nc-sa' }
+      it { is_expected.to eq 'https://creativecommons.org/licenses/by-nc-sa/3.0/' }
     end
 
     describe '#default_rights' do
       subject { instance.default_rights }
+
+      let(:default_access) { { access: 'world' } }
 
       it { is_expected.to eq 'world' }
     end
@@ -155,9 +107,7 @@ RSpec.describe ApoForm do
     describe '#use_statement' do
       subject { instance.use_statement }
 
-      before do
-        apo.use_statement = 'Rights are owned by Stanford University Libraries'
-      end
+      let(:default_access) { { useAndReproductionStatement: 'Rights are owned by Stanford University Libraries' } }
 
       it { is_expected.to eq 'Rights are owned by Stanford University Libraries' }
     end
@@ -165,21 +115,15 @@ RSpec.describe ApoForm do
     describe '#copyright_statement' do
       subject { instance.copyright_statement }
 
-      before do
-        apo.copyright_statement = 'Additional copyright info'
-      end
+      let(:default_access) { { copyright: 'Additional copyright info' } }
 
       it { is_expected.to eq 'Additional copyright info' }
     end
 
-    describe '#mods_title' do
-      subject { instance.mods_title }
+    describe '#title' do
+      subject { instance.title }
 
-      before do
-        apo.mods_title = 'Ampex'
-      end
-
-      it { is_expected.to eq 'Ampex' }
+      it { is_expected.to eq 'Stored title' }
     end
 
     describe '#to_param' do
@@ -200,7 +144,7 @@ RSpec.describe ApoForm do
   end
 
   context 'with an unsaved model' do
-    let(:apo) { Dor::AdminPolicyObject.new }
+    let(:apo) { nil }
 
     describe '#permissions' do
       subject { instance.permissions }
@@ -235,23 +179,17 @@ RSpec.describe ApoForm do
     describe '#use_statement' do
       subject { instance.use_statement }
 
-      it { is_expected.to eq '' }
+      it { is_expected.to be_nil }
     end
 
     describe '#copyright_statement' do
       subject { instance.copyright_statement }
 
-      it { is_expected.to eq '' }
+      it { is_expected.to be_nil }
     end
 
-    describe '#mods_title' do
-      subject { instance.mods_title }
-
-      it { is_expected.to eq '' }
-    end
-
-    describe '#to_param' do
-      subject { instance.to_param }
+    describe '#title' do
+      subject { instance.title }
 
       it { is_expected.to be_nil }
     end
@@ -265,128 +203,11 @@ RSpec.describe ApoForm do
         expect(subject.size).to eq 11
       end
     end
-
-    describe '#save' do
-      let(:registered_model) do
-        Dor::AdminPolicyObject.new(pid: 'druid:zt570qh4444')
-      end
-      let(:agreement_id) { 'druid:dd327rv8888' }
-      let(:collection_form) { instance_double(CollectionForm, validate: true, model: created_collection) }
-      let(:collection_id) { 'druid:gh567vb7777' }
-
-      let(:coll_title) { 'col title' }
-
-      let(:base_params) do
-        { # These data mimic the APO registration form
-          'title' => +'New APO Title',
-          'agreement' => agreement_id,
-          permissions: {
-            '0' => { access: 'manage', name: 'developers', type: 'group' },
-            '1' => { access: 'manage', name: 'dpg-staff', type: 'group' },
-            '2' => { access: 'view', name: 'viewer-role', type: 'group' },
-            '3' => { access: 'view', name: 'forensics-staff', type: 'group' }
-          },
-          'collection_radio' => 'create',
-          'collection_title' => coll_title,
-          'collection_rights' => 'world',
-          'collection_abstract' => '',
-          'default_object_rights' => 'world',
-          'use' => '',
-          'copyright' => '',
-          'use_license' => 'by-nc',
-          'workflow' => 'accessionWF',
-          'register' => ''
-        }.with_indifferent_access
-      end
-
-      let(:workflow_client) { instance_double(Dor::Workflow::Client, status: true) }
-      let(:created_apo) do
-        Cocina::Models::AdminPolicy.new(externalIdentifier: 'druid:zt570qh4444',
-                                        type: Cocina::Models::Vocab.admin_policy,
-                                        label: '',
-                                        version: 1,
-                                        administrative: {
-                                          hasAdminPolicy: 'druid:hv992ry2431'
-                                        }).to_json
-      end
-
-      let(:created_collection) do
-        Cocina::Models::Collection.new(externalIdentifier: collection_id,
-                                       type: Cocina::Models::Vocab.collection,
-                                       label: '',
-                                       version: 1,
-                                       access: {})
-      end
-      let(:collection_req_body_hash) do
-        {
-          type: 'http://cocina.sul.stanford.edu/models/collection.jsonld',
-          label: coll_title,
-          version: 1,
-          access: { access: 'world' },
-          administrative: { hasAdminPolicy: 'druid:zt570qh4444' }
-        }
-      end
-
-      before do
-        allow(Dor::Workflow::Client).to receive(:new).and_return(workflow_client)
-        expect(CollectionForm).to receive(:new).and_return(collection_form)
-        expect(collection_form).to receive(:save)
-        expect(Argo::Indexer).to receive(:reindex_pid_remotely)
-
-        expect(Dor).to receive(:find).with(registered_model.pid).and_return(registered_model)
-        expect(registered_model).to receive(:new_record?).and_return(false)
-        expect(registered_model).to receive(:save)
-        expect(registered_model).to receive(:add_roleplayer).exactly(4).times
-
-        stub_request(:post, "#{Settings.dor_services.url}/v1/objects")
-          .with(
-            body: '{"type":"http://cocina.sul.stanford.edu/models/admin_policy.jsonld",' \
-            '"label":"New APO Title","version":1,' \
-            '"administrative":{"defaultObjectRights":"\\u003c?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?\\u003e' \
-            '\\u003crightsMetadata\\u003e\\u003caccess type=\\"discover\\"\\u003e\\u003cmachine\\u003e' \
-            '\\u003cworld/\\u003e\\u003c/machine\\u003e' \
-            '\\u003c/access\\u003e\\u003caccess type=\\"read\\"\\u003e\\u003cmachine\\u003e\\u003cworld/\\u003e\\u003c/machine\\u003e' \
-            '\\u003c/access\\u003e\\u003cuse\\u003e\\u003chuman type=\\"useAndReproduction\\"/\\u003e\\u003chuman type=\\"creativeCommons\\"/' \
-            '\\u003e\\u003cmachine type=\\"creativeCommons\\" uri=\\"\\"/\\u003e\\u003chuman type=\\"openDataCommons\\"/' \
-            '\\u003e\\u003cmachine type=\\"openDataCommons\\" uri=\\"\\"/\\u003e\\u003c/use\\u003e\\u003ccopyright\\u003e\\u003chuman/' \
-            '\\u003e\\u003c/copyright\\u003e\\u003c/rightsMetadata\\u003e","hasAdminPolicy":"druid:hv992ry2431"}}'
-          )
-          .to_return(status: 200, body: created_apo, headers: {})
-
-        expect(workflow_client).to receive(:create_workflow_by_name).with(registered_model.pid, 'accessionWF', version: '1')
-        expect(registered_model).to receive(:"use_license=").with(params['use_license'])
-
-        # verify that the collection is also created
-        expect(registered_model).to receive(:add_default_collection).with(collection_id)
-      end
-
-      context 'with tags in the params' do
-        let(:params) { base_params.merge(tag: tags) }
-        let(:tags) { ['One : Two', 'Two : Three'] }
-
-        it 'hits the dor-services-app administrative tags endpoint to add tags' do
-          instance.validate(params)
-          instance.save
-          expect(fake_tags_client).to have_received(:create).once.with(tags: tags)
-        end
-      end
-
-      context 'without tags in the params' do
-        let(:params) { base_params }
-
-        it 'hits the registration service to register both an APO and a collection' do
-          instance.validate(params)
-          instance.save
-          expect(fake_tags_client).not_to have_received(:create)
-        end
-      end
-    end
   end
 
   describe '#default_collection_objects' do
     subject { instance.default_collection_objects }
 
-    let(:apo) { Dor::AdminPolicyObject.new }
     let(:search_service) { instance_double(Blacklight::SearchService, fetch: [nil, [doc1]]) }
     let(:doc1) { instance_double(SolrDocument) }
 

--- a/spec/requests/create_new_admin_policy_spec.rb
+++ b/spec/requests/create_new_admin_policy_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Create a new Admin Policy' do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in user, groups: ['sdr:administrator-role']
+  end
+
+  context 'when the parameters are invalid' do
+    it 'redraws the form' do
+      post '/apo', params: { apo_form: { title: '' } }
+      expect(response).to be_successful
+    end
+  end
+end

--- a/spec/requests/update_an_existing_admin_policy_spec.rb
+++ b/spec/requests/update_an_existing_admin_policy_spec.rb
@@ -26,14 +26,47 @@ RSpec.describe 'Update an existing Admin Policy' do
 
   before do
     sign_in user, groups: ['sdr:administrator-role']
-
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
   end
 
   context 'when the parameters are invalid' do
+    let(:workflow_service) { instance_double(Dor::Workflow::Client, workflow_templates: []) }
+
     it 'redraws the form' do
       patch "/apo/#{pid}", params: { apo_form: { title: '' } }
       expect(response).to be_successful
+    end
+  end
+
+  context 'when the parameters are valid' do
+    let(:result) { cocina_model }
+    let(:object_client) do
+      instance_double(Dor::Services::Client::Object, find: cocina_model, update: result)
+    end
+
+    let(:objects_client) { instance_double(Dor::Services::Client::Objects, register: nil) }
+    let(:workflow_service) { instance_double(Dor::Workflow::Client, create_workflow_by_name: nil) }
+
+    before do
+      allow(Dor::Services::Client).to receive(:objects).and_return(objects_client)
+      allow(Dor::Workflow::Client).to receive(:new).and_return(workflow_service)
+    end
+
+    it 'updates the record and does not re-register' do
+      patch "/apo/#{pid}", params: {
+        apo_form: {
+          title: 'my title',
+          agreement_object_id: 'druid:dd327rv8888',
+          default_rights: 'world',
+          default_workflows: ['registrationWF'],
+          collection: { collection: '' }
+        }
+      }
+      expect(object_client).to have_received(:update)
+      expect(objects_client).not_to have_received(:register)
+      expect(workflow_service).not_to have_received(:create_workflow_by_name)
+
+      expect(response).to redirect_to solr_document_path(pid)
     end
   end
 end

--- a/spec/requests/update_an_existing_admin_policy_spec.rb
+++ b/spec/requests/update_an_existing_admin_policy_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Update an existing Admin Policy' do
+  let(:pid) { 'druid:bc123df4567' }
+  let(:user) { create(:user) }
+  let(:object_client) do
+    instance_double(Dor::Services::Client::Object, find: cocina_model)
+  end
+  let(:cocina_model) do
+    Cocina::Models.build(
+      'label' => 'The item',
+      'version' => 1,
+      'type' => Cocina::Models::Vocab.admin_policy,
+      'externalIdentifier' => pid,
+      'description' => {
+        'title' => [{ value: 'My APO' }]
+      },
+      administrative: {
+        hasAdminPolicy: 'druid:cg532dg5405',
+        registrationWorkflow: ['registrationWF']
+      }
+    )
+  end
+
+  before do
+    sign_in user, groups: ['sdr:administrator-role']
+
+    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+  end
+
+  context 'when the parameters are invalid' do
+    it 'redraws the form' do
+      patch "/apo/#{pid}", params: { apo_form: { title: '' } }
+      expect(response).to be_successful
+    end
+  end
+end

--- a/spec/requests/update_an_existing_admin_policy_spec.rb
+++ b/spec/requests/update_an_existing_admin_policy_spec.rb
@@ -47,26 +47,47 @@ RSpec.describe 'Update an existing Admin Policy' do
     let(:objects_client) { instance_double(Dor::Services::Client::Objects, register: nil) }
     let(:workflow_service) { instance_double(Dor::Workflow::Client, create_workflow_by_name: nil) }
 
+    let(:params) do
+      {
+        apo_form: {
+          title: 'my title',
+          agreement_object_id: 'druid:dd327rv8888',
+          default_rights: rights,
+          default_workflows: ['registrationWF'],
+          collection: { collection: '' }
+        }
+      }
+    end
+
     before do
       allow(Dor::Services::Client).to receive(:objects).and_return(objects_client)
       allow(Dor::Workflow::Client).to receive(:new).and_return(workflow_service)
     end
 
-    it 'updates the record and does not re-register' do
-      patch "/apo/#{pid}", params: {
-        apo_form: {
-          title: 'my title',
-          agreement_object_id: 'druid:dd327rv8888',
-          default_rights: 'world',
-          default_workflows: ['registrationWF'],
-          collection: { collection: '' }
-        }
-      }
-      expect(object_client).to have_received(:update)
-      expect(objects_client).not_to have_received(:register)
-      expect(workflow_service).not_to have_received(:create_workflow_by_name)
+    context 'with controlledDigitalLending' do
+      let(:rights) { 'cdl-stanford-nd' }
 
-      expect(response).to redirect_to solr_document_path(pid)
+      it 'updates the record and does not re-register' do
+        patch "/apo/#{pid}", params: params
+        expect(object_client).to have_received(:update)
+        expect(objects_client).not_to have_received(:register)
+        expect(workflow_service).not_to have_received(:create_workflow_by_name)
+
+        expect(response).to redirect_to solr_document_path(pid)
+      end
+    end
+
+    context 'with citation-only' do
+      let(:rights) { 'citation-only' }
+
+      it 'updates the record and does not re-register' do
+        patch "/apo/#{pid}", params: params
+        expect(object_client).to have_received(:update)
+        expect(objects_client).not_to have_received(:register)
+        expect(workflow_service).not_to have_received(:create_workflow_by_name)
+
+        expect(response).to redirect_to solr_document_path(pid)
+      end
     end
   end
 end

--- a/spec/services/admin_policy_change_set_persister_spec.rb
+++ b/spec/services/admin_policy_change_set_persister_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe AdminPolicyChangeSetPersister do
     let(:copyright_statement) { 'My copyright statement' }
     let(:agreement_object_id) { 'druid:dd327rv8888' }
     let(:use_license) { 'https://creativecommons.org/licenses/by-nc/3.0/' }
-    let(:default_workflow) { 'registrationWF' }
+    let(:default_workflows) { ['registrationWF'] }
 
     let(:change_set) do
       instance_double(AdminPolicyChangeSet,
@@ -41,7 +41,7 @@ RSpec.describe AdminPolicyChangeSetPersister do
                       use_statement: use_statement,
                       title: 'My title',
                       agreement_object_id: agreement_object_id,
-                      default_workflow: default_workflow,
+                      default_workflows: default_workflows,
                       default_rights: 'world',
                       use_license: use_license,
                       permissions: { '0' => { name: 'developer', access: 'manage', type: 'group' },
@@ -121,7 +121,7 @@ RSpec.describe AdminPolicyChangeSetPersister do
                         use_statement: use_statement,
                         title: 'My title',
                         agreement_object_id: agreement_object_id,
-                        default_workflow: default_workflow,
+                        default_workflows: default_workflows,
                         default_rights: 'world',
                         use_license: use_license,
                         permissions: {},

--- a/spec/services/admin_policy_change_set_persister_spec.rb
+++ b/spec/services/admin_policy_change_set_persister_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AdminPolicyChangeSetPersister do
+  let(:fake_tags_client) { instance_double(Dor::Services::Client::AdministrativeTags, create: true) }
+  let(:instance) { described_class.new(apo, change_set) }
+
+  before do
+    allow(instance).to receive(:tags_client).and_return(fake_tags_client)
+  end
+
+  context 'with a persisted model (update)' do
+    let(:apo) do
+      Cocina::Models::AdminPolicy.new(
+        externalIdentifier: 'druid:zt570qh4444',
+        version: 1,
+        administrative: administrative,
+        label: 'My title',
+        type: Cocina::Models::Vocab.admin_policy,
+        description: {
+          title: [{ value: 'Exsiting title' }]
+        }
+      )
+    end
+    let(:administrative) do
+      {
+        hasAdminPolicy: 'druid:xx666zz7777'
+      }
+    end
+
+    let(:use_statement) { 'My use and reproduction statement' }
+    let(:copyright_statement) { 'My copyright statement' }
+    let(:agreement_object_id) { 'druid:dd327rv8888' }
+    let(:use_license) { 'https://creativecommons.org/licenses/by-nc/3.0/' }
+    let(:default_workflow) { 'registrationWF' }
+
+    let(:change_set) do
+      instance_double(AdminPolicyChangeSet,
+                      copyright_statement: copyright_statement,
+                      use_statement: use_statement,
+                      title: 'My title',
+                      agreement_object_id: agreement_object_id,
+                      default_workflow: default_workflow,
+                      default_rights: 'world',
+                      use_license: use_license,
+                      permissions: { '0' => { name: 'developer', access: 'manage', type: 'group' },
+                                     '1' => { name: 'service-manager', access: 'manage', type: 'group' },
+                                     '2' => { name: 'metadata-staff', access: 'manage', type: 'group' },
+                                     '3' => { name: 'justins', access: 'view', type: 'group' } },
+                      collections_for_registration: { '0' => { id: 'druid:zj785yp4820' } },
+                      collection_radio: 'none',
+                      collection: {})
+    end
+
+    let(:default_object_rights) do
+      '<?xml version="1.0" encoding="UTF-8"?><rightsMetadata>' \
+      '<access type="discover"><machine><world/></machine></access>' \
+      '<access type="read"><machine><world/></machine></access>' \
+      '<use><human type="useAndReproduction"/><human type="creativeCommons"/>' \
+      '<machine type="creativeCommons" uri=""/><human type="openDataCommons"/>' \
+      '<machine type="openDataCommons" uri=""/></use>' \
+      '<copyright><human/></copyright></rightsMetadata>'
+    end
+
+    describe '#sync' do
+      subject(:result) { instance.sync }
+
+      it 'sets clean APO metadata for defaultObjectRights' do
+        expect(result.to_h).to eq(
+          administrative: {
+            defaultAccess: {
+              access: 'world',
+              copyright: 'My copyright statement',
+              license: 'https://creativecommons.org/licenses/by-nc/3.0/',
+              useAndReproductionStatement: 'My use and reproduction statement'
+            },
+            collectionsForRegistration: ['druid:zj785yp4820'],
+            defaultObjectRights: default_object_rights,
+            hasAdminPolicy: 'druid:xx666zz7777',
+            referencesAgreement: 'druid:dd327rv8888',
+            registrationWorkflow: ['registrationWF'],
+            roles: [
+              {
+                members: [
+                  { identifier: 'sdr:developer', type: 'workgroup' },
+                  { identifier: 'sdr:service-manager', type: 'workgroup' },
+                  { identifier: 'sdr:metadata-staff', type: 'workgroup' }
+                ],
+                name: 'dor-apo-manager'
+              },
+              {
+                members: [
+                  { identifier: 'sdr:justins', type: 'workgroup' }
+                ],
+                name: 'dor-apo-viewer'
+              }
+            ]
+          },
+          description: {
+            title: [{ value: 'My title' }]
+          },
+          externalIdentifier: 'druid:zt570qh4444',
+          label: 'My title',
+          type: 'http://cocina.sul.stanford.edu/models/admin_policy.jsonld',
+          version: 1
+        )
+      end
+    end
+
+    context 'when registered by is set' do
+      subject(:update) { instance.update }
+
+      let(:object_client) { instance_double(Dor::Services::Client::Object, update: cocina_model) }
+      let(:cocina_model) do
+        instance_double(Cocina::Models::DRO, externalIdentifier: 'druid:999')
+      end
+      let(:change_set) do
+        instance_double(AdminPolicyChangeSet,
+                        copyright_statement: copyright_statement,
+                        use_statement: use_statement,
+                        title: 'My title',
+                        agreement_object_id: agreement_object_id,
+                        default_workflow: default_workflow,
+                        default_rights: 'world',
+                        use_license: use_license,
+                        permissions: {},
+                        registered_by: 'jcoyne85',
+                        collection_radio: 'none',
+                        collections_for_registration: {},
+                        collection: {})
+      end
+
+      before do
+        allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+      end
+
+      it 'hits the dor-services-app administrative tags endpoint to add tags' do
+        update
+        expect(fake_tags_client).to have_received(:create).once.with(tags: ['Registered By : jcoyne85'])
+      end
+    end
+  end
+end

--- a/spec/services/admin_policy_change_set_persister_spec.rb
+++ b/spec/services/admin_policy_change_set_persister_spec.rb
@@ -71,6 +71,8 @@ RSpec.describe AdminPolicyChangeSetPersister do
           administrative: {
             defaultAccess: {
               access: 'world',
+              controlledDigitalLending: false,
+              download: 'world',
               copyright: 'My copyright statement',
               license: 'https://creativecommons.org/licenses/by-nc/3.0/',
               useAndReproductionStatement: 'My use and reproduction statement'

--- a/spec/support/collection_method_sender.rb
+++ b/spec/support/collection_method_sender.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CollectionMethodSender
+  def initialize(cocina_request)
+    @cocina_model = cocina_request
+  end
+
+  attr_reader :cocina_model
+
+  def title=(title)
+    @cocina_model = @cocina_model.new(description: { title: [{ value: title }] })
+  end
+
+  def label=(label)
+    @cocina_model = @cocina_model.new(label: label)
+  end
+end


### PR DESCRIPTION
*NOTE* this requires the `update_descriptive` feature flag to be set to "true" in dor-services-app.

Hold for testing on stage with @andrewjbtw 

## Why was this change made?

Fixes #2420
Fixes #2622
Fixes #2621
Fixes #2379 
Fixes #2628
Fixes #2630

Ref #2418  



## How was this change tested?



## Which documentation and/or configurations were updated?



