### PR TITLE
Emit valid Cocina JSON for rendering

### DIFF
--- a/app/javascript/controllers/json_renderer.js
+++ b/app/javascript/controllers/json_renderer.js
@@ -2,10 +2,10 @@ import * as renderjson from 'renderjson'
 import { Controller } from 'stimulus'
 
 export default class extends Controller {
-  static targets = ['section']
+  static targets = ['cocina', 'section']
 
   connect() {
-    const cocina = JSON.parse(this.sectionTarget.dataset.cocina)
+    const cocina = JSON.parse(this.cocinaTarget.innerText)
     this.sectionTarget.appendChild(renderjson.set_show_to_level(1)(cocina))
   }
 }

--- a/app/views/catalog/_cocina_default.html.erb
+++ b/app/views/catalog/_cocina_default.html.erb
@@ -2,6 +2,8 @@
   Cocina Model
 </h3>
 <div id="document-cocina-section" class="document-section" style="display:none" data-controller="json-renderer">
-  <table class="detail" data-target="json-renderer.section" data-cocina='<%= @cocina.to_json.html_safe %>'>
-  </table>
+  <script type="application/json" data-target="json-renderer.cocina">
+    <%= @cocina.to_json.html_safe %>
+  </script>
+  <div class="detail" data-target="json-renderer.section"></div>
 </div>


### PR DESCRIPTION
Fixes #2531

## Why was this change made?

To prevent Cocina with quotation marks and such from borking the collapsible/expandable Cocina display. The prior implementation had the complication that the JSON was stuffed in a data tag, an HTML attribute, where quotation marks caused the HTML to prematurely terminate the attribute. Instead, stuff the JSON in its own `<script>` tag to avoid that complication.

## How was this change tested?

CI and stage

## Which documentation and/or configurations were updated?

None

