### PR TITLE
Decouples datastream controller from Fedora.

### DIFF
--- a/app/views/datastreams/edit.html.erb
+++ b/app/views/datastreams/edit.html.erb
@@ -1,12 +1,12 @@
 <%= render BlacklightModalComponent.new do |component| %>
-  <% component.with(:header, params[:dsid]) %>
+  <% component.with(:header, params[:id]) %>
   <% component.with(:body) do %>
     <% if can?(:manage_item, @cocina) %>
-      <%= form_tag item_datastream_path(@cocina.externalIdentifier, @ds.dsid), id: 'xmlEditForm', method: :patch do %>
+      <%= form_tag item_datastream_path(@cocina.externalIdentifier, params[:id]), id: 'xmlEditForm', method: :patch do %>
           <input type="hidden" name="id" value="<%= @cocina.externalIdentifier %>">
-          <input name="dsid" id="datastream" type="hidden" value="<%= params[:dsid] %>">
+          <input name="dsid" id="datastream" type="hidden" value="<%= params[:id] %>">
           <div class="form-group">
-            <textarea name="content" id="content" class='form-control'><%= @ds.content.to_s %></textarea>
+            <textarea name="content" id="content" class='form-control'><%= @content %></textarea>
           </div>
           <div class="form-group">
             <button type="submit" id="update" class="btn btn-primary">Update Datastream</button>

--- a/app/views/datastreams/show.html.erb
+++ b/app/views/datastreams/show.html.erb
@@ -1,19 +1,10 @@
 <%= render BlacklightModalComponent.new do |component| %>
-  <% component.with(:header, params[:dsid]) %>
+  <% component.with(:header, params[:id]) %>
   <% component.with(:body) do %>
     <%# If the user is a repo admin or is permitted to manage both content and %>
     <%# rights, display raw xml editing %>
     <% if can?(:manage_item, @cocina) && Settings.editable_datastreams.include?(params[:id]) %>
-      <%= link_to "Edit #{@ds.dsid}", edit_item_datastream_path(@ds.pid, @ds.dsid), title: @ds.dsid, data: { blacklight_modal: 'preserve' } %>
-    <% end %>
-
-    <% unless params[:id] == 'full_dc' %>
-      <div class="CodeRay">
-        <textarea id="content" class="form-control" rows=3 disabled>
-          <foxml:datastream ID="<%= @ds.dsid %>" STATE="<%= @ds.state %>" CONTROL_GROUP="<%= @ds.controlGroup %>" VERSIONABLE="<%= @ds.versionable %>">
-          <foxml:datastreamVersion ID="<%= @ds.dsVersionID %>" LABEL="<%= @ds.label %>" CREATED="<%= @ds.createDate&.xmlschema %>" MIMETYPE="<%= @ds.mimeType %>">
-        </textarea>
-      </div>
+      <%= link_to "Edit #{params[:id]}", edit_item_datastream_path(@cocina.externalIdentifier, params[:id]), title: params[:id], data: { blacklight_modal: 'preserve' } %>
     <% end %>
     <%= CodeRay::Duo[:xml, :div].highlight(@content).html_safe %>
   <% end %>

--- a/spec/features/item_view_metadata_spec.rb
+++ b/spec/features/item_view_metadata_spec.rb
@@ -217,8 +217,15 @@ RSpec.describe 'Item view', js: true do
         }
       end
 
+      before do
+        allow(metadata_client).to receive(:datastream)
+          .with('descMetadata')
+          .and_return('<titleInfo><title>Slides, IA 11, Geodesic Domes, Double Skin "Growth" House, N.C. State, 1953</title></titleInfo>')
+      end
+
       it 'shows the file info' do
         visit solr_document_path item_id
+
         within '.document-metadata' do
           expect(page).to have_css 'dt', text: 'DRUID:'
           expect(page).to have_css 'dd', text: item_id

--- a/spec/requests/edit_datastream_spec.rb
+++ b/spec/requests/edit_datastream_spec.rb
@@ -3,19 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe 'Draw the edit datastream form' do
-  let(:item) do
-    instance_double(Dor::Item, pid: 'druid:bc123df4567', datastreams: { 'descMetadata' => datastream })
-  end
-  let(:datastream) do
-    instance_double(Dor::DescMetadataDS, dsid: 'descMetadata', content: xml)
-  end
-
-  let(:xml) do
-    <<~XML
-      <descMetadata></descMetadata>
-    XML
-  end
-
   let(:document) do
     instance_double(SolrDocument,
                     id: 'druid:bc123df4567',
@@ -27,12 +14,17 @@ RSpec.describe 'Draw the edit datastream form' do
   let(:user) { create(:user) }
 
   context 'for content managers' do
-    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+    let(:object_client) do
+      instance_double(Dor::Services::Client::Object,
+                      find: cocina_model,
+                      metadata: metadata_client)
+    end
+    let(:metadata_client) { instance_double(Dor::Services::Client::Metadata) }
     let(:cocina_model) { instance_double(Cocina::Models::DRO, externalIdentifier: 'druid:bc123df4567') }
 
     before do
       allow(Dor::Services::Client).to receive(:object).and_return(object_client)
-      allow(Dor).to receive(:find).with('druid:bc123df4567').and_return(item)
+      allow(metadata_client).to receive(:datastream).with('descMetadata').and_return('<descMetadata></descMetadata>')
 
       sign_in create(:user), groups: ['sdr:administrator-role']
 

--- a/spec/requests/update_datastream_spec.rb
+++ b/spec/requests/update_datastream_spec.rb
@@ -62,24 +62,6 @@ RSpec.describe 'Update a datastream' do
       end
     end
 
-    context 'for an uncommon datastream (as on an old ETD)' do
-      before do
-        allow(Dor).to receive(:find).with(pid).and_return(item)
-        allow(item).to receive_messages(save: nil)
-      end
-
-      let(:item) { Dor::Item.new pid: pid }
-
-      it 'updates the datastream' do
-        expect(item).to receive(:datastreams).and_return(
-          'properties' => double(ActiveFedora::Datastream, 'content=': xml)
-        )
-        expect(item).to receive(:save)
-        patch "/items/#{pid}/datastreams/properties", params: { content: xml }
-        expect(response).to redirect_to "/view/#{pid}"
-      end
-    end
-
     it 'errors on empty xml' do
       expect { patch "/items/#{pid}/datastreams/contentMetadata", params: { content: ' ' } }.to raise_error(ArgumentError)
     end

--- a/spec/views/datastreams/show.html.erb_spec.rb
+++ b/spec/views/datastreams/show.html.erb_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe 'datastreams/show.html.erb' do
     params[:id] = dsid
     params[:item_id] = pid
     allow(view).to receive(:can?).and_return(true)
-    @obj = obj
-    @ds = Dor::IdentityMetadataDS.new(obj, 'identityMetadata')
+    @cocina = cocina
+    @content = '<identityMetadata></identityMetadata>'
   end
 
   let(:pid) { 'druid:abc123' }
-  let(:obj) { instance_double(Dor::Item, pid: pid) }
+  let(:cocina) { instance_double(Cocina::Models::DRO, externalIdentifier: pid) }
 
   context 'with an editable datastream' do
     let(:dsid) { 'identityMetadata' }


### PR DESCRIPTION
closes #2437

## Why was this change made?
Less Fedora, more DOR services app.


## How was this change tested?
Unit, QA


## Which documentation and/or configurations were updated?
NA


