### PR TITLE
allow book reading direction to be set with content type updates

### DIFF
--- a/app/controllers/content_types_controller.rb
+++ b/app/controllers/content_types_controller.rb
@@ -48,20 +48,16 @@ class ContentTypesController < ApplicationController
   end
 
   def old_content_type
-    if @cocina_object.type == 'http://cocina.sul.stanford.edu/models/book.jsonld' && @cocina_object.structural.hasMemberOrders[0]&.viewingDirection == 'right-to-left'
+    if @cocina_object.type == Cocina::Models::Vocab.book && @cocina_object.structural.hasMemberOrders[0]&.viewingDirection == 'right-to-left'
       # if we have a book type, we need to also check the viewing direction
       'book (rtl)'
     else
-      Constants::CONTENT_TYPES.key(@cocina_object.type)
+      Constants::CONTENT_TYPES.key(@cocina_object.type) || ''
     end
-  rescue StandardError
-    ''
   end
 
   def old_resource_type
-    Constants::RESOURCE_TYPES.key(@cocina_object.structural.contains.first.type)
-  rescue StandardError
-    ''
+    Constants::RESOURCE_TYPES.key(@cocina_object.structural.contains&.first&.type) || ''
   end
 
   def new_content_type

--- a/app/controllers/content_types_controller.rb
+++ b/app/controllers/content_types_controller.rb
@@ -48,7 +48,7 @@ class ContentTypesController < ApplicationController
   end
 
   def old_content_type
-    if @cocina_object.type == Cocina::Models::Vocab.book && @cocina_object.structural.hasMemberOrders[0]&.viewingDirection == 'right-to-left'
+    if @cocina_object.type == Cocina::Models::Vocab.book && @cocina_object.structural.hasMemberOrders&.first&.viewingDirection == 'right-to-left'
       # if we have a book type, we need to also check the viewing direction
       'book (rtl)'
     else
@@ -57,6 +57,8 @@ class ContentTypesController < ApplicationController
   end
 
   def old_resource_type
+    return '' if [Cocina::Models::Vocab.collection, Cocina::Models::Vocab.admin_policy].include? @cocina_object.type
+
     Constants::RESOURCE_TYPES.key(@cocina_object.structural.contains&.first&.type) || ''
   end
 

--- a/app/controllers/content_types_controller.rb
+++ b/app/controllers/content_types_controller.rb
@@ -40,6 +40,14 @@ class ContentTypesController < ApplicationController
     {}.tap do |attributes|
       attributes[:type] = Constants::CONTENT_TYPES[params[:new_content_type]] if content_type_should_change?
       attributes[:structural] = structural_with_resource_type_changes if resource_types_should_change?
+
+      # The book content type is a special case, since we need to deal with the rtl vs ltr viewing direction attribute update
+      case params[:new_content_type]
+      when 'book (ltr)'
+        attributes[:structural][:hasMemberOrders] = [{ viewingDirection: 'left-to-right' }]
+      when 'book (rtl)'
+        attributes[:structural][:hasMemberOrders] = [{ viewingDirection: 'right-to-left' }]
+      end
     end
   end
 

--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -25,17 +25,8 @@ module RegistrationHelper
   end
 
   def valid_content_types
-    [
-      'Book (ltr)',
-      'Book (rtl)',
-      'File',
-      'Image',
-      'Map',
-      'Media',
-      '3D',
-      'Document',
-      'Geo',
-      'Webarchive-seed'
-    ]
+    # the content types selectable in registration are capitalized but match what is available when setting content types
+    #  in the bulk and item detail page for setting content types (exception: '3d' needs to go '3D')
+    Constants::CONTENT_TYPES.keys.map { |content_type| content_type == '3d' ? '3D' : content_type.capitalize }
   end
 end

--- a/app/views/content_types/_content_type.html.erb
+++ b/app/views/content_types/_content_type.html.erb
@@ -3,33 +3,23 @@
 <p>More complex updates should be executed by hand on the datastream XML.</p>
 
 <%= form_tag item_content_type_path(item_id: @cocina_object.externalIdentifier), id: 'content_type_form', method: :patch do %>
-  <% old_content_type = begin
-                          Constants::CONTENT_TYPES.key(@cocina_object.type)
-                        rescue StandardError
-                          ''
-                        end %>
-  <% old_resource_type = begin
-                           Constants::RESOURCE_TYPES.key(@cocina_object.structural.contains.first.type)
-                         rescue StandardError
-                           ''
-                         end %>
   <% display_content_types = [['none', '']] + Constants::CONTENT_TYPES.keys %>
   <% display_resource_types = [['none', '']] + Constants::RESOURCE_TYPES.keys %>
   <div class='form-group'>
-    <label>Old content type</label>
-    <%= old_content_type %><%= hidden_field_tag :old_content_type, old_content_type %>
+    <label>Old content type</label>:
+    <%= @old_content_type %><%= hidden_field_tag :old_content_type, @old_content_type %>
   </div>
   <div class='form-group'>
     <label>Old resource type</label>
-    <%= select_tag :old_resource_type, options_for_select(display_resource_types, old_resource_type), class: 'form-control' %>
+    <%= select_tag :old_resource_type, options_for_select(display_resource_types, @old_resource_type), class: 'form-control' %>
   </div>
   <div class='form-group'>
     <label>New content type</label>
-    <%= select_tag :new_content_type, options_for_select(display_content_types, old_content_type), class: 'form-control' %>
+    <%= select_tag :new_content_type, options_for_select(display_content_types, @old_content_type), class: 'form-control' %>
   </div>
   <div class='form-group'>
     <label>New resource type</label>
-    <%= select_tag :new_resource_type, options_for_select(display_resource_types, old_resource_type), class: 'form-control' %>
+    <%= select_tag :new_resource_type, options_for_select(display_resource_types, @old_resource_type), class: 'form-control' %>
   </div>
   <button class='btn btn-primary'>Update</button>
 <% end %>

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -50,13 +50,14 @@ module Constants
   ].freeze
 
   CONTENT_TYPES = {
-    'image' => Cocina::Models::Vocab.image,
-    'book' => Cocina::Models::Vocab.book,
+    'book (ltr)' => Cocina::Models::Vocab.book,
+    'book (rtl)' => Cocina::Models::Vocab.book,
     'file' => Cocina::Models::Vocab.object,
+    'image' => Cocina::Models::Vocab.image,
     'map' => Cocina::Models::Vocab.map,
     'media' => Cocina::Models::Vocab.media,
-    'document' => Cocina::Models::Vocab.document,
     '3d' => Cocina::Models::Vocab.three_dimensional,
+    'document' => Cocina::Models::Vocab.document,
     'geo' => Cocina::Models::Vocab.geo,
     'webarchive-seed' => Cocina::Models::Vocab.webarchive_seed
   }.freeze

--- a/spec/controllers/content_types_controller_spec.rb
+++ b/spec/controllers/content_types_controller_spec.rb
@@ -83,10 +83,30 @@ RSpec.describe ContentTypesController, type: :controller do
     let(:state_service) { instance_double(StateService, allows_modification?: true) }
 
     context 'with access' do
-      it 'is successful at changing the content type' do
+      it 'is successful at changing the content type to media' do
         patch :update, params: { item_id: pid, old_content_type: 'image', new_content_type: 'media' }
         expect(response).to redirect_to solr_document_path(pid)
-        expect(object_client).to have_received(:update).with(params: a_cocina_object_with_types(content_type: Cocina::Models::Vocab.media)).once
+        expect(object_client).to have_received(:update)
+          .with(params: a_cocina_object_with_types(content_type: Cocina::Models::Vocab.media, viewing_direction: nil))
+          .once
+        expect(Argo::Indexer).to have_received(:reindex_pid_remotely).once
+      end
+
+      it 'is successful at changing the content type to book (ltr)' do
+        patch :update, params: { item_id: pid, old_content_type: 'image', new_content_type: 'book (ltr)' }
+        expect(response).to redirect_to solr_document_path(pid)
+        expect(object_client).to have_received(:update)
+          .with(params: a_cocina_object_with_types(content_type: Cocina::Models::Vocab.book, viewing_direction: 'left-to-right'))
+          .once
+        expect(Argo::Indexer).to have_received(:reindex_pid_remotely).once
+      end
+
+      it 'is successful at changing the content type to book (rtl)' do
+        patch :update, params: { item_id: pid, old_content_type: 'image', new_content_type: 'book (rtl)' }
+        expect(response).to redirect_to solr_document_path(pid)
+        expect(object_client).to have_received(:update)
+          .with(params: a_cocina_object_with_types(content_type: Cocina::Models::Vocab.book, viewing_direction: 'right-to-left'))
+          .once
         expect(Argo::Indexer).to have_received(:reindex_pid_remotely).once
       end
 

--- a/spec/controllers/content_types_controller_spec.rb
+++ b/spec/controllers/content_types_controller_spec.rb
@@ -11,11 +11,12 @@ RSpec.describe ContentTypesController, type: :controller do
   let(:pid) { 'druid:bc123df4567' }
   let(:user) { create :user }
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, update: true) }
+  let(:content_type) { Cocina::Models::Vocab.image }
   let(:cocina_model) do
     Cocina::Models.build(
       'label' => 'My Item',
       'version' => 1,
-      'type' => Cocina::Models::Vocab.image,
+      'type' => content_type,
       'externalIdentifier' => pid,
       'access' => {
         'access' => 'world'
@@ -25,51 +26,128 @@ RSpec.describe ContentTypesController, type: :controller do
       'identification' => {}
     )
   end
+  let(:cocina_model_with_member_order) do
+    Cocina::Models.build(
+      'label' => 'My Item',
+      'version' => 1,
+      'type' => content_type,
+      'externalIdentifier' => pid,
+      'access' => {
+        'access' => 'world'
+      },
+      'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+      'structural' => structural_with_member_orders,
+      'identification' => {}
+    )
+  end
+  let(:contains) do
+    [
+      Cocina::Models::FileSet.new(
+        externalIdentifier: 'bc123df4567_2',
+        type: Cocina::Models::Vocab::Resources.document,
+        label: 'document files',
+        version: 1,
+        structural: Cocina::Models::FileSetStructural.new(
+          contains: [
+            Cocina::Models::File.new(
+              externalIdentifier: 'bc123df4567.pdf',
+              type: Cocina::Models::Vocab.file,
+              label: 'the PDF',
+              filename: 'bc123df4567.pdf',
+              version: 1
+            )
+          ]
+        )
+      ),
+      Cocina::Models::FileSet.new(
+        externalIdentifier: 'bc123df4567_2',
+        type: Cocina::Models::Vocab::Resources.image,
+        label: 'image files',
+        version: 1,
+        structural: Cocina::Models::FileSetStructural.new(
+          contains: [
+            Cocina::Models::File.new(
+              externalIdentifier: 'bc123df4567.png',
+              type: Cocina::Models::Vocab.file,
+              label: 'the PNG',
+              filename: 'bc123df4567.png',
+              version: 1
+            )
+          ]
+        )
+      )
+    ]
+  end
   let(:structural) do
     Cocina::Models::DROStructural.new(
-      contains: [
-        Cocina::Models::FileSet.new(
-          externalIdentifier: 'bc123df4567_2',
-          type: Cocina::Models::Vocab::Resources.document,
-          label: 'document files',
-          version: 1,
-          structural: Cocina::Models::FileSetStructural.new(
-            contains: [
-              Cocina::Models::File.new(
-                externalIdentifier: 'bc123df4567.pdf',
-                type: Cocina::Models::Vocab.file,
-                label: 'the PDF',
-                filename: 'bc123df4567.pdf',
-                version: 1
-              )
-            ]
-          )
-        ),
-        Cocina::Models::FileSet.new(
-          externalIdentifier: 'bc123df4567_2',
-          type: Cocina::Models::Vocab::Resources.image,
-          label: 'image files',
-          version: 1,
-          structural: Cocina::Models::FileSetStructural.new(
-            contains: [
-              Cocina::Models::File.new(
-                externalIdentifier: 'bc123df4567.png',
-                type: Cocina::Models::Vocab.file,
-                label: 'the PNG',
-                filename: 'bc123df4567.png',
-                version: 1
-              )
-            ]
-          )
-        )
-      ]
+      contains: contains
+    )
+  end
+  let(:structural_with_member_orders) do
+    Cocina::Models::DROStructural.new(
+      hasMemberOrders: [{ viewingDirection: reading_order }],
+      contains: contains
     )
   end
 
-  describe 'show' do
-    it 'is successful' do
-      get :show, params: { item_id: pid }
-      expect(response).to be_successful
+  describe '#show' do
+    context 'with no reading direction (memberOrder) set' do
+      context 'for an object with an image content type' do
+        let(:content_type) { Cocina::Models::Vocab.image }
+
+        it 'is successful' do
+          get :show, params: { item_id: pid }
+          expect(response).to be_successful
+          expect(controller.send(:old_content_type)).to eq 'image'
+        end
+      end
+
+      context 'for an object with a book content type' do
+        let(:content_type) { Cocina::Models::Vocab.book }
+
+        it 'is successful' do
+          get :show, params: { item_id: pid }
+          expect(response).to be_successful
+          expect(controller.send(:old_content_type)).to eq 'book (ltr)'
+        end
+      end
+    end
+
+    context 'with a specific reading direction (memberOrder) set' do
+      let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model_with_member_order, update: true) }
+
+      context 'for an object with an image content type and memberOrder of left-to-right' do
+        let(:content_type) { Cocina::Models::Vocab.image }
+        let(:reading_order) { 'left-to-right' }
+
+        it 'is successful' do
+          get :show, params: { item_id: pid }
+          expect(response).to be_successful
+          expect(controller.send(:old_content_type)).to eq 'image'
+        end
+      end
+
+      context 'for an object with a book content type and memberOrder of left-to-right' do
+        let(:content_type) { Cocina::Models::Vocab.book }
+        let(:reading_order) { 'left-to-right' }
+
+        it 'is successful' do
+          get :show, params: { item_id: pid }
+          expect(response).to be_successful
+          expect(controller.send(:old_content_type)).to eq 'book (ltr)'
+        end
+      end
+
+      context 'for an object with a book content type and memberOrder of right-to-left' do
+        let(:content_type) { Cocina::Models::Vocab.book }
+        let(:reading_order) { 'right-to-left' }
+
+        it 'is successful' do
+          get :show, params: { item_id: pid }
+          expect(response).to be_successful
+          expect(controller.send(:old_content_type)).to eq 'book (rtl)'
+        end
+      end
     end
   end
 

--- a/spec/features/item_registration_spec.rb
+++ b/spec/features/item_registration_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe 'Item registration page', js: true do
 
     find("option[value='goobiWF']")
     select 'goobiWF', from: 'workflow_id'
+    select 'Book (ltr)', from: 'content_type'
 
     fill_in 'tags_0', with: 'tag : test'
 

--- a/spec/helpers/registration_helper_spec.rb
+++ b/spec/helpers/registration_helper_spec.rb
@@ -33,6 +33,12 @@ RSpec.describe RegistrationHelper do
     end
   end
 
+  describe '#valid_content_types' do
+    it 'returns the expected content types in the expected order' do
+      expect(valid_content_types).to eq ['Book (ltr)', 'Book (rtl)', 'File', 'Image', 'Map', 'Media', '3D', 'Document', 'Geo', 'Webarchive-seed']
+    end
+  end
+
   it 'returns nothing when permission_keys is empty' do
     expect(Dor::SearchService).not_to receive(:query)
     expect(apo_list([])).to eq []

--- a/spec/support/cocina_matchers.rb
+++ b/spec/support/cocina_matchers.rb
@@ -5,6 +5,8 @@ RSpec::Matchers.define :a_cocina_object_with_types do |expected|
   match do |actual|
     if expected[:content_type] && expected[:resource_types]
       match_cocina_type?(actual, expected) && match_contained_cocina_types?(actual, expected)
+    elsif expected[:content_type] && expected[:viewing_direction]
+      match_cocina_type?(actual, expected) && match_cocina_viewing_direction?(actual, expected)
     elsif expected[:content_type]
       match_cocina_type?(actual, expected)
     elsif expected[:resource_types]
@@ -16,6 +18,10 @@ RSpec::Matchers.define :a_cocina_object_with_types do |expected|
 
   def match_cocina_type?(actual, expected)
     actual.type == expected[:content_type]
+  end
+
+  def match_cocina_viewing_direction?(actual, expected)
+    actual.structural.hasMemberOrders.map(&:viewingDirection).all? { |viewing_direction| viewing_direction.in?(expected[:viewing_direction]) }
   end
 
   def match_contained_cocina_types?(actual, expected)

--- a/spec/support/cocina_matchers.rb
+++ b/spec/support/cocina_matchers.rb
@@ -21,7 +21,7 @@ RSpec::Matchers.define :a_cocina_object_with_types do |expected|
   end
 
   def match_cocina_viewing_direction?(actual, expected)
-    actual.structural.hasMemberOrders.map(&:viewingDirection).all? { |viewing_direction| viewing_direction.in?(expected[:viewing_direction]) }
+    actual.structural.hasMemberOrders.map(&:viewingDirection).all? { |viewing_direction| viewing_direction == expected[:viewing_direction] }
   end
 
   def match_contained_cocina_types?(actual, expected)


### PR DESCRIPTION
## Why was this change made?

~~NOTE: If would best to review, merge and deploy sul-dlss/dor-services-app#2605 first, though if done out of order, this would just result in a `<bookData>` node being left behind in contentMetada if you switched from a book type to a non book type.~~ <-- merged

Fixes #2534 - allow book type content type updates to set reading direction like they do at registration

Note: with this PR the reading direction will be set/removed correctly in the cocina model, but it does not get removed from contentMetadata if you change from a book type to a non-book type.  As noted above, this problem is fixed in sul-dlss/dor-services-app#2605, in the part of the code that translates the cocina model data back into contentMetadata.

## How was this change tested?

Updated tests and verified on argo-qa


## Which documentation and/or configurations were updated?



