### PR TITLE
Prevent error retrieving list of collections for registration

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -110,6 +110,6 @@ class RegistrationsController < ApplicationController
   end
 
   def registration_collection_ids_for_apo
-    object_client.find.administrative.collectionsForRegistration
+    Array(object_client.find.administrative.collectionsForRegistration)
   end
 end

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -231,6 +231,8 @@ RSpec.describe RegistrationsController, type: :controller do
     end
 
     context 'when there are no collections' do
+      let(:collections) { nil }
+
       it 'shows "None"' do
         get 'collection_list', params: { apo_id: druid, format: :json }
         data = JSON.parse(response.body)


### PR DESCRIPTION

## Why was this change made?

This occurs when an APO has no collections for registration.
Fixes #2564
Fixes #2565 
## How was this change tested?



## Which documentation and/or configurations were updated?



