### PR TITLE
Update content metadata rendering to support the opaque ids now used …

### DIFF
--- a/app/components/contents/file_component.rb
+++ b/app/components/contents/file_component.rb
@@ -2,12 +2,13 @@
 
 module Contents
   class FileComponent < ViewComponent::Base
-    def initialize(file:, viewable:)
+    def initialize(file:, object_id:, viewable:)
       @file = file
+      @object_id = object_id
       @viewable = viewable
     end
 
-    attr_reader :file
+    attr_reader :file, :object_id
 
     def viewable?
       @viewable
@@ -16,9 +17,7 @@ module Contents
     delegate :access, :administrative, :filename, :hasMimeType, :size, :externalIdentifier, to: :file
 
     def link_attrs
-      # TODO: we should avoid having to parse meaning out of identifiers
-      object_id, file_id = externalIdentifier.split('/')
-      { item_id: object_id, id: file_id }
+      { item_id: object_id, id: filename }
     end
 
     def routing

--- a/app/components/contents/resource_component.html.erb
+++ b/app/components/contents/resource_component.html.erb
@@ -4,7 +4,7 @@
     <br><span class="label">Label</span> <%= label %>
   <% end %>
   <ul class="child-list">
-    <%= render Contents::FileComponent.with_collection(files, viewable: viewable?) %>
+    <%= render Contents::FileComponent.with_collection(files, object_id: object_id, viewable: viewable?) %>
     <%# TODO: external files%>
   </ul>
 </li>

--- a/app/components/contents/resource_component.rb
+++ b/app/components/contents/resource_component.rb
@@ -2,13 +2,14 @@
 
 module Contents
   class ResourceComponent < ViewComponent::Base
-    def initialize(resource:, resource_counter:, viewable:)
+    def initialize(resource:, resource_counter:, object_id:, viewable:)
       @resource = resource
       @resource_counter = resource_counter
+      @object_id = object_id
       @viewable = viewable
     end
 
-    attr_reader :resource, :resource_counter
+    attr_reader :resource, :resource_counter, :object_id
 
     def viewable?
       @viewable

--- a/app/components/contents/structural_component.html.erb
+++ b/app/components/contents/structural_component.html.erb
@@ -1,3 +1,3 @@
 <ul class="resource-list">
-  <%= render Contents::ResourceComponent.with_collection(structural.contains, viewable: viewable?) %>
+  <%= render Contents::ResourceComponent.with_collection(structural.contains, object_id: object_id, viewable: viewable?) %>
 </ul>

--- a/app/components/contents/structural_component.rb
+++ b/app/components/contents/structural_component.rb
@@ -2,12 +2,13 @@
 
 module Contents
   class StructuralComponent < ViewComponent::Base
-    def initialize(structural:, viewable:)
+    def initialize(structural:, object_id:, viewable:)
       @structural = structural
       @viewable = viewable
+      @object_id = object_id
     end
 
-    attr_reader :structural
+    attr_reader :structural, :object_id
 
     def viewable?
       @viewable

--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -13,7 +13,7 @@ class FilesController < ApplicationController
 
     @has_been_accessioned = WorkflowClientFactory.build.lifecycle(druid: params[:item_id], milestone_name: 'accessioned')
     files = @cocina_model.structural.contains.map { |fs| fs.structural.contains }.flatten
-    @file = files.find { |file| file.externalIdentifier == "#{params[:item_id]}/#{params[:id]}" }
+    @file = files.find { |file| file.filename == params[:id] }
 
     if @has_been_accessioned
       begin

--- a/app/views/catalog/_contents_default.html.erb
+++ b/app/views/catalog/_contents_default.html.erb
@@ -11,7 +11,7 @@
     <% end %>
     <span class="label">Type</span>
     <%= document.content_type %>
-    <%= render Contents::StructuralComponent.new(structural: @cocina.structural, viewable: can?(:view_content, @cocina)) %>
+    <%= render Contents::StructuralComponent.new(structural: @cocina.structural, object_id: @cocina.externalIdentifier, viewable: can?(:view_content, @cocina)) %>
   <% else %>
     <span class="label">Preservation Size</span> 0 bytes
   <% end %>

--- a/spec/components/contents/file_component_spec.rb
+++ b/spec/components/contents/file_component_spec.rb
@@ -3,12 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Contents::FileComponent, type: :component do
-  let(:component) { described_class.new(file: file, viewable: true) }
+  let(:component) { described_class.new(file: file, object_id: 'druid:kb487gt5106', viewable: true) }
   let(:rendered) { render_inline(component) }
   let(:file) do
     instance_double(Cocina::Models::File,
                     filename: '0220_MLK_Kids_Gadson_459-25.tif',
-                    externalIdentifier: 'druid:kb487gt5106/0220_MLK_Kids_Gadson_459-25.tif',
+                    externalIdentifier: 'http://cocina.sul.stanford.edu/file/b7cdfa7a-6e1f-484b-bbb0-f9a46c40dbb4',
                     hasMimeType: 'image/tiff',
                     size: 99,
                     access: access,

--- a/spec/controllers/files_controller_spec.rb
+++ b/spec/controllers/files_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe FilesController, type: :controller do
     instance_double(Cocina::Models::FileSetStructural, contains: [file])
   end
   let(:file) do
-    instance_double(Cocina::Models::File, filename: "M1090_S15_B01_F07_0106.jp2")
+    instance_double(Cocina::Models::File, filename: 'M1090_S15_B01_F07_0106.jp2')
   end
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
 

--- a/spec/controllers/files_controller_spec.rb
+++ b/spec/controllers/files_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe FilesController, type: :controller do
     instance_double(Cocina::Models::FileSetStructural, contains: [file])
   end
   let(:file) do
-    instance_double(Cocina::Models::File, externalIdentifier: "#{pid}/M1090_S15_B01_F07_0106.jp2")
+    instance_double(Cocina::Models::File, filename: "M1090_S15_B01_F07_0106.jp2")
   end
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
 

--- a/spec/features/collection_manage_release_spec.rb
+++ b/spec/features/collection_manage_release_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe 'Collection manage release' do
   let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, create: true) }
   let(:cocina_model) do
     instance_double(Cocina::Models::DRO,
+                    externalIdentifier: 'druid:999', 
                     administrative: administrative,
                     structural: structural,
                     as_json: {})

--- a/spec/features/collection_manage_release_spec.rb
+++ b/spec/features/collection_manage_release_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Collection manage release' do
   let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, create: true) }
   let(:cocina_model) do
     instance_double(Cocina::Models::DRO,
-                    externalIdentifier: 'druid:999', 
+                    externalIdentifier: 'druid:999',
                     administrative: administrative,
                     structural: structural,
                     as_json: {})


### PR DESCRIPTION
…by the API



## Why was this change made?

Fixes #2563

## How was this change tested?



## Which documentation and/or configurations were updated?



