### PR TITLE
Removed a sort field that doesn't exist

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -170,7 +170,6 @@ class CatalogController < ApplicationController
     config.add_search_field 'text', label: 'All Fields'
     config.add_sort_field 'id asc', label: 'Druid'
     config.add_sort_field 'score desc', label: 'Relevance'
-    config.add_sort_field 'creator_title_ssi asc', label: 'Creator and Title'
 
     config.spell_max = 5
 

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Search results' do
         expect(page).to have_css 'a.btn.btn-outline-secondary', text: 'Bulk Action'
         within '#sort-dropdown' do
           expect(page).to have_css 'button', text: 'Sort by Druid'
-          expect(page).to have_css '.dropdown-item', count: 3
+          expect(page).to have_css '.dropdown-item', count: 2
         end
         within '#per_page-dropdown' do
           expect(page).to have_css 'button', text: '10 per page'


### PR DESCRIPTION


## Why was this change made?

This was added in https://github.com/sul-dlss/argo/commit/893a1eb1cabe58623e2320b76af68adfa6fd3a46 but we never actually indexed into that field

## How was this change tested?



## Which documentation and/or configurations were updated?



