### PR TITLE
Remove scale from qf

### DIFF
--- a/app/helpers/blacklight_config_helper.rb
+++ b/app/helpers/blacklight_config_helper.rb
@@ -15,7 +15,6 @@ module BlacklightConfigHelper
         originInfo_place_placeTerm_tesim
         originInfo_publisher_tesim
         sw_display_title_tesim
-        scale_ssim
         source_id_ssim
         tag_ssim
         title_tesim


### PR DESCRIPTION


## Why was this change made?
Scale is not a useful field to search with, it's for display


## How was this change tested?



## Which documentation and/or configurations were updated?



