### PR TITLE
Remove obsolete field title_tesim

### DIFF
--- a/app/helpers/blacklight_config_helper.rb
+++ b/app/helpers/blacklight_config_helper.rb
@@ -18,7 +18,6 @@ module BlacklightConfigHelper
         scale_ssim
         source_id_ssim
         tag_ssim
-        title_tesim
         topic_tesim
       ),
       facet: true,


### PR DESCRIPTION


## Why was this change made?
Nothing sets this: https://sul-solr-prod-a.stanford.edu/solr/argo3_prod/select?fl=id+title_tesim&q=title_tesim%3A*


## How was this change tested?



## Which documentation and/or configurations were updated?



