### PR TITLE
Get rid of unused ActiveFedora mocks

### DIFF
--- a/spec/controllers/content_types_controller_spec.rb
+++ b/spec/controllers/content_types_controller_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe ContentTypesController, type: :controller do
   end
 
   let(:pid) { 'druid:bc123df4567' }
-  let(:item) { Dor::Item.new(pid: pid) }
   let(:user) { create :user }
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, update: true) }
   let(:cocina_model) do

--- a/spec/controllers/dor/objects_controller_spec.rb
+++ b/spec/controllers/dor/objects_controller_spec.rb
@@ -5,11 +5,9 @@ require 'rails_helper'
 RSpec.describe Dor::ObjectsController, type: :controller do
   before do
     sign_in(create(:user))
-    allow(Dor).to receive(:find).with(pid).and_return(mock_object)
   end
 
   let(:pid) { 'druid:abc' }
-  let(:mock_object) { instance_double(Dor::Item) }
   let(:workflow_service) { instance_double(Dor::Workflow::Client, create_workflow_by_name: nil) }
   let(:object_client) { instance_double(Dor::Services::Client::Object, administrative_tags: administrative_tags) }
   let(:administrative_tags) { instance_double(Dor::Services::Client::AdministrativeTags, create: true) }

--- a/spec/controllers/versions_controller_spec.rb
+++ b/spec/controllers/versions_controller_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 RSpec.describe VersionsController, type: :controller do
   let(:pid) { 'druid:bc123df4567' }
-  let(:item) { Dor::Item.new pid: pid }
   let(:object_service) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
   let(:cocina_model) do
     Cocina::Models.build(

--- a/spec/features/item_manage_release_spec.rb
+++ b/spec/features/item_manage_release_spec.rb
@@ -5,16 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Item manage release' do
   let(:current_user) { create(:user, sunetid: 'esnowden') }
   before do
-    obj = instance_double(
-      Dor::Item,
-      current_version: '1',
-      admin_policy_object: nil,
-      datastreams: {},
-      catkey: nil,
-      identityMetadata: double(ng_xml: Nokogiri::XML(''))
-    )
     sign_in current_user, groups: ['sdr:administrator-role']
-    allow(Dor).to receive(:find).and_return(obj)
     allow(StateService).to receive(:new).and_return(state_service)
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
   end

--- a/spec/features/item_view_metadata_spec.rb
+++ b/spec/features/item_view_metadata_spec.rb
@@ -10,29 +10,10 @@ RSpec.describe 'Item view', js: true do
     allow(Dor::Workflow::Client).to receive(:new).and_return(workflow_client)
     allow(Preservation::Client.objects).to receive(:current_version).and_return('1')
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
-    allow(Dor).to receive(:find).and_return(obj)
-    allow(obj).to receive(:new_record?).and_return(false)
-    obj.descMetadata.mods_title = 'Slides, IA 11, Geodesic Domes, Double Skin "Growth" House, N.C. State, 1953'
-    allow(obj.descMetadata).to receive(:new?).and_return(false) # Must come after setting properties
-    obj.contentMetadata.content = <<~XML
-      <contentMetadata type="file">
-        <resource type="image" sequence="126" id="hj185xx2222_126">
-          <label>M1090_S15_B02_F01_0126</label>
-          <file mimetype="image/jp2" preserve="yes" format="JPEG2000" size="3304904" shelve="yes" id="M1090_S15_B02_F01_0126.jp2" publish="yes">
-            <imageData width="5033" height="3472"/>
-            <attr name="representation">uncropped</attr>
-            <checksum type="sha1">a992c8237b640b4ea413dfd3baec5e8972f53613</checksum>
-            <checksum type="md5">f92f9722cb9993dd35fdea6a2219b673</checksum>
-          </file>
-        </resource>
-      </contentMetadata>
-    XML
-    allow(obj.contentMetadata).to receive(:new?).and_return(false)
   end
 
   let(:blacklight_config) { CatalogController.blacklight_config }
   let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
-  let(:obj) { Dor::Item.new(pid: item_id) }
   let(:item_id) { 'druid:hj185xx2222' }
   let(:event) { Dor::Services::Client::Events::Event.new(event_type: 'shelve_request_received', data: { 'host' => 'dor-services-stage.stanford.edu' }) }
   let(:datastream) { Dor::Services::Client::Metadata::Datastream.new(dsid: 'descMetadata', pid: item_id) }

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -5,8 +5,6 @@ require 'cancan/matchers'
 
 RSpec.describe Ability do
   let(:subject) { described_class.new(user) }
-  let(:item) { Dor::Item.new(pid: 'x') }
-
   let(:dro) do
     Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
                             label: 'test',
@@ -52,15 +50,8 @@ RSpec.describe Ability do
   let(:manager) { false }
   let(:viewer) { false }
   let(:roles) { [] }
-
   let(:new_apo_id) { 'druid:hv992yv2222' }
   let(:new_apo) { Dor::AdminPolicyObject.new(pid: new_apo_id) }
-
-  let(:item_with_apo) { Dor::Item.new(pid: 'y') }
-
-  before do
-    allow(item_with_apo).to receive(:admin_policy_object).and_return(new_apo)
-  end
 
   context 'as an administrator' do
     let(:admin) { true }

--- a/spec/models/workflow_status_spec.rb
+++ b/spec/models/workflow_status_spec.rb
@@ -28,8 +28,6 @@ RSpec.describe WorkflowStatus do
       end-accession
     ]
   end
-  let(:pid) { 'druid:bc123df4567' }
-  let(:item) { Dor::Item.new pid: pid }
 
   describe '#pid' do
     subject { workflow_status.pid }

--- a/spec/presenters/buttons_presenter_spec.rb
+++ b/spec/presenters/buttons_presenter_spec.rb
@@ -19,17 +19,11 @@ RSpec.describe ButtonsPresenter, type: :presenter do
       allow(StateService).to receive(:new).and_return(state_service)
     end
 
-    context 'a Dor::Item the user can manage, with the usual data streams, and no catkey or embargo info' do
+    context 'a DRO the user can manage, with the usual data streams, and no catkey or embargo info' do
       subject(:buttons) { presenter.buttons }
 
       let(:item_id) { 'druid:kv840xx0000' }
-      let(:governing_apo) { instance_double(Dor::AdminPolicyObject, pid: governing_apo_id) }
-      let(:object) do
-        instance_double(Dor::Item, pid: item_id, current_version: '3',
-                                   admin_policy_object: governing_apo,
-                                   embargoed?: false,
-                                   catkey: catkey)
-      end
+
       let(:doc) do
         SolrDocument.new('id' => item_id,
                          'processing_status_text_ssi' => 'not registered',
@@ -154,13 +148,8 @@ RSpec.describe ButtonsPresenter, type: :presenter do
       end
     end
 
-    context 'a Dor::AdminPolicyObject the user can manage' do
+    context 'an AdminPolicy the user can manage' do
       let(:view_apo_id) { 'druid:zt570qh4444' }
-      let(:object) do
-        instance_double(Dor::AdminPolicyObject,
-                        current_version: '3',
-                        catkey: nil)
-      end
 
       let(:doc) do
         SolrDocument.new('id' => view_apo_id,
@@ -250,7 +239,6 @@ RSpec.describe ButtonsPresenter, type: :presenter do
       instance_double(Dor::IdentityMetadataDS)
     end
     let(:item_id) { 'druid:kv840xx0000' }
-    let(:object) { instance_double(Dor::Item, pid: item_id, current_version: '3') }
 
     context 'when registered' do
       let(:doc) do

--- a/spec/requests/manage_release_spec.rb
+++ b/spec/requests/manage_release_spec.rb
@@ -3,9 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe 'Draw the manage release form' do
-  # let(:item) do
-  #   instance_double(Dor::Item, pid: 'druid:bc123df4567')
-  # end
   let(:document) do
     instance_double(SolrDocument,
                     id: 'druid:bc123df4567',

--- a/spec/requests/set_catkey_spec.rb
+++ b/spec/requests/set_catkey_spec.rb
@@ -5,13 +5,11 @@ require 'rails_helper'
 RSpec.describe 'Set catkey for an object' do
   let(:user) { create(:user) }
   let(:pid) { 'druid:dc243mg0841' }
-  let(:fedora_obj) { instance_double(Dor::Item, pid: pid, current_version: 1, admin_policy_object: nil) }
   let(:cocina) { instance_double(Cocina::Models::DRO) }
   let(:object_service) { instance_double(Dor::Services::Client::Object, find: cocina) }
 
   before do
     allow(Dor::Services::Client).to receive(:object).with(pid).and_return(object_service)
-    allow(Dor).to receive(:find).and_return(fedora_obj)
   end
 
   context 'without manage content access' do

--- a/spec/requests/set_collection_spec.rb
+++ b/spec/requests/set_collection_spec.rb
@@ -5,12 +5,10 @@ require 'rails_helper'
 RSpec.describe 'Set the collection for an object' do
   let(:user) { create(:user) }
   let(:pid) { 'druid:bc123df4567' }
-  let(:fedora_obj) { instance_double(Dor::Item, pid: pid, current_version: 1, admin_policy_object: nil) }
   let(:collection_druid) { 'druid:tv123cg4444' }
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, update: true) }
 
   before do
-    allow(Dor).to receive(:find).and_return(fedora_obj)
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
   end
 

--- a/spec/requests/set_governing_apo_spec.rb
+++ b/spec/requests/set_governing_apo_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe 'Set APO for an object' do
     let(:user) { create(:user) }
     let(:pid) { 'druid:dc243mg0841' }
     let(:new_apo_id) { 'druid:ab123cd4567' }
-    let(:fedora_obj) { instance_double(Dor::Item, pid: pid, current_version: 1, admin_policy_object: nil) }
     let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, update: true) }
     let(:cocina_model) do
       Cocina::Models.build(
@@ -26,7 +25,6 @@ RSpec.describe 'Set APO for an object' do
     let(:state_service) { instance_double(StateService, allows_modification?: true) }
 
     before do
-      allow(Dor).to receive(:find).and_return(fedora_obj)
       allow(Dor::Services::Client).to receive(:object).and_return(object_client)
       allow(Argo::Indexer).to receive(:reindex_pid_remotely)
       sign_in user, groups: ['sdr:administrator-role']

--- a/spec/requests/set_source_id_spec.rb
+++ b/spec/requests/set_source_id_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe 'Set source id for an object' do
   context 'when they have manage access' do
     let(:user) { create(:user) }
     let(:pid) { 'druid:cc243mg0841' }
-    let(:fedora_obj) { instance_double(Dor::Item, pid: pid, current_version: 1, admin_policy_object: nil) }
     let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, update: true) }
 
     let(:cocina_model) do
@@ -35,7 +34,6 @@ RSpec.describe 'Set source id for an object' do
     end
 
     before do
-      allow(Dor).to receive(:find).and_return(fedora_obj)
       allow(Dor::Services::Client).to receive(:object).and_return(object_client)
       allow(Argo::Indexer).to receive(:reindex_pid_remotely)
       sign_in user, groups: ['sdr:administrator-role']

--- a/spec/services/state_service_spec.rb
+++ b/spec/services/state_service_spec.rb
@@ -14,12 +14,7 @@ RSpec.describe StateService do
     let(:workflow_client) { instance_double(Dor::Workflow::Client) }
 
     context 'when version is not passed in' do
-      let(:item) { instance_double(Dor::Item, current_version: 4) }
-      let(:service) { described_class.new(pid, version: item.current_version) }
-
-      before do
-        allow(Dor).to receive(:find).and_return(item)
-      end
+      let(:service) { described_class.new(pid, version: 4) }
 
       context "if the object hasn't been submitted" do
         before do

--- a/spec/views/catalog/_contents_default.html.erb_spec.rb
+++ b/spec/views/catalog/_contents_default.html.erb_spec.rb
@@ -4,33 +4,6 @@ require 'rails_helper'
 
 RSpec.describe 'catalog/_contents_default.html.erb', type: :view do
   context 'with files' do
-    let(:content_md) do
-      Dor::ContentMetadataDS.new.tap do |cm|
-        cm.content = <<~XML
-          <contentMetadata objectId="bb000zn0114" type="image">
-            <resource id="bb000zn0114_1" sequence="1" type="image">
-              <label>Image 1</label>
-              <file id="PC0062_2008-194_Q03_02_007.jpg" preserve="yes" publish="no" shelve="no" mimetype="image/jpeg" size="1480110">
-                <checksum type="md5">8e656c63ea1ad476e515518a46824fac</checksum>
-                <checksum type="sha1">0cd3613c7dda558433ad955f0cf4f2730e3ec958</checksum>
-                <imageData width="2548" height="1696"/>
-              </file>
-              <file id="PC0062_2008-194_Q03_02_007.jp2" mimetype="image/jp2" size="819813" preserve="no" publish="yes" shelve="yes">
-                <checksum type="md5">1f8d562f4f1fd87946a437176bb8e564</checksum>
-                <checksum type="sha1">3206db5137c0820ede261488e08f4d4815d16078</checksum>
-                <imageData width="2548" height="1696"/>
-              </file>
-            </resource>
-          </contentMetadata>
-        XML
-      end
-    end
-    let(:object) do
-      instance_double(Dor::Item,
-                      contentMetadata: content_md,
-                      to_param: 'druid:bb000zn0114',
-                      datastreams: { 'contentMetadata' => content_md })
-    end
     let(:solr_doc) do
       SolrDocument.new(id: 'druid:bb000zn0114')
     end
@@ -156,11 +129,10 @@ RSpec.describe 'catalog/_contents_default.html.erb', type: :view do
     before do
       @cocina = Cocina::Models::DRO.new(JSON.parse(attrs))
       allow(view).to receive(:can?).and_return(true)
-      allow(content_md).to receive(:new?).and_return(false)
     end
 
     it 'shows multiple external files' do
-      render 'catalog/contents_default', object: object, document: solr_doc
+      render 'catalog/contents_default', document: solr_doc
       expect(rendered).to have_link('image.jpg', href: '/items/druid:bg954kx8787/files?id=image.jpg')
       expect(rendered).to have_link('image.jp2', href: '/items/druid:bg954kx8787/files?id=image.jp2')
     end


### PR DESCRIPTION
## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



