### PR TITLE
Decouple the registration front end from Fedora

### DIFF
--- a/app/controllers/dor/objects_controller.rb
+++ b/app/controllers/dor/objects_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Dor::ObjectsController < ApplicationController
-  include ApplicationHelper # for fedora_base
   before_action :munge_parameters
 
   def create
@@ -10,7 +9,7 @@ class Dor::ObjectsController < ApplicationController
     result = RegistrationService.register(model: request_model, workflow: params[:workflow_id], tags: form.administrative_tags)
 
     result.either(
-      ->(model) { render json: { pid: model.externalIdentifier }, status: :created, location: object_location(model.externalIdentifier) },
+      ->(model) { render json: { pid: model.externalIdentifier }, status: :created, location: solr_document_url(model.externalIdentifier) },
       ->(message) { render_failure(message) }
     )
   rescue Cocina::Models::ValidationError => e
@@ -41,9 +40,5 @@ class Dor::ObjectsController < ApplicationController
       key = k.underscore
       params[key.to_sym] = v
     end
-  end
-
-  def object_location(pid)
-    fedora_base.merge("objects/#{pid}").to_s
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,10 +5,6 @@ module ApplicationHelper
     'Argo'
   end
 
-  def fedora_base
-    URI.parse(Dor::Config.fedora.safeurl.sub(%r{/*$}, '/'))
-  end
-
   def location_to_send_search_form
     return report_path if report_view?
     return report_workflow_grid_path if workflow_grid_view?

--- a/app/javascript/registration/grid.js
+++ b/app/javascript/registration/grid.js
@@ -5,21 +5,14 @@ import 'jquery-ui/ui/widgets/dialog'
 import 'jquery-ui/ui/widgets/progressbar'
 
 var gridContext = function() {
-  var druidFormatter = function(val, opts, rowObj) {
-    if (val.trim() != '') {
-      var href = dor_path + "objects/druid:" + val.trim();
-      return '<a href="'+href+'" title="'+val+'" target="_blank">'+val+'</a>';
-    } else {
-      return val;
-    }
-  };
+  const view_path = '/view'
 
   var statusFormatter = function(val, opts, rowObj) {
     if (val in $t.statusIcons) {
       var result = '<span class="' + $t.statusIcons[val] + '" title="' +
         (rowObj.error||val)+'" aria-hidden="true"></span>';
       if (rowObj.druid) {
-        var href = dor_path + "objects/druid:" + rowObj.druid;
+        var href = view_path + "/druid:" + rowObj.druid;
         return '<a href="'+href+'" target="_blank">'+result+'</a>';
       }
       return(result)

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -2,9 +2,6 @@
 <% content_for :head do %>
   <%= stylesheet_pack_tag 'registration' %>
   <%= javascript_pack_tag 'registration' %>
-  <script type="text/javascript">
-    var dor_path = "<%= fedora_base %>";
-  </script>
 <% end %>
 
 <div id='properties' class="ui-widget" style="display: none">


### PR DESCRIPTION
It was creating links to Fedora, now create links to the show page instead

## Why was this change made?

Fixes #2586

## How was this change tested?



## Which documentation and/or configurations were updated?



