### PR TITLE
Remove unnecessary mocks

### DIFF
--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe Ability do
   let(:viewer) { false }
   let(:roles) { [] }
   let(:new_apo_id) { 'druid:hv992yv2222' }
-  let(:new_apo) { Dor::AdminPolicyObject.new(pid: new_apo_id) }
 
   context 'as an administrator' do
     let(:admin) { true }

--- a/spec/requests/set_governing_apo_spec.rb
+++ b/spec/requests/set_governing_apo_spec.rb
@@ -62,8 +62,6 @@ RSpec.describe 'Set APO for an object' do
         cocina_model.new('administrative' => { 'hasAdminPolicy' => new_apo_id, 'partOfProject' => 'EEMS' })
       end
 
-      let(:new_apo) { double(Dor::AdminPolicyObject, id: new_apo_id) }
-
       it 'updates the governing APO' do
         post "/items/#{pid}/set_governing_apo", params: { new_apo_id: new_apo_id }
         expect(response).to redirect_to(solr_document_path(pid))


### PR DESCRIPTION
These prevent removing dor-services

## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



