### PR TITLE
Import xml prettify from dor-services

### DIFF
--- a/app/controllers/datastreams_controller.rb
+++ b/app/controllers/datastreams_controller.rb
@@ -13,7 +13,7 @@ class DatastreamsController < ApplicationController
 
   def show
     if params[:id] == 'full_dc'
-      @content = Nokogiri::XML(@object_client.metadata.dublin_core).prettify
+      @content = PrettyXml.print(@object_client.metadata.dublin_core)
     else
       raw_content = @object_client.metadata.datastream(params[:id])
       @content = Nokogiri::XML(raw_content, &:noblanks).to_s

--- a/app/presenters/workflow_xml_presenter.rb
+++ b/app/presenters/workflow_xml_presenter.rb
@@ -8,7 +8,7 @@ class WorkflowXmlPresenter
 
   def pretty_xml
     # rubocop:disable Rails/OutputSafety
-    CodeRay::Duo[:xml, :div].highlight(Nokogiri::XML(xml).prettify).html_safe
+    CodeRay::Duo[:xml, :div].highlight(PrettyXml.print(xml)).html_safe
     # rubocop:enable Rails/OutputSafety
   end
 

--- a/app/services/pretty_xml.rb
+++ b/app/services/pretty_xml.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Display XML with aesthetically pleasing indenting
+class PrettyXml
+  PRETTIFY_XSLT = Nokogiri::XSLT <<-XSLT
+    <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+      <xsl:output omit-xml-declaration="yes" indent="yes"/>
+      <xsl:template match="node()|@*">
+        <xsl:copy>
+          <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+      </xsl:template>
+    </xsl:stylesheet>
+  XSLT
+
+  def self.print(xml)
+    ng_xml = Nokogiri::XML(xml)
+    PRETTIFY_XSLT.transform(ng_xml).to_xml
+  end
+end

--- a/app/views/workflows/_history.html.erb
+++ b/app/views/workflows/_history.html.erb
@@ -1,1 +1,1 @@
-<%= CodeRay::Duo[:xml, :div].highlight(Nokogiri::XML(@history_xml).prettify).html_safe %>
+<%= CodeRay::Duo[:xml, :div].highlight(PrettyXml.print(@history_xml)).html_safe %>


### PR DESCRIPTION


## Why was this change made?


This previously was a monkey-patch on Nokogiri::XML.  This helps us decouple from dor-services

## How was this change tested?



## Which documentation and/or configurations were updated?



