### PR TITLE
Import the Dor::SearchService from dor-services

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -36,9 +36,9 @@ class RegistrationsController < ApplicationController
       col_title_field = SolrDocument::FIELD_TITLE
 
       # grab the collection title from Solr, or fall back to DOR
-      solr_doc = Dor::SearchService.query("id:\"#{col_id}\"",
-                                          rows: 1,
-                                          fl: col_title_field)['response']['docs'].first
+      solr_doc = SearchService.query("id:\"#{col_id}\"",
+                                     rows: 1,
+                                     fl: col_title_field)['response']['docs'].first
       collections[col_id] = "#{short_label(solr_doc[col_title_field].first, truncate_limit)} (#{col_druid})"
     end
 
@@ -73,7 +73,7 @@ class RegistrationsController < ApplicationController
 
   def autocomplete
     facet_field = params[:field]
-    response = Dor::SearchService.query(
+    response = SearchService.query(
       '*:*',
       rows: 0,
       'facet.field': facet_field,

--- a/app/helpers/apo_helper.rb
+++ b/app/helpers/apo_helper.rb
@@ -14,7 +14,7 @@ module ApoHelper
 
   def agreement_options
     q = 'objectType_ssim:agreement '
-    result = Dor::SearchService.query(q, rows: 99_999, fl: 'id,tag_ssim,sw_display_title_tesim')['response']['docs']
+    result = SearchService.query(q, rows: 99_999, fl: 'id,tag_ssim,sw_display_title_tesim')['response']['docs']
     result.sort! do |a, b|
       a['sw_display_title_tesim'].to_s <=> b['sw_display_title_tesim'].to_s
     end

--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -8,7 +8,7 @@ module RegistrationHelper
 
     q = permission_keys.map { |key| %(apo_register_permissions_ssim:"#{key}") }.join(' OR ')
 
-    result = Dor::SearchService.query(
+    result = SearchService.query(
       q,
       defType: 'lucene',
       rows: 99_999,

--- a/app/models/track_sheet.rb
+++ b/app/models/track_sheet.rb
@@ -113,10 +113,10 @@ class TrackSheet
   # @note To the extent we use Solr input filters or copyField(s), the Solr version will differ from the to_solr hash.
   # @note That difference shouldn't be important for the few known fields we use here.
   def find_or_create_in_solr_by_id(druid)
-    doc = Dor::SearchService.query(%(id:"druid:#{druid}"), rows: 1)['response']['docs'].first
+    doc = SearchService.query(%(id:"druid:#{druid}"), rows: 1)['response']['docs'].first
     return doc unless doc.nil?
 
     Argo::Indexer.reindex_pid_remotely("druid:#{druid}")
-    Dor::SearchService.query(%(id:"druid:#{druid}"), rows: 1)['response']['docs'].first
+    SearchService.query(%(id:"druid:#{druid}"), rows: 1)['response']['docs'].first
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,7 +50,7 @@ class User < ApplicationRecord
     return @role_cache[admin_policy_id] if @role_cache[admin_policy_id]
 
     # Try to retrieve a Solr doc
-    obj_doc = Dor::SearchService.query('id:"' + admin_policy_id + '"')['response']['docs'].first || {}
+    obj_doc = SearchService.query('id:"' + admin_policy_id + '"')['response']['docs'].first || {}
     return [] if obj_doc.empty?
 
     apo_roles = Set.new

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Searches against Solr
+class SearchService
+  class << self
+    def query(query, args = {})
+      params = args.merge(q: query)
+      params[:start] ||= 0
+      solr.get 'select', params: params
+    end
+
+    delegate :blacklight_config, to: CatalogController
+
+    def solr
+      blacklight_config.repository_class.new(blacklight_config).connection
+    end
+  end
+end

--- a/lib/tasks/argo.rake
+++ b/lib/tasks/argo.rake
@@ -7,12 +7,12 @@ end
 # @return [#keys]
 def workgroups_facet(apo_field = nil)
   apo_field = apo_field_default if apo_field.nil?
-  resp = Dor::SearchService.query('objectType_ssim:adminPolicy', rows: 0,
-                                                                 'facet.field': apo_field,
-                                                                 'facet.prefix': 'workgroup:',
-                                                                 'facet.mincount': 1,
-                                                                 'facet.limit': -1,
-                                                                 'json.nl': 'map')
+  resp = SearchService.query('objectType_ssim:adminPolicy', rows: 0,
+                                                            'facet.field': apo_field,
+                                                            'facet.prefix': 'workgroup:',
+                                                            'facet.mincount': 1,
+                                                            'facet.limit': -1,
+                                                            'json.nl': 'map')
   resp['facet_counts']['facet_fields'][apo_field] || {}
 end
 

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe RegistrationsController, type: :controller do
       end
 
       before do
-        allow(Dor::SearchService).to receive(:query).and_return(solr_response)
+        allow(SearchService).to receive(:query).and_return(solr_response)
       end
 
       it 'alpha-sorts the collection list by title, except for the "None" entry, which should come first' do

--- a/spec/helpers/registration_helper_spec.rb
+++ b/spec/helpers/registration_helper_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RegistrationHelper do
     it 'runs the appropriate query for the given permission keys' do
       q = perm_keys.map { |key| %(apo_register_permissions_ssim:"#{key}") }.join(' OR ')
 
-      expect(Dor::SearchService).to receive(:query).with(
+      expect(SearchService).to receive(:query).with(
         q,
         defType: 'lucene',
         rows: 99_999,
@@ -26,7 +26,7 @@ RSpec.describe RegistrationHelper do
         { 'id' => 2, 'tag_ssim' => 'AdminPolicy : default', 'sw_display_title_tesim' => 'y' },
         { 'id' => 3, 'tag_ssim' => 'prefix : suffix2', 'sw_display_title_tesim' => 'x' }
       ]
-      expect(Dor::SearchService).to receive(:query).and_return('response' => { 'docs' => result_rows })
+      expect(SearchService).to receive(:query).and_return('response' => { 'docs' => result_rows })
 
       apos = apo_list(perm_keys)
       expect(apos).to eq [%w[y 2], %w[x 3], %w[z 1]]
@@ -34,7 +34,7 @@ RSpec.describe RegistrationHelper do
   end
 
   it 'returns nothing when permission_keys is empty' do
-    expect(Dor::SearchService).not_to receive(:query)
+    expect(SearchService).not_to receive(:query)
     expect(apo_list([])).to eq []
   end
 end

--- a/spec/models/track_sheet_spec.rb
+++ b/spec/models/track_sheet_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe TrackSheet do
     subject(:call) { instance.send(:find_or_create_in_solr_by_id, druid) }
 
     before do
-      allow(Dor::SearchService).to receive(:query)
+      allow(SearchService).to receive(:query)
         .with('id:"druid:xb482ww9999"', rows: 1)
         .and_return(response)
     end
@@ -30,7 +30,7 @@ RSpec.describe TrackSheet do
       before do
         allow(Argo::Indexer).to receive(:reindex_pid_remotely)
 
-        allow(Dor::SearchService).to receive(:query)
+        allow(SearchService).to receive(:query)
           .with('id:"druid:xb482ww9999"', rows: 1)
           .and_return(response, second_response)
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe User, type: :model do
 
   describe 'roles' do
     # The exact DRUID is not important in these specs, because
-    # the Dor::SearchService is mocked to return solr_doc.
+    # the SearchService is mocked to return solr_doc.
     let(:druid) { 'druid:ab123cd4567' }
     let(:answer) do
       {
@@ -214,7 +214,7 @@ RSpec.describe User, type: :model do
     end
 
     before do
-      allow(Dor::SearchService).to receive(:query).and_return(answer)
+      allow(SearchService).to receive(:query).and_return(answer)
     end
 
     it 'accepts any object identifier' do
@@ -238,7 +238,7 @@ RSpec.describe User, type: :model do
 
     it 'returns an empty set of roles if the DRUID solr search fails' do
       empty_doc = { 'response' => { 'docs' => [] } }
-      allow(Dor::SearchService).to receive(:query).and_return(empty_doc)
+      allow(SearchService).to receive(:query).and_return(empty_doc)
       # check that the code will return immediately if solr doc is empty
       expect(subject).not_to receive(:groups)
       expect(subject).not_to receive(:solr_role_allowed?)
@@ -252,7 +252,7 @@ RSpec.describe User, type: :model do
 
     it 'hangs onto results through the life of the user object, avoiding multiple solr searches to find the roles for the same pid multiple times' do
       expect(subject).to receive(:groups).and_return(['testdoesnotcarewhatishere']).at_least(:once)
-      expect(Dor::SearchService).to receive(:query).once
+      expect(SearchService).to receive(:query).once
       subject.roles(druid)
       subject.roles(druid)
     end


### PR DESCRIPTION

## Why was this change made?

So we can decouple from dor-services

Fixes #2600 

## How was this change tested?



## Which documentation and/or configurations were updated?



