### PR TITLE
Search the id field

### DIFF
--- a/app/helpers/blacklight_config_helper.rb
+++ b/app/helpers/blacklight_config_helper.rb
@@ -6,6 +6,7 @@ module BlacklightConfigHelper
       'q.alt': '*:*',
       defType: 'dismax',
       qf: %(
+        id
         collection_title_tesim
         dor_id_tesim
         identifier_tesim


### PR DESCRIPTION


## Why was this change made?
So that non-cocina compliant objects can still be found when you search their identifier.
Fixes #2614 



## How was this change tested?



## Which documentation and/or configurations were updated?



