### PR TITLE
Insert a missing closing tag

### DIFF
--- a/app/views/apo/_form.html.erb
+++ b/app/views/apo/_form.html.erb
@@ -10,7 +10,7 @@
     <%= select_tag :agreement, options_for_select(agreement_options, @form.agreement_object_id), class: 'form-control' %>
   </div>
 
-  <sharing data-permissions="<%= @form.permissions.to_json %>">
+  <sharing data-permissions="<%= @form.permissions.to_json %>"></sharing>
 
   <% if @form.default_collection_objects.present? %>
     <label>Default Collections</label><br>


### PR DESCRIPTION


## Why was this change made?

The only elements in HTML that are void elements are:
area, base, br, col, command, embed, hr, img, input, keygen, link, meta, param, source, track, wbr

A non-void element must have a closing tag.
http://www.w3.org/TR/html-markup/syntax.html#syntax-elements

## How was this change tested?



## Which documentation and/or configurations were updated?



