### PR TITLE
Ensure the manage catkey function works for collections

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -192,7 +192,7 @@ RSpec/MessageChain:
 RSpec/MessageSpies:
   Enabled: false
 
-# Offense count: 336
+# Offense count: 340
 # Configuration parameters: AllowSubject.
 RSpec/MultipleMemoizedHelpers:
   Max: 19
@@ -202,7 +202,7 @@ RSpec/MultipleMemoizedHelpers:
 RSpec/NamedSubject:
   Enabled: false
 
-# Offense count: 77
+# Offense count: 81
 RSpec/NestedGroups:
   Max: 6
 
@@ -338,7 +338,7 @@ Style/CommentedKeyword:
   Exclude:
     - 'lib/tasks/argo.rake'
 
-# Offense count: 74
+# Offense count: 75
 # Configuration parameters: AllowedConstants.
 Style/Documentation:
   Enabled: false

--- a/app/components/sidebar_controls_component.rb
+++ b/app/components/sidebar_controls_component.rb
@@ -61,7 +61,7 @@ class SidebarControlsComponent < ApplicationComponent
   end
 
   def manage_catkey
-    render ActionButton.new(url: catkey_ui_item_path(id: pid), label: 'Manage catkey')
+    render ActionButton.new(url: edit_item_catkey_path(item_id: pid), label: 'Manage catkey')
   end
 
   def edit_collections

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,4 +49,16 @@ class ApplicationController < ActionController::Base
       render plain: 'Not Found', status: :not_found
     end
   end
+
+  def enforce_versioning
+    return redirect_to solr_document_path(@cocina.externalIdentifier), flash: { error: 'Unable to retrieve the cocina model' } if @cocina.is_a? NilModel
+
+    state_service = StateService.new(@cocina.externalIdentifier, version: @cocina.version)
+
+    # if this object has been submitted and doesn't have an open version, they cannot change it.
+    return true if state_service.allows_modification?
+
+    redirect_to solr_document_path(params[:id]), flash: { error: 'Object cannot be modified in its current state.' }
+    false
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,7 +58,7 @@ class ApplicationController < ActionController::Base
     # if this object has been submitted and doesn't have an open version, they cannot change it.
     return true if state_service.allows_modification?
 
-    redirect_to solr_document_path(params[:id]), flash: { error: 'Object cannot be modified in its current state.' }
+    redirect_to solr_document_path(@cocina.externalIdentifier), flash: { error: 'Object cannot be modified in its current state.' }
     false
   end
 end

--- a/app/controllers/catkeys_controller.rb
+++ b/app/controllers/catkeys_controller.rb
@@ -1,38 +1,57 @@
 # frozen_string_literal: true
 
 class CatkeysController < ApplicationController
+  before_action :load_and_authorize_resource
+
   rescue_from Dor::Services::Client::UnexpectedResponse do |exception|
     md = /\((.*)\)/.match exception.message
     detail = JSON.parse(md[1])['errors'].first['detail']
-    redirect_to solr_document_path(params[:id]),
+    redirect_to solr_document_path(params[:item_id]),
                 flash: { error: "Unable to retrieve the cocina model: #{detail.truncate(200)}" }
   end
 
   def edit
-    @cocina = maybe_load_cocina(params[:item_id])
-    authorize! :manage_item, @cocina
-
+    @change_set = change_set_class.new(@cocina)
     respond_to do |format|
       format.html { render layout: !request.xhr? }
     end
   end
 
   def update
-    @cocina = maybe_load_cocina(params[:item_id])
-    authorize! :manage_item, @cocina
     return unless enforce_versioning
 
-    change_set = ItemChangeSet.new(catkey: params[:new_catkey].strip)
-    ItemChangeSetPersister.update(@cocina, change_set)
+    change_set = change_set_class.new(@cocina)
+    change_set.validate(catkey: update_params[:catkey].strip)
+    change_set.save
     Argo::Indexer.reindex_pid_remotely(@cocina.externalIdentifier)
 
     respond_to do |format|
       if params[:bulk]
         format.html { render status: :ok, plain: 'Updated catkey' }
       else
-        msg = "Catkey for #{params[:id]} has been updated!"
+        msg = "Catkey for #{@cocina.externalIdentifier} has been updated!"
         format.any { redirect_to solr_document_path(@cocina.externalIdentifier), notice: msg }
       end
     end
+  end
+
+  private
+
+  def change_set_class
+    case @cocina
+    when Cocina::Models::DRO
+      ItemChangeSet
+    when Cocina::Models::Collection
+      CollectionChangeSet
+    end
+  end
+
+  def load_and_authorize_resource
+    @cocina = maybe_load_cocina(params[:item_id])
+    authorize! :manage_item, @cocina
+  end
+
+  def update_params
+    params[change_set_class.model_name.param_key]
   end
 end

--- a/app/controllers/catkeys_controller.rb
+++ b/app/controllers/catkeys_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class CatkeysController < ApplicationController
+  rescue_from Dor::Services::Client::UnexpectedResponse do |exception|
+    md = /\((.*)\)/.match exception.message
+    detail = JSON.parse(md[1])['errors'].first['detail']
+    redirect_to solr_document_path(params[:id]),
+                flash: { error: "Unable to retrieve the cocina model: #{detail.truncate(200)}" }
+  end
+
+  def edit
+    @cocina = maybe_load_cocina(params[:item_id])
+    authorize! :manage_item, @cocina
+
+    respond_to do |format|
+      format.html { render layout: !request.xhr? }
+    end
+  end
+
+  def update
+    @cocina = maybe_load_cocina(params[:item_id])
+    authorize! :manage_item, @cocina
+    return unless enforce_versioning
+
+    change_set = ItemChangeSet.new(catkey: params[:new_catkey].strip)
+    ItemChangeSetPersister.update(@cocina, change_set)
+    Argo::Indexer.reindex_pid_remotely(@cocina.externalIdentifier)
+
+    respond_to do |format|
+      if params[:bulk]
+        format.html { render status: :ok, plain: 'Updated catkey' }
+      else
+        msg = "Catkey for #{params[:id]} has been updated!"
+        format.any { redirect_to solr_document_path(@cocina.externalIdentifier), notice: msg }
+      end
+    end
+  end
+end

--- a/app/forms/application_change_set.rb
+++ b/app/forms/application_change_set.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# A superclass for the change sets that handles forms backed by Cocina objects
+class ApplicationChangeSet < Reform::Form
+  # needed for generating the update route
+  def to_param
+    model.externalIdentifier
+  end
+
+  def persisted?
+    model.present?
+  end
+end

--- a/app/models/collection_change_set.rb
+++ b/app/models/collection_change_set.rb
@@ -1,10 +1,22 @@
 # frozen_string_literal: true
 
 # Represents a set of changes to a collection
-class CollectionChangeSet < Reform::Form
+class CollectionChangeSet < ApplicationChangeSet
+  property :catkey, virtual: true
   property :copyright_statement, virtual: true
   property :license, virtual: true
   property :use_statement, virtual: true
+
+  def self.model_name
+    Struct.new(:param_key, :route_key, :i18n_key, :name).new('collection', 'collection', 'collection', 'Collection')
+  end
+
+  # When the object is initialized, copy the properties from the cocina model to the form:
+  def setup_properties!(_options)
+    return unless model.identification
+
+    self.catkey = model.identification.catalogLinks&.find { |link| link.catalog == 'symphony' }&.catalogRecordId
+  end
 
   def save_model
     CollectionChangeSetPersister.update(model, self)

--- a/app/models/item_change_set.rb
+++ b/app/models/item_change_set.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Represents a set of changes to an item.
-class ItemChangeSet < Reform::Form
+class ItemChangeSet < ApplicationChangeSet
   property :admin_policy_id, virtual: true
   property :catkey, virtual: true
   property :collection_ids, virtual: true
@@ -14,11 +14,6 @@ class ItemChangeSet < Reform::Form
 
   def self.model_name
     Struct.new(:param_key, :route_key, :i18n_key, :name).new('item', 'item', 'item', 'Item')
-  end
-
-  # needed for generating the update route
-  def to_key
-    Array(@cocina_item&.externalIdentifier)
   end
 
   # When the object is initialized, copy the properties from the cocina model to the form:

--- a/app/views/catkeys/_edit.html.erb
+++ b/app/views/catkeys/_edit.html.erb
@@ -1,6 +1,7 @@
-<%= form_tag item_catkey_path(@cocina.externalIdentifier), method: :patch do %>
+<%= form_with model: @change_set, url: item_catkey_path(@change_set), method: :patch do |f| %>
   <div class="form-group">
-    <input class="form-control" name="new_catkey" id="new_catkey" type="text" value="<%= @cocina.identification.catalogLinks&.find { |link| link.catalog == 'symphony' }&.catalogRecordId %>">
+    <%= f.label :catkey %>
+    <%= f.text_field :catkey, class: 'form-control' %>
     <p class='help-block'>
     </p>
   </div>

--- a/app/views/catkeys/_edit.html.erb
+++ b/app/views/catkeys/_edit.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag catkey_item_path(@cocina.externalIdentifier) do %>
+<%= form_tag item_catkey_path(@cocina.externalIdentifier), method: :patch do %>
   <div class="form-group">
     <input class="form-control" name="new_catkey" id="new_catkey" type="text" value="<%= @cocina.identification.catalogLinks&.find { |link| link.catalog == 'symphony' }&.catalogRecordId %>">
     <p class='help-block'>

--- a/app/views/catkeys/edit.html.erb
+++ b/app/views/catkeys/edit.html.erb
@@ -1,4 +1,4 @@
 <%= render BlacklightModalComponent.new do |component| %>
   <% component.header { 'Manage catkey' } %>
-  <% component.body { render 'catkey_ui' } %>
+  <% component.body { render 'edit' } %>
 <% end %>

--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 #
 # This file contains migration options to ease your Rails 6.1 upgrade.
@@ -46,7 +47,7 @@
 # Rails.application.config.active_record.legacy_connection_handling = false
 
 # Make `form_with` generate non-remote forms by default.
-# Rails.application.config.action_view.form_with_generates_remote_forms = false
+Rails.application.config.action_view.form_with_generates_remote_forms = false
 
 # Set the default queue name for the analysis job to the queue adapter default.
 # Rails.application.config.active_storage.queues.analysis = nil

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,6 +126,7 @@ Rails.application.routes.draw do
     end
 
     resources :datastreams, only: %i[show edit update]
+    resource :catkey, only: %i[edit update]
 
     member do
       post 'refresh_metadata'
@@ -133,7 +134,6 @@ Rails.application.routes.draw do
       post 'embargo', action: :embargo_update, as: 'embargo_update'
       get 'embargo_form'
       get 'source_id_ui'
-      get 'catkey_ui'
       match 'tags_bulk', via: %i[get post]
       get 'collection_ui'
       get 'collection/delete',   action: :remove_collection, as: 'remove_collection'
@@ -146,7 +146,6 @@ Rails.application.routes.draw do
       post 'set_governing_apo'
       post :apply_apo_defaults
       post 'source_id'
-      post 'catkey'
     end
   end
 

--- a/spec/components/sidebar_controls_component_spec.rb
+++ b/spec/components/sidebar_controls_component_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe SidebarControlsComponent, type: :component do
         expect(rendered.css("a[href='/dor/republish/druid:kv840xx0000']").inner_text).to eq 'Republish'
         expect(rendered.css("a.disabled[data-confirm][data-method='delete'][href='/items/druid:kv840xx0000/purge']").inner_text).to eq 'Purge'
         expect(rendered.css("a[href='/items/druid:kv840xx0000/source_id_ui']").inner_text).to eq 'Change source id'
-        expect(rendered.css("a[href='/items/druid:kv840xx0000/catkey_ui']").inner_text).to eq 'Manage catkey'
+        expect(rendered.css("a[href='/items/druid:kv840xx0000/catkey/edit']").inner_text).to eq 'Manage catkey'
         expect(rendered.css("a[href='/items/druid:kv840xx0000/tags/edit']").inner_text).to eq 'Edit tags'
         expect(rendered.css("a[href='/items/druid:kv840xx0000/collection_ui']").inner_text).to eq 'Edit collections'
         expect(rendered.css("a[href='/items/druid:kv840xx0000/content_type']").inner_text).to eq 'Set content type'

--- a/spec/features/item_catkey_change_spec.rb
+++ b/spec/features/item_catkey_change_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Item catkey change' do
     let(:state_service) { instance_double(StateService, allows_modification?: false) }
 
     it 'cannot change the catkey' do
-      visit catkey_ui_item_path druid
+      visit edit_item_catkey_path druid
       fill_in 'new_catkey', with: '12345'
       click_button 'Update'
       expect(page).to have_css 'body', text: 'Object cannot be modified in ' \
@@ -71,7 +71,7 @@ RSpec.describe 'Item catkey change' do
     end
 
     it 'changes the catkey' do
-      visit catkey_ui_item_path druid
+      visit edit_item_catkey_path druid
       fill_in 'new_catkey', with: '12345'
       click_button 'Update'
       expect(page).to have_css '.alert.alert-info', text: 'Catkey for ' \

--- a/spec/features/item_catkey_change_spec.rb
+++ b/spec/features/item_catkey_change_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Item catkey change' do
 
     it 'cannot change the catkey' do
       visit edit_item_catkey_path druid
-      fill_in 'new_catkey', with: '12345'
+      fill_in 'Catkey', with: '12345'
       click_button 'Update'
       expect(page).to have_css 'body', text: 'Object cannot be modified in ' \
         'its current state.'
@@ -72,7 +72,7 @@ RSpec.describe 'Item catkey change' do
 
     it 'changes the catkey' do
       visit edit_item_catkey_path druid
-      fill_in 'new_catkey', with: '12345'
+      fill_in 'Catkey', with: '12345'
       click_button 'Update'
       expect(page).to have_css '.alert.alert-info', text: 'Catkey for ' \
         "#{druid} has been updated!"

--- a/spec/requests/set_catkey_spec.rb
+++ b/spec/requests/set_catkey_spec.rb
@@ -2,23 +2,21 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Set catkey for an object' do
+RSpec.describe 'Set catkey' do
   let(:user) { create(:user) }
   let(:pid) { 'druid:dc243mg0841' }
-  let(:cocina) { instance_double(Cocina::Models::DRO) }
-  let(:object_service) { instance_double(Dor::Services::Client::Object, find: cocina) }
-
-  before do
-    allow(Dor::Services::Client).to receive(:object).with(pid).and_return(object_service)
-  end
 
   context 'without manage content access' do
+    let(:cocina) { instance_double(Cocina::Models::DRO) }
+    let(:object_service) { instance_double(Dor::Services::Client::Object, find: cocina) }
+
     before do
+      allow(Dor::Services::Client).to receive(:object).with(pid).and_return(object_service)
       sign_in user
     end
 
     it 'returns a 403' do
-      patch "/items/#{pid}/catkey", params: { new_catkey: '12345' }
+      patch "/items/#{pid}/catkey", params: { item: { catkey: '12345' } }
 
       expect(response.code).to eq('403')
     end
@@ -27,41 +25,141 @@ RSpec.describe 'Set catkey for an object' do
   context 'when they have manage access' do
     let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, update: true) }
 
-    let(:cocina_model) do
-      Cocina::Models.build({
-                             'label' => 'My ETD',
-                             'version' => 1,
-                             'type' => Cocina::Models::Vocab.object,
-                             'externalIdentifier' => pid,
-                             'access' => {},
-                             'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
-                             'structural' => {},
-                             'identification' => {}
-                           })
-    end
-
-    let(:updated_model) do
-      cocina_model.new(
-        {
-          'identification' => {
-            'catalogLinks' => [{ catalog: 'symphony', catalogRecordId: '12345' }]
-          }
-        }
-      )
-    end
-
     before do
       allow(Dor::Services::Client).to receive(:object).and_return(object_client)
-      allow(Argo::Indexer).to receive(:reindex_pid_remotely)
       sign_in user, groups: ['sdr:administrator-role']
     end
 
-    it 'updates the catkey, trimming whitespace' do
-      patch "/items/#{pid}/catkey", params: { new_catkey: '   12345 ' }
+    describe 'display the form' do
+      context 'with an item' do
+        let(:cocina_model) do
+          Cocina::Models.build({
+                                 'label' => 'My ETD',
+                                 'version' => 1,
+                                 'type' => Cocina::Models::Vocab.object,
+                                 'externalIdentifier' => pid,
+                                 'access' => {},
+                                 'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+                                 'structural' => {},
+                                 'identification' => {}
+                               })
+        end
 
-      expect(object_client).to have_received(:update)
-        .with(params: updated_model)
-      expect(Argo::Indexer).to have_received(:reindex_pid_remotely).with(pid)
+        it 'draws the form' do
+          get "/items/#{pid}/catkey/edit"
+
+          expect(response).to be_successful
+        end
+      end
+
+      context 'with a collection that has no identification' do
+        let(:cocina_model) do
+          Cocina::Models.build({
+                                 'label' => 'My ETD',
+                                 'version' => 1,
+                                 'type' => Cocina::Models::Vocab.collection,
+                                 'externalIdentifier' => pid,
+                                 'access' => {},
+                                 'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' }
+                               })
+        end
+
+        it 'draws the form' do
+          get "/items/#{pid}/catkey/edit"
+
+          expect(response).to be_successful
+        end
+      end
+
+      context 'with a collection that has identification' do
+        let(:cocina_model) do
+          Cocina::Models.build({
+                                 'label' => 'My ETD',
+                                 'version' => 1,
+                                 'type' => Cocina::Models::Vocab.collection,
+                                 'externalIdentifier' => pid,
+                                 'access' => {},
+                                 'identification' => {
+                                   'catalogLinks' => [
+                                     {
+                                       'catalog' => 'symphony',
+                                       'catalogRecordId' => '10448742'
+                                     }
+                                   ]
+                                 },
+                                 'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' }
+                               })
+        end
+
+        it 'draws the form' do
+          get "/items/#{pid}/catkey/edit"
+
+          expect(response).to be_successful
+          expect(response.body).to include '10448742'
+        end
+      end
+    end
+
+    describe 'submitting changes' do
+      let(:updated_model) do
+        cocina_model.new(
+          {
+            'identification' => {
+              'catalogLinks' => [{ catalog: 'symphony', catalogRecordId: '12345' }]
+            }
+          }
+        )
+      end
+
+      before do
+        allow(Argo::Indexer).to receive(:reindex_pid_remotely)
+      end
+
+      context 'with an item' do
+        let(:cocina_model) do
+          Cocina::Models.build({
+                                 'label' => 'My ETD',
+                                 'version' => 1,
+                                 'type' => Cocina::Models::Vocab.object,
+                                 'externalIdentifier' => pid,
+                                 'access' => {},
+                                 'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+                                 'structural' => {},
+                                 'identification' => {}
+                               })
+        end
+
+        it 'updates the catkey, trimming whitespace' do
+          patch "/items/#{pid}/catkey", params: { item: { catkey: '   12345 ' } }
+
+          expect(object_client).to have_received(:update)
+            .with(params: updated_model)
+          expect(Argo::Indexer).to have_received(:reindex_pid_remotely).with(pid)
+        end
+      end
+
+      context 'with a collection that has no identification' do
+        let(:cocina_model) do
+          Cocina::Models.build({
+                                 'label' => 'My ETD',
+                                 'version' => 1,
+                                 'type' => Cocina::Models::Vocab.collection,
+                                 'externalIdentifier' => pid,
+                                 'access' => {
+                                   'access' => 'world'
+                                 },
+                                 'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' }
+                               })
+        end
+
+        it 'updates the catkey, trimming whitespace' do
+          patch "/items/#{pid}/catkey", params: { collection: { catkey: '   12345 ' } }
+
+          expect(object_client).to have_received(:update)
+            .with(params: updated_model)
+          expect(Argo::Indexer).to have_received(:reindex_pid_remotely).with(pid)
+        end
+      end
     end
   end
 end

--- a/spec/requests/set_catkey_spec.rb
+++ b/spec/requests/set_catkey_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Set catkey for an object' do
     end
 
     it 'returns a 403' do
-      post "/items/#{pid}/catkey", params: { new_catkey: '12345' }
+      patch "/items/#{pid}/catkey", params: { new_catkey: '12345' }
 
       expect(response.code).to eq('403')
     end
@@ -57,7 +57,7 @@ RSpec.describe 'Set catkey for an object' do
     end
 
     it 'updates the catkey, trimming whitespace' do
-      post "/items/#{pid}/catkey", params: { new_catkey: '   12345 ' }
+      patch "/items/#{pid}/catkey", params: { new_catkey: '   12345 ' }
 
       expect(object_client).to have_received(:update)
         .with(params: updated_model)


### PR DESCRIPTION
## Why was this change made?
Previously there was a null pointer exception when the identification metatata was not present. This was seen happening on collections that don't yet have a catkey.

Refactored catkey management out of ItemsController which had too many responsibilities.

Fixes #2626 



## How was this change tested?



## Which documentation and/or configurations were updated?



