### PR TITLE
Use slots instead of deprecated content areas

### DIFF
--- a/app/components/blacklight_modal_component.rb
+++ b/app/components/blacklight_modal_component.rb
@@ -2,5 +2,7 @@
 
 # Designed to use bootstrap styles to fill within the Blacklight modal
 class BlacklightModalComponent < ViewComponent::Base
-  with_content_areas :header, :body, :footer
+  renders_one :header
+  renders_one :body
+  renders_one :footer
 end

--- a/app/views/bulk_jobs/_bulk_index_table.html.erb
+++ b/app/views/bulk_jobs/_bulk_index_table.html.erb
@@ -48,11 +48,11 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <%= render BlacklightModalComponent.new do |component| %>
-        <% component.with(:header, 'Confirm Delete') %>
-        <% component.with(:body) do %>
+        <% component.header { 'Confirm Delete' } %>
+        <% component.body do %>
           Are you sure you want to delete the job directory and the files it contains? Note that this will not stop a currently running job.
         <% end %>
-        <% component.with(:footer) do %>
+        <% component.footer do %>
           <a href="#" id="confirm-delete-job" class="btn btn-success success">Delete</a>
         <% end %>
       <% end %>

--- a/app/views/bulk_jobs/status_help.html.erb
+++ b/app/views/bulk_jobs/status_help.html.erb
@@ -1,7 +1,7 @@
 <div data-blacklight-modal="container">
   <%= render BlacklightModalComponent.new do |component| %>
-    <% component.with(:header, 'Status Help') %>
-    <% component.with(:body) do %>
+    <% component.header { 'Status Help' } %>
+    <% component.body do %>
       <div class="container-fluid">
           <div class="row spreadsheet-help-row">
               <div class="col-md-4"><strong>completed</strong></div>

--- a/app/views/catalog/facet.html.erb
+++ b/app/views/catalog/facet.html.erb
@@ -4,14 +4,14 @@
 
 <div data-controller="facet-filter">
   <%= render BlacklightModalComponent.new do |component| %>
-    <% component.with(:header, facet_field_label(@facet.key)) %>
-    <% component.with(:body) do %>
+    <% component.header { facet_field_label(@facet.key) } %>
+    <% component.body do %>
       <%= render 'facet_index_navigation' if @facet.index_range && @display_facet.index? %>
       <div data-target="facet-filter.list">
         <%= render_facet_limit(@display_facet, layout: false) %>
       </div>
     <% end %>
-    <% component.with(:footer) do %>
+    <% component.footer do %>
       <div class="facet_pagination bottom row">
         <div class="col-sm-4">
           <input type="text" id="filterInput" data-action="keyup->facet-filter#filter" placeholder="Filter..." class="form-control form-control-sm">

--- a/app/views/content_types/show.html.erb
+++ b/app/views/content_types/show.html.erb
@@ -1,4 +1,4 @@
 <%= render BlacklightModalComponent.new do |component| %>
-  <% component.with(:header, 'Set content type') %>
-  <% component.with(:body) { render 'content_type' } %>
+  <% component.header { 'Set content type' } %>
+  <% component.body { render 'content_type' } %>
 <% end %>

--- a/app/views/datastreams/edit.html.erb
+++ b/app/views/datastreams/edit.html.erb
@@ -1,6 +1,6 @@
 <%= render BlacklightModalComponent.new do |component| %>
-  <% component.with(:header, params[:id]) %>
-  <% component.with(:body) do %>
+  <% component.header { params[:id] } %>
+  <% component.body do %>
     <% if can?(:manage_item, @cocina) %>
       <%= form_tag item_datastream_path(@cocina.externalIdentifier, params[:id]), id: 'xmlEditForm', method: :patch do %>
           <input type="hidden" name="id" value="<%= @cocina.externalIdentifier %>">

--- a/app/views/datastreams/show.html.erb
+++ b/app/views/datastreams/show.html.erb
@@ -1,6 +1,6 @@
 <%= render BlacklightModalComponent.new do |component| %>
-  <% component.with(:header, params[:id]) %>
-  <% component.with(:body) do %>
+  <% component.header { params[:id] } %>
+  <% component.body do %>
     <%# If the user is a repo admin or is permitted to manage both content and %>
     <%# rights, display raw xml editing %>
     <% if can?(:manage_item, @cocina) && Settings.editable_datastreams.include?(params[:id]) %>

--- a/app/views/files/index.html.erb
+++ b/app/views/files/index.html.erb
@@ -1,6 +1,6 @@
 <%= render BlacklightModalComponent.new do |component| %>
-  <% component.with(:header, 'File Availability') %>
-  <% component.with(:body) do %>
+  <% component.header { 'File Availability' } %>
+  <% component.body do %>
     <% if @file.administrative.shelve %>
       <p>
         Stacks: <%= link_to params[:file], stacks_url_full_size(params[:item_id], params[:id]) %>

--- a/app/views/items/catkey_ui.html.erb
+++ b/app/views/items/catkey_ui.html.erb
@@ -1,4 +1,4 @@
 <%= render BlacklightModalComponent.new do |component| %>
-  <% component.with(:header, 'Manage catkey') %>
-  <% component.with(:body) { render 'catkey_ui' } %>
+  <% component.header { 'Manage catkey' } %>
+  <% component.body { render 'catkey_ui' } %>
 <% end %>

--- a/app/views/items/collection_ui.html.erb
+++ b/app/views/items/collection_ui.html.erb
@@ -1,4 +1,4 @@
 <%= render BlacklightModalComponent.new do |component| %>
-  <% component.with(:header, 'Edit collections') %>
-  <% component.with(:body) { render 'collection_ui' } %>
+  <% component.header { 'Edit collections' } %>
+  <% component.body { render 'collection_ui' } %>
 <% end %>

--- a/app/views/items/embargo_form.html.erb
+++ b/app/views/items/embargo_form.html.erb
@@ -1,4 +1,4 @@
 <%= render BlacklightModalComponent.new do |component| %>
-  <% component.with(:header, 'Update embargo') %>
-  <% component.with(:body) { render 'embargo_form' } %>
+  <% component.header { 'Update embargo' } %>
+  <% component.body { render 'embargo_form' } %>
 <% end %>

--- a/app/views/items/file.html.erb
+++ b/app/views/items/file.html.erb
@@ -1,4 +1,4 @@
 <%= render BlacklightModalComponent.new do |component| %>
-  <% component.with(:header, 'Files') %>
-  <% component.with(:body) { render 'file' } %>
+  <% component.header { 'Files' } %>
+  <% component.body { render 'file' } %>
 <% end %>

--- a/app/views/items/rights.html.erb
+++ b/app/views/items/rights.html.erb
@@ -1,4 +1,4 @@
 <%= render BlacklightModalComponent.new do |component| %>
-  <% component.with(:header, 'Set rights') %>
-  <% component.with(:body) { render 'rights' } %>
+  <% component.header { 'Set rights' } %>
+  <% component.body { render 'rights' } %>
 <% end %>

--- a/app/views/items/set_governing_apo_ui.html.erb
+++ b/app/views/items/set_governing_apo_ui.html.erb
@@ -1,4 +1,4 @@
 <%= render BlacklightModalComponent.new do |component| %>
-  <% component.with(:header, 'Set governing APO') %>
-  <% component.with(:body) { render 'set_governing_apo_ui' } %>
+  <% component.header { 'Set governing APO' } %>
+  <% component.body { render 'set_governing_apo_ui' } %>
 <% end %>

--- a/app/views/items/source_id_ui.html.erb
+++ b/app/views/items/source_id_ui.html.erb
@@ -1,4 +1,4 @@
 <%= render BlacklightModalComponent.new do |component| %>
-  <% component.with(:header, 'Change source id') %>
-  <% component.with(:body) { render 'source_id_ui' } %>
+  <% component.header { 'Change source id' } %>
+  <% component.body { render 'source_id_ui' } %>
 <% end %>

--- a/app/views/manage_releases/show.html.erb
+++ b/app/views/manage_releases/show.html.erb
@@ -1,4 +1,4 @@
 <%= render BlacklightModalComponent.new do |component| %>
-  <% component.with(:header, 'Manage release') %>
-  <% component.with(:body) { render 'show' } %>
+  <% component.header { 'Manage release' } %>
+  <% component.body { render 'show' } %>
 <% end %>

--- a/app/views/metadata/descriptive.html.erb
+++ b/app/views/metadata/descriptive.html.erb
@@ -1,4 +1,4 @@
 <%= render BlacklightModalComponent.new do |component| %>
-  <% component.with(:header, render_mods_display(@mods_display).title.first.html_safe) %>
-  <% component.with(:body) { render 'descriptive' } %>
+  <% component.header { render_mods_display(@mods_display).title.first.html_safe } %>
+  <% component.body { render 'descriptive' } %>
 <% end %>

--- a/app/views/metadata/full_dc.html.erb
+++ b/app/views/metadata/full_dc.html.erb
@@ -1,6 +1,6 @@
 <%= render BlacklightModalComponent.new do |component| %>
-  <% component.with(:header, 'Dublin Core (derived from MODS)') %>
-  <% component.with(:body) do %>
+  <% component.header { 'Dublin Core (derived from MODS)' } %>
+  <% component.body do %>
     <div class="lightbox-head">
       <span class="section-head-link">
         <%= link_to 'View XML', item_datastream_path(params[:item_id], 'full_dc'), title: 'Dublin Core (derived from MODS)', data: { blacklight_modal: 'trigger' } %>

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -1,4 +1,4 @@
 <%= render BlacklightModalComponent.new do |component| %>
-  <% component.with(:header, 'Update tags or delete a tag') %>
-  <% component.with(:body) { render 'edit' } %>
+  <% component.header { 'Update tags or delete a tag' } %>
+  <% component.body { render 'edit' } %>
 <% end %>

--- a/app/views/versions/close_ui.html.erb
+++ b/app/views/versions/close_ui.html.erb
@@ -1,4 +1,4 @@
 <%= render BlacklightModalComponent.new do |component| %>
-  <% component.with(:header, 'Close version') %>
-  <% component.with(:body) { render 'close_ui' } %>
+  <% component.header { 'Close version' } %>
+  <% component.body { render 'close_ui' } %>
 <% end %>

--- a/app/views/versions/open_ui.html.erb
+++ b/app/views/versions/open_ui.html.erb
@@ -1,4 +1,4 @@
 <%= render BlacklightModalComponent.new do |component| %>
-  <% component.with(:header, 'Open for modification') %>
-  <% component.with(:body) { render 'open_ui' } %>
+  <% component.header { 'Open for modification' } %>
+  <% component.body { render 'open_ui' } %>
 <% end %>

--- a/app/views/workflows/history.html.erb
+++ b/app/views/workflows/history.html.erb
@@ -1,4 +1,4 @@
 <%= render BlacklightModalComponent.new do |component| %>
-  <% component.with(:header, 'Workflow history') %>
-  <% component.with(:body) { render 'history' } %>
+  <% component.header { 'Workflow history' } %>
+  <% component.body { render 'history' } %>
 <% end %>

--- a/app/views/workflows/new.html.erb
+++ b/app/views/workflows/new.html.erb
@@ -1,4 +1,4 @@
 <%= render BlacklightModalComponent.new do |component| %>
-  <% component.with(:header, 'Add workflow') %>
-  <% component.with(:body) { render 'new' } %>
+  <% component.header { 'Add workflow' } %>
+  <% component.body { render 'new' } %>
 <% end %>

--- a/app/views/workflows/show.html.erb
+++ b/app/views/workflows/show.html.erb
@@ -1,6 +1,6 @@
 <%= render BlacklightModalComponent.new do |component| %>
-  <% component.with(:header, 'Workflow view') %>
-  <% component.with(:body) do %>
+  <% component.header { 'Workflow view' } %>
+  <% component.body do %>
     <% if params[:raw] %>
       <%= @presenter.pretty_xml %>
     <% else %>

--- a/spec/components/blacklight_modal_component_spec.rb
+++ b/spec/components/blacklight_modal_component_spec.rb
@@ -5,9 +5,9 @@ require 'rails_helper'
 RSpec.describe BlacklightModalComponent, type: :component do
   it 'renders the bootstrap modal' do
     render_inline(described_class.new) do |component|
-      component.with(:header, 'header')
-      component.with(:body, 'body')
-      component.with(:footer, 'footer')
+      component.header { 'header' }
+      component.body { 'body' }
+      component.footer { 'footer' }
     end
     expect(page).to have_button('×')
     expect(page).to have_content('header')


### PR DESCRIPTION


## Why was this change made?

Avoids some of these warnings:
```
Use slots (https://viewcomponent.org/guide/slots.html) instead. (called from _app_views_catalog__search_sidebar_html_erb___1760964059338821852_371500 at /home/circleci/project/app/views/catalog/_search_sidebar.html.erb:1)
DEPRECATION WARNING:  is deprecated and will be removed in ViewComponent v3.0.0.
```

## How was this change tested?



## Which documentation and/or configurations were updated?



