### PR TITLE
Remove Sidekiq session_secret it is obsolete

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,6 @@
 
 Rails.application.routes.draw do
   require 'sidekiq/web'
-  Sidekiq::Web.set :session_secret, Rails.application.secrets[:secret_key_base]
   mount Sidekiq::Web => '/queues'
 
   get '/is_it_working' => 'ok_computer/ok_computer#show', defaults: { check: 'default' }


### PR DESCRIPTION
## Why was this change made?
To avoid a deprecation warning


## How was this change tested?



## Which documentation and/or configurations were updated?



