### PR TITLE
Remove escaped space from solr query

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -48,7 +48,7 @@ class CollectionsController < ApplicationController
   def collection_exists?(title:, catkey:)
     return false unless title || catkey
 
-    query = '_query_:"{!raw+f=has_model_ssim}info:fedora/afmodel:Dor_Collection"'
+    query = '_query_:"{!raw f=has_model_ssim}info:fedora/afmodel:Dor_Collection"'
     query += " AND title_ssi:\"#{title}\"" if title
     query += " AND identifier_ssim:\"catkey:#{params[:catkey]}\"" if catkey
 

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe CollectionsController do
         }
         expect(response.body).to eq('true')
         expect(solr_client).to have_received(:get).with('select', params: a_hash_including(
-          q: '_query_:"{!raw+f=has_model_ssim}info:fedora/afmodel:Dor_Collection" AND title_ssi:"foo"'
+          q: '_query_:"{!raw f=has_model_ssim}info:fedora/afmodel:Dor_Collection" AND title_ssi:"foo"'
         ))
       end
     end
@@ -110,7 +110,7 @@ RSpec.describe CollectionsController do
         }
         expect(response.body).to eq('true')
         expect(solr_client).to have_received(:get).with('select', params: a_hash_including(
-          q: '_query_:"{!raw+f=has_model_ssim}info:fedora/afmodel:Dor_Collection" AND identifier_ssim:"catkey:123"'
+          q: '_query_:"{!raw f=has_model_ssim}info:fedora/afmodel:Dor_Collection" AND identifier_ssim:"catkey:123"'
         ))
       end
     end
@@ -136,7 +136,7 @@ RSpec.describe CollectionsController do
         }
         expect(response.body).to eq('true')
         expect(solr_client).to have_received(:get).with('select', params: a_hash_including(
-          q: '_query_:"{!raw+f=has_model_ssim}info:fedora/afmodel:Dor_Collection" AND title_ssi:"foo" AND identifier_ssim:"catkey:123"'
+          q: '_query_:"{!raw f=has_model_ssim}info:fedora/afmodel:Dor_Collection" AND title_ssi:"foo" AND identifier_ssim:"catkey:123"'
         ))
       end
     end


### PR DESCRIPTION
## Why was this change made?

Fixes: https://app.honeybadger.io/projects/49894/faults/78684696

## How was this change tested?



## Which documentation and/or configurations were updated?



