### PR TITLE
Create a test support method for clearing out solr

### DIFF
--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe ReportController, type: :controller do
   before do
-    solr_conn.delete_by_query('*:*')
+    reset_solr
     solr_conn.add(id: 'druid:xb482ww9999',
                   objectType_ssim: 'item',
                   obj_label_tesim: 'Report about stuff')

--- a/spec/factories/apos.rb
+++ b/spec/factories/apos.rb
@@ -1,23 +1,6 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :ur_apo, class: 'Cocina::Models::RequestAdminPolicy' do
-    initialize_with do
-      nil
-    end
-    to_create do
-      # Solves an odd bootstrapping problem, where the dor-indexing-app can only index cocina-models,
-      # but cocina-model can't be built unless the AdminPolicy is found in Solr
-      blacklight_config = CatalogController.blacklight_config
-      conn = blacklight_config.repository_class.new(blacklight_config).connection
-      conn.add(id: 'druid:hv992ry2431',
-               objectType_ssim: ['adminPolicy'],
-               has_model_ssim: ['info:fedora/afmodel:Dor_AdminPolicyObject'])
-      conn.commit
-      SolrDocument.new(id: 'druid:hv992ry2431')
-    end
-  end
-
   factory :apo, class: 'Cocina::Models::RequestAdminPolicy' do
     initialize_with do |*_args|
       ApoMethodSender.new(
@@ -36,7 +19,7 @@ FactoryBot.define do
       Dor::Services::Client.objects.register(params: builder.cocina_model)
     end
 
-    admin_policy_id { FactoryBot.create_for_repository(:ur_apo).id }
+    admin_policy_id { 'druid:hv992ry2431' }
 
     type { Cocina::Models::Vocab.admin_policy }
   end

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
       Dor::Services::Client.objects.register(params: builder.cocina_model)
     end
 
-    admin_policy_id { FactoryBot.create_for_repository(:ur_apo).pid }
+    admin_policy_id { 'druid:hv992ry2431' }
 
     type { Cocina::Models::Vocab.collection }
   end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
       Dor::Services::Client.objects.register(params: builder.cocina_model)
     end
 
-    admin_policy_id { FactoryBot.create_for_repository(:ur_apo).id }
+    admin_policy_id { 'druid:hv992ry2431' }
     label { 'test object' }
     type { Cocina::Models::Vocab.object }
 

--- a/spec/features/item_registration_spec.rb
+++ b/spec/features/item_registration_spec.rb
@@ -5,15 +5,6 @@ require 'rails_helper'
 RSpec.describe 'Item registration page', js: true do
   let(:user) { create(:user) }
   let(:ur_apo_id) { 'druid:hv992ry2431' }
-  let(:solr_doc) do
-    {
-      id: ur_apo_id,
-      apo_register_permissions_ssim: ['workgroup:dlss:developers'],
-      objectType_ssim: ['adminPolicy'],
-      sw_display_title_tesim: ['[Internal System Objects]']
-    }
-  end
-
   let(:blacklight_config) { CatalogController.blacklight_config }
   let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
@@ -32,9 +23,7 @@ RSpec.describe 'Item registration page', js: true do
 
   before do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
-
-    solr_conn.add(solr_doc)
-    solr_conn.commit
+    reset_solr
     sign_in user, groups: ['sdr:administrator-role', 'dlss:developers']
   end
 

--- a/spec/features/set_governing_apo_spec.rb
+++ b/spec/features/set_governing_apo_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe 'Set governing APO' do
   let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
 
   before do
-    solr_conn.delete_by_query('*:*')
-    solr_conn.commit
+    reset_solr
 
     new_apo
     item

--- a/spec/support/reset_solr.rb
+++ b/spec/support/reset_solr.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module ResetSolr
+  def reset_solr
+    blacklight_config = CatalogController.blacklight_config
+    solr_conn = blacklight_config.repository_class.new(blacklight_config).connection
+    solr_conn.delete_by_query('*:*')
+
+    # Solves an odd bootstrapping problem, where the dor-indexing-app can only index cocina-models,
+    # but cocina-model can't be built unless the AdminPolicy is found in Solr
+    solr_conn.add(id: 'druid:hv992ry2431',
+                  objectType_ssim: ['adminPolicy'],
+                  apo_register_permissions_ssim: ['workgroup:dlss:developers'],
+                  sw_display_title_tesim: ['[Internal System Objects]'],
+                  has_model_ssim: ['info:fedora/afmodel:Dor_AdminPolicyObject'])
+    solr_conn.commit
+  end
+end
+
+RSpec.configure do |config|
+  config.include ResetSolr
+  config.before(:suite) { Class.new { include ResetSolr }.new.reset_solr }
+end


### PR DESCRIPTION


## Why was this change made?

This also bootstraps the UR-APO, so that it's never missing.  dor-services-app depends on it finding the APO in solr.

## How was this change tested?



## Which documentation and/or configurations were updated?



