### PR TITLE
Provide validations for the CollectionForm

### DIFF
--- a/app/forms/collection_form.rb
+++ b/app/forms/collection_form.rb
@@ -4,15 +4,26 @@
 # This is for the collection form and it's only used for create, not for update
 # as it registers a new object (of type collection) on each call to `#save`
 class CollectionForm
+  extend ActiveModel::Naming
+  extend ActiveModel::Translation
+
   def initialize
     @errors = ActiveModel::Errors.new(self)
+  end
+
+  # needed so that we can use ActiveModel::Errors
+  def self.model_name
+    Struct.new(:param_key, :route_key, :i18n_key, :human).new('collection_form', 'collection', 'collection', 'Collection')
   end
 
   # @param [HashWithIndifferentAccess] params the parameters from the form
   # @return [Boolean] true if the parameters are valid
   def validate(params)
     @params = params
-    @errors.push('missing collection_title or collection_catkey') unless params[:collection_title].present? || params[:collection_catkey].present?
+    unless params[:collection_title].present? || params[:collection_catkey].present?
+      @errors.add(:base, :title_or_catkey_blank,
+                  message: 'missing collection_title or collection_catkey')
+    end
     @errors.empty?
   end
 
@@ -23,7 +34,7 @@ class CollectionForm
 
   attr_reader :errors, :model, :params
 
-  delegate :model_name, :to_key, :to_model, :new_record?, to: :model
+  delegate :to_key, :to_model, :new_record?, to: :model
 
   private
 

--- a/spec/forms/collection_form_spec.rb
+++ b/spec/forms/collection_form_spec.rb
@@ -44,6 +44,21 @@ RSpec.describe CollectionForm do
       allow(instance).to receive(:sync)
     end
 
+    context 'when fields are missing' do
+      let(:params) do
+        {
+          collection_title: '',
+          collection_abstract: '',
+          collection_rights: 'dark'
+        }.with_indifferent_access
+      end
+
+      it "doesn't validate" do
+        expect(instance.validate(params.merge(apo_pid: apo_pid))).to be false
+        expect(instance.errors.full_messages).to eq ['missing collection_title or collection_catkey']
+      end
+    end
+
     context 'when metadata_source is label' do
       let(:params) do
         {


### PR DESCRIPTION


## Why was this change made?

Previously there would be an error if the collection title or catkey were both left blank

## How was this change tested?



## Which documentation and/or configurations were updated?



