### PR TITLE
Drop unused responders dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,6 @@ gem 'dor-workflow-client', '~> 3.19'
 gem 'mods_display'
 gem 'okcomputer' # monitors application and its dependencies
 gem 'preservation-client', '~> 3.2'
-gem 'responders', '~> 2.0'
 gem 'rsolr'
 gem 'sdr-client', '~> 0.55.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -566,7 +566,6 @@ DEPENDENCIES
   rails (~> 5.2.1)
   rails-controller-testing
   rake
-  responders (~> 2.0)
   rest-client
   retries
   rsolr


### PR DESCRIPTION
## Why was this change made?
 We don't need this


## How was this change tested?



## Which documentation and/or configurations were updated?



