### PR TITLE
clarify comments and remove unused let vars

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,7 +32,6 @@ Metrics/BlockLength:
   Max: 25
   IgnoredMethods:
     - 'configure_blacklight'
-    - 'Dor.configure'
   Exclude:
     - 'config/routes.rb'
     - 'spec/**/*'

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -23,7 +23,7 @@ class CollectionsController < ApplicationController
 
     cocina_admin_policy = object_client.find
     collections = Array(cocina_admin_policy.administrative.collectionsForRegistration)
-    # The following two steps mimic the behavior of `Dor::AdministrativeMetadataDS#add_default_collection`
+    # The following two steps mimic the behavior of `Dor::AdministrativeMetadataDS#add_default_collection` (from the now de-coupled dor-services gem)
     # 1. If collection is already listed, remove it temporarily
     collections.delete(collection_pid)
     # 2. Move the collection PID to the front of the list of registration collections

--- a/app/forms/access_form.rb
+++ b/app/forms/access_form.rb
@@ -12,7 +12,8 @@ class AccessForm
   end
 
   # @param [HashWithIndifferentAccess] params the values from the form
-  # @option params [String] :rights the rights representation from the form (must be one of the keys in Dor::RightsMetadataDS::RIGHTS_TYPE_CODES, or 'default')
+  # @option params [String] :rights the rights representation from the form (must be one of the keys in Dor::RightsMetadataDS::RIGHTS_TYPE_CODES, or 'default',
+  # see the now de-coupled dor-services gem)
   def validate(params)
     rights = params[:rights]
     # valid_rights_options is implemented by concrete class.

--- a/app/services/cocina_access.rb
+++ b/app/services/cocina_access.rb
@@ -4,7 +4,8 @@
 class CocinaAccess
   extend Dry::Monads[:maybe]
 
-  # @param [String] the rights representation from the form (must be one of the keys in Dor::RightsMetadataDS::RIGHTS_TYPE_CODES, or 'default')
+  # @param [String] the rights representation from the form (must be one of the keys in Dor::RightsMetadataDS::RIGHTS_TYPE_CODES, or 'default',
+  # see the now de-coupled dor-services gem)
   # @return [Maybe<Hash<Symbol,String>>] a hash representing a subset of the Access subschema of the Cocina model
   def self.from_form_value(rights)
     # Default only appears on the registration form, not the update form.

--- a/app/services/cocina_dro_access.rb
+++ b/app/services/cocina_dro_access.rb
@@ -4,7 +4,8 @@
 class CocinaDROAccess
   extend Dry::Monads[:maybe]
 
-  # @param [String] rights the rights representation from the form (must be one of the keys in Dor::RightsMetadataDS::RIGHTS_TYPE_CODES, or 'default')
+  # @param [String] rights the rights representation from the form (must be one of the keys in Dor::RightsMetadataDS::RIGHTS_TYPE_CODES, or 'default',
+  # see the now de-coupled dor-services gem)
   # @return [Maybe<Hash<Symbol,String>>] a hash representing a subset of the Access subschema of the Cocina model
   def self.from_form_value(rights)
     # Default only appears on the registration form, not the update form.

--- a/spec/presenters/buttons_presenter_spec.rb
+++ b/spec/presenters/buttons_presenter_spec.rb
@@ -235,9 +235,6 @@ RSpec.describe ButtonsPresenter, type: :presenter do
   describe '#registered_only?' do
     subject { presenter.send(:registered_only?) }
 
-    let(:id_md) do
-      instance_double(Dor::IdentityMetadataDS)
-    end
     let(:item_id) { 'druid:kv840xx0000' }
 
     context 'when registered' do

--- a/spec/views/files/index.html.erb_spec.rb
+++ b/spec/views/files/index.html.erb_spec.rb
@@ -3,28 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe 'files/index.html.erb' do
-  let(:contentMetadata) do
-    cm = Dor::ContentMetadataDS.new
-    cm.content = '<contentMetadata type="image" objectId="rn653dy9317">
-  <resource type="image" sequence="106" id="rn653dy9317_106">
-    <label>Image 106</label>
-    <file mimetype="image/jp2" publish="yes" shelve="yes" format="JPEG2000" preserve="yes" size="3305991" id="M1090_S15_B01_F07_0106.jp2">
-      <imageData width="5102" height="3426"/>
-      <attr name="representation">uncropped</attr>
-      <checksum type="sha1">fd28e74b3139b04a0e5c5c3d3263598f629f8967</checksum>
-      <checksum type="md5">244cbb3960407f59ac77a916870e0502</checksum>
-    </file>
-    <file mimetype="image/tiff" publish="no" shelve="no" format="TIFF" preserve="yes" size="52467428" id="M1090_S15_B01_F07_0106.tif">
-      <imageData width="5102" height="3426"/>
-      <attr name="representation">uncropped</attr>
-      <checksum type="sha1">cf336c4f714b180a09bbfefde159d689e1d517bd</checksum>
-      <checksum type="md5">56978088366e66f87d4d5a531f2fea04</checksum>
-    </file>
-  </resource>
-</contentMetadata>'
-    cm
-  end
-
   let(:admin) { instance_double(Cocina::Models::FileAdministrative, shelve: true, sdrPreserve: true) }
 
   before do


### PR DESCRIPTION
now that dor-services gem is no longer used directly

## Why was this change made?

ran grep to find leftovers from the dor-services gem removal (this was the dor-services cruft i found yesterday and mentioned at standup this morning)
```
argo % git grep 'Dor::' | grep -v 'Dor::Services::Client' | grep -v 'Dor::Workflow'                   main
app/controllers/collections_controller.rb:    # The following two steps mimic the behavior of `Dor::AdministrativeMetadataDS#add_default_collection`
app/controllers/dor/objects_controller.rb:class Dor::ObjectsController < ApplicationController
app/forms/access_form.rb:  # @option params [String] :rights the rights representation from the form (must be one of the keys in Dor::RightsMetadataDS::RIGHTS_TYPE_CODES, or 'default')
app/services/cocina_access.rb:  # @param [String] the rights representation from the form (must be one of the keys in Dor::RightsMetadataDS::RIGHTS_TYPE_CODES, or 'default')
app/services/cocina_dro_access.rb:  # @param [String] rights the rights representation from the form (must be one of the keys in Dor::RightsMetadataDS::RIGHTS_TYPE_CODES, or 'default')
spec/controllers/dor/objects_controller_spec.rb:RSpec.describe Dor::ObjectsController, type: :controller do
spec/features/item_registration_spec.rb:    expect_any_instance_of(Dor::ObjectsController).to receive(:create) do |arg|
spec/features/item_registration_spec.rb:    # it also forces capybara to wait for the Dor::ObjectsController#create call to finish, meaning the
spec/presenters/buttons_presenter_spec.rb:      instance_double(Dor::IdentityMetadataDS)
spec/views/files/index.html.erb_spec.rb:    cm = Dor::ContentMetadataDS.new
argo %                                                                                                main
argo %                                                                                                main
argo % git grep 'Dor\.'                                                                               main
.rubocop.yml:    - 'Dor.configure'
argo %                                                                                                
```

i left the `Dor::ObjectsController` namespacing alone -- i did actually quickly try to move it to `ObjectsController`, but i backed off when it didn't look like it'd be super super quick, because it also isn't 100% obvious to me that dropping the `Dor::` namespace is the right thing to do.

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?

various comments, `.rubocop.yml`
