### PR TITLE
Document quick fixture creation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,19 @@ docker-compose run --rm web yarn install
 docker-compose run --rm web bin/rake webpacker:compile
 ```
 
+## Creating fixture data
+
+To begin registering items in the Argo UI, there will need to be at least one agreement object and one APO object in the index. To create and index one of each of these objects, run the following commands:
+
+```
+$ docker-compose exec web bin/rails c
+> require_relative 'spec/support/create_strategy_repository_pattern'
+> require_relative 'spec/support/item_method_sender'
+> require_relative 'spec/support/apo_method_sender'
+> FactoryBot.create_for_repository(:agreement)
+> FactoryBot.create_for_repository(:apo, roles: [{ name: 'dor-apo-manager', members: [{ identifier: 'sdr:administrator-role', type: 'workgroup' }] }])
+```
+
 ## Internals
 
 Argo uses Blacklight and ActiveFedora to expose the repository contents, and `dor-services` to enable editing and updating. Its key components include:


### PR DESCRIPTION

## Why was this change made?

This makes it easier to begin registering items and using the Argo UI. Thanks to @jcoyne for the tips.

## How was this change tested?

I tested the steps locally.

## Which documentation and/or configurations were updated?

README

