### PR TITLE
remove pids_only param from search context when returning to search view

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -243,6 +243,11 @@ class CatalogController < ApplicationController
     end
   end
 
+  # do not add the pids_only search param to the blacklight search history (used in bulk actions only)
+  def blacklisted_search_session_params
+    super << :pids_only
+  end
+
   # This overrides Blacklight to pass context to the search service
   # @return [Hash] a hash of context information to pass through to the search service
   def search_service_context


### PR DESCRIPTION
## Why was this change made?

fixes #2645 - remove pids_only param when linking back to search results from a bulk action

## How was this change tested?

Localhost browser and qa


## Which documentation and/or configurations were updated?



