### PR TITLE
Edit APO: sort default collections case insensitively

### DIFF
--- a/app/forms/apo_form.rb
+++ b/app/forms/apo_form.rb
@@ -58,7 +58,13 @@ class ApoForm
 
   # @return [Array<SolrDocument>]
   def default_collection_objects
-    @default_collection_objects ||= search_service.fetch(default_collections, rows: default_collections.size).last.sort_by(&:label)
+    @default_collection_objects ||=
+      search_service
+      .fetch(default_collections, rows: default_collections.size)
+      .last
+      .sort_by do |solr_doc|
+        solr_doc.label.downcase
+      end
   end
 
   def to_param

--- a/spec/forms/apo_form_spec.rb
+++ b/spec/forms/apo_form_spec.rb
@@ -213,7 +213,10 @@ RSpec.describe ApoForm do
 
     let(:default_collection_druids) { administrative[:collectionsForRegistration] }
     let(:default_collection_objects) do
-      default_collection_druids.map { |druid| instance_double(SolrDocument, label: druid) }
+      default_collection_druids.map do |druid|
+        label = druid[-1].to_i.even? ? druid : druid.upcase # introduce arbitrary mixed case to test sorting
+        instance_double(SolrDocument, label: label)
+      end
     end
     let(:search_service_result) { [nil, default_collection_objects] }
     let(:search_service) { instance_double(Blacklight::SearchService) }
@@ -223,6 +226,6 @@ RSpec.describe ApoForm do
                                               .and_return(search_service_result)
     end
 
-    it { is_expected.to eq default_collection_objects.sort_by(&:label) }
+    it { is_expected.to eq(default_collection_objects.sort_by { |solr_doc| solr_doc.label.downcase }) }
   end
 end


### PR DESCRIPTION
## Why was this change made?

quick touchup to make sort for default collection list case insensitive, per discussion with @andrewjbtw on slack this morning (re: #2659).

## How was this change tested?

unit tests and local dev instance.  happy to test on -stage or -qa also, if that's desired.

##### before
<img width="881" alt="Screen Shot 2021-04-13 at 3 41 23 PM" src="https://user-images.githubusercontent.com/7741604/114630255-0ab6ff00-9c6f-11eb-8724-dd887eb01e9c.png">

##### after
<img width="829" alt="Screen Shot 2021-04-13 at 3 42 03 PM" src="https://user-images.githubusercontent.com/7741604/114630270-16a2c100-9c6f-11eb-803c-63ff8886f9b0.png">


## Which documentation and/or configurations were updated?

n/a