### PR TITLE
Refactor: Set an embargo using the update API

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -121,13 +121,8 @@ class ItemsController < ApplicationController
                          flash: { error: 'Invalid date' }
     end
 
-    object_client = Dor::Services::Client.object(@cocina.externalIdentifier)
-    existing_embargo = @cocina.access.embargo
-    updated_embargo = existing_embargo.new(releaseDate: params[:embargo_date])
-    updated_access = @cocina.access.new(embargo: updated_embargo)
-    updated_item = @cocina.new(access: updated_access)
-
-    object_client.update(params: updated_item)
+    change_set = ItemChangeSet.new { |change| change.embargo_release_date = params[:embargo_date] }
+    ItemChangeSetPersister.update(@cocina, change_set)
 
     respond_to do |format|
       format.any { redirect_to solr_document_path(params[:id]), notice: 'Embargo was successfully updated' }

--- a/app/models/item_change_set.rb
+++ b/app/models/item_change_set.rb
@@ -7,6 +7,7 @@ class ItemChangeSet
     catkey
     collection_ids
     copyright_statement
+    embargo_release_date
     license
     source_id
     use_statement

--- a/app/services/item_change_set_persister.rb
+++ b/app/services/item_change_set_persister.rb
@@ -27,10 +27,15 @@ class ItemChangeSetPersister
 
   attr_reader :model, :change_set
 
-  delegate :collection_ids_changed?, :source_id_changed?, :catkey_changed?, :admin_policy_id_changed?,
-           :collection_ids, :source_id, :catkey, :admin_policy_id, :license, :license_changed?,
-           :copyright_statement, :copyright_statement_changed?, :use_statement, :use_statement_changed?,
+  delegate :admin_policy_id, :admin_policy_id_changed?,
            :barcode, :barcode_changed?,
+           :catkey, :catkey_changed?,
+           :collection_ids, :collection_ids_changed?,
+           :copyright_statement, :copyright_statement_changed?,
+           :embargo_release_date, :embargo_release_date_changed?,
+           :license, :license_changed?,
+           :source_id, :source_id_changed?,
+           :use_statement, :use_statement_changed?,
            to: :change_set
 
   def object_client
@@ -52,7 +57,7 @@ class ItemChangeSetPersister
   end
 
   def access_changed?
-    copyright_statement_changed? || license_changed? || use_statement_changed?
+    copyright_statement_changed? || license_changed? || use_statement_changed? || embargo_release_date_changed?
   end
 
   def updated_access(updated)
@@ -61,6 +66,8 @@ class ItemChangeSetPersister
       license: license_changed? ? license : updated.access.license,
       useAndReproductionStatement: use_statement_changed? ? use_statement : updated.access.useAndReproductionStatement
     }.compact
+
+    access_properties[:embargo] = updated.access.embargo.new(releaseDate: embargo_release_date) if embargo_release_date_changed?
 
     updated.new(access: updated.access.new(access_properties))
   end

--- a/spec/services/item_change_set_persister_spec.rb
+++ b/spec/services/item_change_set_persister_spec.rb
@@ -100,9 +100,44 @@ RSpec.describe ItemChangeSetPersister do
       end
     end
 
+    context 'when change set has changed embargo_release_date' do
+      let(:change_set) do
+        ItemChangeSet.new { |change| change.embargo_release_date = new_embargo_release_date }
+      end
+      let(:new_embargo_release_date) { '2055-07-17' }
+      let(:model) do
+        Cocina::Models::DRO.new(
+          externalIdentifier: 'druid:bc123df4568',
+          label: 'test',
+          type: Cocina::Models::Vocab.object,
+          version: 1,
+          access: {
+            embargo: { releaseDate: '2040-04-04', access: 'world' },
+            copyright: copyright_statement_before,
+            license: license_before,
+            useAndReproductionStatement: use_statement_before
+          },
+          administrative: { hasAdminPolicy: 'druid:bc123df4569' }
+        )
+      end
+
+      it 'invokes object client with item/DRO that has new use statement' do
+        expect(fake_client).to have_received(:update).with(
+          params: a_cocina_object_with_access(
+            embargo: {
+              releaseDate: '2055-07-17',
+              access: 'world'
+            },
+            copyright: copyright_statement_before,
+            license: license_before,
+            useAndReproductionStatement: use_statement_before
+          )
+        )
+      end
+    end
+
     context 'when change set has one changed property and another nil' do
       let(:change_set) { ItemChangeSet.new(use_statement: new_use_statement) }
-
       let(:model) do
         Cocina::Models::DRO.new(
           externalIdentifier: 'druid:bc123df4568',


### PR DESCRIPTION


## Why was this change made?

The update API is now mature enough where we can replace and retire the embargo update API.

## How was this change tested?



## Which documentation and/or configurations were updated?



