### PR TITLE
Adds display of full JSON for cocina.

### DIFF
--- a/app/components/external_links_component.html.erb
+++ b/app/components/external_links_component.html.erb
@@ -7,5 +7,6 @@
   <li class="nav-item"><%= dor_link %></li>
   <li class="nav-item"><%= foxml_link %></li>
   <li class="nav-item"><%= solr_link %></li>
+  <li class="nav-item"><%= cocina_link %></li>
   <li class="nav-item"><small><%= index_info %></small></li>
 </ul>

--- a/app/components/external_links_component.rb
+++ b/app/components/external_links_component.rb
@@ -33,6 +33,11 @@ class ExternalLinksComponent < ViewComponent::Base
             target: '_blank', rel: 'noopener', class: 'nav-link'
   end
 
+  def cocina_link
+    link_to 'Cocina model', cocina_item_path(document, format: :json),
+            target: '_blank', rel: 'noopener', class: 'nav-link'
+  end
+
   def index_info
     "indexed by DOR Services v#{document.dor_services_version}"
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -111,6 +111,14 @@ class ItemsController < ApplicationController
     end
   end
 
+  def cocina
+    authorize! :view_metadata, @cocina
+
+    respond_to do |format|
+      format.json  { render json: @cocina }
+    end
+  end
+
   def embargo_update
     raise ArgumentError, 'Missing embargo_date parameter' unless params[:embargo_date].present?
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,6 +127,7 @@ Rails.application.routes.draw do
     member do
       post 'refresh_metadata'
       get 'mods'
+      get 'cocina'
       post 'embargo', action: :embargo_update, as: 'embargo_update'
       get 'embargo_form'
       get 'source_id_ui'

--- a/spec/components/external_links_component_spec.rb
+++ b/spec/components/external_links_component_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe ExternalLinksComponent, type: :component do
       expect(page).not_to have_link 'Searchworks'
       expect(page).to have_link 'PURL', href: 'https://sul-purl-stage.stanford.edu/ab123cd3445'
       expect(page).to have_link 'Solr document', href: '/view/druid:ab123cd3445.json'
+      expect(page).to have_link 'Cocina model', href: '/items/druid:ab123cd3445/cocina.json'
     end
   end
 
@@ -38,6 +39,7 @@ RSpec.describe ExternalLinksComponent, type: :component do
 
         expect(page).to have_link 'Searchworks', href: 'http://searchworks.stanford.edu/view/123456'
         expect(page).to have_link 'PURL', href: 'https://sul-purl-stage.stanford.edu/ab123cd3445'
+        expect(page).to have_link 'Cocina model', href: '/items/druid:ab123cd3445/cocina.json'
       end
     end
 

--- a/spec/requests/view_cocina_model_spec.rb
+++ b/spec/requests/view_cocina_model_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'View Cocina model' do
+  let(:user) { create(:user) }
+
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: item) }
+  let(:item) do
+    FactoryBot.create_for_repository(:item)
+  end
+
+  before do
+    sign_in user, groups: ['sdr:viewer-role']
+    allow(Dor::Services::Client).to receive(:object).with(item.externalIdentifier).and_return(object_client)
+  end
+
+  it 'return json' do
+    get "/items/#{item.externalIdentifier}/cocina.json"
+    expect(response).to be_successful
+    expect(response.body).to include '{"type":"http://cocina.sul.stanford.edu/models/object.jsonld",'
+  end
+end


### PR DESCRIPTION
closes #2618

## Why was this change made?
Make it easier to view full JSON for cocina object.


## How was this change tested?
Unit, qa


## Which documentation and/or configurations were updated?
NA


