### PR TITLE
Use the show action for the cocina model

### DIFF
--- a/app/components/external_links_component.rb
+++ b/app/components/external_links_component.rb
@@ -34,7 +34,7 @@ class ExternalLinksComponent < ViewComponent::Base
   end
 
   def cocina_link
-    link_to 'Cocina model', cocina_item_path(document, format: :json),
+    link_to 'Cocina model', item_path(document, format: :json),
             target: '_blank', rel: 'noopener', class: 'nav-link'
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -111,7 +111,7 @@ class ItemsController < ApplicationController
     end
   end
 
-  def cocina
+  def show
     authorize! :view_metadata, @cocina
 
     respond_to do |format|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,7 +84,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :items, only: [] do
+  resources :items, only: :show do
     resources 'files', only: %i[index], constraints: { id: /.*/ } do
       member do
         get 'preserved'
@@ -127,7 +127,6 @@ Rails.application.routes.draw do
     member do
       post 'refresh_metadata'
       get 'mods'
-      get 'cocina'
       post 'embargo', action: :embargo_update, as: 'embargo_update'
       get 'embargo_form'
       get 'source_id_ui'

--- a/spec/components/external_links_component_spec.rb
+++ b/spec/components/external_links_component_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ExternalLinksComponent, type: :component do
       expect(page).not_to have_link 'Searchworks'
       expect(page).to have_link 'PURL', href: 'https://sul-purl-stage.stanford.edu/ab123cd3445'
       expect(page).to have_link 'Solr document', href: '/view/druid:ab123cd3445.json'
-      expect(page).to have_link 'Cocina model', href: '/items/druid:ab123cd3445/cocina.json'
+      expect(page).to have_link 'Cocina model', href: '/items/druid:ab123cd3445.json'
     end
   end
 
@@ -39,7 +39,7 @@ RSpec.describe ExternalLinksComponent, type: :component do
 
         expect(page).to have_link 'Searchworks', href: 'http://searchworks.stanford.edu/view/123456'
         expect(page).to have_link 'PURL', href: 'https://sul-purl-stage.stanford.edu/ab123cd3445'
-        expect(page).to have_link 'Cocina model', href: '/items/druid:ab123cd3445/cocina.json'
+        expect(page).to have_link 'Cocina model', href: '/items/druid:ab123cd3445.json'
       end
     end
 

--- a/spec/requests/view_cocina_model_spec.rb
+++ b/spec/requests/view_cocina_model_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'View Cocina model' do
   end
 
   it 'return json' do
-    get "/items/#{item.externalIdentifier}/cocina.json"
+    get "/items/#{item.externalIdentifier}.json"
     expect(response).to be_successful
     expect(response.body).to include '{"type":"http://cocina.sul.stanford.edu/models/object.jsonld",'
   end


### PR DESCRIPTION


## Why was this change made?

This is the idiomatic way to show the data for an object in a Rails app


## How was this change tested?



## Which documentation and/or configurations were updated?



