### PR TITLE
prevent closing a version when invalid cocina

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -206,7 +206,7 @@ class CatalogController < ApplicationController
     _deprecated_response, @document = search_service.fetch(params[:id])
 
     @cocina = maybe_load_cocina(params[:id])
-    flash[:error] = 'Warning: this object cannot currently be represented in the Cocina model.' if @cocina.instance_of?(NilModel)
+    flash[:alert] = 'Warning: this object cannot currently be represented in the Cocina model.' if @cocina.instance_of?(NilModel)
 
     authorize! :view_metadata, @cocina
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -206,6 +206,8 @@ class CatalogController < ApplicationController
     _deprecated_response, @document = search_service.fetch(params[:id])
 
     @cocina = maybe_load_cocina(params[:id])
+    flash[:error] = 'Warning: this object cannot currently be represented in the Cocina model.' if @cocina.instance_of?(NilModel)
+
     authorize! :view_metadata, @cocina
 
     object_client = Dor::Services::Client.object(params[:id])

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -78,7 +78,7 @@ class VersionsController < ApplicationController
   end
 
   def load_and_authorize_resource
-    @cocina_object = Dor::Services::Client.object(params[:item_id]).find
+    @cocina_object = maybe_load_cocina(params[:item_id])
     authorize! :manage_item, @cocina_object
   end
 end

--- a/app/views/versions/_close_ui.html.erb
+++ b/app/views/versions/_close_ui.html.erb
@@ -1,23 +1,23 @@
-<%= form_with(url: close_item_versions_path(@cocina_object.externalIdentifier), method: :post) do %>
-  <div class='form-group'>
-    <label for="significance">Type</label>
-    <select id="significance" name="significance" class='form-control'>
-      <%# loop through the significance levels and pre-select the one that was chosen when opening the version %>
-      <% @significance_selected.keys.each do |significance| %>
-        <option value="<%= significance.to_s %>"<%= @significance_selected[significance] ? ' selected' : '' -%>><%= significance.to_s.capitalize -%></option>
-      <% end %>
-    </select>
-  </div>
-  <div class='form-group'>
-    <label for="description">Version description</label><br>
-    <textarea id="description" name="description" class='form-control'><%= @description %></textarea>
-  </div>
-  <% if @cocina_object.instance_of?(NilModel) %>
-    <div class='alert alert-danger'>This object cannot currently be represented in the Cocina model and thus should
-      not be closed until it is made compliant.</div>
-  <% else %>
+<% if @cocina_object.instance_of?(NilModel) %>
+  <div class='alert alert-warning'>This object cannot currently be represented in the Cocina model and thus should
+    not be closed until it is made compliant.</div>
+<% else %>
+  <%= form_with(url: close_item_versions_path(@cocina_object.externalIdentifier), method: :post) do %>
+    <div class='form-group'>
+      <label for="significance">Type</label>
+      <select id="significance" name="significance" class='form-control'>
+        <%# loop through the significance levels and pre-select the one that was chosen when opening the version %>
+        <% @significance_selected.keys.each do |significance| %>
+          <option value="<%= significance.to_s %>"<%= @significance_selected[significance] ? ' selected' : '' -%>><%= significance.to_s.capitalize -%></option>
+        <% end %>
+      </select>
+    </div>
+    <div class='form-group'>
+      <label for="description">Version description</label><br>
+      <textarea id="description" name="description" class='form-control'><%= @description %></textarea>
+    </div>
     <button type='submit' class='btn btn-primary'>
       Close Version
     </button>
-   <% end %>
+  <% end %>
 <% end %>

--- a/app/views/versions/_close_ui.html.erb
+++ b/app/views/versions/_close_ui.html.erb
@@ -1,6 +1,8 @@
 <% if @cocina_object.instance_of?(NilModel) %>
-  <div class='alert alert-warning'>This object cannot currently be represented in the Cocina model and thus should
-    not be closed until it is made compliant.</div>
+  <div class='alert alert-warning'>
+    This object cannot currently be represented in the Cocina model and thus cannot be closed. Please check the object for possible metadata errors, such as a missing title or source id.
+    If you are unsure of what the issue is, you can ask for help on the #dlss-aaas Slack channel or email <a href="mailto:argo-feedback@lists.stanford.edu">argo-feedback@lists.stanford.edu</a>
+  </div>
 <% else %>
   <%= form_with(url: close_item_versions_path(@cocina_object.externalIdentifier), method: :post) do %>
     <div class='form-group'>

--- a/app/views/versions/_close_ui.html.erb
+++ b/app/views/versions/_close_ui.html.erb
@@ -12,7 +12,12 @@
     <label for="description">Version description</label><br>
     <textarea id="description" name="description" class='form-control'><%= @description %></textarea>
   </div>
-  <button type='submit' class='btn btn-primary'>
-    Close Version
-  </button>
+  <% if @cocina_object.instance_of?(NilModel) %>
+    <div class='alert alert-danger'>This object cannot currently be represented in the Cocina model and thus should
+      not be closed until it is made compliant.</div>
+  <% else %>
+    <button type='submit' class='btn btn-primary'>
+      Close Version
+    </button>
+   <% end %>
 <% end %>


### PR DESCRIPTION
## Why was this change made?

HOLD - Pending approval by @andrewjbtw 

Fixes #2298 - do not allow a user to close an object (in the UI) if the cocina is invalid.  See the UI screenshot below in the comments.

**Important note**: this does not prevent closing via a bulk action.

## How was this change tested?

Existing tests and verified on QA too

Find objects that are in this state for testing:
QA: https://argo-qa.stanford.edu/catalog?f[data_quality_ssim][]=Cocina+conversion+failed
Stage:  https://argo-stage.stanford.edu/catalog?f[data_quality_ssim][]=Cocina+conversion+failed
Prod: https://argo.stanford.edu/catalog?f[data_quality_ssim][]=Cocina+conversion+failed

To see in action, try this object:

https://argo-qa-a.stanford.edu/view/druid:bg954kx8787

* Open the `identityMetadata` and remove the sourceId element (if it exists) to make it invalid.
* Add the sourceId element back to make it valid again: e.g. ` <sourceId source="petucket">test-04182021abcdef</sourceId>`



## Which documentation and/or configurations were updated?



