### PR TITLE
Lazy load the tags facet 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem 'rest-client'
 gem 'retries'
 gem 'ruby-prof'
 gem 'rubyzip'
+gem 'turbo-rails', '~> 0.5.9'
 gem 'zip_tricks', '5.3.1' # 5.3.1 is required as 5.4+ breaks the download all feature
 
 # Stanford related gems

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -501,6 +501,8 @@ GEM
     thor (1.1.0)
     thread_safe (0.3.6)
     ttfunk (1.4.0)
+    turbo-rails (0.5.9)
+      rails (>= 6.0.0)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     unf (0.1.4)
@@ -601,6 +603,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3 (~> 1.4.2)
+  turbo-rails (~> 0.5.9)
   view_component (~> 2.0)
   web-console
   webdrivers

--- a/app/components/lazy_tag_facet_component.html.erb
+++ b/app/components/lazy_tag_facet_component.html.erb
@@ -1,0 +1,9 @@
+<turbo-frame id="tag-facet" src="<%= lazy_tag_facet_catalog_path(helpers.search_state.params_for_search)%>" target="_top">
+  <div class="card facet-limit blacklight-exploded_tag_ssim">
+    <h3 class="card-header p-0 facet-field-heading" id="facet-exploded_tag_ssim-header">
+      <button type="button" disabled style="cursor: wait" class="btn btn-block p-2 text-left collapse-toggle collapsed" aria-expanded="false">
+        Tag
+      </button>
+    </h3>
+  </div>
+</turbo-frame>

--- a/app/components/lazy_tag_facet_component.rb
+++ b/app/components/lazy_tag_facet_component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class LazyTagFacetComponent < ViewComponent::Base
+  def initialize(**); end
+end

--- a/app/controllers/apo_controller.rb
+++ b/app/controllers/apo_controller.rb
@@ -29,7 +29,7 @@ class ApoController < ApplicationController
       @form = ApoForm.new(nil, search_service: search_service)
       respond_to do |format|
         format.json { render status: :bad_request, json: { errors: form.errors } }
-        format.html { render 'new' }
+        format.html { render 'new', status: :unprocessable_entity }
       end
       return
     end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -61,7 +61,7 @@ class CatalogController < ApplicationController
     # description), whereas tag_ssim only indexes whole tags.  we want to facet on exploded_tag_ssim
     # to get the hierarchy.
     config.add_facet_field 'exploded_tag_ssim',                 label: 'Tag',                 limit: 9999,
-                                                                component: Blacklight::Hierarchy::FacetFieldListComponent,
+                                                                component: LazyTagFacetComponent,
                                                                 unless: ->(controller, _config, _response) { controller.params[:no_tags] }
     config.add_facet_field 'objectType_ssim',                   label: 'Object Type',         component: true, limit: 10
     config.add_facet_field SolrDocument::FIELD_CONTENT_TYPE,    label: 'Content Type',        component: true, limit: 10
@@ -199,6 +199,14 @@ class CatalogController < ApplicationController
   def index
     @presenter = HomeTextPresenter.new(current_user)
     super
+  end
+
+  def lazy_tag_facet
+    (response,) = search_service.search_results
+    facet_config = facet_configuration_for_field('exploded_tag_ssim')
+    display_facet = response.aggregations[facet_config.field]
+    @facet_field_presenter = facet_config.presenter.new(facet_config, display_facet, view_context)
+    render partial: 'lazy_tag_facet'
   end
 
   def show

--- a/app/javascript/argo.js
+++ b/app/javascript/argo.js
@@ -55,6 +55,13 @@ export default class Argo {
 
         this.apoEditor()
         this.collapsableSections()
+        this.blacklight()
+    }
+
+    // Because blacklight doesn't yet support turbo, we need to manually initialize
+    // the features we care about.
+    blacklight() {
+      Blacklight.activate()
     }
 
     tagsAutocomplete() {

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -28,6 +28,4 @@ import Argo from 'argo'
 import 'blacklight-frontend/app/assets/javascripts/blacklight/blacklight'
 import 'modules/blacklight-override'
 
-// The Blacklight onLoad event works better than the regular onLoad event if
-// turbolinks is enabled.
-Blacklight.onLoad(function() { new Argo().initialize() })
+document.addEventListener("turbo:load", () => { new Argo().initialize() })

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -21,6 +21,7 @@ import 'jquery-ui'
 import 'jquery-validation'
 import "bootstrap/dist/js/bootstrap"
 import "controllers"
+import '@hotwired/turbo-rails'
 
 import Argo from 'argo'
 

--- a/app/javascript/packs/bulk.js
+++ b/app/javascript/packs/bulk.js
@@ -269,7 +269,7 @@ function set_tags() {
 	upd_values_for_druids(tags_url, 'tags', row_processing_fn, "user supplied druids and tags.", is_invalid_row_fn, "invalid tags", get_upd_req_params_from_row_fn);
 }
 
-Blacklight.onLoad(()=>{
+document.addEventListener("turbo:load", () => {
   $('#get_druids').on('click', get_druids)
 	$('#paste-druids-button').on('click', () => $('#pid_list').show(400))
 	$('#prepare').on('click', () => $('#open').show(400))

--- a/app/javascript/spreadsheet.js
+++ b/app/javascript/spreadsheet.js
@@ -63,7 +63,7 @@
 
 // Confirmation modal dialog for when the user presses the delete button in the
 // spreadsheet bulk upload table.
-$(document).ready(function() {
+document.addEventListener("turbo:load", function() {
   // The form we want to submit has both ':' and '/' in its ID, which need to
   // be escaped
   function escapeCharacters(identifier) {

--- a/app/views/catalog/_lazy_tag_facet.html.erb
+++ b/app/views/catalog/_lazy_tag_facet.html.erb
@@ -1,0 +1,6 @@
+<turbo-frame id="tag-facet" target="_top">
+  <%= render Blacklight::Hierarchy::FacetFieldListComponent.new(
+        facet_field: @facet_field_presenter,
+        layout: Blacklight::FacetFieldComponent)
+  %>
+</turbo-frame>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -11,8 +11,8 @@
     <title><%= render_page_title %></title>
     <%= opensearch_description_tag application_name, opensearch_catalog_url(format: 'xml') %>
     <%= favicon_pack_tag 'favicon.ico' %>
-    <%= javascript_pack_tag 'application' %>
-    <%= stylesheet_pack_tag 'application' %>
+    <%= javascript_pack_tag 'application', 'data-turbo-track': 'reload' %>
+    <%= stylesheet_pack_tag 'application', 'data-turbo-track': 'reload' %>
 
     <%= csrf_meta_tags %>
     <%= content_for(:head) %>

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -1,7 +1,7 @@
 <% @title = 'Register DOR Objects' %>
 <% content_for :head do %>
-  <%= stylesheet_pack_tag 'registration' %>
-  <%= javascript_pack_tag 'registration' %>
+  <%= stylesheet_pack_tag 'registration', 'data-turbo-track': 'reload' %>
+  <%= javascript_pack_tag 'registration', 'data-turbo-track': 'reload' %>
 <% end %>
 
 <div id='properties' class="ui-widget" style="display: none">

--- a/app/views/report/_document_list.html.erb
+++ b/app/views/report/_document_list.html.erb
@@ -1,5 +1,5 @@
 <% content_for :head do %>
-  <%= javascript_pack_tag 'report' %>
+  <%= javascript_pack_tag 'report', 'data-turbo-track': 'reload' %>
   <script type="text/javascript">
     report_model = {
       total_rows: <%= @response['response']['numFound'] %>,

--- a/app/views/report/bulk.html.erb
+++ b/app/views/report/bulk.html.erb
@@ -1,5 +1,5 @@
-<%= javascript_pack_tag 'bulk' %>
 <% content_for :head do %>
+<%= javascript_pack_tag 'bulk', 'data-turbo-track': 'reload' %>
 <script type="text/javascript">
 report_model = {
   total_rows: <%= @response['response']['numFound'] %>,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,9 @@ Rails.application.routes.draw do
 
   resource :catalog, only: [:index], controller: 'catalog', path: '/catalog' do
     concerns :searchable
+    member do
+      get 'lazy_tag_facet'
+    end
   end
 
   resources :solr_documents, only: [:show], controller: 'catalog', path: '/view' do

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@github/time-elements": "^3.0.7",
+    "@hotwired/turbo-rails": "^7.0.0-beta.5",
     "@rails/ujs": "^6.0.3-4",
     "@rails/webpacker": "^5.1.1",
     "autocomplete.js": "^0.37.1",

--- a/spec/requests/create_new_admin_policy_spec.rb
+++ b/spec/requests/create_new_admin_policy_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Create a new Admin Policy' do
   context 'when the parameters are invalid' do
     it 'redraws the form' do
       post '/apo', params: { apo_form: { title: '' } }
-      expect(response).to be_successful
+      expect(response).to have_http_status(:unprocessable_entity)
     end
   end
 end

--- a/spec/support/selenium_webdriver.rb
+++ b/spec/support/selenium_webdriver.rb
@@ -18,3 +18,4 @@ Capybara.register_driver :headless_chrome do |app|
 end
 
 Capybara.disable_animation = true
+Capybara.default_max_wait_time = 7

--- a/yarn.lock
+++ b/yarn.lock
@@ -853,6 +853,19 @@
   resolved "https://registry.yarnpkg.com/@github/time-elements/-/time-elements-3.1.1.tgz#b52be933a87a0b585a5df6fd2dea6ccda5d776b9"
   integrity sha512-95TquDedxMpNb8BUrVIt9NEfdNBw4DRjdcECDPx4Ix6gkksI2npKRJBOV9XJMYjEIBo50iAiJzUuwL/fh3ptFw==
 
+"@hotwired/turbo-rails@^7.0.0-beta.5":
+  version "7.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-7.0.0-beta.5.tgz#a0efdb7a20613845c43afe6f376b353e62f7e68d"
+  integrity sha512-zj+ZYbs2IHeJHtLavcLX5K0oW/3K8s3zjok4lpujxqLactp3OpuqBZxKBr+tgODnAX/WYFoKLpzivyx3xVRfTw==
+  dependencies:
+    "@hotwired/turbo" "^7.0.0-beta.4"
+    "@rails/actioncable" "^6.1.0"
+
+"@hotwired/turbo@^7.0.0-beta.4":
+  version "7.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.0.0-beta.5.tgz#3167e8e882b9075c5b3b2e2f32432cca2862c61c"
+  integrity sha512-z10dI2U/StkMSmnfJUsyez6jrhnitgzjyw2CxE3LnAAzW/TBhvsMYKsVG7Xu337r3gh0r6UwIFWyvvtm3in6gg==
+
 "@npmcli/move-file@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@npmcli/move-file/-/move-file-1.1.2.tgz#1a82c3e372f7cae9253eb66d72543d6b8685c674"
@@ -860,6 +873,11 @@
   dependencies:
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
+
+"@rails/actioncable@^6.1.0":
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-6.1.3.tgz#c8a67ec4d22ecd6931f7ebd98143fddbc815419a"
+  integrity sha512-m02524MR9cTnUNfGz39Lkx9jVvuL0tle4O7YgvouJ7H83FILxzG1nQ5jw8pAjLAr9XQGu+P1sY4SKE3zyhCNjw==
 
 "@rails/ujs@^6.0.3-4":
   version "6.1.3"


### PR DESCRIPTION
This depends on #2643

## Why was this change made?



## How was this change tested?
The gif does not display the beach-ball cursor correctly:
![lazy-facet](https://user-images.githubusercontent.com/92044/115044885-91e8ba80-9e9b-11eb-8a95-336edfea8a4f.gif)


## Which documentation and/or configurations were updated?



