### PR TITLE
Upgrade cookies to use JSON serialization

### DIFF
--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -4,4 +4,4 @@
 
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :marshal
+Rails.application.config.action_dispatch.cookies_serializer = :hybrid


### PR DESCRIPTION


## Why was this change made?
The hybrid serializer will upgrade any existing marshal cookies to JSON cookies


## How was this change tested?



## Which documentation and/or configurations were updated?



