### PR TITLE
Restore missing remove icon on the tags facet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ gem 'zip_tricks', '5.3.1' # 5.3.1 is required as 5.4+ breaks the download all fe
 
 # Stanford related gems
 gem 'blacklight', '~> 7.13'
-gem 'blacklight-hierarchy', '~> 5.0'
+gem 'blacklight-hierarchy', '~> 5.1'
 gem 'dor-services-client', '~> 6.30'
 gem 'dor-workflow-client', '~> 3.19'
 gem 'mods_display'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       ostruct (>= 0.3.2)
       rails (>= 5.1, < 7)
       view_component (>= 2.23.0)
-    blacklight-hierarchy (5.0.0)
+    blacklight-hierarchy (5.1.0)
       blacklight (~> 7.13)
       deprecation
       rails (>= 5.1, < 7)
@@ -528,7 +528,7 @@ PLATFORMS
 DEPENDENCIES
   barby
   blacklight (~> 7.13)
-  blacklight-hierarchy (~> 5.0)
+  blacklight-hierarchy (~> 5.1)
   bootsnap (>= 1.1.0)
   byebug
   cancancan

--- a/app/javascript/argo.js
+++ b/app/javascript/argo.js
@@ -7,6 +7,8 @@ import JSONRenderer from 'controllers/json_renderer'
 import Tokens from 'controllers/tokens'
 import WorkflowGrid from 'controllers/workflow_grid_controller'
 import { Application } from 'stimulus'
+import BlacklightHierarchyController from 'blacklight-hierarchy/app/assets/javascripts/blacklight/hierarchy/blacklight_hierarchy_controller'
+
 require('@github/time-elements')
 
 function pathTo(path) {
@@ -49,6 +51,7 @@ export default class Argo {
         application.register("workflow-grid", WorkflowGrid)
         application.register("collection-editor", CollectionEditor)
         application.register("tokens", Tokens)
+        application.register("b-h-collapsible", BlacklightHierarchyController)
     }
 
     apoEditor() {

--- a/app/javascript/blacklight_hierarchy.js
+++ b/app/javascript/blacklight_hierarchy.js
@@ -1,1 +1,0 @@
-//= require blacklight/hierarchy/hierarchy

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -39,8 +39,6 @@ import Argo from 'argo'
 import 'blacklight-frontend/app/assets/javascripts/blacklight/blacklight'
 import 'modules/blacklight-override'
 
-import 'blacklight-hierarchy/app/assets/javascripts/blacklight/hierarchy/hierarchy'
-
 // The Blacklight onLoad event works better than the regular onLoad event if
 // turbolinks is enabled.
 Blacklight.onLoad(function(){

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@rails/webpacker": "^5.1.1",
     "autocomplete.js": "^0.37.1",
     "blacklight-frontend": "^7.7.0",
-    "blacklight-hierarchy": "^4.0.0",
+    "blacklight-hierarchy": "5.1.0",
     "free-jqgrid": "^4.15.5",
     "jquery": "^3.4.1",
     "jquery-ui": "^1.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1512,10 +1512,10 @@ blacklight-frontend@>=7.1.0-alpha, blacklight-frontend@^7.7.0:
     jquery "^3.5.1"
     typeahead.js "^0.11.1"
 
-blacklight-hierarchy@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/blacklight-hierarchy/-/blacklight-hierarchy-4.1.0.tgz#628285d4df47acfb1323c2ad58433af45890ad93"
-  integrity sha512-G2hlriQaJ6beSlMfx2umPZ3t06YIXBLv7i6ijf9EJPhvAsE0uWeTisrISBWfBWrKfxzDAVRvDqh5wBQGKDbbgA==
+blacklight-hierarchy@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/blacklight-hierarchy/-/blacklight-hierarchy-5.1.0.tgz#6d081b3a8bd08540b27d5e8a79923a56c0c33606"
+  integrity sha512-yi5m8Bd6bq7FibcUw/M9NEGPZvImRcynvU1cIEMZx1+Ejs3C+drONTZEnd+TJ47fvghrr5EbdrT0ONk43qbBPQ==
   dependencies:
     blacklight-frontend ">=7.1.0-alpha"
     jquery ">=3.0"


### PR DESCRIPTION
## Why was this change made?
This went missing in the Blacklight 7 upgrade.




## How was this change tested?

Before
<img width="387" alt="Screen Shot 2021-04-16 at 3 58 24 PM" src="https://user-images.githubusercontent.com/92044/115083321-cb85e980-9ecc-11eb-80c2-f8ad5196bbcd.png">
After

<img width="391" alt="Screen Shot 2021-04-16 at 4 02 38 PM" src="https://user-images.githubusercontent.com/92044/115083625-49e28b80-9ecd-11eb-8048-a4b0c38fdee6.png">


## Which documentation and/or configurations were updated?



