### PR TITLE
Don't set hasMemberOrder for non-book types.

### DIFF
--- a/app/controllers/content_types_controller.rb
+++ b/app/controllers/content_types_controller.rb
@@ -68,7 +68,7 @@ class ContentTypesController < ApplicationController
 
   # If the new content type is a book, we need to set the viewing direction attribute in the cocina model
   def member_orders
-    return [nil] unless new_content_type.start_with?('book')
+    return [] unless new_content_type.start_with?('book')
 
     viewing_direction = if new_content_type == 'book (ltr)'
                           'left-to-right'

--- a/spec/controllers/content_types_controller_spec.rb
+++ b/spec/controllers/content_types_controller_spec.rb
@@ -192,8 +192,12 @@ RSpec.describe ContentTypesController, type: :controller do
         patch :update, params: { item_id: pid, old_resource_type: 'document', new_resource_type: 'file', new_content_type: 'image' }
         expect(response).to redirect_to solr_document_path(pid)
         expect(object_client).to have_received(:update)
-          .with(params: a_cocina_object_with_types(resource_types: [Cocina::Models::Vocab::Resources.file, Cocina::Models::Vocab::Resources.image]))
-          .once
+          .with(
+            params: a_cocina_object_with_types(
+              resource_types: [Cocina::Models::Vocab::Resources.file, Cocina::Models::Vocab::Resources.image],
+              without_order: true
+            )
+          ).once
         expect(Argo::Indexer).to have_received(:reindex_pid_remotely).once
       end
 

--- a/spec/support/cocina_matchers.rb
+++ b/spec/support/cocina_matchers.rb
@@ -3,6 +3,8 @@
 # Provides RSpec matchers for Cocina models
 RSpec::Matchers.define :a_cocina_object_with_types do |expected|
   match do |actual|
+    return false if expected[:without_order] && !match_no_orders?
+
     if expected[:content_type] && expected[:resource_types]
       match_cocina_type?(actual, expected) && match_contained_cocina_types?(actual, expected)
     elsif expected[:content_type] && expected[:viewing_direction]
@@ -14,6 +16,10 @@ RSpec::Matchers.define :a_cocina_object_with_types do |expected|
     else
       raise ArgumentError, 'must provide content_type and/or resource_types keyword args'
     end
+  end
+
+  def match_no_orders?
+    actual.structural.hasMemberOrders.blank?
   end
 
   def match_cocina_type?(actual, expected)


### PR DESCRIPTION


## Why was this change made?
Fixes #2681


## How was this change tested?



## Which documentation and/or configurations were updated?



