### PR TITLE
Updates cocina model for new access/embargo modeling.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,13 +65,13 @@ gem 'zip_tricks', '5.3.1' # 5.3.1 is required as 5.4+ breaks the download all fe
 # Stanford related gems
 gem 'blacklight', '~> 7.13'
 gem 'blacklight-hierarchy', '~> 5.1'
-gem 'dor-services-client', '~> 6.30'
+gem 'dor-services-client', '~> 6.33'
 gem 'dor-workflow-client', '~> 3.19'
 gem 'mods_display'
 gem 'okcomputer' # monitors application and its dependencies
 gem 'preservation-client', '~> 3.2'
 gem 'rsolr'
-gem 'sdr-client', '~> 0.55.1'
+gem 'sdr-client', '~> 0.56'
 
 gem 'devise'
 gem 'devise-remote-user', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (3.0.0)
-    cocina-models (0.58.2)
+    cocina-models (0.59.0)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -168,9 +168,9 @@ GEM
     docile (1.3.5)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    dor-services-client (6.32.0)
+    dor-services-client (6.33.0)
       activesupport (>= 4.2, < 7)
-      cocina-models (~> 0.58.0)
+      cocina-models (~> 0.59.0)
       deprecation
       faraday (>= 0.15, < 2)
       moab-versioning (~> 4.0)
@@ -298,6 +298,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
     mini_mime (1.1.0)
+    mini_portile2 (2.5.0)
     minitest (5.14.4)
     moab-versioning (4.4.1)
       druid-tools (>= 1.0.0)
@@ -321,6 +322,9 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (6.15.0)
     nio4r (2.5.7)
+    nokogiri (1.11.3)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     nokogiri (1.11.3-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.11.3-x86_64-linux)
@@ -478,9 +482,9 @@ GEM
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.4)
     rubyzip (2.3.0)
-    sdr-client (0.55.1)
+    sdr-client (0.56.0)
       activesupport
-      cocina-models (~> 0.58.1)
+      cocina-models (~> 0.59.0)
       dry-monads
       faraday (>= 0.16)
     selenium-webdriver (3.142.7)
@@ -561,6 +565,7 @@ GEM
     zip_tricks (5.3.1)
 
 PLATFORMS
+  ruby
   x86_64-darwin-18
   x86_64-darwin-19
   x86_64-linux
@@ -580,7 +585,7 @@ DEPENDENCIES
   devise
   devise-remote-user (~> 1.0)
   dlss-capistrano (~> 3.1)
-  dor-services-client (~> 6.30)
+  dor-services-client (~> 6.33)
   dor-workflow-client (~> 3.19)
   dry-monads
   equivalent-xml (>= 0.6.0)
@@ -618,7 +623,7 @@ DEPENDENCIES
   rubocop-rspec (~> 2.1.0)
   ruby-prof
   rubyzip
-  sdr-client (~> 0.55.1)
+  sdr-client (~> 0.56)
   selenium-webdriver
   sidekiq (~> 6.0)
   simplecov

--- a/app/forms/collection_rights_form.rb
+++ b/app/forms/collection_rights_form.rb
@@ -11,7 +11,7 @@ class CollectionRightsForm < AccessForm
 
   def sync
     access_additions = CocinaAccess.from_form_value(rights)
-    updated_access = model.access.new(access_additions.value!)
+    updated_access = model.access.new(access_additions.value!.except(:download, :readLocation, :controlledDigitalLending))
 
     @model = model.new(access: updated_access)
   end
@@ -24,13 +24,7 @@ class CollectionRightsForm < AccessForm
   end
 
   def derive_rights_from_cocina
-    if @model.access.readLocation
-      "loc:#{@model.access.readLocation}"
-    elsif @model.access.access == 'citation-only'
-      'none' # TODO: we could remove this if we switch to REGISTRATION_RIGHTS_OPTIONS from DEFAULT_RIGHTS_OPTIONS
-    else
-      @model.access.access
-    end
+    @model.access.access
   end
 
   def rights_list_for_apo

--- a/app/services/cocina_dro_access.rb
+++ b/app/services/cocina_dro_access.rb
@@ -13,14 +13,16 @@ class CocinaDroAccess
 
     data = if rights == 'cdl-stanford-nd'
              {
-               access: 'citation-only',
+               access: 'stanford',
                download: 'none',
+               readLocation: nil,
                controlledDigitalLending: true
              }
            elsif rights.end_with?('-nd') || %w[dark citation-only].include?(rights)
              {
                access: rights.delete_suffix('-nd'),
                download: 'none',
+               readLocation: nil,
                controlledDigitalLending: false
              }
            elsif rights.start_with?('loc:')
@@ -34,6 +36,7 @@ class CocinaDroAccess
              {
                access: rights,
                download: rights,
+               readLocation: nil,
                controlledDigitalLending: false
              }
            end

--- a/app/views/apo/_form.html.erb
+++ b/app/views/apo/_form.html.erb
@@ -75,7 +75,7 @@
       <div class="form-group">
         <%= collection.label :collection_rights, "Collection Rights", class: "col-sm-2 control-label" %>
         <div class="col-sm-10">
-          <%= collection.select :collection_rights, options_for_select(Constants::DEFAULT_RIGHTS_OPTIONS, 'world'), {}, class: 'form-control' %>
+          <%= collection.select :collection_rights, options_for_select(Constants::COLLECTION_RIGHTS_OPTIONS, 'world'), {}, class: 'form-control' %>
         </div>
       </div>
     </div>
@@ -90,7 +90,7 @@
       <div class="form-group">
         <%= collection.label :collection_rights_catkey, "Collection Rights", class: "col-sm-2 control-label" %>
         <div class="col-sm-10">
-          <%= collection.select :collection_rights_catkey, options_for_select(Constants::DEFAULT_RIGHTS_OPTIONS, 'world'), {}, class: 'form-control' %>
+          <%= collection.select :collection_rights_catkey, options_for_select(Constants::COLLECTION_RIGHTS_OPTIONS, 'world'), {}, class: 'form-control' %>
         </div>
       </div>
     </div>

--- a/app/views/collections/new.html.erb
+++ b/app/views/collections/new.html.erb
@@ -36,7 +36,7 @@
         <label for="collection_rights">
           Collection Object Visibility
         </label>
-        <%= select_tag :collection_rights, options_for_select(Constants::DEFAULT_RIGHTS_OPTIONS, 'world'), class: 'form-control' %>
+        <%= select_tag :collection_rights, options_for_select(Constants::COLLECTION_RIGHTS_OPTIONS, 'world'), class: 'form-control' %>
       </div>
     </div>
     <div id="create-collection-catkey" class="collection_div" style="display:none">
@@ -51,7 +51,7 @@
         <label for="collection_rights_catkey">
           Collection Object Visibility
         </label>
-        <%= select_tag :collection_rights_catkey, options_for_select(Constants::DEFAULT_RIGHTS_OPTIONS, 'world'), class: 'form-control' %>
+        <%= select_tag :collection_rights_catkey, options_for_select(Constants::COLLECTION_RIGHTS_OPTIONS, 'world'), class: 'form-control' %>
       </div>
     </div>
     <div class="form-group">

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -39,15 +39,7 @@ module Constants
 
   COLLECTION_RIGHTS_OPTIONS = [
     %w[World world],
-    %w[Stanford stanford],
-    ['Location: Special Collections', 'loc:spec'],
-    ['Location: Music Library', 'loc:music'],
-    ['Location: Archive of Recorded Sound', 'loc:ars'],
-    ['Location: Art Library', 'loc:art'],
-    ['Location: Hoover Library', 'loc:hoover'],
-    ['Location: Media & Microtext', 'loc:m&m'],
-    ['Dark (Preserve Only)', 'dark'],
-    ['Citation Only', 'citation-only']
+    ['Dark (Preserve Only)', 'dark']
   ].freeze
 
   LICENSE_OPTIONS = {

--- a/spec/controllers/content_types_controller_spec.rb
+++ b/spec/controllers/content_types_controller_spec.rb
@@ -18,9 +18,7 @@ RSpec.describe ContentTypesController, type: :controller do
       'version' => 1,
       'type' => content_type,
       'externalIdentifier' => pid,
-      'access' => {
-        'access' => 'world'
-      },
+      'access' => {},
       'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
       'structural' => structural,
       'identification' => {}
@@ -32,9 +30,7 @@ RSpec.describe ContentTypesController, type: :controller do
       'version' => 1,
       'type' => content_type,
       'externalIdentifier' => pid,
-      'access' => {
-        'access' => 'world'
-      },
+      'access' => {},
       'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
       'structural' => structural_with_member_orders,
       'identification' => {}

--- a/spec/controllers/dor/objects_controller_spec.rb
+++ b/spec/controllers/dor/objects_controller_spec.rb
@@ -82,9 +82,7 @@ RSpec.describe Dor::ObjectsController, type: :controller do
                                 type: Cocina::Models::Vocab.document,
                                 label: '',
                                 version: 1,
-                                access: {
-                                  access: 'location-based'
-                                },
+                                access: {},
                                 administrative: {
                                   hasAdminPolicy: 'druid:hv992ry2431'
                                 }).to_json
@@ -132,8 +130,7 @@ RSpec.describe Dor::ObjectsController, type: :controller do
                                 version: 1,
                                 access: {
                                   access: 'stanford',
-                                  download: 'stanford',
-                                  controlledDigitalLending: false
+                                  download: 'stanford'
                                 },
                                 administrative: {
                                   hasAdminPolicy: 'druid:hv992ry2431'
@@ -145,7 +142,7 @@ RSpec.describe Dor::ObjectsController, type: :controller do
           .with(
             body: '{"type":"http://cocina.sul.stanford.edu/models/image.jsonld",' \
             '"label":"test parameters for registration","version":1,' \
-            '"access":{"access":"stanford","controlledDigitalLending":false,"download":"stanford"},' \
+            '"access":{"access":"stanford","download":"stanford","readLocation":null,"controlledDigitalLending":false},' \
             '"administrative":{"hasAdminPolicy":"druid:hv992ry2431"},' \
             '"identification":{"sourceId":"foo:bar","catalogLinks":[]},' \
             '"structural":{"isMemberOf":["druid:hv992ry7777"]}}'
@@ -183,7 +180,8 @@ RSpec.describe Dor::ObjectsController, type: :controller do
                                 version: 1,
                                 access: {
                                   access: 'location-based',
-                                  controlledDigitalLending: false
+                                  download: 'location-based',
+                                  readLocation: 'music'
                                 },
                                 administrative: {
                                   hasAdminPolicy: 'druid:hv992ry2431'
@@ -195,7 +193,7 @@ RSpec.describe Dor::ObjectsController, type: :controller do
           .with(
             body: '{"type":"http://cocina.sul.stanford.edu/models/book.jsonld",' \
             '"label":"test parameters for registration","version":1,' \
-            '"access":{"access":"location-based","controlledDigitalLending":false,"download":"location-based","readLocation":"music"},' \
+            '"access":{"access":"location-based","download":"location-based","readLocation":"music","controlledDigitalLending":false},' \
             '"administrative":{"hasAdminPolicy":"druid:hv992ry2431"},' \
             '"identification":{"sourceId":"foo:bar","catalogLinks":[]},' \
             '"structural":{"hasMemberOrders":[{"viewingDirection":"left-to-right"}],' \
@@ -234,8 +232,7 @@ RSpec.describe Dor::ObjectsController, type: :controller do
                                 version: 1,
                                 access: {
                                   access: 'world',
-                                  download: 'none',
-                                  controlledDigitalLending: false
+                                  download: 'none'
                                 },
                                 administrative: {
                                   hasAdminPolicy: 'druid:hv992ry2431'
@@ -247,7 +244,7 @@ RSpec.describe Dor::ObjectsController, type: :controller do
           .with(
             body: '{"type":"http://cocina.sul.stanford.edu/models/image.jsonld",' \
             '"label":"test parameters for registration","version":1,' \
-            '"access":{"access":"world","controlledDigitalLending":false,"download":"none"},' \
+            '"access":{"access":"world","download":"none","readLocation":null,"controlledDigitalLending":false},' \
             '"administrative":{"hasAdminPolicy":"druid:hv992ry2431"},' \
             '"identification":{"sourceId":"foo:bar","catalogLinks":[]},' \
             '"structural":{"isMemberOf":["druid:hv992ry7777"]}}'
@@ -284,9 +281,8 @@ RSpec.describe Dor::ObjectsController, type: :controller do
                                 label: '',
                                 version: 1,
                                 access: {
-                                  access: 'world',
-                                  download: 'none',
-                                  controlledDigitalLending: false
+                                  access: 'dark',
+                                  download: 'none'
                                 },
                                 administrative: {
                                   hasAdminPolicy: 'druid:hv992ry2431'
@@ -298,7 +294,7 @@ RSpec.describe Dor::ObjectsController, type: :controller do
           .with(
             body: '{"type":"http://cocina.sul.stanford.edu/models/image.jsonld",' \
             '"label":"test parameters for registration","version":1,' \
-            '"access":{"access":"dark","controlledDigitalLending":false,"download":"none"},' \
+            '"access":{"access":"dark","download":"none","readLocation":null,"controlledDigitalLending":false},' \
             '"administrative":{"hasAdminPolicy":"druid:hv992ry2431"},' \
             '"identification":{"sourceId":"foo:bar","catalogLinks":[]},' \
             '"structural":{"isMemberOf":["druid:hv992ry7777"]}}'
@@ -358,7 +354,7 @@ RSpec.describe Dor::ObjectsController, type: :controller do
                                 label: '',
                                 version: 1,
                                 access: {
-                                  access: 'citation-only',
+                                  access: 'stanford',
                                   download: 'none',
                                   controlledDigitalLending: true
                                 },
@@ -372,7 +368,7 @@ RSpec.describe Dor::ObjectsController, type: :controller do
           .with(
             body: '{"type":"http://cocina.sul.stanford.edu/models/book.jsonld",' \
         '"label":"test parameters for registration","version":1,' \
-        '"access":{"access":"citation-only","controlledDigitalLending":true,"download":"none"},' \
+        '"access":{"access":"stanford","download":"none","readLocation":null,"controlledDigitalLending":true},' \
         '"administrative":{"hasAdminPolicy":"druid:hv992ry2431"},' \
         '"identification":{"sourceId":"foo:bar","catalogLinks":[]},' \
         '"structural":{"hasMemberOrders":[{"viewingDirection":"left-to-right"}],' \

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ItemsController, type: :controller do
                            'version' => 1,
                            'type' => Cocina::Models::Vocab.object,
                            'externalIdentifier' => pid,
-                           'access' => { 'access' => 'world' },
+                           'access' => {},
                            'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
                            'structural' => {},
                            'identification' => {
@@ -88,10 +88,12 @@ RSpec.describe ItemsController, type: :controller do
                              'type' => Cocina::Models::Vocab.object,
                              'externalIdentifier' => pid,
                              'access' => {
-                               'access' => 'world',
+                               'access' => 'stanford',
+                               'download' => 'stanford',
                                'embargo' => {
                                  'releaseDate' => '2040-05-05',
-                                 'access' => 'world'
+                                 'access' => 'world',
+                                 'download' => 'world'
                                }
                              },
                              'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
@@ -174,7 +176,7 @@ RSpec.describe ItemsController, type: :controller do
                              'version' => 1,
                              'type' => Cocina::Models::Vocab.object,
                              'externalIdentifier' => pid,
-                             'access' => { 'access' => 'world' },
+                             'access' => {},
                              'administrative' => { 'hasAdminPolicy' => 'druid:cg532dg5405' },
                              'structural' => structural
                            })
@@ -194,7 +196,7 @@ RSpec.describe ItemsController, type: :controller do
                                  'version' => 1,
                                  'type' => Cocina::Models::Vocab.object,
                                  'externalIdentifier' => pid,
-                                 'access' => { 'access' => 'world' },
+                                 'access' => {},
                                  'administrative' => { 'hasAdminPolicy' => 'druid:cg532dg5405' },
                                  'structural' => { 'isMemberOf' => ['druid:gg333xx4444', 'druid:bc555gh3434'] }
                                })
@@ -220,7 +222,7 @@ RSpec.describe ItemsController, type: :controller do
                                  'version' => 1,
                                  'type' => Cocina::Models::Vocab.object,
                                  'externalIdentifier' => pid,
-                                 'access' => { 'access' => 'world' },
+                                 'access' => {},
                                  'administrative' => { 'hasAdminPolicy' => 'druid:cg532dg5405' },
                                  'structural' => { 'isMemberOf' => ['druid:bc555gh3434'] }
                                })
@@ -254,7 +256,7 @@ RSpec.describe ItemsController, type: :controller do
                              'version' => 1,
                              'type' => Cocina::Models::Vocab.object,
                              'externalIdentifier' => pid,
-                             'access' => { 'access' => 'world' },
+                             'access' => {},
                              'administrative' => { 'hasAdminPolicy' => 'druid:cg532dg5405' },
                              'structural' => { 'isMemberOf' => ['druid:gg333xx4444', 'druid:bc555gh3434'] }
                            })
@@ -272,7 +274,7 @@ RSpec.describe ItemsController, type: :controller do
                                'version' => 1,
                                'type' => Cocina::Models::Vocab.object,
                                'externalIdentifier' => pid,
-                               'access' => { 'access' => 'world' },
+                               'access' => {},
                                'administrative' => { 'hasAdminPolicy' => 'druid:cg532dg5405' },
                                'structural' => { 'isMemberOf' => ['druid:gg333xx4444'] }
                              })

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -131,9 +131,7 @@ RSpec.describe ReportController, type: :controller do
         'version' => 1,
         'type' => Cocina::Models::Vocab.object,
         'externalIdentifier' => pid,
-        'access' => {
-          'access' => 'world'
-        },
+        'access' => {},
         'administrative' => { hasAdminPolicy: 'druid:cg532dg5405', partOfProject: 'EEMS' },
         'structural' => {},
         'identification' => {}

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -44,9 +44,7 @@ RSpec.describe TagsController, type: :controller do
         'version' => 1,
         'type' => Cocina::Models::Vocab.object,
         'externalIdentifier' => pid,
-        'access' => {
-          'access' => 'world'
-        },
+        'access' => {},
         'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
         'structural' => {},
         'identification' => {}

--- a/spec/controllers/versions_controller_spec.rb
+++ b/spec/controllers/versions_controller_spec.rb
@@ -11,9 +11,7 @@ RSpec.describe VersionsController, type: :controller do
       'version' => 2,
       'type' => Cocina::Models::Vocab.object,
       'externalIdentifier' => pid,
-      'access' => {
-        'access' => 'world'
-      },
+      'access' => {},
       'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
       'structural' => {},
       'identification' => {}

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -13,9 +13,7 @@ RSpec.describe WorkflowsController, type: :controller do
       'version' => 2,
       'type' => Cocina::Models::Vocab.object,
       'externalIdentifier' => pid,
-      'access' => {
-        'access' => 'world'
-      },
+      'access' => {},
       'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
       'structural' => {},
       'identification' => {}

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -13,7 +13,8 @@ FactoryBot.define do
                                        },
                                        'administrative' => {
                                          'hasAdminPolicy' => admin_policy_id
-                                       }
+                                       },
+                                       'access' => {}
                                      })
       )
     end

--- a/spec/features/item_catkey_change_spec.rb
+++ b/spec/features/item_catkey_change_spec.rb
@@ -19,9 +19,7 @@ RSpec.describe 'Item catkey change' do
                            'version' => 1,
                            'type' => Cocina::Models::Vocab.object,
                            'externalIdentifier' => druid,
-                           'access' => {
-                             'access' => 'world'
-                           },
+                           'access' => {},
                            'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
                            'structural' => {},
                            'identification' => {}

--- a/spec/features/item_source_id_change_spec.rb
+++ b/spec/features/item_source_id_change_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe 'Item source id change' do
                            'type' => Cocina::Models::Vocab.object,
                            'externalIdentifier' => druid,
                            'access' => {
-                             'access' => 'world'
+                             'access' => 'world',
+                             'download' => 'world'
                            },
                            'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
                            'structural' => {},

--- a/spec/forms/collection_rights_form_spec.rb
+++ b/spec/forms/collection_rights_form_spec.rb
@@ -27,31 +27,14 @@ RSpec.describe CollectionRightsForm do
 
     let(:model) { instance_double(Cocina::Models::Collection, access: cocina_access) }
     let(:cocina_access) do
-      instance_double(Cocina::Models::Access, access: access, readLocation: read_location)
+      instance_double(Cocina::Models::Access, access: access)
     end
     let(:access) { 'world' }
 
-    let(:read_location) { nil }
-
     it { is_expected.to eq 'world' }
-
-    context 'with location access' do
-      let(:access) { 'location-based' }
-      let(:read_location) { 'music' }
-
-      it { is_expected.to eq 'loc:music' }
-    end
-
-    context 'with citation only' do
-      let(:access) { 'citation-only' }
-      let(:download) { 'none' }
-
-      it { is_expected.to eq 'none' }
-    end
 
     context 'with dark' do
       let(:access) { 'dark' }
-      let(:download) { 'none' }
 
       it { is_expected.to eq 'dark' }
     end
@@ -60,15 +43,7 @@ RSpec.describe CollectionRightsForm do
   describe '#rights_list' do
     it 'displays the rights list with (APO default)' do
       expect(instance.rights_list).to eq [['World (APO default)', 'world'],
-                                          %w[Stanford stanford],
-                                          ['Location: Special Collections', 'loc:spec'],
-                                          ['Location: Music Library', 'loc:music'],
-                                          ['Location: Archive of Recorded Sound', 'loc:ars'],
-                                          ['Location: Art Library', 'loc:art'],
-                                          ['Location: Hoover Library', 'loc:hoover'],
-                                          ['Location: Media & Microtext', 'loc:m&m'],
-                                          ['Dark (Preserve Only)', 'dark'],
-                                          ['Citation Only', 'citation-only']]
+                                          ['Dark (Preserve Only)', 'dark']]
     end
   end
 end

--- a/spec/jobs/close_version_job_spec.rb
+++ b/spec/jobs/close_version_job_spec.rb
@@ -17,9 +17,7 @@ RSpec.describe CloseVersionJob, type: :job do
       'version' => 1,
       'type' => Cocina::Models::Vocab.object,
       'externalIdentifier' => pids[0],
-      'access' => {
-        'access' => 'world'
-      },
+      'access' => {},
       'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
       'structural' => {},
       'identification' => {}
@@ -31,9 +29,7 @@ RSpec.describe CloseVersionJob, type: :job do
       'version' => 1,
       'type' => Cocina::Models::Vocab.object,
       'externalIdentifier' => pids[1],
-      'access' => {
-        'access' => 'world'
-      },
+      'access' => {},
       'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
       'structural' => {},
       'identification' => {}

--- a/spec/jobs/prepare_job_spec.rb
+++ b/spec/jobs/prepare_job_spec.rb
@@ -18,9 +18,7 @@ RSpec.describe PrepareJob, type: :job do
       'version' => 2,
       'type' => Cocina::Models::Vocab.object,
       'externalIdentifier' => pids[0],
-      'access' => {
-        'access' => 'world'
-      },
+      'access' => {},
       'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
       'structural' => {},
       'identification' => {}
@@ -32,9 +30,7 @@ RSpec.describe PrepareJob, type: :job do
       'version' => 3,
       'type' => Cocina::Models::Vocab.object,
       'externalIdentifier' => pids[1],
-      'access' => {
-        'access' => 'world'
-      },
+      'access' => {},
       'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
       'structural' => {},
       'identification' => {}

--- a/spec/jobs/purge_job_spec.rb
+++ b/spec/jobs/purge_job_spec.rb
@@ -19,9 +19,7 @@ RSpec.describe PurgeJob, type: :job do
       'version' => 2,
       'type' => Cocina::Models::Vocab.object,
       'externalIdentifier' => pids[0],
-      'access' => {
-        'access' => 'world'
-      },
+      'access' => {},
       'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
       'structural' => {},
       'identification' => {}
@@ -33,9 +31,7 @@ RSpec.describe PurgeJob, type: :job do
       'version' => 3,
       'type' => Cocina::Models::Vocab.object,
       'externalIdentifier' => pids[1],
-      'access' => {
-        'access' => 'world'
-      },
+      'access' => {},
       'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
       'structural' => {},
       'identification' => {}

--- a/spec/jobs/release_object_job_spec.rb
+++ b/spec/jobs/release_object_job_spec.rb
@@ -11,9 +11,7 @@ RSpec.describe ReleaseObjectJob do
       'version' => 2,
       'type' => Cocina::Models::Vocab.object,
       'externalIdentifier' => pids[0],
-      'access' => {
-        'access' => 'world'
-      },
+      'access' => {},
       'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
       'structural' => {},
       'identification' => {}
@@ -25,9 +23,7 @@ RSpec.describe ReleaseObjectJob do
       'version' => 3,
       'type' => Cocina::Models::Vocab.object,
       'externalIdentifier' => pids[1],
-      'access' => {
-        'access' => 'world'
-      },
+      'access' => {},
       'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
       'structural' => {},
       'identification' => {}

--- a/spec/jobs/set_catkeys_and_barcodes_csv_job_spec.rb
+++ b/spec/jobs/set_catkeys_and_barcodes_csv_job_spec.rb
@@ -22,9 +22,7 @@ RSpec.describe SetCatkeysAndBarcodesCsvJob do
       'version' => 2,
       'type' => Cocina::Models::Vocab.object,
       'externalIdentifier' => pids[0],
-      'access' => {
-        'access' => 'world'
-      },
+      'access' => {},
       'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
       'structural' => {},
       'identification' => {

--- a/spec/jobs/set_catkeys_and_barcodes_job_spec.rb
+++ b/spec/jobs/set_catkeys_and_barcodes_job_spec.rb
@@ -22,9 +22,7 @@ RSpec.describe SetCatkeysAndBarcodesJob do
       'version' => 2,
       'type' => Cocina::Models::Vocab.object,
       'externalIdentifier' => pids[0],
-      'access' => {
-        'access' => 'world'
-      },
+      'access' => {},
       'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
       'structural' => {},
       'identification' => {
@@ -39,9 +37,7 @@ RSpec.describe SetCatkeysAndBarcodesJob do
       'version' => 3,
       'type' => Cocina::Models::Vocab.object,
       'externalIdentifier' => pids[1],
-      'access' => {
-        'access' => 'world'
-      },
+      'access' => {},
       'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
       'structural' => {},
       'identification' => {
@@ -56,9 +52,7 @@ RSpec.describe SetCatkeysAndBarcodesJob do
       'version' => 3,
       'type' => Cocina::Models::Vocab.object,
       'externalIdentifier' => pids[2],
-      'access' => {
-        'access' => 'world'
-      },
+      'access' => {},
       'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
       'structural' => {},
       'identification' => {}
@@ -126,9 +120,7 @@ RSpec.describe SetCatkeysAndBarcodesJob do
         'version' => 3,
         'type' => Cocina::Models::Vocab.object,
         'externalIdentifier' => pids[0],
-        'access' => {
-          'access' => 'world'
-        },
+        'access' => {},
         'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
         'structural' => {},
         'identification' => {

--- a/spec/jobs/set_governing_apo_job_spec.rb
+++ b/spec/jobs/set_governing_apo_job_spec.rb
@@ -70,9 +70,7 @@ RSpec.describe SetGoverningApoJob do
             'version' => 2,
             'type' => Cocina::Models::Vocab.object,
             'externalIdentifier' => pids[0],
-            'access' => {
-              'access' => 'world'
-            },
+            'access' => {},
             'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
             'structural' => {},
             'identification' => {}
@@ -84,9 +82,7 @@ RSpec.describe SetGoverningApoJob do
             'version' => 3,
             'type' => Cocina::Models::Vocab.object,
             'externalIdentifier' => pids[2],
-            'access' => {
-              'access' => 'world'
-            },
+            'access' => {},
             'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
             'structural' => {},
             'identification' => {}
@@ -136,9 +132,7 @@ RSpec.describe SetGoverningApoJob do
         'version' => 1,
         'type' => Cocina::Models::Vocab.object,
         'externalIdentifier' => pid,
-        'access' => {
-          'access' => 'world'
-        },
+        'access' => {},
         'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
         'structural' => {},
         'identification' => {}

--- a/spec/requests/apply_apo_defaults_spec.rb
+++ b/spec/requests/apply_apo_defaults_spec.rb
@@ -14,9 +14,7 @@ RSpec.describe 'Apply APO defaults' do
       'version' => 1,
       'type' => Cocina::Models::Vocab.object,
       'externalIdentifier' => pid,
-      'access' => {
-        'access' => 'world'
-      },
+      'access' => {},
       'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
       'structural' => {},
       'identification' => {}

--- a/spec/requests/manage_release_spec.rb
+++ b/spec/requests/manage_release_spec.rb
@@ -20,9 +20,7 @@ RSpec.describe 'Draw the manage release form' do
       'version' => 1,
       'type' => Cocina::Models::Vocab.object,
       'externalIdentifier' => pid,
-      'access' => {
-        'access' => 'world'
-      },
+      'access' => {},
       'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
       'structural' => {},
       'identification' => {}

--- a/spec/requests/set_catkey_spec.rb
+++ b/spec/requests/set_catkey_spec.rb
@@ -33,9 +33,7 @@ RSpec.describe 'Set catkey for an object' do
                              'version' => 1,
                              'type' => Cocina::Models::Vocab.object,
                              'externalIdentifier' => pid,
-                             'access' => {
-                               'access' => 'world'
-                             },
+                             'access' => {},
                              'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
                              'structural' => {},
                              'identification' => {}

--- a/spec/requests/set_collection_spec.rb
+++ b/spec/requests/set_collection_spec.rb
@@ -24,9 +24,7 @@ RSpec.describe 'Set the collection for an object' do
                                'version' => 1,
                                'type' => Cocina::Models::Vocab.object,
                                'externalIdentifier' => pid,
-                               'access' => {
-                                 'access' => 'world'
-                               },
+                               'access' => {},
                                'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
                                'structural' => {},
                                'identification' => {}
@@ -59,9 +57,7 @@ RSpec.describe 'Set the collection for an object' do
                                'version' => 1,
                                'type' => Cocina::Models::Vocab.object,
                                'externalIdentifier' => pid,
-                               'access' => {
-                                 'access' => 'world'
-                               },
+                               'access' => {},
                                'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
                                'structural' => { 'isMemberOf' => [collection_druid] },
                                'identification' => {}
@@ -94,9 +90,7 @@ RSpec.describe 'Set the collection for an object' do
                                'version' => 1,
                                'type' => Cocina::Models::Vocab.object,
                                'externalIdentifier' => pid,
-                               'access' => {
-                                 'access' => 'world'
-                               },
+                               'access' => {},
                                'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
                                'structural' => {
                                  'isMemberOf' => ['druid:xg999dg9393']

--- a/spec/requests/set_governing_apo_spec.rb
+++ b/spec/requests/set_governing_apo_spec.rb
@@ -14,9 +14,7 @@ RSpec.describe 'Set APO for an object' do
         'version' => 1,
         'type' => Cocina::Models::Vocab.object,
         'externalIdentifier' => pid,
-        'access' => {
-          'access' => 'world'
-        },
+        'access' => {},
         'administrative' => { hasAdminPolicy: 'druid:cg532dg5405', partOfProject: 'EEMS' },
         'structural' => {},
         'identification' => {}

--- a/spec/requests/set_rights_spec.rb
+++ b/spec/requests/set_rights_spec.rb
@@ -23,9 +23,11 @@ RSpec.describe 'Set rights for an object' do
                                'externalIdentifier' => pid,
                                'access' => {
                                  'access' => 'world',
+                                 'download' => 'world',
                                  embargo: {
                                    releaseDate: '2021-02-11T00:00:00.000+00:00',
-                                   access: 'world'
+                                   access: 'world',
+                                   download: 'world'
                                  }
                                },
                                'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
@@ -42,7 +44,7 @@ RSpec.describe 'Set rights for an object' do
                                            'label' => 'Page 1',
                                            'type' => 'http://cocina.sul.stanford.edu/models/file.jsonld',
                                            'version' => 1,
-                                           'access' => { access: 'world' },
+                                           'access' => { access: 'world', download: 'world' },
                                            'administrative' => {
                                              'publish' => true,
                                              'shelve' => true,
@@ -66,10 +68,12 @@ RSpec.describe 'Set rights for an object' do
               'access' => {
                 'access' => 'dark',
                 'download' => 'none',
+                'readLocation' => nil,
                 'controlledDigitalLending' => false,
                 embargo: {
                   releaseDate: '2021-02-11T00:00:00.000+00:00',
-                  access: 'world'
+                  access: 'world',
+                  download: 'world'
                 }
               },
               'structural' => {
@@ -86,7 +90,7 @@ RSpec.describe 'Set rights for an object' do
                           'label' => 'Page 1',
                           'type' => 'http://cocina.sul.stanford.edu/models/file.jsonld',
                           'version' => 1,
-                          'access' => { access: 'dark' },
+                          'access' => { access: 'dark', download: 'none', readLocation: nil, controlledDigitalLending: false },
                           'administrative' => { 'shelve' => false },
                           'filename' => 'page1.txt'
                         }
@@ -115,11 +119,44 @@ RSpec.describe 'Set rights for an object' do
               'access' => {
                 'access' => 'stanford',
                 'download' => 'stanford',
+                'readLocation' => nil,
                 'controlledDigitalLending' => false,
                 'embargo' => {
                   'releaseDate' => '2021-02-11T00:00:00.000+00:00',
-                  'access' => 'world'
+                  'access' => 'world',
+                  'download' => 'world'
                 }
+              },
+              'structural' => {
+                'contains' => [
+                  {
+                    'externalIdentifier' => 'cc243mg0841_1',
+                    'label' => 'Fileset 1',
+                    'type' => 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
+                    'version' => 1,
+                    'structural' => {
+                      'contains' => [
+                        { 'externalIdentifier' => 'cc243mg0841_1',
+                          'label' => 'Page 1',
+                          'type' => 'http://cocina.sul.stanford.edu/models/file.jsonld',
+                          'version' => 1,
+                          'access' => {
+                            'access' => 'stanford',
+                            'download' => 'stanford',
+                            'readLocation' => nil,
+                            'controlledDigitalLending' => false
+                          },
+                          'administrative' => {
+                            'publish' => true,
+                            'shelve' => true,
+                            'sdrPreserve' => true
+                          },
+                          'hasMessageDigests' => [],
+                          'filename' => 'page1.txt' }
+                      ]
+                    }
+                  }
+                ]
               }
             }
           )
@@ -139,13 +176,46 @@ RSpec.describe 'Set rights for an object' do
           cocina_model.new(
             {
               'access' => {
-                'access' => 'citation-only',
+                'access' => 'stanford',
                 'download' => 'none',
+                'readLocation' => nil,
                 'controlledDigitalLending' => true,
                 'embargo' => {
                   'releaseDate' => '2021-02-11T00:00:00.000+00:00',
-                  'access' => 'world'
+                  'access' => 'world',
+                  'download' => 'world'
                 }
+              },
+              'structural' => {
+                'contains' => [
+                  {
+                    'externalIdentifier' => 'cc243mg0841_1',
+                    'label' => 'Fileset 1',
+                    'type' => 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
+                    'version' => 1,
+                    'structural' => {
+                      'contains' => [
+                        { 'externalIdentifier' => 'cc243mg0841_1',
+                          'label' => 'Page 1',
+                          'type' => 'http://cocina.sul.stanford.edu/models/file.jsonld',
+                          'version' => 1,
+                          'access' => {
+                            'access' => 'stanford',
+                            'download' => 'none',
+                            'readLocation' => nil,
+                            'controlledDigitalLending' => true
+                          },
+                          'administrative' => {
+                            'publish' => true,
+                            'shelve' => true,
+                            'sdrPreserve' => true
+                          },
+                          'hasMessageDigests' => [],
+                          'filename' => 'page1.txt' }
+                      ]
+                    }
+                  }
+                ]
               }
             }
           )
@@ -168,12 +238,13 @@ RSpec.describe 'Set rights for an object' do
                                  'type' => Cocina::Models::Vocab.object,
                                  'externalIdentifier' => pid,
                                  'access' => {
-                                   'access' => 'citation-only',
+                                   'access' => 'stanford',
                                    'download' => 'none',
                                    'controlledDigitalLending' => true,
                                    'embargo' => {
                                      releaseDate: '2021-02-11T00:00:00.000+00:00',
-                                     access: 'world'
+                                     access: 'world',
+                                     download: 'world'
                                    }
                                  },
                                  'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
@@ -190,7 +261,12 @@ RSpec.describe 'Set rights for an object' do
                                              'label' => 'Page 1',
                                              'type' => 'http://cocina.sul.stanford.edu/models/file.jsonld',
                                              'version' => 1,
-                                             'access' => { access: 'world' },
+                                             'access' => {
+                                               'access' => 'world',
+                                               'download' => 'world',
+                                               'readLocation' => nil,
+                                               'controlledDigitalLending' => false
+                                             },
                                              'administrative' => {
                                                'publish' => true,
                                                'shelve' => true,
@@ -213,10 +289,12 @@ RSpec.describe 'Set rights for an object' do
               'access' => {
                 'access' => 'world',
                 'download' => 'world',
+                'readLocation' => nil,
                 'controlledDigitalLending' => false,
                 'embargo' => {
                   'releaseDate' => '2021-02-11T00:00:00.000+00:00',
-                  'access' => 'world'
+                  'access' => 'world',
+                  'download' => 'world'
                 }
               }
             }
@@ -225,6 +303,65 @@ RSpec.describe 'Set rights for an object' do
 
         it 'sets the access' do
           post "/items/#{pid}/set_rights", params: { dro_rights_form: { rights: 'world' } }
+          expect(response).to redirect_to(solr_document_path(pid))
+          expect(object_client).to have_received(:update)
+            .with(params: updated_model)
+          expect(Argo::Indexer).to have_received(:reindex_pid_remotely).with(pid)
+        end
+      end
+
+      context 'when setting citation-only access' do
+        let(:updated_model) do
+          cocina_model.new(
+            {
+              'access' => {
+                'access' => 'citation-only',
+                'download' => 'none',
+                'readLocation' => nil,
+                'controlledDigitalLending' => false,
+                'embargo' => {
+                  'releaseDate' => '2021-02-11T00:00:00.000+00:00',
+                  'access' => 'world',
+                  'download' => 'world'
+                }
+              },
+              'structural' => {
+                'contains' => [
+                  {
+                    'externalIdentifier' => 'cc243mg0841_1',
+                    'label' => 'Fileset 1',
+                    'type' => 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
+                    'version' => 1,
+                    'structural' => {
+                      'contains' => [
+                        { 'externalIdentifier' => 'cc243mg0841_1',
+                          'label' => 'Page 1',
+                          'type' => 'http://cocina.sul.stanford.edu/models/file.jsonld',
+                          'version' => 1,
+                          'access' => {
+                            'access' => 'dark',
+                            'download' => 'none',
+                            'readLocation' => nil,
+                            'controlledDigitalLending' => false
+                          },
+                          'administrative' => {
+                            'publish' => true,
+                            'shelve' => true,
+                            'sdrPreserve' => true
+                          },
+                          'hasMessageDigests' => [],
+                          'filename' => 'page1.txt' }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          )
+        end
+
+        it 'sets the access' do
+          post "/items/#{pid}/set_rights", params: { dro_rights_form: { rights: 'citation-only' } }
           expect(response).to redirect_to(solr_document_path(pid))
           expect(object_client).to have_received(:update)
             .with(params: updated_model)
@@ -268,39 +405,19 @@ RSpec.describe 'Set rights for an object' do
         end
       end
 
-      context 'when setting an object to stanford-only' do
-        let(:updated_model) do
-          cocina_model.new(
-            {
-              'access' => {
-                'access' => 'stanford'
-              }
-            }
-          )
-        end
-
-        it 'sets the access' do
-          post "/items/#{pid}/set_rights", params: { collection_rights_form: { rights: 'stanford' } }
-          expect(response).to redirect_to(solr_document_path(pid))
-          expect(object_client).to have_received(:update)
-            .with(params: updated_model)
-          expect(Argo::Indexer).to have_received(:reindex_pid_remotely).with(pid)
-        end
-      end
-
       context 'when a bulk request' do
         let(:updated_model) do
           cocina_model.new(
             {
               'access' => {
-                'access' => 'stanford'
+                'access' => 'dark'
               }
             }
           )
         end
 
         it 'sets the access' do
-          post "/items/#{pid}/set_rights", params: { bulk: true, dro_rights_form: { rights: 'stanford' } }
+          post "/items/#{pid}/set_rights", params: { bulk: true, dro_rights_form: { rights: 'dark' } }
           expect(response).to have_http_status(:ok)
           expect(object_client).to have_received(:update)
             .with(params: updated_model)

--- a/spec/requests/set_source_id_spec.rb
+++ b/spec/requests/set_source_id_spec.rb
@@ -14,9 +14,7 @@ RSpec.describe 'Set source id for an object' do
                              'version' => 1,
                              'type' => Cocina::Models::Vocab.object,
                              'externalIdentifier' => pid,
-                             'access' => {
-                               'access' => 'world'
-                             },
+                             'access' => {},
                              'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
                              'structural' => {},
                              'identification' => { sourceId: 'some:thing' }

--- a/spec/requests/show_rights_spec.rb
+++ b/spec/requests/show_rights_spec.rb
@@ -47,9 +47,11 @@ RSpec.describe 'Show rights for an object' do
                                'externalIdentifier' => pid,
                                'access' => {
                                  'access' => 'world',
+                                 'download' => 'none',
                                  embargo: {
                                    releaseDate: '2021-02-11T00:00:00.000+00:00',
-                                   access: 'world'
+                                   access: 'world',
+                                   download: 'world'
                                  }
                                },
                                'administrative' => { hasAdminPolicy: apo_pid },
@@ -66,7 +68,7 @@ RSpec.describe 'Show rights for an object' do
                                            'label' => 'Page 1',
                                            'type' => 'http://cocina.sul.stanford.edu/models/file.jsonld',
                                            'version' => 1,
-                                           'access' => { access: 'world' },
+                                           'access' => { access: 'world', download: 'none' },
                                            'administrative' => {
                                              'publish' => true,
                                              'shelve' => true,

--- a/spec/requests/update_datastream_spec.rb
+++ b/spec/requests/update_datastream_spec.rb
@@ -15,9 +15,7 @@ RSpec.describe 'Update a datastream' do
       'version' => 1,
       'type' => Cocina::Models::Vocab.object,
       'externalIdentifier' => pid,
-      'access' => {
-        'access' => 'world'
-      },
+      'access' => {},
       'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
       'structural' => {},
       'identification' => {}

--- a/spec/services/admin_policy_change_set_persister_spec.rb
+++ b/spec/services/admin_policy_change_set_persister_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe AdminPolicyChangeSetPersister do
               access: 'world',
               controlledDigitalLending: false,
               download: 'world',
+              readLocation: nil,
               copyright: 'My copyright statement',
               license: 'https://creativecommons.org/licenses/by-nc/3.0/',
               useAndReproductionStatement: 'My use and reproduction statement'

--- a/spec/services/item_change_set_persister_spec.rb
+++ b/spec/services/item_change_set_persister_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe ItemChangeSetPersister do
           type: Cocina::Models::Vocab.object,
           version: 1,
           access: {
-            embargo: { releaseDate: '2040-04-04', access: 'world' },
+            embargo: { releaseDate: '2040-04-04', access: 'world', download: 'world' },
             copyright: copyright_statement_before,
             license: license_before,
             useAndReproductionStatement: use_statement_before
@@ -126,8 +126,10 @@ RSpec.describe ItemChangeSetPersister do
           params: a_cocina_object_with_access(
             embargo: {
               releaseDate: '2055-07-17',
-              access: 'world'
+              access: 'world',
+              download: 'world'
             },
+            access: 'dark',
             copyright: copyright_statement_before,
             license: license_before,
             useAndReproductionStatement: use_statement_before


### PR DESCRIPTION
## Why was this change made?
Tighter modeling of access/embargoes, including collection access.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


