### PR TITLE
Refactor change sets to use reform-rails

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,8 +37,9 @@ class ItemsController < ApplicationController
   end
 
   def set_collection
-    change_set = ItemChangeSet.new(collection_ids: Array(params[:collection].presence))
-    ItemChangeSetPersister.update(@cocina, change_set)
+    change_set = ItemChangeSet.new(@cocina)
+    change_set.validate(collection_ids: Array(params[:collection].presence))
+    change_set.save
     reindex
 
     response_message = if params[:collection].present?
@@ -59,9 +60,9 @@ class ItemsController < ApplicationController
   def add_collection
     response_message = if params[:collection].present?
                          new_collections = Array(@cocina.structural.isMemberOf) + [params[:collection]]
-                         change_set = ItemChangeSet.new(collection_ids: new_collections)
-                         ItemChangeSetPersister.update(@cocina, change_set)
-
+                         change_set = ItemChangeSet.new(@cocina)
+                         change_set.validate(collection_ids: new_collections)
+                         change_set.save
                          reindex
                          'Collection added successfully'
                        else
@@ -88,8 +89,9 @@ class ItemsController < ApplicationController
 
   def remove_collection
     new_collections = @cocina.structural.isMemberOf - [params[:collection]]
-    change_set = ItemChangeSet.new(collection_ids: new_collections)
-    ItemChangeSetPersister.update(@cocina, change_set)
+    change_set = ItemChangeSet.new(@cocina)
+    change_set.validate(collection_ids: new_collections)
+    change_set.save
     reindex
 
     response_message = 'Collection successfully removed'
@@ -129,8 +131,9 @@ class ItemsController < ApplicationController
                          flash: { error: 'Invalid date' }
     end
 
-    change_set = ItemChangeSet.new { |change| change.embargo_release_date = params[:embargo_date] }
-    ItemChangeSetPersister.update(@cocina, change_set)
+    change_set = ItemChangeSet.new(@cocina)
+    change_set.validate(embargo_release_date: params[:embargo_date])
+    change_set.save
 
     respond_to do |format|
       format.any { redirect_to solr_document_path(params[:id]), notice: 'Embargo was successfully updated' }
@@ -152,8 +155,9 @@ class ItemsController < ApplicationController
   end
 
   def source_id
-    change_set = ItemChangeSet.new(source_id: params[:new_id])
-    ItemChangeSetPersister.update(@cocina, change_set)
+    change_set = ItemChangeSet.new(@cocina)
+    change_set.validate(source_id: params[:new_id])
+    change_set.save
     reindex
 
     respond_to do |format|
@@ -167,8 +171,9 @@ class ItemsController < ApplicationController
   end
 
   def catkey
-    change_set = ItemChangeSet.new(catkey: params[:new_catkey].strip)
-    ItemChangeSetPersister.update(@cocina, change_set)
+    change_set = ItemChangeSet.new(@cocina)
+    change_set.validate(catkey: params[:new_catkey].strip)
+    change_set.save
     reindex
 
     respond_to do |format|
@@ -266,8 +271,9 @@ class ItemsController < ApplicationController
 
     authorize! :manage_governing_apo, @cocina, params[:new_apo_id]
 
-    change_set = ItemChangeSet.new(admin_policy_id: params[:new_apo_id])
-    ItemChangeSetPersister.update(@cocina, change_set)
+    change_set = ItemChangeSet.new(@cocina)
+    change_set.validate(admin_policy_id: params[:new_apo_id])
+    change_set.save
     reindex
 
     redirect_to solr_document_path(params[:id]), notice: 'Governing APO updated!'

--- a/app/jobs/set_governing_apo_job.rb
+++ b/app/jobs/set_governing_apo_job.rb
@@ -35,9 +35,10 @@ class SetGoverningApoJob < GenericJob
     state_service = StateService.new(current_druid, version: cocina_item.version)
     check_can_set_governing_apo!(cocina_item, state_service)
     open_new_version(current_druid, cocina_item.version, 'Set new governing APO') unless state_service.allows_modification?
-    change_set = ItemChangeSet.new { |change| change.admin_policy_id = new_apo_id }
-    ItemChangeSetPersister.update(cocina_item, change_set)
 
+    change_set = ItemChangeSet.new(cocina_item)
+    change_set.validate(admin_policy_id: new_apo_id)
+    change_set.save
     Argo::Indexer.reindex_pid_remotely(current_druid)
 
     log.puts("#{Time.current} SetGoverningApoJob: Successfully updated #{current_druid} (bulk_action.id=#{bulk_action.id})")

--- a/app/models/collection_change_set.rb
+++ b/app/models/collection_change_set.rb
@@ -1,34 +1,12 @@
 # frozen_string_literal: true
 
 # Represents a set of changes to a collection
-class CollectionChangeSet
-  PROPERTIES = %i[
-    copyright_statement
-    license
-    use_statement
-  ].freeze
+class CollectionChangeSet < Reform::Form
+  property :copyright_statement, virtual: true
+  property :license, virtual: true
+  property :use_statement, virtual: true
 
-  def initialize(attributes = {})
-    @changes = attributes.slice(*PROPERTIES)
-    yield self if block_given?
-  end
-
-  PROPERTIES.each do |property|
-    define_method(property) do
-      @changes[property]
-    end
-
-    define_method("#{property}_changed?") do
-      @changes.key?(property)
-    end
-
-    define_method("#{property}=") do |value|
-      @changes[property] = value
-    end
-  end
-
-  # Allows collaborators to ask if the change set includes *any* changes
-  def changed?
-    @changes.any?
+  def save_model
+    CollectionChangeSetPersister.update(model, self)
   end
 end

--- a/app/models/item_change_set.rb
+++ b/app/models/item_change_set.rb
@@ -1,47 +1,35 @@
 # frozen_string_literal: true
 
 # Represents a set of changes to an item.
-class ItemChangeSet
-  PROPERTIES = %i[
-    admin_policy_id
-    catkey
-    collection_ids
-    copyright_statement
-    embargo_release_date
-    license
-    source_id
-    use_statement
-    barcode
-  ].freeze
+class ItemChangeSet < Reform::Form
+  property :admin_policy_id, virtual: true
+  property :catkey, virtual: true
+  property :collection_ids, virtual: true
+  property :copyright_statement, virtual: true
+  property :embargo_release_date, virtual: true
+  property :license, virtual: true
+  property :source_id, virtual: true
+  property :use_statement, virtual: true
+  property :barcode, virtual: true
 
-  def initialize(attributes = {})
-    @changes = attributes.slice(*PROPERTIES)
-    yield self if block_given?
+  def self.model_name
+    Struct.new(:param_key, :route_key, :i18n_key, :name).new('item', 'item', 'item', 'Item')
   end
 
-  PROPERTIES.each do |property|
-    define_method(property) do
-      @changes[property]
-    end
-
-    define_method("#{property}_changed?") do
-      @changes.key?(property)
-    end
-
-    define_method("#{property}=") do |value|
-      @changes[property] = value
-    end
+  # needed for generating the update route
+  def to_key
+    Array(@cocina_item&.externalIdentifier)
   end
 
-  # Allows collaborators to ask if the change set includes *any* changes
-  def changed?
-    @changes.any?
+  # When the object is initialized, copy the properties from the cocina model to the form:
+  def setup_properties!(_options)
+    return unless model.identification
+
+    self.catkey = model.identification.catalogLinks&.find { |link| link.catalog == 'symphony' }&.catalogRecordId
+    self.barcode = model.identification.barcode
   end
 
-  def ==(other)
-    PROPERTIES.each do |property|
-      return false if public_send(property) != other.public_send(property)
-    end
-    true
+  def save_model
+    ItemChangeSetPersister.update(model, self)
   end
 end

--- a/app/services/collection_change_set_persister.rb
+++ b/app/services/collection_change_set_persister.rb
@@ -24,20 +24,18 @@ class CollectionChangeSetPersister
 
   attr_reader :model, :change_set
 
-  delegate :license, :license_changed?, :copyright_statement,
-           :copyright_statement_changed?, :use_statement,
-           :use_statement_changed?, to: :change_set
+  delegate :license, :copyright_statement, :use_statement, :changed?, to: :change_set
 
   def access_changed?
-    copyright_statement_changed? || license_changed? || use_statement_changed?
+    changed?(:copyright_statement) || changed?(:license) || changed?(:use_statement)
   end
 
   def updated_access(updated)
     updated.new(
       access: updated.access.new(
-        copyright: copyright_statement_changed? ? copyright_statement : updated.access.copyright,
-        license: license_changed? ? license : updated.access.license,
-        useAndReproductionStatement: use_statement_changed? ? use_statement : updated.access.useAndReproductionStatement
+        copyright: changed?(:copyright_statement) ? copyright_statement : updated.access.copyright,
+        license: changed?(:license) ? license : updated.access.license,
+        useAndReproductionStatement: changed?(:use_statement) ? use_statement : updated.access.useAndReproductionStatement
       )
     )
   end

--- a/app/services/license_and_rights_statements_setter.rb
+++ b/app/services/license_and_rights_statements_setter.rb
@@ -46,7 +46,7 @@ class LicenseAndRightsStatementsSetter
 
     open_new_version! unless state_service.allows_modification?
 
-    change_set_persister_class.update(cocina_object, change_set)
+    change_set.save
   end
 
   private
@@ -71,10 +71,12 @@ class LicenseAndRightsStatementsSetter
   end
 
   def change_set
-    change_set_class.new do |change|
-      change.license = license unless license.nil?
-      change.copyright_statement = copyright_statement unless copyright_statement.nil?
-      change.use_statement = use_statement unless use_statement.nil?
+    args = {}
+    args[:license] = license unless license.nil?
+    args[:copyright_statement] = copyright_statement unless copyright_statement.nil?
+    args[:use_statement] = use_statement unless use_statement.nil?
+    change_set_class.new(cocina_object).tap do |change_set|
+      change_set.validate(args)
     end
   end
 
@@ -83,14 +85,6 @@ class LicenseAndRightsStatementsSetter
       ItemChangeSet
     elsif cocina_object.collection?
       CollectionChangeSet
-    end
-  end
-
-  def change_set_persister_class
-    if cocina_object.dro?
-      ItemChangeSetPersister
-    elsif cocina_object.collection?
-      CollectionChangeSetPersister
     end
   end
 

--- a/spec/jobs/set_catkeys_and_barcodes_csv_job_spec.rb
+++ b/spec/jobs/set_catkeys_and_barcodes_csv_job_spec.rb
@@ -75,10 +75,14 @@ RSpec.describe SetCatkeysAndBarcodesCsvJob do
   end
 
   let(:object_client1) { instance_double(Dor::Services::Client::Object, find: item1) }
+  let(:object_client2) { instance_double(Dor::Services::Client::Object, find: item2) }
+  let(:object_client3) { instance_double(Dor::Services::Client::Object, find: item3) }
 
   before do
     allow(subject).to receive(:bulk_action).and_return(bulk_action_no_process_callback)
     allow(Dor::Services::Client).to receive(:object).with(pids[0]).and_return(object_client1)
+    allow(Dor::Services::Client).to receive(:object).with(pids[1]).and_return(object_client2)
+    allow(Dor::Services::Client).to receive(:object).with(pids[2]).and_return(object_client3)
   end
 
   describe '#perform' do
@@ -95,9 +99,7 @@ RSpec.describe SetCatkeysAndBarcodesCsvJob do
           csv_file: csv_file
         }
       expect(subject).to receive(:with_bulk_action_log).and_yield(buffer)
-      expect(subject).to receive(:update_catkey_and_barcode).with(pids[0], ItemChangeSet.new(barcode: barcodes[0], catkey: catkeys[0]), buffer)
-      expect(subject).to receive(:update_catkey_and_barcode).with(pids[1], ItemChangeSet.new(barcode: nil, catkey: nil), buffer)
-      expect(subject).to receive(:update_catkey_and_barcode).with(pids[2], ItemChangeSet.new(barcode: barcodes[2], catkey: catkeys[2]), buffer)
+      expect(subject).to receive(:update_catkey_and_barcode).with(ItemChangeSet, buffer).exactly(3).times
       subject.perform(bulk_action_no_process_callback.id, params)
       expect(bulk_action_no_process_callback.druid_count_total).to eq pids.length
     end

--- a/spec/jobs/set_catkeys_and_barcodes_job_spec.rb
+++ b/spec/jobs/set_catkeys_and_barcodes_job_spec.rb
@@ -66,6 +66,8 @@ RSpec.describe SetCatkeysAndBarcodesJob do
   end
 
   let(:object_client1) { instance_double(Dor::Services::Client::Object, find: item1) }
+  let(:object_client2) { instance_double(Dor::Services::Client::Object, find: item2) }
+  let(:object_client3) { instance_double(Dor::Services::Client::Object, find: item3) }
 
   before do
     allow(subject).to receive(:bulk_action).and_return(bulk_action_no_process_callback)
@@ -73,6 +75,11 @@ RSpec.describe SetCatkeysAndBarcodesJob do
   end
 
   describe '#perform' do
+    before do
+      allow(Dor::Services::Client).to receive(:object).with(pids[1]).and_return(object_client2)
+      allow(Dor::Services::Client).to receive(:object).with(pids[2]).and_return(object_client3)
+    end
+
     context 'when catkey and barcode selected' do
       it 'attempts to update the catkey/barcode for each druid with correct corresponding catkey/barcode' do
         params =
@@ -86,9 +93,9 @@ RSpec.describe SetCatkeysAndBarcodesJob do
             }
           }
         expect(subject).to receive(:with_bulk_action_log).and_yield(buffer)
-        expect(subject).to receive(:update_catkey_and_barcode).with(pids[0], ItemChangeSet.new(barcode: barcodes[0], catkey: catkeys[0]), buffer)
-        expect(subject).to receive(:update_catkey_and_barcode).with(pids[1], ItemChangeSet.new(barcode: nil, catkey: nil), buffer)
-        expect(subject).to receive(:update_catkey_and_barcode).with(pids[2], ItemChangeSet.new(barcode: barcodes[2], catkey: catkeys[2]), buffer)
+        expect(subject).to receive(:update_catkey_and_barcode).with(ItemChangeSet, buffer)
+        expect(subject).to receive(:update_catkey_and_barcode).with(ItemChangeSet, buffer)
+        expect(subject).to receive(:update_catkey_and_barcode).with(ItemChangeSet, buffer)
         subject.perform(bulk_action_no_process_callback.id, params)
         expect(bulk_action_no_process_callback.druid_count_total).to eq pids.length
       end
@@ -149,6 +156,12 @@ RSpec.describe SetCatkeysAndBarcodesJob do
       )
     end
 
+    let(:change_set) do
+      ItemChangeSet.new(item1).tap do |change_set|
+        change_set.validate(catkey: catkey, barcode: barcode)
+      end
+    end
+
     before do
       allow(Dor::Services::Client).to receive(:object).with(pid).and_return(object_client)
       allow(StateService).to receive(:new).and_return(state_service)
@@ -163,7 +176,7 @@ RSpec.describe SetCatkeysAndBarcodesJob do
       end
 
       it 'logs and returns' do
-        subject.send(:update_catkey_and_barcode, pid, ItemChangeSet.new(catkey: catkey, barcode: barcode), buffer)
+        subject.send(:update_catkey_and_barcode, change_set, buffer)
         expect(object_client).not_to have_received(:update)
         expect(buffer.string).to include('Not authorized')
       end
@@ -177,7 +190,7 @@ RSpec.describe SetCatkeysAndBarcodesJob do
       end
 
       it 'logs' do
-        subject.send(:update_catkey_and_barcode, pid, ItemChangeSet.new(catkey: catkey, barcode: barcode), buffer)
+        subject.send(:update_catkey_and_barcode, change_set, buffer)
         expect(object_client).not_to have_received(:update)
         expect(buffer.string).to include('Catkey/barcode failed')
       end
@@ -188,7 +201,7 @@ RSpec.describe SetCatkeysAndBarcodesJob do
 
       it 'updates catkey and barcode and versions objects' do
         expect(subject).to receive(:open_new_version).with(pid, 3, "Catkey updated to #{catkey}. Barcode updated to #{barcode}.")
-        subject.send(:update_catkey_and_barcode, pid, ItemChangeSet.new(catkey: catkey, barcode: barcode), buffer)
+        subject.send(:update_catkey_and_barcode, change_set, buffer)
         expect(object_client).to have_received(:update)
           .with(params: updated_model)
       end
@@ -199,7 +212,7 @@ RSpec.describe SetCatkeysAndBarcodesJob do
 
       it 'updates catkey and barcode and does not version objects if not needed' do
         expect(subject).not_to receive(:open_new_version).with(pid, 3, "Catkey updated to #{catkey}. Barcode updated to #{barcode}.")
-        subject.send(:update_catkey_and_barcode, pid, ItemChangeSet.new(catkey: catkey, barcode: barcode), buffer)
+        subject.send(:update_catkey_and_barcode, change_set, buffer)
         expect(object_client).to have_received(:update)
           .with(params: updated_model)
       end
@@ -214,7 +227,7 @@ RSpec.describe SetCatkeysAndBarcodesJob do
 
       it 'removes catkey and barcode' do
         expect(subject).to receive(:open_new_version).with(pid, 3, 'Catkey removed. Barcode removed.')
-        subject.send(:update_catkey_and_barcode, pid, ItemChangeSet.new(barcode: nil, catkey: nil), buffer)
+        subject.send(:update_catkey_and_barcode, change_set, buffer)
         expect(object_client).to have_received(:update)
           .with(params: updated_model)
       end

--- a/spec/services/collection_change_set_persister_spec.rb
+++ b/spec/services/collection_change_set_persister_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe CollectionChangeSetPersister do
     let(:instance) do
       described_class.new(model, change_set)
     end
+    let(:change_set) { CollectionChangeSet.new(model) }
     let(:license_before) { 'http://opendatacommons.org/licenses/pddl/1.0/' }
     let(:model) do
       Cocina::Models::Collection.new(
@@ -42,19 +43,14 @@ RSpec.describe CollectionChangeSetPersister do
 
     before do
       allow(instance).to receive(:object_client).and_return(fake_client)
-      instance.update
     end
 
     context 'when change set has changed copyright statement' do
-      let(:change_set) do
-        instance_double(
-          CollectionChangeSet,
-          copyright_statement: new_copyright_statement,
-          copyright_statement_changed?: true,
-          license_changed?: false,
-          use_statement_changed?: false
-        )
+      before do
+        change_set.validate(copyright_statement: new_copyright_statement)
+        instance.update
       end
+
       let(:new_copyright_statement) { 'A Changed Copyright Statement' }
 
       it 'invokes object client with collection that has new copyright statement' do
@@ -69,15 +65,11 @@ RSpec.describe CollectionChangeSetPersister do
     end
 
     context 'when change set has changed license' do
-      let(:change_set) do
-        instance_double(
-          CollectionChangeSet,
-          copyright_statement_changed?: false,
-          license: new_license,
-          license_changed?: true,
-          use_statement_changed?: false
-        )
+      before do
+        change_set.validate(license: new_license)
+        instance.update
       end
+
       let(:new_license) { 'https://creativecommons.org/licenses/by-nc-nd/3.0/' }
 
       it 'invokes object client with collection that has new license' do
@@ -92,15 +84,11 @@ RSpec.describe CollectionChangeSetPersister do
     end
 
     context 'when change set has changed use statement' do
-      let(:change_set) do
-        instance_double(
-          CollectionChangeSet,
-          copyright_statement_changed?: false,
-          license_changed?: false,
-          use_statement: new_use_statement,
-          use_statement_changed?: true
-        )
+      before do
+        change_set.validate(use_statement: new_use_statement)
+        instance.update
       end
+
       let(:new_use_statement) { 'A Changed Use Statement' }
 
       it 'invokes object client with collection that has new use statement' do
@@ -115,13 +103,8 @@ RSpec.describe CollectionChangeSetPersister do
     end
 
     context 'when change set has no changes' do
-      let(:change_set) do
-        instance_double(
-          CollectionChangeSet,
-          copyright_statement_changed?: false,
-          license_changed?: false,
-          use_statement_changed?: false
-        )
+      before do
+        instance.update
       end
 
       it 'invokes object client with collection as before' do

--- a/spec/services/item_change_set_persister_spec.rb
+++ b/spec/services/item_change_set_persister_spec.rb
@@ -46,16 +46,19 @@ RSpec.describe ItemChangeSetPersister do
     let(:use_statement_before) { 'My First Use Statement' }
     let(:barcode_before) { '36105014757517' }
     let(:catkey_before) { '367268' }
+    let(:change_set) { ItemChangeSet.new(model) }
 
     before do
       allow(instance).to receive(:object_client).and_return(fake_client)
-      instance.update
     end
 
     context 'when change set has changed copyright statement' do
-      let(:change_set) { ItemChangeSet.new(copyright_statement: new_copyright_statement) }
-
       let(:new_copyright_statement) { 'A Changed Copyright Statement' }
+
+      before do
+        change_set.validate(copyright_statement: new_copyright_statement)
+        instance.update
+      end
 
       it 'invokes object client with item/DRO that has new copyright statement' do
         expect(fake_client).to have_received(:update).with(
@@ -69,9 +72,12 @@ RSpec.describe ItemChangeSetPersister do
     end
 
     context 'when change set has changed license' do
-      let(:change_set) { ItemChangeSet.new(license: new_license) }
-
       let(:new_license) { 'https://creativecommons.org/licenses/by-nc-nd/3.0/' }
+
+      before do
+        change_set.validate(license: new_license)
+        instance.update
+      end
 
       it 'invokes object client with item/DRO that has new license' do
         expect(fake_client).to have_received(:update).with(
@@ -85,9 +91,12 @@ RSpec.describe ItemChangeSetPersister do
     end
 
     context 'when change set has changed use statement' do
-      let(:change_set) { ItemChangeSet.new(use_statement: new_use_statement) }
-
       let(:new_use_statement) { 'A Changed Use Statement' }
+
+      before do
+        change_set.validate(use_statement: new_use_statement)
+        instance.update
+      end
 
       it 'invokes object client with item/DRO that has new use statement' do
         expect(fake_client).to have_received(:update).with(
@@ -101,9 +110,6 @@ RSpec.describe ItemChangeSetPersister do
     end
 
     context 'when change set has changed embargo_release_date' do
-      let(:change_set) do
-        ItemChangeSet.new { |change| change.embargo_release_date = new_embargo_release_date }
-      end
       let(:new_embargo_release_date) { '2055-07-17' }
       let(:model) do
         Cocina::Models::DRO.new(
@@ -119,6 +125,11 @@ RSpec.describe ItemChangeSetPersister do
           },
           administrative: { hasAdminPolicy: 'druid:bc123df4569' }
         )
+      end
+
+      before do
+        change_set.validate(embargo_release_date: new_embargo_release_date)
+        instance.update
       end
 
       it 'invokes object client with item/DRO that has new use statement' do
@@ -137,7 +148,6 @@ RSpec.describe ItemChangeSetPersister do
     end
 
     context 'when change set has one changed property and another nil' do
-      let(:change_set) { ItemChangeSet.new(use_statement: new_use_statement) }
       let(:model) do
         Cocina::Models::DRO.new(
           externalIdentifier: 'druid:bc123df4568',
@@ -154,6 +164,11 @@ RSpec.describe ItemChangeSetPersister do
       end
       let(:new_use_statement) { 'A Changed Use Statement' }
 
+      before do
+        change_set.validate(use_statement: new_use_statement)
+        instance.update
+      end
+
       it 'invokes object client with item/DRO that has new use statement' do
         expect(fake_client).to have_received(:update).with(
           params: a_cocina_object_with_access(
@@ -165,7 +180,9 @@ RSpec.describe ItemChangeSetPersister do
     end
 
     context 'when change set has no changes' do
-      let(:change_set) { ItemChangeSet.new }
+      before do
+        instance.update
+      end
 
       it 'invokes object client with item/DRO as before' do
         expect(fake_client).to have_received(:update).with(
@@ -179,9 +196,12 @@ RSpec.describe ItemChangeSetPersister do
     end
 
     context 'when change set has changed barcode' do
-      let(:change_set) { ItemChangeSet.new(barcode: new_barcode) }
-
       let(:new_barcode) { '36105014757518' }
+
+      before do
+        change_set.validate(barcode: new_barcode)
+        instance.update
+      end
 
       it 'invokes object client with item/DRO that has new barcode' do
         expect(fake_client).to have_received(:update).with(
@@ -194,7 +214,10 @@ RSpec.describe ItemChangeSetPersister do
     end
 
     context 'when change set has removed barcode' do
-      let(:change_set) { ItemChangeSet.new(barcode: nil) }
+      before do
+        change_set.validate(barcode: nil)
+        instance.update
+      end
 
       it 'invokes object client with item/DRO that has no barcode' do
         expect(fake_client).to have_received(:update).with(
@@ -206,9 +229,12 @@ RSpec.describe ItemChangeSetPersister do
     end
 
     context 'when change set has changed catkey' do
-      let(:change_set) { ItemChangeSet.new(catkey: new_catkey) }
-
       let(:new_catkey) { '367269' }
+
+      before do
+        change_set.validate(catkey: new_catkey)
+        instance.update
+      end
 
       it 'invokes object client with item/DRO that has new catkey' do
         expect(fake_client).to have_received(:update).with(
@@ -221,7 +247,10 @@ RSpec.describe ItemChangeSetPersister do
     end
 
     context 'when change set has removed catkey' do
-      let(:change_set) { ItemChangeSet.new(catkey: nil) }
+      before do
+        change_set.validate(catkey: nil)
+        instance.update
+      end
 
       it 'invokes object client with item/DRO that has no catkey' do
         expect(fake_client).to have_received(:update).with(


### PR DESCRIPTION


## Why was this change made?

This allows us to use a standard pattern rather than inventing our own.  This is more maintainable as we have less code to maintain and it is a library we are using in other projects such as h2.  Now fewer classes need to be aware of Persisters.

## How was this change tested?



## Which documentation and/or configurations were updated?



