### PR TITLE
Split the stimulus controllers into their own file

### DIFF
--- a/app/javascript/argo.js
+++ b/app/javascript/argo.js
@@ -1,13 +1,4 @@
 import Form from 'modules/apo_form'
-import CollectionEditor from 'controllers/collection_editor'
-import BulkActions from 'controllers/bulk_actions'
-import BulkUpload from 'controllers/bulk_upload'
-import FacetFilter from 'controllers/facet_filter'
-import JSONRenderer from 'controllers/json_renderer'
-import Tokens from 'controllers/tokens'
-import WorkflowGrid from 'controllers/workflow_grid_controller'
-import { Application } from 'stimulus'
-import BlacklightHierarchyController from 'blacklight-hierarchy/app/assets/javascripts/blacklight/hierarchy/blacklight_hierarchy_controller'
 
 require('@github/time-elements')
 
@@ -43,15 +34,6 @@ export default class Argo {
     initialize() {
         this.apoEditor()
         this.collapsableSections()
-        const application = Application.start()
-        application.register("bulk_actions", BulkActions)
-        application.register("bulk_upload", BulkUpload)
-        application.register("facet-filter", FacetFilter)
-        application.register('json-renderer', JSONRenderer)
-        application.register("workflow-grid", WorkflowGrid)
-        application.register("collection-editor", CollectionEditor)
-        application.register("tokens", Tokens)
-        application.register("b-h-collapsible", BlacklightHierarchyController)
     }
 
     apoEditor() {

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,0 +1,19 @@
+import { Application } from 'stimulus'
+import CollectionEditor from 'controllers/collection_editor'
+import BulkActions from 'controllers/bulk_actions'
+import BulkUpload from 'controllers/bulk_upload'
+import FacetFilter from 'controllers/facet_filter'
+import JSONRenderer from 'controllers/json_renderer'
+import Tokens from 'controllers/tokens'
+import WorkflowGrid from 'controllers/workflow_grid_controller'
+import BlacklightHierarchyController from 'blacklight-hierarchy/app/assets/javascripts/blacklight/hierarchy/blacklight_hierarchy_controller'
+
+const application = Application.start()
+application.register("bulk_actions", BulkActions)
+application.register("bulk_upload", BulkUpload)
+application.register("facet-filter", FacetFilter)
+application.register('json-renderer', JSONRenderer)
+application.register("workflow-grid", WorkflowGrid)
+application.register("collection-editor", CollectionEditor)
+application.register("tokens", Tokens)
+application.register("b-h-collapsible", BlacklightHierarchyController)

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -20,6 +20,7 @@ require('jquery-ui/themes/base/all')
 import 'jquery-ui'
 import 'jquery-validation'
 import "bootstrap/dist/js/bootstrap"
+import "controllers"
 
 import 'spreadsheet' // Note: this library is used to read/write spreadsheet documents, not display
 


### PR DESCRIPTION

## Why was this change made?

The stimulus application was being initialized in Argo.initialize, which is called on every page load.  This is not ideal, especially when using turbo or turbolinks.  This also gives better organization by separating the stimulus from the non-stimulus part of the application


## How was this change tested?



## Which documentation and/or configurations were updated?



