### PR TITLE
Stop using the 'Old content type' filter when updating type

### DIFF
--- a/app/controllers/content_types_controller.rb
+++ b/app/controllers/content_types_controller.rb
@@ -38,21 +38,12 @@ class ContentTypesController < ApplicationController
 
   def cocina_update_attributes
     {}.tap do |attributes|
-      attributes[:type] = Constants::CONTENT_TYPES[new_content_type] if content_type_should_change?
+      attributes[:type] = Constants::CONTENT_TYPES[new_content_type]
       attributes[:structural] = if resource_types_should_change?
                                   structural_with_resource_type_changes
                                 else
                                   @cocina_object.structural.new(hasMemberOrders: member_orders)
                                 end
-    end
-  end
-
-  def old_content_type
-    if @cocina_object.type == Cocina::Models::Vocab.book && @cocina_object.structural.hasMemberOrders&.first&.viewingDirection == 'right-to-left'
-      # if we have a book type, we need to also check the viewing direction
-      'book (rtl)'
-    else
-      Constants::CONTENT_TYPES.key(@cocina_object.type) || ''
     end
   end
 
@@ -93,10 +84,6 @@ class ContentTypesController < ApplicationController
     Array(@cocina_object.structural.contains).map(&:type).any? { |resource_type| resource_type == Constants::RESOURCE_TYPES[params[:old_resource_type]] }
   end
 
-  def content_type_should_change?
-    @cocina_object.type == Constants::CONTENT_TYPES[params[:old_content_type]]
-  end
-
   def valid_content_type?
     Constants::CONTENT_TYPES.keys.include?(new_content_type)
   end
@@ -109,7 +96,6 @@ class ContentTypesController < ApplicationController
     raise 'missing druid' if params[:item_id].blank?
 
     @cocina_object = object_client.find
-    @old_content_type = old_content_type
     @old_resource_type = old_resource_type
   end
 end

--- a/app/javascript/packs/bulk.js
+++ b/app/javascript/packs/bulk.js
@@ -33,7 +33,6 @@ function set_content_type(druids){
 	var params={
 		'new_content_type': document.getElementById('new_content_type').value,
 		'new_resource_type': document.getElementById('new_resource_type').value,
-		'old_content_type': document.getElementById('old_content_type').value,
 		'old_resource_type': document.getElementById('old_resource_type').value
 	}
 	process_patch(druids, set_content_type_url, params, "Updated");

--- a/app/views/content_types/_content_type.html.erb
+++ b/app/views/content_types/_content_type.html.erb
@@ -6,16 +6,12 @@
   <% display_content_types = [['none', '']] + Constants::CONTENT_TYPES.keys %>
   <% display_resource_types = [['none', '']] + Constants::RESOURCE_TYPES.keys %>
   <div class='form-group'>
-    <label>Old content type</label>:
-    <%= @old_content_type %><%= hidden_field_tag :old_content_type, @old_content_type %>
-  </div>
-  <div class='form-group'>
     <label>Old resource type</label>
     <%= select_tag :old_resource_type, options_for_select(display_resource_types, @old_resource_type), class: 'form-control' %>
   </div>
   <div class='form-group'>
     <label>New content type</label>
-    <%= select_tag :new_content_type, options_for_select(display_content_types, @old_content_type), class: 'form-control' %>
+    <%= select_tag :new_content_type, options_for_select(display_content_types), class: 'form-control' %>
   </div>
   <div class='form-group'>
     <label>New resource type</label>

--- a/app/views/report/bulk.html.erb
+++ b/app/views/report/bulk.html.erb
@@ -102,15 +102,7 @@ ul li{
 <br>
 
 <div class="bulk_operation" id="content_type" name="content_type">
-  <% current_content_types = []
-     # retrieving the content types this way gives a list of values interleaved with facet counts, e.g.:
-     #  ["googleScannedBook", 10, "book", 7]
-     # so just use the evens
-     @response['facet_counts']['facet_fields']['content_type_ssim'].each_with_index do |k, idx|
-       current_content_types << k if idx.even?
-     end
-     current_content_types = [['none', '']] + current_content_types
-     current_resource_types = [['none', '']] + Constants::RESOURCE_TYPES.keys
+  <% current_resource_types = [['none', '']] + Constants::RESOURCE_TYPES.keys
      new_content_types = [['none', '']] + Constants::CONTENT_TYPES.keys
      new_resource_types = [['none', '']] + Constants::RESOURCE_TYPES.keys %>
   <h1>Set content and resource types</h1>
@@ -121,8 +113,6 @@ ul li{
   <p><%= I18n.t('argo.content_type.suggeted_mappings').html_safe %></p>
   <p>More complex updates should be executed by hand on the datastream XML of individual objects.</p>
   <p>
-    <label>Old content type</label>
-    <%= select_tag :old_content_type, options_for_select(current_content_types) %><br>
     <label>Old resource type</label>
     <%= select_tag :old_resource_type, options_for_select(current_resource_types) %><br>
     <label>New content type</label>

--- a/spec/controllers/content_types_controller_spec.rb
+++ b/spec/controllers/content_types_controller_spec.rb
@@ -87,63 +87,11 @@ RSpec.describe ContentTypesController, type: :controller do
   end
 
   describe '#show' do
-    context 'with no reading direction (memberOrder) set' do
-      context 'for an object with an image content type' do
-        let(:content_type) { Cocina::Models::Vocab.image }
+    let(:content_type) { Cocina::Models::Vocab.image }
 
-        it 'is successful' do
-          get :show, params: { item_id: pid }
-          expect(response).to be_successful
-          expect(controller.send(:old_content_type)).to eq 'image'
-        end
-      end
-
-      context 'for an object with a book content type' do
-        let(:content_type) { Cocina::Models::Vocab.book }
-
-        it 'is successful' do
-          get :show, params: { item_id: pid }
-          expect(response).to be_successful
-          expect(controller.send(:old_content_type)).to eq 'book (ltr)'
-        end
-      end
-    end
-
-    context 'with a specific reading direction (memberOrder) set' do
-      let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model_with_member_order, update: true) }
-
-      context 'for an object with an image content type and memberOrder of left-to-right' do
-        let(:content_type) { Cocina::Models::Vocab.image }
-        let(:reading_order) { 'left-to-right' }
-
-        it 'is successful' do
-          get :show, params: { item_id: pid }
-          expect(response).to be_successful
-          expect(controller.send(:old_content_type)).to eq 'image'
-        end
-      end
-
-      context 'for an object with a book content type and memberOrder of left-to-right' do
-        let(:content_type) { Cocina::Models::Vocab.book }
-        let(:reading_order) { 'left-to-right' }
-
-        it 'is successful' do
-          get :show, params: { item_id: pid }
-          expect(response).to be_successful
-          expect(controller.send(:old_content_type)).to eq 'book (ltr)'
-        end
-      end
-
-      context 'for an object with a book content type and memberOrder of right-to-left' do
-        let(:content_type) { Cocina::Models::Vocab.book }
-        let(:reading_order) { 'right-to-left' }
-
-        it 'is successful' do
-          get :show, params: { item_id: pid }
-          expect(response).to be_successful
-          expect(controller.send(:old_content_type)).to eq 'book (rtl)'
-        end
-      end
+    it 'is successful' do
+      get :show, params: { item_id: pid }
+      expect(response).to be_successful
     end
   end
 
@@ -158,7 +106,7 @@ RSpec.describe ContentTypesController, type: :controller do
 
     context 'with access' do
       it 'is successful at changing the content type to media' do
-        patch :update, params: { item_id: pid, old_content_type: 'image', new_content_type: 'media' }
+        patch :update, params: { item_id: pid, new_content_type: 'media' }
         expect(response).to redirect_to solr_document_path(pid)
         expect(object_client).to have_received(:update)
           .with(params: a_cocina_object_with_types(content_type: Cocina::Models::Vocab.media, viewing_direction: nil))
@@ -167,7 +115,7 @@ RSpec.describe ContentTypesController, type: :controller do
       end
 
       it 'is successful at changing the content type to book (ltr)' do
-        patch :update, params: { item_id: pid, old_content_type: 'image', new_content_type: 'book (ltr)' }
+        patch :update, params: { item_id: pid, new_content_type: 'book (ltr)' }
         expect(response).to redirect_to solr_document_path(pid)
         expect(object_client).to have_received(:update)
           .with(params: a_cocina_object_with_types(content_type: Cocina::Models::Vocab.book, viewing_direction: 'left-to-right'))
@@ -176,7 +124,7 @@ RSpec.describe ContentTypesController, type: :controller do
       end
 
       it 'is successful at changing the content type to book (rtl)' do
-        patch :update, params: { item_id: pid, old_content_type: 'image', new_content_type: 'book (rtl)' }
+        patch :update, params: { item_id: pid, new_content_type: 'book (rtl)' }
         expect(response).to redirect_to solr_document_path(pid)
         expect(object_client).to have_received(:update)
           .with(params: a_cocina_object_with_types(content_type: Cocina::Models::Vocab.book, viewing_direction: 'right-to-left'))
@@ -198,7 +146,7 @@ RSpec.describe ContentTypesController, type: :controller do
       end
 
       it 'is successful when effectively a no-op' do
-        patch :update, params: { item_id: pid, old_content_type: 'media', new_content_type: 'image', old_resource_type: 'file', new_resource_type: 'document' }
+        patch :update, params: { item_id: pid, new_content_type: 'image', old_resource_type: 'file', new_resource_type: 'document' }
         expect(response).to redirect_to solr_document_path(pid)
         expect(object_client).to have_received(:update)
           .with(
@@ -218,7 +166,7 @@ RSpec.describe ContentTypesController, type: :controller do
           patch :update, params: { item_id: pid, new_content_type: 'media' }
           expect(response).to redirect_to solr_document_path(pid)
           expect(object_client).to have_received(:update)
-            .with(params: a_cocina_object_with_types(content_type: Cocina::Models::Vocab.image))
+            .with(params: a_cocina_object_with_types(content_type: Cocina::Models::Vocab.media))
         end
       end
 

--- a/spec/views/content_types/_content_type.html.erb_spec.rb
+++ b/spec/views/content_types/_content_type.html.erb_spec.rb
@@ -13,8 +13,6 @@ RSpec.describe 'content_types/_content_type.html.erb' do
   it 'renders the partial content' do
     assign(:cocina_object, cocina_object)
     render
-    expect(rendered).to have_css 'form .form-group label', text: 'Old content type'
-    expect(rendered).to have_css 'input[type="hidden"]#old_content_type', visible: false
     expect(rendered).to have_css 'form .form-group label', text: 'Old resource type'
     expect(rendered).to have_css 'select.form-control#old_resource_type'
     expect(rendered).to have_css 'form .form-group label', text: 'New content type'


### PR DESCRIPTION

## Why was this change made?
fixes #2694

See this comment for context: https://github.com/sul-dlss/argo/issues/2694#issuecomment-824458429



## How was this change tested?



## Which documentation and/or configurations were updated?



