### PR TITLE
Remove useless code

### DIFF
--- a/app/javascript/packs/bulk.js
+++ b/app/javascript/packs/bulk.js
@@ -158,7 +158,6 @@ function get_tags() {
 
 function show_buttons() {
 	$('#updates').show(400);
-	$('.update_buttons').removeAttr("disabled");
 }
 
 function stop_all() {

--- a/app/views/report/bulk.html.erb
+++ b/app/views/report/bulk.html.erb
@@ -63,13 +63,13 @@ ul li{
     </div>
     <div class="row bulk-buttons-row">
       <div class="col-sm-2">
-        <button class="btn btn-primary btn-block" class="update_buttons" id="refresh-mods-button">Refresh MODS</button>
-        <button class="btn btn-primary btn-block" class="update_buttons" id="show_source_id" name="show_source_id">Set source Id</button>
-        <button class="btn btn-primary btn-block" class="update_buttons" id="set-object-rights-button">Set object rights</button>
+        <button class="btn btn-primary btn-block" id="refresh-mods-button">Refresh MODS</button>
+        <button class="btn btn-primary btn-block" id="show_source_id" name="show_source_id">Set source Id</button>
+        <button class="btn btn-primary btn-block" id="set-object-rights-button">Set object rights</button>
       </div>
       <div class="col-sm-2">
-        <button class="btn btn-primary btn-block" class="update_buttons" id="set-content-type-button">Set content type</button>
-        <button class="btn btn-primary btn-block" class="update_buttons" id="set-collection-button">Set collection</button>
+        <button class="btn btn-primary btn-block" id="set-content-type-button">Set content type</button>
+        <button class="btn btn-primary btn-block" id="set-collection-button">Set collection</button>
       </div>
       <div class="col-sm-2">
         <button class="btn btn-danger btn-block" id="apply-apo-defaults-button">Apply APO defaults</button>


### PR DESCRIPTION

## Why was this change made?
Because these elements had two class attributes the latter one was being ignored, so nothing matched that selector.  Furthermore, these nodes weren't disabled, so undisabling did nothing



## How was this change tested?



## Which documentation and/or configurations were updated?



