### PR TITLE
show the publish attribute for a file correctly

### DIFF
--- a/app/components/contents/file_component.rb
+++ b/app/components/contents/file_component.rb
@@ -22,7 +22,7 @@ module Contents
 
     def routing
       [].tap do |vals|
-        vals << 'publish' if access.access == 'world' # TODO: change this when publish is added to cocina
+        vals << 'publish' if administrative.publish
         vals << 'shelve' if administrative.shelve
         vals << 'preserve' if administrative.sdrPreserve
       end.join('/')

--- a/spec/components/contents/file_component_spec.rb
+++ b/spec/components/contents/file_component_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Contents::FileComponent, type: :component do
   end
 
   let(:access) { instance_double(Cocina::Models::FileAccess, access: 'world') }
-  let(:admin) { instance_double(Cocina::Models::FileAdministrative, sdrPreserve: true, shelve: true) }
+  let(:admin) { instance_double(Cocina::Models::FileAdministrative, sdrPreserve: true, publish: true, shelve: true) }
 
   it 'renders the component' do
     expect(rendered.css('a[href="/items/druid:kb487gt5106/files?id=0220_MLK_Kids_Gadson_459-25.tif"]').to_html)


### PR DESCRIPTION
## Why was this change made?

Fixes infrastructure-integration-test#240

The integration tests depend on the publish attribute being shown correctly based on the actual file attributes and not on the access for the whole object.  We have that attribute in cocina now, so can use it.

## How was this change tested?

On -qa
Existing tests



## Which documentation and/or configurations were updated?



