### PR TITLE
Fix errors that were not showing when an object is not open

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -350,7 +350,7 @@ class ItemsController < ApplicationController
     # if this object has been submitted and doesn't have an open version, they cannot change it.
     return true if state_service.allows_modification?
 
-    render status: :bad_request, plain: 'Object cannot be modified in its current state.'
+    redirect_to solr_document_path(params[:id]), flash: { error: 'Object cannot be modified in its current state.' }
     false
   end
 end

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -384,10 +384,10 @@ RSpec.describe ItemsController, type: :controller do
           context "when the object doesn't allow modification" do
             let(:state_service) { instance_double(StateService, allows_modification?: false) }
 
-            it 'returns a 400 with an error message' do
+            it 'redirects with an error message' do
               get :refresh_metadata, params: { id: pid }
-              expect(response).to have_http_status(:bad_request)
-              expect(response.body).to eq 'Object cannot be modified in its current state.'
+              expect(response).to redirect_to solr_document_path(pid)
+              expect(flash[:error]).to eq 'Object cannot be modified in its current state.'
             end
           end
         end

--- a/spec/features/item_source_id_change_spec.rb
+++ b/spec/features/item_source_id_change_spec.rb
@@ -6,30 +6,11 @@ RSpec.describe 'Item source id change' do
   before do
     sign_in create(:user), groups: ['sdr:administrator-role']
     allow(StateService).to receive(:new).and_return(state_service)
-    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
-  end
-
-  let(:blacklight_config) { CatalogController.blacklight_config }
-  let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
-  let(:druid) { 'druid:kv840xx0000' }
-  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
-  let(:cocina_model) do
-    Cocina::Models.build({
-                           'label' => 'My ETD',
-                           'version' => 1,
-                           'type' => Cocina::Models::Vocab.object,
-                           'externalIdentifier' => druid,
-                           'access' => {
-                             'access' => 'world',
-                             'download' => 'world'
-                           },
-                           'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
-                           'structural' => {},
-                           'identification' => { sourceId: 'some:thing' }
-                         })
   end
 
   describe 'when modification is not allowed' do
+    let(:item) { FactoryBot.create_for_repository(:item) }
+    let(:druid) { item.externalIdentifier }
     let(:state_service) { instance_double(StateService, allows_modification?: false) }
 
     it 'cannot change the source id' do
@@ -42,6 +23,24 @@ RSpec.describe 'Item source id change' do
   end
 
   describe 'when modification is allowed' do
+    let(:blacklight_config) { CatalogController.blacklight_config }
+    let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
+    let(:druid) { 'druid:kv840xx0000' }
+    let(:cocina_model) do
+      Cocina::Models.build({
+                             'label' => 'My ETD',
+                             'version' => 1,
+                             'type' => Cocina::Models::Vocab.object,
+                             'externalIdentifier' => druid,
+                             'access' => {
+                               'access' => 'world',
+                               'download' => 'world'
+                             },
+                             'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+                             'structural' => {},
+                             'identification' => { sourceId: 'some:thing' }
+                           })
+    end
     let(:state_service) { instance_double(StateService, allows_modification?: true) }
     let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
     let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
@@ -59,6 +58,8 @@ RSpec.describe 'Item source id change' do
     let(:metadata_client) { instance_double(Dor::Services::Client::Metadata, datastreams: []) }
 
     before do
+      allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+
       # The indexer calls to the workflow service, so stub that out as it's unimportant to this test.
       allow(Dor::Workflow::Client).to receive(:new).and_return(workflow_client)
       allow(Dor::Services::Client).to receive(:object).and_return(object_client)

--- a/spec/requests/set_governing_apo_spec.rb
+++ b/spec/requests/set_governing_apo_spec.rb
@@ -32,11 +32,10 @@ RSpec.describe 'Set APO for an object' do
     context 'object modification not allowed' do
       let(:state_service) { instance_double(StateService, allows_modification?: false) }
 
-      it 'returns a 400' do
+      it 'redirects with an error' do
         post "/items/#{pid}/set_governing_apo", params: { new_apo_id: new_apo_id }
 
-        expect(response).to have_http_status(:bad_request)
-        expect(response.body).to eq 'Object cannot be modified in its current state.'
+        expect(response).to redirect_to solr_document_path(pid)
       end
     end
 


### PR DESCRIPTION


## Why was this change made?
This was caused because turbo expects form responses to be redirect or render a template
This is also a better UI than was there before because it now shows the error on the page in an alert dialog rather than just showing plaintext.




## How was this change tested?

<img width="865" alt="Screen Shot 2021-04-23 at 4 09 53 PM" src="https://user-images.githubusercontent.com/92044/115929999-5a0ae580-a44e-11eb-9e25-f518b1b2b514.png">

## Which documentation and/or configurations were updated?



