### PR TITLE
Don't redefine object_id

### DIFF
--- a/app/components/contents/external_file_component.html.erb
+++ b/app/components/contents/external_file_component.html.erb
@@ -5,7 +5,7 @@
         External File
       </span>
       <%= filename %>
-      (from item '<%= link_to object_id, solr_document_path(object_id) %>',
+      (from item '<%= link_to druid, solr_document_path(druid) %>',
        resource '<%= resource_id %>')
     </li>
   </ul>

--- a/app/components/contents/external_file_component.rb
+++ b/app/components/contents/external_file_component.rb
@@ -10,7 +10,7 @@ module Contents
 
     attr_reader :resource_id, :filename
 
-    def object_id
+    def druid
       druid, = resource_id.split('_')
       "druid:#{druid}"
     end


### PR DESCRIPTION


## Why was this change made?

It's a ruby internal and bad stuff can happen if you do this

## How was this change tested?



## Which documentation and/or configurations were updated?



