### PR TITLE
make indexing spec less flaky - part two

### DIFF
--- a/spec/lib/argo/indexer_spec.rb
+++ b/spec/lib/argo/indexer_spec.rb
@@ -25,13 +25,13 @@ RSpec.describe Argo::Indexer do
 
     it 'raises a ReindexRemotelyError exception in cases of predictable failures' do
       expect(RestClient).to receive(:post).at_least(3).times.and_raise(RestClient::Exception.new(double))
-      expect(mock_default_logger).to receive(:error).with(/failed to reindex/)
+      expect(mock_default_logger).to receive(:error).at_least(:once).with(/failed to reindex/)
       expect { described_class.reindex_pid_remotely(mock_pid) }.to raise_error(Argo::Exceptions::ReindexError)
     end
 
     it 'raises a ReindexRemotelyError exception in cases of remote host is down' do
       expect(RestClient).to receive(:post).at_least(3).times.and_raise(Errno::ECONNREFUSED)
-      expect(mock_default_logger).to receive(:error).with(/failed to reindex/)
+      expect(mock_default_logger).to receive(:error).at_least(:once).with(/failed to reindex/)
       expect { described_class.reindex_pid_remotely(mock_pid) }.to raise_error(Argo::Exceptions::ReindexError)
     end
 


### PR DESCRIPTION
## Why was this change made?

Follow on from #2695, an attempt to make the indexer spec that depends on retries less prone to flakiness

## How was this change tested?

The test suite


## Which documentation and/or configurations were updated?



