### PR TITLE
Ensure release options display on the manage release form

### DIFF
--- a/app/components/manage_release/collection_form_component.html.erb
+++ b/app/components/manage_release/collection_form_component.html.erb
@@ -1,4 +1,4 @@
-<%= f.fields_for :manage_release do |manage_release_fields| %>
+<%= form.fields_for :manage_release do |manage_release_fields| %>
   <div class='form-group'>
     <label>What should be released/withdrawn?</label>
     <div class='radio'>

--- a/app/components/manage_release/collection_form_component.rb
+++ b/app/components/manage_release/collection_form_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module ManageRelease
+  class CollectionFormComponent < ApplicationComponent
+    def initialize(form:, current_user:)
+      @form = form
+      @current_user = current_user
+    end
+
+    attr_reader :form, :current_user
+  end
+end

--- a/app/components/manage_release/form_component.html.erb
+++ b/app/components/manage_release/form_component.html.erb
@@ -8,7 +8,7 @@
   <div class='form-group'>
     <label>Released for:</label> <%= @document.released_to.to_sentence %>
   </div>
-  <%= render "#{@document.object_type}_manage_release_bulk_action_form", f: f %>
+  <%= child_form(f) %>
   <div class='form-group'>
     <button type='submit' class='btn btn-primary'>Submit</button>
   </div>

--- a/app/components/manage_release/form_component.rb
+++ b/app/components/manage_release/form_component.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ManageRelease
+  class FormComponent < ApplicationComponent
+    def initialize(bulk_action:, document:)
+      @bulk_action = bulk_action
+      @document = document
+    end
+
+    def child_form(form)
+      case @document.object_type
+      when 'collection'
+        render CollectionFormComponent.new(form: form, current_user: helpers.current_user)
+      else
+        render ItemFormComponent.new(form: form, current_user: helpers.current_user)
+      end
+    end
+  end
+end

--- a/app/components/manage_release/item_form_component.html.erb
+++ b/app/components/manage_release/item_form_component.html.erb
@@ -1,0 +1,1 @@
+<%= render 'bulk_actions/forms/manage_release_form', f: form, current_user: current_user %>

--- a/app/components/manage_release/item_form_component.rb
+++ b/app/components/manage_release/item_form_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module ManageRelease
+  class ItemFormComponent < ApplicationComponent
+    def initialize(form:, current_user:)
+      @form = form
+      @current_user = current_user
+    end
+
+    attr_reader :form, :current_user
+  end
+end

--- a/app/views/bulk_actions/forms/_manage_release_form.html.erb
+++ b/app/views/bulk_actions/forms/_manage_release_form.html.erb
@@ -1,23 +1,21 @@
-<div>
-  <% f.fields_for :manage_release do |manage_release_fields| %>
-    <div class='form-group'>
-      <div class='radio'>
-        <label class='checkbox-inline'>
-          <%= manage_release_fields.radio_button(:tag, true, checked: true) %>
-          Release this object*
-        </label>
-        <label class='checkbox-inline'>
-          <%= manage_release_fields.radio_button(:tag, false) %>
-          Do not release this object*
-        </label>
-      </div>
+<% f.fields_for :manage_release do |manage_release_fields| %>
+  <div class='form-group'>
+    <div class='radio'>
+      <label class='checkbox-inline'>
+        <%= manage_release_fields.radio_button(:tag, true, checked: true) %>
+        Release this object*
+      </label>
+      <label class='checkbox-inline'>
+        <%= manage_release_fields.radio_button(:tag, false) %>
+        Do not release this object*
+      </label>
     </div>
-    <div class='form-group'>
-      <label for='bulk_action_manage_release_to'>to</label>
-      <%= manage_release_fields.select :to, Constants::RELEASE_TARGETS, {}, class: 'form-control' %>
-    </div>
-    <%= manage_release_fields.hidden_field('what', value: 'self') %>
-    <%= manage_release_fields.hidden_field('who', value: current_user.sunetid) %>
-  <% end %>
-</div>
+  </div>
+  <div class='form-group'>
+    <label for='bulk_action_manage_release_to'>to</label>
+    <%= manage_release_fields.select :to, Constants::RELEASE_TARGETS, {}, class: 'form-control' %>
+  </div>
+  <%= manage_release_fields.hidden_field('what', value: 'self') %>
+  <%= manage_release_fields.hidden_field('who', value: current_user.sunetid) %>
+<% end %>
 <span class='help-block'>* for items this overrides any collection release instructions; for a collection this releases the collection object itself, not its members</span>

--- a/app/views/manage_releases/_item_manage_release_bulk_action_form.html.erb
+++ b/app/views/manage_releases/_item_manage_release_bulk_action_form.html.erb
@@ -1,1 +1,0 @@
-<%= render 'bulk_actions/forms/manage_release_form', f: f %>

--- a/app/views/manage_releases/show.html.erb
+++ b/app/views/manage_releases/show.html.erb
@@ -1,4 +1,6 @@
 <%= render BlacklightModalComponent.new do |component| %>
   <% component.header { 'Manage release' } %>
-  <% component.body { render 'show' } %>
+  <% component.body {
+    render ManageRelease::FormComponent.new(bulk_action: @bulk_action, document: @document)
+  } %>
 <% end %>

--- a/spec/components/manage_release/collection_form_component_spec.rb
+++ b/spec/components/manage_release/collection_form_component_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ManageRelease::CollectionFormComponent, type: :component do
+  subject(:component) { described_class.new(form: form, current_user: build(:user)) }
+
+  let(:form) { ActionView::Helpers::FormBuilder.new(nil, nil, controller.view_context, {}) }
+  let(:rendered) { render_inline(component) }
+
+  it 'renders the options' do
+    expect(rendered.css('label').to_html).to include(
+      'This collection and all its members*',
+      'Only this collection description but not any of its members',
+      'Release it',
+      'Do not release it (withdraw)'
+    )
+  end
+end

--- a/spec/components/manage_release/form_component_spec.rb
+++ b/spec/components/manage_release/form_component_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ManageRelease::FormComponent, type: :component do
+  subject(:component) { described_class.new(bulk_action: bulk_action, document: document) }
+
+  let(:document) { SolrDocument.new(id: 'druid:123', objectType_ssim: 'collection') }
+  let(:bulk_action) { BulkAction.new }
+  let(:rendered) { render_inline(component) }
+
+  before do
+    allow(controller).to receive_messages(
+      current_user: build(:user)
+    )
+  end
+
+  it 'renders the form' do
+    expect(rendered.to_html).to include(
+      'Manage release to discovery applications for collection druid:123'
+    )
+
+    expect(rendered.css('button').inner_html).to eq 'Submit'
+  end
+end

--- a/spec/components/manage_release/item_form_component_spec.rb
+++ b/spec/components/manage_release/item_form_component_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ManageRelease::ItemFormComponent, type: :component do
+  subject(:component) { described_class.new(form: form, current_user: build(:user)) }
+
+  let(:form) { ActionView::Helpers::FormBuilder.new(nil, nil, controller.view_context, {}) }
+  let(:rendered) { render_inline(component) }
+
+  it 'renders the options' do
+    expect(rendered.css('label').to_html).to include(
+      'Release this object*',
+      'Do not release this object*'
+    )
+
+    expect(rendered.css('select option').to_html).to include(
+      'Searchworks',
+      'Earthworks'
+    )
+  end
+end


### PR DESCRIPTION

## Why was this change made?

This fixes a regression introduced in https://github.com/sul-dlss/argo/commit/9ec63b6fae8df19413c55f12881f3bb659ed9c96 where an erb was rendered both from within and without a component and the component way doesn't support capture blocks

Ref https://github.com/sul-dlss/argo/pull/2693#issuecomment-828043108


## How was this change tested?



## Which documentation and/or configurations were updated?



