### PR TITLE
adjust comments to remove references to dor-services

### DIFF
--- a/app/forms/access_form.rb
+++ b/app/forms/access_form.rb
@@ -5,15 +5,18 @@
 class AccessForm
   extend ActiveModel::Naming
   # @param [Cocina::Models::DRO, Cocina::Models::Collection] model
-  # @param [String] the default rights to assign to the object, from Constants::REGISTRATION_RIGHTS_OPTIONS (which is defined as RIGHTS_TYPE_CODES in dor-services)
+  # @param [String] the default rights to assign to the object
+  # must be one of the options in Constants::COLLECTION_RIGHTS_OPTIONS or Constants::REGISTRATION_RIGHTS_OPTIONS depending on form
+  # (used to be one of the keys in Dor::RightsMetadataDS::RIGHTS_TYPE_CODES in the now de-coupled dor-services gem)
   def initialize(model, default_rights: nil)
     @model = model
     @default_rights = default_rights || 'citation-only'
   end
 
   # @param [HashWithIndifferentAccess] params the values from the form
-  # @option params [String] :rights the rights representation from the form (must be one of the keys in Dor::RightsMetadataDS::RIGHTS_TYPE_CODES, or 'default',
-  # see the now de-coupled dor-services gem)
+  # @option params [String] :rights the rights representation from the form
+  # must be one of the options in Constants::COLLECTION_RIGHTS_OPTIONS or Constants::REGISTRATION_RIGHTS_OPTIONS depending on form
+  # (used to be one of the keys in Dor::RightsMetadataDS::RIGHTS_TYPE_CODES in the now de-coupled dor-services gem)
   def validate(params)
     rights = params[:rights]
     # valid_rights_options is implemented by concrete class.

--- a/app/services/cocina_access.rb
+++ b/app/services/cocina_access.rb
@@ -4,8 +4,7 @@
 class CocinaAccess
   extend Dry::Monads[:maybe]
 
-  # @param [String] the rights representation from the form (must be one of the keys in Dor::RightsMetadataDS::RIGHTS_TYPE_CODES, or 'default',
-  # see the now de-coupled dor-services gem)
+  # @param [String] the rights representation from the form (must be one of the keys in Constants::COLLECTION_RIGHTS_OPTIONS, or 'default')
   # @return [Maybe<Hash<Symbol,String>>] a hash representing a subset of the Access subschema of the Cocina model
   def self.from_form_value(rights)
     # Default only appears on the registration form, not the update form.

--- a/app/services/cocina_dro_access.rb
+++ b/app/services/cocina_dro_access.rb
@@ -4,8 +4,7 @@
 class CocinaDroAccess
   extend Dry::Monads[:maybe]
 
-  # @param [String] rights the rights representation from the form (must be one of the keys in Dor::RightsMetadataDS::RIGHTS_TYPE_CODES, or 'default',
-  # see the now de-coupled dor-services gem)
+  # @param [String] rights the rights representation from the form (must be one of the keys in Constants::REGISTRATION_RIGHTS_OPTIONS, or 'default')
   # @return [Maybe<Hash<Symbol,String>>] a hash representing a subset of the Access subschema of the Cocina model
   def self.from_form_value(rights)
     # Default only appears on the registration form, not the update form.


### PR DESCRIPTION
## Why was this change made?

A few changes to inline comments to reflect where the constants used are from (not in dor-services gem anymore).

## How was this change tested?



## Which documentation and/or configurations were updated?



