### PR TITLE
Restores tests to set_catkeys_and_barcodes_job_spec.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -117,6 +117,11 @@ Lint/TopLevelReturnWithArgument:
 Lint/UnreachableLoop:
   Enabled: true
 
+RSpec/MultipleMemoizedHelpers:
+  Enabled: true
+  Exclude:
+    - 'spec/jobs/set_catkeys_and_barcodes_job_spec.rb'
+
 Style/ExponentialNotation:
   Enabled: true
 


### PR DESCRIPTION
## Why was this change made?
Tests were removed in https://github.com/sul-dlss/argo/pull/2693/files#diff-9a7dc28d99cfc95d006d7f19b549215a08e149e9a9a050c1f05f4b6bd1019896L89-L91


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


