### PR TITLE
Extract embargo controller from ItemsController

### DIFF
--- a/app/components/sidebar_controls_component.rb
+++ b/app/components/sidebar_controls_component.rb
@@ -47,9 +47,8 @@ class SidebarControlsComponent < ApplicationComponent
     render ActionButton.new(url: item_manage_release_path(pid), label: 'Manage release')
   end
 
-  # TODO: add a date picker and button to change the embargo date for those who should be able to.
   def update_embargo
-    render ActionButton.new(url: embargo_form_item_path(pid), label: 'Update embargo')
+    render ActionButton.new(url: edit_item_embargo_path(pid), label: 'Update embargo')
   end
 
   def content_type

--- a/app/controllers/embargos_controller.rb
+++ b/app/controllers/embargos_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class EmbargosController < ApplicationController
+  before_action :load_and_authorize_resource
+
+  def edit
+    respond_to do |format|
+      format.html { render layout: !request.xhr? }
+    end
+  end
+
+  def update
+    raise ArgumentError, 'Missing embargo_date parameter' if params[:embargo_date].blank?
+
+    begin
+      params[:embargo_date].to_date
+    rescue Date::Error
+      return redirect_to solr_document_path(@cocina.externalIdentifier),
+                         flash: { error: 'Invalid date' }
+    end
+
+    change_set = ItemChangeSet.new(@cocina)
+    change_set.validate(embargo_release_date: params[:embargo_date])
+    change_set.save
+
+    respond_to do |format|
+      format.any { redirect_to solr_document_path(@cocina.externalIdentifier), notice: 'Embargo was successfully updated' }
+    end
+  end
+
+  private
+
+  def load_and_authorize_resource
+    @cocina = maybe_load_cocina(params[:item_id])
+
+    authorize! :manage_item, @cocina
+  end
+end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,8 +9,6 @@ class ItemsController < ApplicationController
     purge_object
     source_id
     tags_bulk
-    embargo_update
-    embargo_form
   ]
 
   before_action :enforce_versioning, only: %i[
@@ -26,12 +24,6 @@ class ItemsController < ApplicationController
     detail = JSON.parse(md[1])['errors'].first['detail']
     redirect_to solr_document_path(params[:id]),
                 flash: { error: "Unable to retrieve the cocina model: #{detail.truncate(200)}" }
-  end
-
-  def embargo_form
-    respond_to do |format|
-      format.html { render layout: !request.xhr? }
-    end
   end
 
   def set_collection
@@ -116,25 +108,6 @@ class ItemsController < ApplicationController
 
     respond_to do |format|
       format.json { render json: @cocina }
-    end
-  end
-
-  def embargo_update
-    raise ArgumentError, 'Missing embargo_date parameter' unless params[:embargo_date].present?
-
-    begin
-      params[:embargo_date].to_date
-    rescue Date::Error
-      return redirect_to solr_document_path(params[:id]),
-                         flash: { error: 'Invalid date' }
-    end
-
-    change_set = ItemChangeSet.new(@cocina)
-    change_set.validate(embargo_release_date: params[:embargo_date])
-    change_set.save
-
-    respond_to do |format|
-      format.any { redirect_to solr_document_path(params[:id]), notice: 'Embargo was successfully updated' }
     end
   end
 

--- a/app/views/embargos/_form.html.erb
+++ b/app/views/embargos/_form.html.erb
@@ -4,7 +4,7 @@
   });
 </script>
 <div id='embargo_update'>
-  <%= form_tag embargo_update_item_path(@cocina.externalIdentifier), method: :POST do %>
+  <%= form_tag item_embargo_path(@cocina.externalIdentifier), method: 'PATCH' do %>
     <div class='form-group'>
       <label for='embargo_date'>New date</label>
       <input name="embargo_date" id="embargo_date" type="text">

--- a/app/views/embargos/edit.html.erb
+++ b/app/views/embargos/edit.html.erb
@@ -1,4 +1,4 @@
 <%= render BlacklightModalComponent.new do |component| %>
   <% component.header { 'Update embargo' } %>
-  <% component.body { render 'embargo_form' } %>
+  <% component.body { render 'form' } %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,13 +126,13 @@ Rails.application.routes.draw do
     end
 
     resources :datastreams, only: %i[show edit update]
+
     resource :catkey, only: %i[edit update]
+    resource :embargo, only: %i[edit update]
 
     member do
       post 'refresh_metadata'
       get 'mods'
-      post 'embargo', action: :embargo_update, as: 'embargo_update'
-      get 'embargo_form'
       get 'source_id_ui'
       match 'tags_bulk', via: %i[get post]
       get 'collection_ui'

--- a/spec/components/sidebar_controls_component_spec.rb
+++ b/spec/components/sidebar_controls_component_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe SidebarControlsComponent, type: :component do
 
       it 'only includes the embargo update button if the user is an admin and the object is embargoed' do
         allow(doc).to receive(:embargoed?).and_return(true)
-        expect(rendered.css("a[href='/items/druid:kv840xx0000/embargo_form']").inner_text).to eq 'Update embargo'
+        expect(rendered.css("a[href='/items/druid:kv840xx0000/embargo/edit']").inner_text).to eq 'Update embargo'
         expect(rendered.css('a').size).to eq 15
       end
 

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -80,63 +80,6 @@ RSpec.describe ItemsController, type: :controller do
     end
   end
 
-  describe '#embargo_update' do
-    let(:cocina) do
-      Cocina::Models.build({
-                             'label' => 'My ETD',
-                             'version' => 1,
-                             'type' => Cocina::Models::Vocab.object,
-                             'externalIdentifier' => pid,
-                             'access' => {
-                               'access' => 'stanford',
-                               'download' => 'stanford',
-                               'embargo' => {
-                                 'releaseDate' => '2040-05-05',
-                                 'access' => 'world',
-                                 'download' => 'world'
-                               }
-                             },
-                             'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
-                             'structural' => {},
-                             'identification' => {
-                               'catalogLinks' => catalog_links
-                             }
-                           })
-    end
-    let(:object_service) { instance_double(Dor::Services::Client::Object, find: cocina, update: true) }
-
-    context "when they don't have manage access" do
-      it 'returns 403' do
-        allow(controller).to receive(:authorize!).with(:manage_item, cocina).and_raise(CanCan::AccessDenied)
-        post :embargo_update, params: { id: pid, embargo_date: '2100-01-01' }
-        expect(response).to have_http_status(:forbidden)
-      end
-    end
-
-    context 'when they have manage access' do
-      before do
-        allow(controller).to receive(:authorize!).and_return(true)
-      end
-
-      it 'calls Dor::Services::Client::Embargo#update' do
-        post :embargo_update, params: { id: pid, embargo_date: '2100-01-01' }
-        expect(response).to have_http_status(:found) # redirect to catalog page
-        expect(object_service).to have_received(:update)
-      end
-
-      it 'requires a date' do
-        expect { post :embargo_update, params: { id: pid } }.to raise_error(ArgumentError)
-      end
-
-      context 'when the date is malformed' do
-        it 'shows the error' do
-          post :embargo_update, params: { id: pid, embargo_date: 'not-a-date' }
-          expect(flash[:error]).to eq 'Invalid date'
-        end
-      end
-    end
-  end
-
   describe '#tags_bulk' do
     let(:current_tag) { 'Some : Thing' }
     let(:fake_tags_client) do

--- a/spec/features/apo_displays_spec.rb
+++ b/spec/features/apo_displays_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'Viewing an Admin policy' do
 
     context 'embargo form' do
       it 'renders the embargo update ui' do
-        visit "/items/#{apo_druid}/embargo_form"
+        visit "/items/#{apo_druid}/embargo/edit"
         expect(page).to have_content('Embargo')
       end
     end

--- a/spec/requests/embargo_spec.rb
+++ b/spec/requests/embargo_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Set embargo for an object' do
+  before do
+    allow(Dor::Services::Client).to receive(:object).with(pid).and_return(object_service)
+  end
+
+  let(:user) { create(:user) }
+  let(:object_service) { instance_double(Dor::Services::Client::Object, find: cocina) }
+
+  describe '#update' do
+    let(:pid) { 'druid:bc123df4567' }
+    let(:cocina) do
+      Cocina::Models.build({
+                             'label' => 'My ETD',
+                             'version' => 1,
+                             'type' => Cocina::Models::Vocab.object,
+                             'externalIdentifier' => pid,
+                             'access' => {
+                               'access' => 'stanford',
+                               'download' => 'stanford',
+                               'embargo' => {
+                                 'releaseDate' => '2040-05-05',
+                                 'access' => 'world',
+                                 'download' => 'world'
+                               }
+                             },
+                             'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+                             'structural' => {},
+                             'identification' => {}
+                           })
+    end
+    let(:object_service) { instance_double(Dor::Services::Client::Object, find: cocina, update: true) }
+
+    context "when they don't have manage access" do
+      before do
+        sign_in user
+      end
+
+      it 'returns 403' do
+        patch "/items/#{pid}/embargo", params: { embargo_date: '2100-01-01' }
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'when they have manage access' do
+      before do
+        sign_in user, groups: ['sdr:administrator-role']
+      end
+
+      it 'calls Dor::Services::Client::Embargo#update' do
+        patch "/items/#{pid}/embargo", params: { embargo_date: '2100-01-01' }
+        expect(response).to have_http_status(:found) # redirect to catalog page
+        expect(object_service).to have_received(:update)
+      end
+
+      it 'requires a date' do
+        expect { patch "/items/#{pid}/embargo", params: {} }.to raise_error(ArgumentError)
+      end
+
+      context 'when the date is malformed' do
+        it 'shows the error' do
+          patch "/items/#{pid}/embargo", params: { embargo_date: 'not-a-date' }
+          expect(flash[:error]).to eq 'Invalid date'
+        end
+      end
+    end
+  end
+end

--- a/spec/views/embargos/_form.html.erb_spec.rb
+++ b/spec/views/embargos/_form.html.erb_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'items/_embargo_form.html.erb' do
+RSpec.describe 'embargos/_form.html.erb' do
   let(:current_user) { mock_user(admin?: true) }
 
   before do

--- a/spec/views/embargos/edit.html.erb_spec.rb
+++ b/spec/views/embargos/edit.html.erb_spec.rb
@@ -2,9 +2,9 @@
 
 require 'rails_helper'
 
-RSpec.describe 'items/embargo_form.html.erb' do
-  it 'renders the JS template' do
-    stub_template 'items/_embargo_form.html.erb' => 'stubbed_embargo_form'
+RSpec.describe 'embargos/edit.html.erb' do
+  it 'renders the template' do
+    stub_template 'embargos/_form.html.erb' => 'stubbed_embargo_form'
     render
     expect(rendered).to have_css '.modal-header h3.modal-title', text: 'Update embargo'
     expect(rendered).to have_css '.modal-body', text: 'stubbed_embargo_form'


### PR DESCRIPTION


## Why was this change made?
This refactor will enable us to add new embargoes in #2009


## How was this change tested?



## Which documentation and/or configurations were updated?



