### PR TITLE
Increase the wait time for the register agreement spec

### DIFF
--- a/spec/features/register_agreement_spec.rb
+++ b/spec/features/register_agreement_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Register an Agreement', js: true do
 
     click_button 'Create Agreement'
 
-    expect(page).to have_text 'Agreement created'
+    expect(page).to have_text 'Agreement created', wait: 20
     expect(page).to have_text 'Agreement Title'
   end
 end


### PR DESCRIPTION


## Why was this change made?

This test often takes a while and having a larger timeout helps

## How was this change tested?



## Which documentation and/or configurations were updated?



