### PR TITLE
Disable save button after submitting edit tags form

### DIFF
--- a/app/javascript/controllers/nested_form_controller.js
+++ b/app/javascript/controllers/nested_form_controller.js
@@ -17,4 +17,11 @@ export default class extends Controller {
     item.querySelector("input[name*='_destroy']").value = 1
     item.style.display = 'none'
   }
+
+  disableSubmit(event) {
+    const submitButton = event.currentTarget
+    submitButton.disabled = true
+    submitButton.innerText = 'Saving...'
+    submitButton.form.submit()
+  }
 }

--- a/app/views/tags/_edit.html.erb
+++ b/app/views/tags/_edit.html.erb
@@ -18,5 +18,5 @@
     <%= button_tag '+ Add another tag', type: 'button', class: "col-sm-2 btn btn-outline-primary",  data: { action: "nested-form#addAssociation" } %>
   </div>
 
-  <button class='btn btn-primary'>Save</button>
+  <button class='btn btn-primary' data-action="nested-form#disableSubmit">Save</button>
 <% end %>


### PR DESCRIPTION
Fixes #2729

## Why was this change made?

This provides users immediate feedback that clicking the button worked as expected and suggest to them that the page transition should happen momentarily. It also prevents double-submits. Note that I attempted to add test coverage to the edit_tags feature spec, but I cannot inspect the button element after clicking the button because the selenium driver says the reference is stale. Does not seem worth the time to futz with Capybara to test such a tiny change.

![Peek 2021-04-29 11-40](https://user-images.githubusercontent.com/131982/116602197-3e855c00-a8e0-11eb-9b77-d3115e640f0c.gif)


## How was this change tested?

CI

## Which documentation and/or configurations were updated?

None


