### PR TITLE
Add download attribute to download links

### DIFF
--- a/app/views/bulk_actions/index.html.erb
+++ b/app/views/bulk_actions/index.html.erb
@@ -34,7 +34,7 @@
             <%= bulk_action.druid_count_success %> /
             <%= bulk_action.druid_count_fail %>
           </td>
-          <td><%= link_to('Log', file_bulk_action_path(bulk_action.id, filename: Settings.bulk_metadata.log)) %></td>
+          <td><%= link_to('Log', file_bulk_action_path(bulk_action.id, filename: Settings.bulk_metadata.log), download: true) %></td>
           <td><%= render_bulk_action_type(bulk_action) %></td>
           <td>
             <%= link_to 'Delete', bulk_action, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' %>


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement/download

## Why was this change made?
Fixes #2731 


## How was this change tested?



## Which documentation and/or configurations were updated?



