### PR TITLE
correctly set download links for bulk action reports

### DIFF
--- a/app/views/bulk_actions/_checksum_report_job.html.erb
+++ b/app/views/bulk_actions/_checksum_report_job.html.erb
@@ -1,3 +1,3 @@
 <% if bulk_action.has_report?(Settings.checksum_report_job.csv_filename) %>
-  <%= link_to('Download Checksum Report', file_bulk_action_path(bulk_action.id, filename: Settings.checksum_report_job.csv_filename)) %>
+  <%= link_to('Download Checksum Report', file_bulk_action_path(bulk_action.id, filename: Settings.checksum_report_job.csv_filename), download: true) %>
 <% end %>

--- a/app/views/bulk_actions/_descmetadata_download_job.html.erb
+++ b/app/views/bulk_actions/_descmetadata_download_job.html.erb
@@ -1,3 +1,3 @@
 <% if bulk_action.present? && bulk_action.status == 'Completed' %>
-  <%= link_to('Download Metadata', file_bulk_action_path(bulk_action.id, filename: Settings.bulk_metadata.zip)) %>
+  <%= link_to('Download Metadata', file_bulk_action_path(bulk_action.id, filename: Settings.bulk_metadata.zip), download: true) %>
 <% end %>

--- a/app/views/bulk_actions/_export_tags_job.html.erb
+++ b/app/views/bulk_actions/_export_tags_job.html.erb
@@ -1,3 +1,3 @@
 <% if bulk_action.has_report?(Settings.export_tags_job.csv_filename) %>
-  <%= link_to('Download Exported Tags (CSV)', file_bulk_action_path(bulk_action.id, filename: Settings.export_tags_job.csv_filename, mime_type: 'text/csv')) %>
+  <%= link_to('Download Exported Tags (CSV)', file_bulk_action_path(bulk_action.id, filename: Settings.export_tags_job.csv_filename, mime_type: 'text/csv'), download: true) %>
 <% end %>

--- a/app/views/bulk_actions/_register_druids_job.html.erb
+++ b/app/views/bulk_actions/_register_druids_job.html.erb
@@ -1,3 +1,3 @@
 <% if bulk_action.has_report?(Settings.register_druids_job.csv_filename) %>
-  <%= link_to 'Download Report', file_bulk_action_path(bulk_action.id, filename: Settings.register_druids_job.csv_filename, format: :csv) %>
+  <%= link_to 'Download Report', file_bulk_action_path(bulk_action.id, filename: Settings.register_druids_job.csv_filename, format: :csv), download: true %>
 <% end %>


### PR DESCRIPTION
## Why was this change made?

Follow on from #2734 and #2731

## How was this change tested?



## Which documentation and/or configurations were updated?



