### PR TITLE
Stop relying on the dor_services_version_ssim field

### DIFF
--- a/app/components/external_links_component.html.erb
+++ b/app/components/external_links_component.html.erb
@@ -8,5 +8,4 @@
   <li class="nav-item"><%= foxml_link %></li>
   <li class="nav-item"><%= solr_link %></li>
   <li class="nav-item"><%= cocina_link %></li>
-  <li class="nav-item"><small><%= index_info %></small></li>
 </ul>

--- a/app/components/external_links_component.rb
+++ b/app/components/external_links_component.rb
@@ -38,10 +38,6 @@ class ExternalLinksComponent < ViewComponent::Base
             target: '_blank', rel: 'noopener', class: 'nav-link'
   end
 
-  def index_info
-    "indexed by DOR Services v#{document.dor_services_version}"
-  end
-
   def released_to_searchworks?
     document.released_to.include?('Searchworks')
   end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -34,7 +34,6 @@ class SolrDocument
   attribute :current_version, Blacklight::Types::String, FIELD_CURRENT_VERSION
   attribute :embargo_status, Blacklight::Types::String, FIELD_EMBARGO_STATUS
   attribute :embargo_release_date, Blacklight::Types::String, FIELD_EMBARGO_RELEASE_DATE
-  attribute :dor_services_version, Blacklight::Types::String, :dor_services_version_ssi
   attribute :first_shelved_image, Blacklight::Types::String, :first_shelved_image_ss
 
   attribute :registered_date, Blacklight::Types::Array, FIELD_REGISTERED_DATE

--- a/spec/components/external_links_component_spec.rb
+++ b/spec/components/external_links_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ExternalLinksComponent, type: :component do
     instance_double(SolrDocument, id: 'druid:ab123cd3445',
                                   to_param: 'druid:ab123cd3445',
                                   druid: 'ab123cd3445',
-                                  catkey: catkey, released_to: released_to, dor_services_version: '9.0.0')
+                                  catkey: catkey, released_to: released_to)
   end
   let(:catkey) { nil }
 


### PR DESCRIPTION


## Why was this change made?

This no longer makes sense when we move dor-services out of the stack

## How was this change tested?



## Which documentation and/or configurations were updated?



