### PR TITLE
Upgrade @rails/ujs to 6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@github/time-elements": "^3.0.7",
     "@hotwired/turbo-rails": "^7.0.0-beta.5",
-    "@rails/ujs": "^6.0.3-4",
+    "@rails/ujs": "^6.1.3-2",
     "@rails/webpacker": "^5.1.1",
     "autocomplete.js": "^0.37.1",
     "blacklight-frontend": "^7.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -915,10 +915,10 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-6.1.3.tgz#c8a67ec4d22ecd6931f7ebd98143fddbc815419a"
   integrity sha512-m02524MR9cTnUNfGz39Lkx9jVvuL0tle4O7YgvouJ7H83FILxzG1nQ5jw8pAjLAr9XQGu+P1sY4SKE3zyhCNjw==
 
-"@rails/ujs@^6.0.3-4":
-  version "6.0.3-7"
-  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-6.0.3-7.tgz#8be007e500baafed256895830ae446178511773b"
-  integrity sha512-J7dvCTkZ/zaQLge1mttypoE/1j5YDcSAuu4fun8CoTqVGkcbwZu4f4jy+HKxdomtrZzXWSHlSeIe9vOtLnhmeA==
+"@rails/ujs@^6.1.3-2":
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-6.1.3.tgz#90ef26caa0925492b1a3b1495db09cfbe49e745e"
+  integrity sha512-9mip5o+LVouWAqLMNJWhxda+D5uP+4RziNECgOGJlL6k3rc5SC/ljCHpV9Cym4i3oeGZkpZJ2tu4frCwt84kzQ==
 
 "@rails/webpacker@^5.1.1":
   version "5.3.0"


### PR DESCRIPTION


## Why was this change made?


It was accidentally reverted in https://github.com/sul-dlss/argo/pull/2743

## How was this change tested?



## Which documentation and/or configurations were updated?



