### PR TITLE
Default APO form to the correct current license

### DIFF
--- a/app/forms/apo_form.rb
+++ b/app/forms/apo_form.rb
@@ -92,8 +92,8 @@ class ApoForm
   # entries, unless the current value is a deprecated entry, in which case, include that entry with the
   # deprecation warning in a parenthetical.
   def options_for_use_license_type(current_value)
-    Constants::LICENSE_OPTIONS.map do |key, attributes|
-      if key == current_value && attributes.key?(:deprecation_warning)
+    Constants::LICENSE_OPTIONS.map do |attributes|
+      if attributes.fetch(:uri) == current_value && attributes.key?(:deprecation_warning)
         ["#{attributes.fetch(:label)} (#{attributes.fetch(:deprecation_warning)})", attributes.fetch(:uri)]
       elsif !attributes.key?(:deprecation_warning)
         [attributes.fetch(:label), attributes.fetch(:uri)]

--- a/app/forms/bulk_action_form.rb
+++ b/app/forms/bulk_action_form.rb
@@ -63,7 +63,7 @@ class BulkActionForm < BaseForm
   end
 
   def options_for_use_license_type
-    Constants::LICENSE_OPTIONS.map do |_key, attributes|
+    Constants::LICENSE_OPTIONS.map do |attributes|
       next if attributes.key?(:deprecation_warning)
 
       [attributes.fetch(:label), attributes.fetch(:uri)]

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -24,33 +24,30 @@ module Constants
     ['Dark (Preserve Only)', 'dark']
   ].freeze
 
-  LICENSE_OPTIONS = {
-    'pddl' => { label: 'Open Data Commons Public Domain Dedication and License 1.0',
-                uri: 'https://opendatacommons.org/licenses/pddl/1-0/' },
-    'odc-by' => { label: 'Open Data Commons Attribution License 1.0',
-                  uri: 'https://opendatacommons.org/licenses/by/1-0/' },
-    'odc-odbl' => { label: 'Open Data Commons Open Database License 1.0',
-                    uri: 'https://opendatacommons.org/licenses/odbl/1-0/' },
-    'cc0' => { label: 'No Rights Reserved',
-               uri: 'https://creativecommons.org/publicdomain/zero/1.0/legalcode' },
-    'by' => { label: 'Attribution 3.0 Unported',
-              uri: 'https://creativecommons.org/licenses/by/3.0/legalcode' },
-    'by-sa' => { label: 'Attribution Share Alike 3.0 Unported',
-                 uri: 'https://creativecommons.org/licenses/by-sa/3.0/legalcode' },
-    'by_sa' => { label: 'Attribution Share Alike 3.0 Unported',
-                 uri: 'https://creativecommons.org/licenses/by-sa/3.0/legalcode',
-                 deprecation_warning: 'license code "by_sa" was a typo in argo, prefer "by-sa"' },
-    'by-nd' => { label: 'Attribution No Derivatives 3.0 Unported',
-                 uri: 'https://creativecommons.org/licenses/by-nd/3.0/legalcode' },
-    'by-nc' => { label: 'Attribution Non-Commercial 3.0 Unported',
-                 uri: 'https://creativecommons.org/licenses/by-nc/3.0/legalcode' },
-    'by-nc-sa' => { label: 'Attribution Non-Commercial Share Alike 3.0 Unported',
-                    uri: 'https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode' },
-    'by-nc-nd' => { label: 'Attribution Non-Commercial, No Derivatives 3.0 Unported',
-                    uri: 'https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode' },
-    'pdm' => { label: 'Public Domain Mark 1.0',
-               uri: 'https://creativecommons.org/publicdomain/mark/1.0/' }
-  }.freeze
+  LICENSE_OPTIONS = [
+    { label: 'Open Data Commons Public Domain Dedication and License 1.0',
+      uri: 'https://opendatacommons.org/licenses/pddl/1-0/' },
+    { label: 'Open Data Commons Attribution License 1.0',
+      uri: 'https://opendatacommons.org/licenses/by/1-0/' },
+    { label: 'Open Data Commons Open Database License 1.0',
+      uri: 'https://opendatacommons.org/licenses/odbl/1-0/' },
+    { label: 'No Rights Reserved',
+      uri: 'https://creativecommons.org/publicdomain/zero/1.0/legalcode' },
+    { label: 'Attribution 3.0 Unported',
+      uri: 'https://creativecommons.org/licenses/by/3.0/legalcode' },
+    { label: 'Attribution Share Alike 3.0 Unported',
+      uri: 'https://creativecommons.org/licenses/by-sa/3.0/legalcode' },
+    { label: 'Attribution No Derivatives 3.0 Unported',
+      uri: 'https://creativecommons.org/licenses/by-nd/3.0/legalcode' },
+    { label: 'Attribution Non-Commercial 3.0 Unported',
+      uri: 'https://creativecommons.org/licenses/by-nc/3.0/legalcode' },
+    { label: 'Attribution Non-Commercial Share Alike 3.0 Unported',
+      uri: 'https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode' },
+    { label: 'Attribution Non-Commercial, No Derivatives 3.0 Unported',
+      uri: 'https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode' },
+    { label: 'Public Domain Mark 1.0',
+      uri: 'https://creativecommons.org/publicdomain/mark/1.0/' }
+  ].freeze
 
   CONTENT_TYPES = {
     'book (ltr)' => Cocina::Models::Vocab.book,

--- a/spec/features/apo_spec.rb
+++ b/spec/features/apo_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'Create an apo', js: true do
     fill_in 'Title', with: 'New APO Title'
     fill_in 'Default Copyright statement', with: 'New copyright statement'
     fill_in 'Default Use and Reproduction statement', with: 'New use statement'
-    page.select('Attribution No Derivatives 3.0 Unported', from: 'Default use license')
+    select 'Attribution No Derivatives 3.0 Unported', from: 'Default use license'
     click_button 'Update APO'
 
     click_on 'Edit APO'


### PR DESCRIPTION


## Why was this change made?
Previously it was trying to do a lookup on the license code, but the value it was sending in was the URI, so it was never matching.  This also simplifies the licenses table


## How was this change tested?



## Which documentation and/or configurations were updated?



