### PR TITLE
Stop using the deprecated release_tags api

### DIFF
--- a/app/jobs/generic_job.rb
+++ b/app/jobs/generic_job.rb
@@ -59,15 +59,6 @@ class GenericJob < ActiveJob::Base
     end
   end
 
-  def string_to_boolean(string)
-    case string
-    when 'true'
-      true
-    when 'false'
-      false
-    end
-  end
-
   def update_druid_count(count: pids.length)
     bulk_action.update(druid_count_total: count)
   end

--- a/spec/features/collection_manage_release_spec.rb
+++ b/spec/features/collection_manage_release_spec.rb
@@ -22,12 +22,10 @@ RSpec.describe 'Collection manage release' do
   let(:object_client) do
     instance_double(Dor::Services::Client::Object,
                     find: cocina_model,
-                    release_tags: release_tags_client,
                     events: events_client,
                     metadata: metadata_client,
                     version: version_client)
   end
-  let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, create: true) }
   let(:cocina_model) do
     Cocina::Models.build(
       'label' => 'The model',

--- a/spec/features/item_manage_release_spec.rb
+++ b/spec/features/item_manage_release_spec.rb
@@ -17,12 +17,10 @@ RSpec.describe 'Item manage release' do
   let(:object_client) do
     instance_double(Dor::Services::Client::Object,
                     find: cocina_model,
-                    release_tags: release_tags_client,
                     events: events_client,
                     metadata: metadata_client,
                     version: version_client)
   end
-  let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, create: true) }
   let(:cocina_model) { instance_double(Cocina::Models::DRO, administrative: administrative, as_json: {}) }
   let(:administrative) { instance_double(Cocina::Models::Administrative, releaseTags: []) }
   let(:item) do

--- a/spec/jobs/release_object_job_spec.rb
+++ b/spec/jobs/release_object_job_spec.rb
@@ -29,9 +29,8 @@ RSpec.describe ReleaseObjectJob do
       'identification' => {}
     )
   end
-  let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, create: true) }
-  let(:object_client1) { instance_double(Dor::Services::Client::Object, find: item1, release_tags: release_tags_client) }
-  let(:object_client2) { instance_double(Dor::Services::Client::Object, find: item2, release_tags: release_tags_client) }
+  let(:object_client1) { instance_double(Dor::Services::Client::Object, find: item1, update: double) }
+  let(:object_client2) { instance_double(Dor::Services::Client::Object, find: item2, update: double) }
 
   before do
     allow(Dor::Workflow::Client).to receive(:new).and_return(client)
@@ -51,8 +50,7 @@ RSpec.describe ReleaseObjectJob do
     let(:params) do
       {
         pids: pids,
-        manage_release: { 'to' => 'SEARCHWORKS' },
-        webauth: { 'privgroup' => 'dorstuff', 'login' => 'esnowden' }
+        manage_release: { 'to' => 'SEARCHWORKS', 'who' => 'bergeraj', 'what' => 'self', 'tag' => 'true' }
       }
     end
 
@@ -102,7 +100,8 @@ RSpec.describe ReleaseObjectJob do
           expect(subject).to receive(:bulk_action).and_return(bulk_action).at_least(:once)
           expect(subject.ability).to receive(:can?).and_return(true).exactly(pids.length).times
           # no stubbed release wf calls (they should never get called)
-          allow(release_tags_client).to receive(:create).and_raise Dor::Services::Client::UnexpectedResponse, ': 500 (Response from dor-services-app did not contain a body.'
+          allow(object_client1).to receive(:update).and_raise Dor::Services::Client::UnexpectedResponse, ': 500 (Response from dor-services-app did not contain a body.'
+          allow(object_client2).to receive(:update).and_raise Dor::Services::Client::UnexpectedResponse, ': 500 (Response from dor-services-app did not contain a body.'
         end
 
         it 'updates the total druid count' do


### PR DESCRIPTION

## Why was this change made?

This is now available via the cocina api.

Fixes #2740


## How was this change tested?



## Which documentation and/or configurations were updated?



