### PR TITLE
Allows updating APO for collection.

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -226,7 +226,7 @@ class ItemsController < ApplicationController
 
     authorize! :manage_governing_apo, @cocina, params[:new_apo_id]
 
-    change_set = ItemChangeSet.new(@cocina)
+    change_set = @cocina.is_a?(Cocina::Models::Collection) ? CollectionChangeSet.new(@cocina) : ItemChangeSet.new(@cocina)
     change_set.validate(admin_policy_id: params[:new_apo_id])
     change_set.save
     reindex

--- a/app/models/collection_change_set.rb
+++ b/app/models/collection_change_set.rb
@@ -2,6 +2,7 @@
 
 # Represents a set of changes to a collection
 class CollectionChangeSet < ApplicationChangeSet
+  property :admin_policy_id, virtual: true
   property :catkey, virtual: true
   property :copyright_statement, virtual: true
   property :license, virtual: true

--- a/app/services/collection_change_set_persister.rb
+++ b/app/services/collection_change_set_persister.rb
@@ -18,6 +18,7 @@ class CollectionChangeSetPersister
     updated = model
     updated = update_identification(updated) if changed?(:source_id) || changed?(:catkey) || changed?(:barcode)
     updated = updated_access(updated) if access_changed?
+    updated = updated_administrative(updated) if changed?(:admin_policy_id)
     object_client.update(params: updated)
   end
 
@@ -25,7 +26,7 @@ class CollectionChangeSetPersister
 
   attr_reader :model, :change_set
 
-  delegate :license, :copyright_statement, :use_statement, :catkey, :changed?, to: :change_set
+  delegate :admin_policy_id, :license, :copyright_statement, :use_statement, :catkey, :changed?, to: :change_set
 
   def access_changed?
     changed?(:copyright_statement) || changed?(:license) || changed?(:use_statement)
@@ -47,6 +48,11 @@ class CollectionChangeSetPersister
       identification_props[:catalogLinks] = catkey ? [{ catalog: 'symphony', catalogRecordId: catkey }] : nil
     end
     updated.new(identification: identification_props.compact.presence)
+  end
+
+  def updated_administrative(updated)
+    updated_administrative = updated.administrative.new(hasAdminPolicy: admin_policy_id)
+    updated.new(administrative: updated_administrative)
   end
 
   def object_client

--- a/spec/services/collection_change_set_persister_spec.rb
+++ b/spec/services/collection_change_set_persister_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe CollectionChangeSetPersister do
           copyright: copyright_statement_before,
           license: license_before,
           useAndReproductionStatement: use_statement_before
-        }
+        },
+        administrative: { hasAdminPolicy: 'druid:bc123df4569' }
       )
     end
     let(:use_statement_before) { 'My First Use Statement' }
@@ -113,6 +114,23 @@ RSpec.describe CollectionChangeSetPersister do
             copyright: copyright_statement_before,
             license: license_before,
             useAndReproductionStatement: use_statement_before
+          )
+        )
+      end
+    end
+
+    context 'when change set has changed APO' do
+      before do
+        change_set.validate(admin_policy_id: new_apo)
+        instance.update
+      end
+
+      let(:new_apo) { 'druid:dc123df4569' }
+
+      it 'invokes object client with collection that has new APO' do
+        expect(fake_client).to have_received(:update).with(
+          params: a_cocina_object_with_administrative(
+            hasAdminPolicy: new_apo
           )
         )
       end

--- a/spec/services/item_change_set_persister_spec.rb
+++ b/spec/services/item_change_set_persister_spec.rb
@@ -304,5 +304,22 @@ RSpec.describe ItemChangeSetPersister do
         )
       end
     end
+
+    context 'when change set has changed APO' do
+      before do
+        change_set.validate(admin_policy_id: new_apo)
+        instance.update
+      end
+
+      let(:new_apo) { 'druid:dc123df4569' }
+
+      it 'invokes object client with collection that has new APO' do
+        expect(fake_client).to have_received(:update).with(
+          params: a_cocina_object_with_administrative(
+            hasAdminPolicy: new_apo
+          )
+        )
+      end
+    end
   end
 end

--- a/spec/support/cocina_matchers.rb
+++ b/spec/support/cocina_matchers.rb
@@ -71,3 +71,16 @@ RSpec::Matchers.define :a_cocina_object_with_identification do |expected|
     end
   end
 end
+
+# NOTE: each k/v pair in the hash passed to this matcher will need to be present in actual
+RSpec::Matchers.define :a_cocina_object_with_administrative do |expected|
+  match do |actual|
+    expected.all? do |expected_key, expected_value|
+      # NOTE: there's no better method on Hash that I could find for this.
+      #        #include? and #member? only check keys, not k/v pairs
+      actual.administrative.to_h.any? do |actual_key, actual_value|
+        actual_key == expected_key && actual_value == expected_value
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #2764

## Why was this change made?
Allow a user to update APO for collection. Existing code was treating a Cocina collection like a DRO.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


