### PR TITLE
Update cocina-models to 0.61.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,13 +66,13 @@ gem 'zip_tricks', '5.3.1' # 5.3.1 is required as 5.4+ breaks the download all fe
 # Stanford related gems
 gem 'blacklight', '~> 7.18'
 gem 'blacklight-hierarchy', '~> 5.1'
-gem 'dor-services-client', '~> 6.33'
+gem 'dor-services-client', '~> 7.0'
 gem 'dor-workflow-client', '~> 3.19'
 gem 'mods_display'
 gem 'okcomputer' # monitors application and its dependencies
 gem 'preservation-client', '~> 3.2'
 gem 'rsolr'
-gem 'sdr-client', '~> 0.56'
+gem 'sdr-client', '~> 0.58'
 
 gem 'devise'
 gem 'devise-remote-user', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (3.0.0)
-    cocina-models (0.60.0)
+    cocina-models (0.61.0)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -171,9 +171,9 @@ GEM
     docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    dor-services-client (6.36.0)
+    dor-services-client (7.0.0)
       activesupport (>= 4.2, < 7)
-      cocina-models (~> 0.60.0)
+      cocina-models (~> 0.61.0)
       deprecation
       faraday (>= 0.15, < 2)
       moab-versioning (~> 4.0)
@@ -499,9 +499,9 @@ GEM
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.4)
     rubyzip (2.3.1)
-    sdr-client (0.57.0)
+    sdr-client (0.58.0)
       activesupport
-      cocina-models (~> 0.60.0)
+      cocina-models (~> 0.61.0)
       dry-monads
       faraday (>= 0.16)
     selenium-webdriver (3.142.7)
@@ -601,7 +601,7 @@ DEPENDENCIES
   devise
   devise-remote-user (~> 1.0)
   dlss-capistrano (~> 3.1)
-  dor-services-client (~> 6.33)
+  dor-services-client (~> 7.0)
   dor-workflow-client (~> 3.19)
   dry-monads
   equivalent-xml (>= 0.6.0)
@@ -640,7 +640,7 @@ DEPENDENCIES
   rubocop-rspec (~> 2.1.0)
   ruby-prof
   rubyzip
-  sdr-client (~> 0.56)
+  sdr-client (~> 0.58)
   selenium-webdriver
   sidekiq (~> 6.0)
   simplecov

--- a/spec/controllers/dor/objects_controller_spec.rb
+++ b/spec/controllers/dor/objects_controller_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Dor::ObjectsController, type: :controller do
             body: '{"type":"http://cocina.sul.stanford.edu/models/document.jsonld",' \
             '"label":"test parameters for registration","version":1,' \
             '"administrative":{"hasAdminPolicy":"druid:hv992ry2431"},' \
-            '"identification":{"sourceId":"foo:bar","catalogLinks":[]},' \
+            '"identification":{"catalogLinks":[],"sourceId":"foo:bar"},' \
             '"structural":{"isMemberOf":["druid:hv992ry7777"]}}'
           )
           .to_return(status: 200, body: json, headers: {})
@@ -144,7 +144,7 @@ RSpec.describe Dor::ObjectsController, type: :controller do
             '"label":"test parameters for registration","version":1,' \
             '"access":{"access":"stanford","download":"stanford","readLocation":null,"controlledDigitalLending":false},' \
             '"administrative":{"hasAdminPolicy":"druid:hv992ry2431"},' \
-            '"identification":{"sourceId":"foo:bar","catalogLinks":[]},' \
+            '"identification":{"catalogLinks":[],"sourceId":"foo:bar"},' \
             '"structural":{"isMemberOf":["druid:hv992ry7777"]}}'
           )
           .to_return(status: 200, body: json, headers: {})
@@ -195,7 +195,7 @@ RSpec.describe Dor::ObjectsController, type: :controller do
             '"label":"test parameters for registration","version":1,' \
             '"access":{"access":"location-based","download":"location-based","readLocation":"music","controlledDigitalLending":false},' \
             '"administrative":{"hasAdminPolicy":"druid:hv992ry2431"},' \
-            '"identification":{"sourceId":"foo:bar","catalogLinks":[]},' \
+            '"identification":{"catalogLinks":[],"sourceId":"foo:bar"},' \
             '"structural":{"hasMemberOrders":[{"viewingDirection":"left-to-right"}],' \
             '"isMemberOf":["druid:hv992ry7777"]}}'
           )
@@ -246,7 +246,7 @@ RSpec.describe Dor::ObjectsController, type: :controller do
             '"label":"test parameters for registration","version":1,' \
             '"access":{"access":"world","download":"none","readLocation":null,"controlledDigitalLending":false},' \
             '"administrative":{"hasAdminPolicy":"druid:hv992ry2431"},' \
-            '"identification":{"sourceId":"foo:bar","catalogLinks":[]},' \
+            '"identification":{"catalogLinks":[],"sourceId":"foo:bar"},' \
             '"structural":{"isMemberOf":["druid:hv992ry7777"]}}'
           )
           .to_return(status: 200, body: json, headers: {})
@@ -296,7 +296,7 @@ RSpec.describe Dor::ObjectsController, type: :controller do
             '"label":"test parameters for registration","version":1,' \
             '"access":{"access":"dark","download":"none","readLocation":null,"controlledDigitalLending":false},' \
             '"administrative":{"hasAdminPolicy":"druid:hv992ry2431"},' \
-            '"identification":{"sourceId":"foo:bar","catalogLinks":[]},' \
+            '"identification":{"catalogLinks":[],"sourceId":"foo:bar"},' \
             '"structural":{"isMemberOf":["druid:hv992ry7777"]}}'
           )
           .to_return(status: 200, body: json, headers: {})
@@ -370,7 +370,7 @@ RSpec.describe Dor::ObjectsController, type: :controller do
         '"label":"test parameters for registration","version":1,' \
         '"access":{"access":"stanford","download":"none","readLocation":null,"controlledDigitalLending":true},' \
         '"administrative":{"hasAdminPolicy":"druid:hv992ry2431"},' \
-        '"identification":{"sourceId":"foo:bar","catalogLinks":[]},' \
+        '"identification":{"catalogLinks":[],"sourceId":"foo:bar"},' \
         '"structural":{"hasMemberOrders":[{"viewingDirection":"left-to-right"}],' \
         '"isMemberOf":["druid:hv992ry7777"]}}'
           )


### PR DESCRIPTION
This is blocked by #2769

## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



