### PR TITLE
Check the released option by default

### DIFF
--- a/app/components/manage_release/collection_form_component.html.erb
+++ b/app/components/manage_release/collection_form_component.html.erb
@@ -16,7 +16,7 @@
     <label>Should it be released or withdrawn?</label>
     <div class='radio'>
       <label class='radio-inline'>
-        <%= manage_release_fields.radio_button(:tag, true) %>
+        <%= manage_release_fields.radio_button(:tag, true, checked: true) %>
         Release it
       </label>
       <label class='radio-inline'>

--- a/spec/components/manage_release/collection_form_component_spec.rb
+++ b/spec/components/manage_release/collection_form_component_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ManageRelease::CollectionFormComponent, type: :component do
   subject(:component) { described_class.new(form: form, current_user: build(:user)) }
 
-  let(:form) { ActionView::Helpers::FormBuilder.new(nil, nil, controller.view_context, {}) }
+  let(:form) { ActionView::Helpers::FormBuilder.new('bulk_action', nil, controller.view_context, {}) }
   let(:rendered) { render_inline(component) }
 
   it 'renders the options' do
@@ -15,5 +15,7 @@ RSpec.describe ManageRelease::CollectionFormComponent, type: :component do
       'Release it',
       'Do not release it (withdraw)'
     )
+
+    expect(rendered.css('#bulk_action_manage_release_tag_true[checked]')).to be_present
   end
 end


### PR DESCRIPTION
in the collections release form.



## Why was this change made?

This aligns this form with the item release form and, since this value is required, it prevents the submission of invalid values.

Fixes #2785

## How was this change tested?



## Which documentation and/or configurations were updated?



