### PR TITLE
filter out workgroups ending with /administrator when constructing query

### DIFF
--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -6,7 +6,7 @@ module RegistrationHelper
   def apo_list(permission_keys)
     return [] if permission_keys.blank?
 
-    q = permission_keys.map { |key| %(apo_register_permissions_ssim:"#{key}") }.join(' OR ')
+    q = permission_keys.filter_map { |key| %(apo_register_permissions_ssim:"#{key}") unless key.end_with?('/administrator') }.join(' OR ')
 
     result = SearchService.query(
       q,

--- a/spec/helpers/registration_helper_spec.rb
+++ b/spec/helpers/registration_helper_spec.rb
@@ -4,10 +4,12 @@ require 'rails_helper'
 
 RSpec.describe RegistrationHelper do
   describe '#apo_list' do
-    let(:perm_keys) { ['sunetid:user', 'workgroup:dlss:mock-group1', 'workgroup:dlss:mock-group2'] }
+    let(:perm_keys) { ['sunetid:user', 'workgroup:dlss:mock-group1', 'workgroup:dlss:mock-group2', 'workgroup:dlss:mock-group2/administrator'] }
 
-    it 'runs the appropriate query for the given permission keys' do
-      q = perm_keys.map { |key| %(apo_register_permissions_ssim:"#{key}") }.join(' OR ')
+    it 'runs the appropriate query for the given permission keys, filtering out groups ending with /administrator' do
+      q = 'apo_register_permissions_ssim:"sunetid:user" OR '\
+          'apo_register_permissions_ssim:"workgroup:dlss:mock-group1" OR '\
+          'apo_register_permissions_ssim:"workgroup:dlss:mock-group2"'
 
       expect(SearchService).to receive(:query).with(
         q,


### PR DESCRIPTION
## Why was this change made?

Fixes #2794 

Following a suggestion from Andrew in the ticket, filtering out all of the workgroups ending in /administrator when constructing the permissions query for the APO list to send to Solr.

Andrew has verified this works correctly on stage and doesn't seem to have any unintended side-effects.  The query change is only for building the list of APOs available for the drop down.

## How was this change tested?

Updated an existing test.

## Which documentation and/or configurations were updated?



