### PR TITLE
fix logging issues with modsulator invalid druid

### DIFF
--- a/app/models/user_log.rb
+++ b/app/models/user_log.rb
@@ -13,6 +13,7 @@ class UserLog
                            'argo.bulk_metadata.bulk_log_validation_error',
                            'argo.bulk_metadata.bulk_log_invalid_column',
                            'argo.bulk_metadata.bulk_log_skipped_mods',
+                           'argo.bulk_metadata.bulk_log_invalid_druid',
                            'argo.bulk_metadata.bulk_log_skipped_accession',
                            'argo.bulk_metadata.bulk_log_skipped_not_accessioned',
                            'argo.bulk_metadata.bulk_log_no_connection',
@@ -26,6 +27,7 @@ class UserLog
   # List the subset of messages that indicate an error with the job
   ERROR_MESSAGES = Set.new ['argo.bulk_metadata.bulk_log_apo_fail',
                             'argo.bulk_metadata.bulk_log_not_exist',
+                            'argo.bulk_metadata.bulk_log_invalid_druid',
                             'argo.bulk_metadata.bulk_log_error_exception',
                             'argo.bulk_metadata.bulk_log_validation_error',
                             'argo.bulk_metadata.bulk_log_invalid_column',

--- a/app/views/bulk_jobs/show.html.erb
+++ b/app/views/bulk_jobs/show.html.erb
@@ -35,6 +35,7 @@
                   (current_key == 'argo.bulk_metadata.bulk_log_error_exception') ||
                   (current_key == 'argo.bulk_metadata.bulk_log_invalid_column') ||
                   (current_key == 'argo.bulk_metadata.bulk_log_skipped_mods') ||
+                  (current_key == 'argo.bulk_metadata.bulk_log_invalid_druid') ||
                   (current_key == 'argo.bulk_metadata.bulk_log_skipped_accession') ||
                   (current_key == 'argo.bulk_metadata.bulk_log_skipped_not_accessioned') ||
                   (current_key == 'argo.bulk_metadata.bulk_log_record_count') ||

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,7 @@ en:
       bulk_log_validation_error:    	   'Error - generated MODS was invalid'
       bulk_log_invalid_column:     	     'Error - spreadsheet contains unrecognized column name'
       bulk_log_skipped_mods:	   	       'Skipped - input matches current MODS'
+      bulk_log_invalid_druid:	   	       'Skipped - invalid druid'
       bulk_log_skipped_accession:  	     'Skipped - item is currently being accessioned'
       bulk_log_skipped_not_accessioned:  'Skipped - item has not yet been accessioned'
       bulk_log_no_connection:      	     'Error - unable to connect to the MODSulator server'


### PR DESCRIPTION
## Why was this change made?

Logging isn't working correctly with invalid druids to the modsulator after #2791 because I missed a few things.


## How was this change tested?

On stage

## Which documentation and/or configurations were updated?



