### PR TITLE
no exception if an object has no collections

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -78,7 +78,7 @@ class ItemsController < ApplicationController
   end
 
   def remove_collection
-    new_collections = @cocina.structural.isMemberOf - [params[:collection]]
+    new_collections = Array(@cocina.structural.isMemberOf) - [params[:collection]]
     change_set = ItemChangeSet.new(@cocina)
     change_set.validate(collection_ids: new_collections)
     change_set.save

--- a/app/views/items/_collection_ui.html.erb
+++ b/app/views/items/_collection_ui.html.erb
@@ -1,18 +1,20 @@
 <div id='collection_message' class='alert-info'></div>
 
-<div class='panel panel-default'>
-  <div class='panel-heading'>
-    <h3 class="panel-title">Remove existing collections</h3>
+<% unless @collection_list.empty? %>
+  <div class='panel panel-default'>
+    <div class='panel-heading'>
+      <h3 class="panel-title">Remove existing collections</h3>
+    </div>
+    <div class='panel-body'>
+      <ul id='collection_list' class='list-group'>
+        <% @collection_list.each do |collection| %>
+          <%= render 'collection_ui_line_item', collection_label: collection.label,
+                                                collection_id: collection.externalIdentifier,
+                                                item_id: @cocina.externalIdentifier %>
+        <% end %>
+    </div>
   </div>
-  <div class='panel-body'>
-    <ul id='collection_list' class='list-group'>
-      <% @collection_list.each do |collection| %>
-        <%= render 'collection_ui_line_item', collection_label: collection.label,
-                                              collection_id: collection.externalIdentifier,
-                                              item_id: @cocina.externalIdentifier %>
-      <% end %>
-  </div>
-</div>
+<% end %>
 
 <div class='panel panel-default'>
   <div class='panel-heading'>

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -240,6 +240,25 @@ RSpec.describe ItemsController, type: :controller do
         expect(object_service).not_to have_received(:update)
       end
     end
+
+    context 'when the object is not in any collections' do
+      let(:cocina) do
+        Cocina::Models.build({
+                               'label' => 'My ETD',
+                               'version' => 1,
+                               'type' => Cocina::Models::Vocab.object,
+                               'externalIdentifier' => pid,
+                               'access' => {},
+                               'administrative' => { 'hasAdminPolicy' => 'druid:cg532dg5405' },
+                               'structural' => {}
+                             })
+      end
+
+      it 'does nothing and does not throw an exception' do
+        post 'remove_collection', params: { id: pid, collection: 'druid:1234' }
+        expect(object_service).not_to have_received(:update).with(params: cocina)
+      end
+    end
   end
 
   describe '#mods' do


### PR DESCRIPTION
## Why was this change made?

Fixes #2800 - though to be honest it's unclear how you can hit this point, because it's unclear why you'd get to the "remove a collection" endpoint for an object without any collections.  See the details on the ticket.

## How was this change tested?

Added a new test


## Which documentation and/or configurations were updated?



