### PR TITLE
changes to address populate with previous search

### DIFF
--- a/app/components/bulk_actions_form_component.html.erb
+++ b/app/components/bulk_actions_form_component.html.erb
@@ -130,7 +130,7 @@
               Edit license, copyright statement, and/or use &amp; reproduction statements
             </span>
           </div>
-          <%= render 'bulk_actions/forms/set_license_and_rights_statements_form', f: f %>
+          <%= render 'bulk_actions/forms/set_license_and_rights_statements_form', f: f, license_options: @form.license_options %>
         </div>
 
         <div role='tabpanel' class='tab-pane' id='ManageEmbargoesJob'>
@@ -145,9 +145,12 @@
     </div>
 
     <div data-bulk_actions-target="commonFields" >
-      <button class='btn btn-primary' data-populate-druids="<%= search_catalog_path(search_of_pids) %>" data-target='#pids'>
-        Populate with previous search
-      </button>
+      <% if @last_search %>
+        <button class='btn btn-primary' data-populate-druids="<%= search_catalog_path(search_of_pids) %>" data-target='#pids'>
+          Populate with previous search
+        </button>
+        <small><%= @last_search.query_params.except('controller', 'action') %></small>
+      <% end %>
       <div class='form-group'>
         <label>Druids to perform bulk action on</label>
         <textarea id='pids' name='bulk_action[pids]' class='form-control' rows='10'></textarea>

--- a/app/controllers/bulk_actions_controller.rb
+++ b/app/controllers/bulk_actions_controller.rb
@@ -13,7 +13,7 @@ class BulkActionsController < ApplicationController
   # GET /bulk_actions/new
   def new
     @form = BulkActionForm.new(BulkAction.new, groups: current_user.groups)
-    @last_search = session[:search].present? ? searches_from_history.find(session[:search]['id']) : searches_from_history.first
+    @last_search = session[:search].present? ? searches_from_history.find(session[:search]['id']) : nil
   end
 
   # POST /bulk_actions

--- a/app/views/bulk_actions/forms/_set_license_and_rights_statements_form.html.erb
+++ b/app/views/bulk_actions/forms/_set_license_and_rights_statements_form.html.erb
@@ -29,6 +29,6 @@
   </div>
 
   <div class="form-group ml-4 mb-5">
-    <%= license_and_rights_statements.select :license, @form.license_options, {}, class: 'form-control'%>
+    <%= license_and_rights_statements.select :license, license_options, {}, class: 'form-control'%>
   </div>
 <% end %>

--- a/spec/components/bulk_actions_form_component_spec.rb
+++ b/spec/components/bulk_actions_form_component_spec.rb
@@ -3,7 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe BulkActionsFormComponent, type: :component do
-  subject(:instance) { described_class.new(form: nil, last_search: last_search) }
+  subject(:instance) { described_class.new(form: bulk_action_form, last_search: last_search) }
+
+  let(:bulk_action_form) { BulkActionForm.new(build(:bulk_action), groups: []) }
+
+  before { allow(controller).to receive(:current_user).and_return(build(:user)) }
 
   describe '#search_of_pids' do
     context "when last search isn't present" do
@@ -11,6 +15,11 @@ RSpec.describe BulkActionsFormComponent, type: :component do
 
       it 'returns an empty string' do
         expect(instance.search_of_pids).to eq ''
+      end
+
+      it 'does not render a populate from previous search button' do
+        render_inline(subject)
+        expect(page).not_to have_button 'Populate with previous search'
       end
     end
 
@@ -23,6 +32,11 @@ RSpec.describe BulkActionsFormComponent, type: :component do
 
       it 'adds a pids_only param' do
         expect(instance.search_of_pids).to include(q: 'cool catz', 'pids_only' => true)
+      end
+
+      it 'renders a populate from previous search button' do
+        render_inline(subject)
+        expect(page).to have_button 'Populate with previous search'
       end
     end
   end

--- a/spec/controllers/bulk_actions_controller_spec.rb
+++ b/spec/controllers/bulk_actions_controller_spec.rb
@@ -33,14 +33,9 @@ RSpec.describe BulkActionsController do
 
     describe 'assigns @last_search' do
       it 'with no session[:search]' do
-        first_search = Search.create
-        last_search = Search.create
-        searches = [last_search, first_search] # Ordered desc from Blacklight
-        expect(subject).to receive(:searches_from_history).and_return searches
         expect(request.session[:search]).to be_nil
         get :new
-        expect(assigns(:last_search)).to be_an Search
-        expect(assigns(:last_search)).to eq last_search
+        expect(assigns(:last_search)).to be_nil
       end
 
       it 'with last session[:search]' do


### PR DESCRIPTION
## Why was this change made?

To address #2792 - though it is not clear it will "fix it".

After doing all of the archeology listed in the comments in #2792, I have undertaken the following (for Bulk Actions only, Bulk Update is not changed):

1. Hide the "Populate with previous search" button if there is no search history present.  Currently the button is always shown even if the user has no search history and clicking it will execute a search to the catalog controller with no query parameters - this makes no sense.
2. If there is no previous search session ID available, treat that as if there was no history rather than trying to find the last item in the search history.  Perhaps there is some session confusion going on with multiple open tabs, this change would simply hide the search button if it can't find a specific previous search ID in the current session rather than risk fetching a search that isn't the one the user may be expecting.
3. Finally, if the search button is shown, show the query params that will be used for the search to the user.  This won't be formatted nicely, but it can allow for some debugging and perhaps give us clues as to what is happening.  It may also prevent the user from accidentally running a job on the wrong druids (as it should be more obvious the search is wrong before you execute it).

Question: there must be an easy way to render the search constraints from the params (as is done on the search results page).  This would be a nicer thing to show instead of the params themselves.  I tried for a while but couldn't figure it out yet.

## How was this change tested?

1. Updated the component test
2. On argo-qa

## Which documentation and/or configurations were updated?



