### PR TITLE
okcomputer: promote or delete optional checks

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -42,41 +42,12 @@ OkComputer::Registry.register 'feature-tables-have-data', TablesHaveDataCheck.ne
 solr_url = Blacklight.connection_config.fetch(:url)
 OkComputer::Registry.register 'dor_search_service_solr', OkComputer::HttpCheck.new("#{solr_url}/admin/ping")
 
-# ------------------------------------------------------------------------------
-
-# NON-CRUCIAL (Optional) checks, avail at /status/<name-of-check>
-#   - at individual endpoint, HTTP response code reflects the actual result
-#   - in /status/all, these checks will display their result text, but will not affect HTTP response code
-OkComputer::Registry.register 'dor_services_url', OkComputer::HttpCheck.new(Settings.dor_services.url)
-OkComputer::Registry.register 'workflow_url', OkComputer::HttpCheck.new(Settings.workflow_url)
-
-# Stacks
-OkComputer::Registry.register 'stacks_local_workspace_root', OkComputer::DirectoryCheck.new(Settings.stacks.local_workspace_root)
 OkComputer::Registry.register 'stacks_host', OkComputer::HttpCheck.new("https://#{Settings.stacks.host}")
-OkComputer::Registry.register 'stacks_file_url', OkComputer::HttpCheck.new(Settings.stacks_file_url)
-OkComputer::Registry.register 'stacks_thumbnail_url', OkComputer::HttpCheck.new(Settings.stacks_url)
+OkComputer::Registry.register 'stacks_local_workspace_root', OkComputer::DirectoryCheck.new(Settings.stacks.local_workspace_root)
 
-# Bulk Metadata - probably for bulk downloads
+# Bulk Metadata  services
 OkComputer::Registry.register 'bulk_metadata_dir', OkComputer::DirectoryCheck.new(Settings.bulk_metadata.directory)
 OkComputer::Registry.register 'bulk_metadata_tmp_dir', OkComputer::DirectoryCheck.new(Settings.bulk_metadata.temporary_directory)
-
-# Modsulator, etc - probably for bulk updates?
-OkComputer::Registry.register 'modsulator_url', OkComputer::HttpCheck.new(Settings.modsulator_url)
-OkComputer::Registry.register 'normalizer_url', OkComputer::HttpCheck.new(Settings.normalizer_url)
+modsulator_url = "#{Settings.modsulator_url.split('v1').first}v1/about"
+OkComputer::Registry.register 'modsulator_app', OkComputer::HttpCheck.new(modsulator_url)
 OkComputer::Registry.register 'spreadsheet_url', OkComputer::HttpCheck.new(Settings.spreadsheet_url)
-
-# purl_url is only used for links out and we decided not to include it here
-
-OkComputer.make_optional %w[
-  bulk_metadata_dir
-  bulk_metadata_tmp_dir
-  dor_services_url
-  modsulator_url
-  normalizer_url
-  spreadsheet_url
-  stacks_file_url
-  stacks_host
-  stacks_local_workspace_root
-  stacks_thumbnail_url
-  workflow_url
-]

--- a/spec/features/status_spec.rb
+++ b/spec/features/status_spec.rb
@@ -17,13 +17,7 @@ RSpec.describe 'application and dependency monitoring' do
       stub_request(:get, "https://#{Settings.stacks.host}")
         .to_return(status: 200, body: '', headers: {})
 
-      stub_request(:get, Settings.stacks_file_url)
-        .to_return(status: 200, body: '', headers: {})
-
-      stub_request(:get, Settings.stacks_url)
-        .to_return(status: 200, body: '', headers: {})
-
-      stub_request(:get, Settings.modsulator_url)
+      stub_request(:get, "#{Settings.modsulator_url.split('v1').first}v1/about")
         .to_return(status: 200, body: '', headers: {})
 
       stub_request(:get, Settings.normalizer_url)
@@ -33,7 +27,6 @@ RSpec.describe 'application and dependency monitoring' do
     it 'checks dependencies' do
       visit '/status/all'
       expect(page).to have_text('dor_search_service_solr') # required check
-      expect(page).to have_text('stacks_file_url') # non-crucial check
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

To address these from okcomputer status/all:

```
  dor_services_url: FAILED Error: '404 Not Found' (0.094s) (OPTIONAL)
  modsulator_url: FAILED Error: '404 Not Found' (0.060s) (OPTIONAL)
  normalizer_url: FAILED Error: '404 Not Found' (0.121s) (OPTIONAL)
  stacks_file_url: FAILED Error: '404 Not Found' (0.077s) (OPTIONAL)
  stacks_thumbnail_url: FAILED Error: '404 Not Found' (0.070s) (OPTIONAL)
  workflow_url: FAILED Error: '404 Not Found' (0.067s) (OPTIONAL)
```

## How was this change tested?

deployed to stage, and everything passed except stacks-host, which I didn't touch:

https://argo-stage-a.stanford.edu/status/all/

```
Default Collection
  bulk_metadata_dir: PASSED Directory '/workspace/bulk/' is writable (as expected). (0.009s)
  bulk_metadata_tmp_dir: PASSED Directory '/workspace/bulk/tmp/' is writable (as expected). (0.010s)
  database: PASSED Schema version: 20210406023300 (0.060s)
  default: PASSED Application is running (0.000s)
  dor_search_service_solr: PASSED HTTP check successful (0.049s)
  feature-tables-have-data: PASSED BulkAction has data. User has data. (0.054s)
  modsulator_app: PASSED HTTP check successful (0.063s)
  rails_cache: PASSED Able to read and write via File store (0.038s)
  ruby_version: PASSED Ruby 2.7.2-p137 (0.000s)
  spreadsheet_url: PASSED HTTP check successful (0.061s)
  stacks_host: FAILED Error: 'SSL_connect returned=1 errno=0 state=error: certificate verify failed (certificate has expired)' (0.034s)
  stacks_local_workspace_root: PASSED Directory '/dor/workspace' is writable (as expected). (0.015s)
```

## Which documentation and/or configurations were updated?



