### PR TITLE
Remove jqueryui autocomplete

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -72,7 +72,7 @@ class RegistrationsController < ApplicationController
   end
 
   def autocomplete
-    facet_field = params[:field]
+    facet_field = 'project_tag_ssim'
     response = SearchService.query(
       '*:*',
       rows: 0,
@@ -83,9 +83,7 @@ class RegistrationsController < ApplicationController
       'json.nl': 'map'
     )
     result = response['facet_counts']['facet_fields'][facet_field].keys.sort
-    respond_to do |format|
-      format.any(:json, :xml) { render request.format.to_sym => result }
-    end
+    render json: result
   end
 
   private

--- a/app/javascript/argo.js
+++ b/app/javascript/argo.js
@@ -10,6 +10,8 @@ import 'modules/permission_list'
 import 'modules/populate_druids'
 import 'modules/sharing'
 import TagsAutocomplete from 'modules/tags_autocomplete'
+import ProjectAutocomplete from 'modules/project_autocomplete'
+
 import Form from 'modules/apo_form'
 import bsCustomFileInput from 'bs-custom-file-input'
 
@@ -46,6 +48,8 @@ $(document).on('keyup', '#collection_catkey', function(e) {
 export default class Argo {
     initialize() {
         this.tagsAutocomplete()
+        this.projectAutocomplete()
+
         this.spreadsheet()
         this.buttonChecker()
         this.dateRangeQuery()
@@ -66,6 +70,10 @@ export default class Argo {
 
     tagsAutocomplete() {
       new TagsAutocomplete().initialize()
+    }
+
+    projectAutocomplete() {
+      new ProjectAutocomplete().initialize()
     }
 
     spreadsheet() {

--- a/app/javascript/modules/project_autocomplete.js
+++ b/app/javascript/modules/project_autocomplete.js
@@ -1,0 +1,22 @@
+import autocomplete from 'autocomplete.js'
+
+export default class {
+  newHitsSource(params) {
+    return function doSearch(query, cb) {
+      fetch(`/registration/suggest_project?term=${query}`)
+        .then(response => response.json())
+        .then(res => cb(res))
+    }
+  }
+
+  initialize() {
+    autocomplete('[data-project-autocomplete]', { minLength: 2 }, [
+      {
+        source: this.newHitsSource({ hitsPerPage: 5 }),
+        displayKey: (suggestion) => suggestion,
+      }
+    ]).on('autocomplete:selected', function(event, suggestion, dataset, context) {
+      console.log(event, suggestion, dataset, context);
+    });
+  }
+}

--- a/app/javascript/registration/grid.js
+++ b/app/javascript/registration/grid.js
@@ -1,6 +1,5 @@
 import DorRegistration from './register'
 import pathTo from './pathTo'
-import 'jquery-ui/ui/widgets/autocomplete'
 import 'jquery-ui/ui/widgets/dialog'
 import 'jquery-ui/ui/widgets/progressbar'
 
@@ -454,11 +453,6 @@ var gridContext = function() {
     },
 
     initializeDialogs: function() {
-      $('#project').autocomplete({
-        source: pathTo('/registration/suggest_project'),
-        minLength: 0,
-      });
-
       // Update Workflow and Form lists when APO changes
       $('#apo_id').change(function(e) {
         $.ajax({

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -11,7 +11,7 @@
   <div class="property-item"><label for="rights">Rights</label><%= select_tag :rights, options_for_select(Constants::REGISTRATION_RIGHTS_OPTIONS), 'data-tagname': 'Process : Rights' %></div>
   <div class="property-item"><label for='workflow_id'>Initial Workflow</label><%= select_tag :workflow_id, '', 'data-rcparam': 'workflowId' %></div>
   <div class="property-item"><label for='content_type'>Content Type</label><%= select_tag :content_type, options_for_select(valid_content_types), class: 'tag-field', 'data-tagname': 'Process : Content Type' %></div>
-  <div class="property-item break"><label for='project'>Project Name</label><%= text_field_tag :project, nil, 'data-rcparam': 'projectName' %></div>
+  <div class="property-item break"><label for='project'>Project Name</label><%= text_field_tag :project, nil, data: { rcparam: 'projectName', project_autocomplete: true } %></div>
   <div class="property-item wide"><label for='tag_1'>Tags</label>
     <span id="tags" style="width: auto">
       <%= text_field_tag :'tags[]', nil, id: 'tags_0', class: 'free tag-field', data: { tag_autocomplete: true } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,7 +157,7 @@ Rails.application.routes.draw do
       get 'collection_list'
       get 'workflow_list'
       get 'rights_list'
-      get 'suggest_project', action: 'autocomplete', field: 'project_tag_ssim'
+      get 'suggest_project', action: 'autocomplete'
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

Jquery-ui is obsolete and challenging to work with because it overlaps in responsibility with bootstrap.

## How was this change tested?



## Which documentation and/or configurations were updated?



