### PR TITLE
Avoid using a deprecated method for configuring Selenium webdriver

### DIFF
--- a/spec/support/selenium_webdriver.rb
+++ b/spec/support/selenium_webdriver.rb
@@ -14,7 +14,7 @@ Capybara.register_driver :headless_chrome do |app|
     opts.args << '--no-sandbox'
     opts.args << '--window-size=1280,1696'
   end
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: browser_options)
 end
 
 Capybara.disable_animation = true


### PR DESCRIPTION


## Why was this change made?
Fixes #2838


## How was this change tested?



## Which documentation and/or configurations were updated?



