### PR TITLE
Details component

### DIFF
--- a/app/components/details_component.html.erb
+++ b/app/components/details_component.html.erb
@@ -1,0 +1,74 @@
+<table class="table table-sm mb-5 caption-header">
+    <caption>Details</caption>
+    <tbody>
+      <tr>
+        <th class="col-3" scope="row">Object type</th>
+        <td>
+            <%= object_type %>
+        </td>
+      </tr>
+
+      <tr>
+        <th class="col-3" scope="row">Content type</th>
+        <td>
+            <%= content_type %>
+        </td>
+      </tr>
+
+      <tr>
+        <th class="col-3" scope="row">Project</th>
+        <td>
+            <%= project_tag %>
+        </td>
+      </tr>
+
+      <tr>
+        <th class="col-3" scope="row">Source IDs</th>
+        <td>
+            <%= source_id %>
+        </td>
+      </tr>
+
+      <tr>
+        <th class="col-3" scope="row">Created</th>
+        <td>
+            <%= created_date %>
+        </td>
+      </tr>
+
+      <tr>
+        <th class="col-3" scope="row">Released to</th>
+        <td>
+            <%= released_to.to_sentence %>
+        </td>
+      </tr>
+
+      <tr>
+        <th class="col-3" scope="row">Preservation size</th>
+        <td>
+            <%= number_to_human_size(preservation_size) %>
+        </td>
+      </tr>
+
+      <tr>
+        <th class="col-3" scope="row">Catkey</th>
+        <td>
+            <%= catkey_id %>
+        </td>
+      </tr>
+
+      <tr>
+        <th class="col-3" scope="row">Barcode</th>
+        <td>
+            <%= barcode %>
+        </td>
+      </tr>
+
+      <tr>
+        <th class="col-3" scope="row">Tags</th>
+        <td>
+            <%= tags %>
+        </td>
+      </tr>
+    </tbody>
+  </table>

--- a/app/components/details_component.rb
+++ b/app/components/details_component.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class DetailsComponent < ApplicationComponent
+  def initialize(solr_document:)
+    @solr_document = solr_document
+  end
+
+  def project_tag
+    render_field 'project_tag_ssim'
+  end
+
+  def tags
+    render_field('tag_ssim')
+  end
+
+  delegate :object_type, :content_type, :source_id, :created_date,
+           :released_to, :preservation_size, :catkey_id, :barcode, to: :@solr_document
+
+  delegate :blacklight_config, :search_state, :search_action_path, to: :helpers
+
+  private
+
+  def render_field(field_name)
+    field_config = fields.fetch(field_name)
+    Blacklight::FieldPresenter.new(self, @solr_document, field_config).render
+  end
+
+  def fields
+    @fields ||= blacklight_config.show_fields_for(:show)
+  end
+end

--- a/app/components/document_component.html.erb
+++ b/app/components/document_component.html.erb
@@ -26,12 +26,11 @@
     <div class="col-md-6">
       <%= render OverviewComponent.new(solr_document: @document) %>
     </div>
+    <div class="col-md-6">
+      <%= render DetailsComponent.new(solr_document: @document) %>
+    </div>
   </div>
 
-  <%= render Blacklight::DocumentMetadataComponent.new(
-      fields: @presenter.field_presenters,
-      show: true
-    ) %>
   <div class="accordion">
     <%= render 'datastreams_default', document: @document %>
     <%= render 'events_default', document: @document %>

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -38,8 +38,8 @@ class CatalogController < ApplicationController
     config.add_index_field SolrDocument::FIELD_CONTENT_TYPE,  label: 'Content Type'
     config.add_index_field SolrDocument::FIELD_APO_ID,        label: 'Admin Policy',      helper_method: :link_to_admin_policy
     config.add_index_field SolrDocument::FIELD_COLLECTION_ID, label: 'Collection',        helper_method: :links_to_collections
-    config.add_index_field 'project_tag_ssim',                label: 'Project',           link_to_facet: true
-    config.add_index_field 'source_id_ssim',                  label: 'Source'
+    config.add_index_field SolrDocument::FIELD_PROJECT_TAG,   label: 'Project',           link_to_facet: true
+    config.add_index_field SolrDocument::FIELD_SOURCE_ID,     label: 'Source'
     config.add_index_field 'identifier_tesim',                label: 'IDs', helper_method: :value_for_identifier_tesim
     config.add_index_field SolrDocument::FIELD_RELEASED_TO,   label: 'Released to'
     config.add_index_field 'status_ssi',                      label: 'Status'

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SolrDocument
+class SolrDocument # rubocop:disable Metrics/ClassLength
   include Blacklight::Solr::Document
   include ApoConcern
   include CollectionConcern
@@ -32,6 +32,10 @@ class SolrDocument
   FIELD_COPYRIGHT                 = 'copyright_ssim'
   FIELD_USE_STATEMENT             = 'use_statement_ssim'
   FIELD_LICENSE                   = 'use_license_machine_ssi'
+  FIELD_PROJECT_TAG               = 'project_tag_ssim'
+  FIELD_TAGS                      = 'tag_ssim'
+  FIELD_SOURCE_ID                 = 'source_id_ssim'
+  FIELD_BARCODE_ID                = 'barcode_id_ssim'
 
   attribute :object_type, Blacklight::Types::String, FIELD_OBJECT_TYPE
   attribute :content_type, Blacklight::Types::String, FIELD_CONTENT_TYPE
@@ -62,6 +66,10 @@ class SolrDocument
   attribute :copyright, Blacklight::Types::String, FIELD_COPYRIGHT
   attribute :use_statement, Blacklight::Types::String, FIELD_USE_STATEMENT
   attribute :license, Blacklight::Types::String, FIELD_LICENSE
+  attribute :project_tag, Blacklight::Types::String, FIELD_PROJECT_TAG
+  attribute :source_id, Blacklight::Types::String, FIELD_SOURCE_ID
+  attribute :barcode, Blacklight::Types::String, FIELD_BARCODE_ID
+  attribute :tags, Blacklight::Types::Array, FIELD_TAGS
 
   # self.unique_key = 'id'
 

--- a/spec/components/details_component_spec.rb
+++ b/spec/components/details_component_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DetailsComponent, type: :component do
+  pending "add some examples to (or delete) #{__FILE__}"
+
+  # it "renders something useful" do
+  #   expect(
+  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
+  #   ).to include(
+  #     "Hello, components!"
+  #   )
+  # end
+end

--- a/spec/features/edit_item_tags_spec.rb
+++ b/spec/features/edit_item_tags_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Edit administrative tags for a single item', js: true do
       click_button 'Save'
     end
     expect(page).to have_content "Tags for #{item.externalIdentifier} have been updated!"
-    within('dd.blacklight-tag_ssim') do
+    within_table('Details') do
       expect(page).to have_content first_new_tag
       expect(page).to have_content second_new_tag
     end
@@ -43,7 +43,7 @@ RSpec.describe 'Edit administrative tags for a single item', js: true do
       click_button 'Save'
     end
     expect(page).to have_content "Tags for #{item.externalIdentifier} have been updated!"
-    within('dd.blacklight-tag_ssim') do
+    within_table('Details') do
       expect(page).to have_content replacement_tag
       expect(page).to have_content second_new_tag
     end
@@ -55,7 +55,7 @@ RSpec.describe 'Edit administrative tags for a single item', js: true do
       click_button 'Save'
     end
     expect(page).to have_content "Tags for #{item.externalIdentifier} have been updated!"
-    within('dd.blacklight-tag_ssim') do
+    within_table('Details') do
       expect(page).not_to have_content replacement_tag
       expect(page).to have_content second_new_tag
     end
@@ -66,7 +66,7 @@ RSpec.describe 'Edit administrative tags for a single item', js: true do
       click_button 'Save'
     end
     expect(page).to have_content "Tags for #{item.externalIdentifier} have been updated!"
-    within('dd.blacklight-tag_ssim') do
+    within_table('Details') do
       expect(page).not_to have_content replacement_tag
       expect(page).not_to have_content second_new_tag
     end

--- a/spec/features/item_view_metadata_spec.rb
+++ b/spec/features/item_view_metadata_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe 'Item view', js: true do
 
     it 'shows the page' do
       visit solr_document_path item_id
-      within '.document-metadata' do
-        expect(page).to have_css 'dt', text: 'DRUID:'
-        expect(page).to have_css 'dd', text: item_id
+      within_table('Overview') do
+        expect(page).to have_css 'th', text: 'DRUID'
+        expect(page).to have_css 'td', text: item_id
       end
     end
   end
@@ -207,26 +207,27 @@ RSpec.describe 'Item view', js: true do
       it 'shows the file info' do
         visit solr_document_path item_id
 
-        within '.document-metadata' do
-          expect(page).to have_css 'dt', text: 'DRUID:'
-          expect(page).to have_css 'dd', text: item_id
-          expect(page).to have_css 'dt', text: 'Object Type:'
-          expect(page).to have_css 'dd', text: 'item'
-          expect(page).to have_css 'dt', text: 'Content Type:'
-          expect(page).to have_css 'dd', text: 'image'
-          expect(page).to have_css 'dt', text: 'Admin Policy:'
-          expect(page).to have_css 'dd a', text: 'Stanford University Libraries - Special Collections'
-          expect(page).to have_css 'dt', text: 'Project:'
-          expect(page).to have_css 'dd a', text: 'Fuller Slides'
-          expect(page).to have_css 'dt', text: 'Source:'
-          expect(page).to have_css 'dd', text: 'fuller:M1090_S15_B02_F01_0126'
-          expect(page).to have_css 'dt', text: 'IDs:'
-          expect(page).to have_css 'dd', text: 'fuller:M1090_S15_B02_F01_0126, uuid:ad2d8894-7eba-11e1-b714-0016034322e7'
-          expect(page).to have_css 'dt', text: 'Tags:'
-          expect(page).to have_css 'dd a', text: 'Project : Fuller Slides'
-          expect(page).to have_css 'dd a', text: 'Registered By : renzo'
-          expect(page).to have_css 'dt', text: 'Status:'
-          expect(page).to have_css 'dd', text: 'v1 Unknown Status'
+        within_table('Overview') do
+          expect(page).to have_css 'th', text: 'DRUID'
+          expect(page).to have_css 'td', text: item_id
+          expect(page).to have_css 'th', text: 'Admin policy'
+          expect(page).to have_css 'td a', text: 'Stanford University Libraries - Special Collections'
+          expect(page).to have_css 'th', text: 'Status'
+          expect(page).to have_css 'td', text: 'v1 Unknown Status'
+        end
+
+        within_table('Details') do
+          expect(page).to have_css 'th', text: 'Object type'
+          expect(page).to have_css 'td', text: 'item'
+          expect(page).to have_css 'th', text: 'Content type'
+          expect(page).to have_css 'td', text: 'image'
+          expect(page).to have_css 'th', text: 'Project'
+          expect(page).to have_css 'td a', text: 'Fuller Slides'
+          expect(page).to have_css 'th', text: 'Source IDs'
+          expect(page).to have_css 'td', text: 'fuller:M1090_S15_B02_F01_0126'
+          expect(page).to have_css 'th', text: 'Tags'
+          expect(page).to have_css 'td a', text: 'Project : Fuller Slides'
+          expect(page).to have_css 'td a', text: 'Registered By : renzo'
         end
 
         click_link 'descMetadata' # Open the datastream modal


### PR DESCRIPTION
## Why was this change made?

To make the show page display the details as defined in the mockups.

## How was this change tested?

![Screen Shot 2021-10-20 at 16 53 16-fullpage](https://user-images.githubusercontent.com/92044/138177787-d3962375-f685-448b-b5c0-2dbd4fafb5d9.png)

## Which documentation and/or configurations were updated?



