### PR TITLE
argo modals should not re-appear after redirect

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -28,4 +28,11 @@ document.addEventListener("turbo:load", async () => {
   // Start argo after free-jqgrid has been loaded
   new Argo().initialize()
 })
+
+ window.addEventListener('turbo:before-cache', function () {
+  // Close any lingering open modal windows
+  $('.modal').modal('hide');
+  $('.modal-backdrop').remove();
+});
+
 import '@hotwired/turbo-rails'


### PR DESCRIPTION
## Why was this change made?

Fixes #2832 -- argo modals re-appear after a re-direct and should not.  After playing around in localhost, it appears to me that the browser seems to be caching the version of the catalog show page that has the modal in it, and then when you re-direct back to the page after performing a reindex or republish, the browser is re-opening the modal.  Took a dumb attempt at just making the redirect URL change after a reindex or republish by adding a param and the problem went away in localhost.  

Is there a better way to do this?  There may be other redirects that cause this as well.

Tried doing this too at the top of the `show` method in the catalog controller, but that didn't have an effect even though I could see it appear in the headers with dev tools:

`response.headers["Cache-Control"] = "no-cache, no-store"`

## How was this change tested?



## Which documentation and/or configurations were updated?



