### PR TITLE
Add missing form label and style to the set APO form.

### DIFF
--- a/app/views/items/_set_governing_apo_ui.html.erb
+++ b/app/views/items/_set_governing_apo_ui.html.erb
@@ -1,6 +1,7 @@
 <%= form_tag set_governing_apo_item_path(@cocina.externalIdentifier) do %>
   <div class='form-group'>
-    <%= select_tag(:new_apo_id, options_for_select(apo_list(current_user.groups), @cocina.administrative.hasAdminPolicy)) %>
+    <%= label_tag :new_apo_id, 'New governing APO' %>
+    <%= select_tag(:new_apo_id, options_for_select(apo_list(current_user.groups), @cocina.administrative.hasAdminPolicy), class: 'form-control') %>
   </div>
   <button class='btn btn-primary'>
     Update


### PR DESCRIPTION

## Why was this change made?

This improves accessability because every element should have a label. It also improves consistency with how this element is presented on the bulk actions page


## How was this change tested?

Before:
<img width="452" alt="Screen Shot 2021-10-22 at 9 42 48 AM" src="https://user-images.githubusercontent.com/92044/138474299-fbd248bc-13b8-4fad-8d00-3094b53722ea.png">

After:
<img width="451" alt="Screen Shot 2021-10-22 at 9 42 13 AM" src="https://user-images.githubusercontent.com/92044/138474300-5719bf00-8157-4ec4-aa9f-98df4240365c.png">

## Which documentation and/or configurations were updated?



