### PR TITLE
Upgrade to Blacklight 7.20.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 gem 'cssbundling-rails', '~> 0.2.4'
 gem 'jsbundling-rails', '~> 0.1.9'
 
-gem 'view_component', '~> 2.31.1' # lock this until BL 7.19.2 is released
+gem 'view_component', '~> 2.42'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -65,7 +65,7 @@ gem 'turbo-rails', '~> 0.7.13'
 gem 'zip_tricks', '5.3.1' # 5.3.1 is required as 5.4+ breaks the download all feature
 
 # Stanford related gems
-gem 'blacklight', '~> 7.18'
+gem 'blacklight', '~> 7.20'
 gem 'blacklight-hierarchy', '~> 5.1'
 gem 'dor-services-client', '~> 7.0'
 gem 'dor-workflow-client', '~> 3.19'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
       parser (>= 2.4)
       smart_properties
     bindex (0.8.1)
-    blacklight (7.19.2)
+    blacklight (7.20.0)
       deprecation
       globalid
       i18n (>= 1.7.0)
@@ -84,7 +84,7 @@ GEM
       kaminari (>= 0.15)
       ostruct (>= 0.3.2)
       rails (>= 5.1, < 7)
-      view_component (>= 2.28.0)
+      view_component (~> 2.42.0)
     blacklight-hierarchy (5.3.0)
       blacklight (~> 7.18)
       deprecation
@@ -552,8 +552,9 @@ GEM
       unf_ext
     unf_ext (0.0.8)
     unicode-display_width (2.1.0)
-    view_component (2.31.1)
-      activesupport (>= 5.0.0, < 7.0)
+    view_component (2.42.0)
+      activesupport (>= 5.0.0, < 8.0)
+      method_source (~> 1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.1.0)
@@ -585,7 +586,7 @@ PLATFORMS
 
 DEPENDENCIES
   barby
-  blacklight (~> 7.18)
+  blacklight (~> 7.20)
   blacklight-hierarchy (~> 5.1)
   bootsnap (>= 1.4.2)
   byebug
@@ -648,7 +649,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   sqlite3 (~> 1.4.2)
   turbo-rails (~> 0.7.13)
-  view_component (~> 2.31.1)
+  view_component (~> 2.42)
   web-console
   webdrivers
   webmock

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "autocomplete.js": "^0.37.1",
     "blacklight-frontend": "^7.7.0",
     "blacklight-hierarchy": "5.1.0",
+    "bootstrap": "^4.6.1",
     "bs-custom-file-input": "^1.3.4",
     "esbuild": "^0.12.28",
     "free-jqgrid": "^4.15.5",
@@ -15,8 +16,7 @@
     "sass": "^1.41.1",
     "stimulus": "^2.0.0"
   },
-  "devDependencies": {
-  },
+  "devDependencies": {},
   "license": "Apache-2.0",
   "scripts": {
     "build": "esbuild app/javascript/*.* --bundle --inject:app/javascript/jquery-shim.js --define:global=window --outdir=app/assets/builds",

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,12 +80,12 @@ binary-extensions@^2.0.0:
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
 blacklight-frontend@>=7.1.0-alpha, blacklight-frontend@^7.7.0:
-  version "7.10.0"
-  resolved "https://registry.yarnpkg.com/blacklight-frontend/-/blacklight-frontend-7.10.0.tgz#7ecad34b0dc3ca0c3a3a2a50e570e7ac88469298"
-  integrity sha512-FHkHhTyX2Kayx3oGtXlC7YWbCFYdYD6Es+SID9GVQyDHmTktMVG2RwEw3luT666ybjiPkCI6a/A+HmeUreoUQw==
+  version "7.20.0"
+  resolved "https://registry.yarnpkg.com/blacklight-frontend/-/blacklight-frontend-7.20.0.tgz#672028e66feedb4e10bee83cf1938fa810499c8c"
+  integrity sha512-qjB4GuAjZhHH5sFY4YhJhkC15Dqpt/mER+M6w8TouukQJRKZXfsz9adkgH2vIYZGC/1C4u16GbmvJM6mCpVudw==
   dependencies:
     bloodhound-js "^1.2.3"
-    bootstrap "^4.3.1"
+    bootstrap ">=4.3.1 <6.0.0"
     jquery "^3.5.1"
     typeahead.js "^0.11.1"
 
@@ -107,7 +107,12 @@ bloodhound-js@^1.2.3:
     storage2 "^0.1.0"
     superagent "^3.8.3"
 
-bootstrap@^4.3.1, bootstrap@^4.6.1:
+"bootstrap@>=4.3.1 <6.0.0":
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.1.3.tgz#ba081b0c130f810fa70900acbc1c6d3c28fa8f34"
+  integrity sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==
+
+bootstrap@^4.6.1:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.6.1.tgz#bc25380c2c14192374e8dec07cf01b2742d222a2"
   integrity sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==

--- a/yarn.lock
+++ b/yarn.lock
@@ -79,10 +79,20 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-blacklight-frontend@>=7.1.0-alpha, blacklight-frontend@^7.7.0:
+blacklight-frontend@>=7.1.0-alpha:
   version "7.20.0"
   resolved "https://registry.yarnpkg.com/blacklight-frontend/-/blacklight-frontend-7.20.0.tgz#672028e66feedb4e10bee83cf1938fa810499c8c"
   integrity sha512-qjB4GuAjZhHH5sFY4YhJhkC15Dqpt/mER+M6w8TouukQJRKZXfsz9adkgH2vIYZGC/1C4u16GbmvJM6mCpVudw==
+  dependencies:
+    bloodhound-js "^1.2.3"
+    bootstrap ">=4.3.1 <6.0.0"
+    jquery "^3.5.1"
+    typeahead.js "^0.11.1"
+
+blacklight-frontend@^7.7.0:
+  version "7.20.1"
+  resolved "https://registry.yarnpkg.com/blacklight-frontend/-/blacklight-frontend-7.20.1.tgz#48e1fb993eea9a463af02970d3216846bf0f3156"
+  integrity sha512-i4VIw1vlUp+vXFezlYOpngWMuD+jK7c869ygYHjNI/uvUf076OdA3E3kfdJ2LWBxWaJ5r7EG9+k2cvnWnJFXWQ==
   dependencies:
     bloodhound-js "^1.2.3"
     bootstrap ">=4.3.1 <6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -107,7 +107,7 @@ bloodhound-js@^1.2.3:
     storage2 "^0.1.0"
     superagent "^3.8.3"
 
-bootstrap@^4.3.1:
+bootstrap@^4.3.1, bootstrap@^4.6.1:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.6.1.tgz#bc25380c2c14192374e8dec07cf01b2742d222a2"
   integrity sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==


### PR DESCRIPTION
## Why was this change made?

So the next dependency updates doesn't inadvertently upgrade to Bootstrap 5.



## How was this change tested?



## Which documentation and/or configurations were updated?



