### PR TITLE
Update to the latest version of turbo-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ gem 'rest-client'
 gem 'retries'
 gem 'ruby-prof'
 gem 'rubyzip'
-gem 'turbo-rails', '~> 0.7.13'
+gem 'turbo-rails', '~> 7.1'
 gem 'zip_tricks', '5.3.1' # 5.3.1 is required as 5.4+ breaks the download all feature
 
 # Stanford related gems

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -543,7 +543,7 @@ GEM
     thor (1.1.0)
     trailblazer-option (0.1.1)
     ttfunk (1.4.0)
-    turbo-rails (0.7.15)
+    turbo-rails (7.1.1)
       rails (>= 6.0.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -648,7 +648,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3 (~> 1.4.2)
-  turbo-rails (~> 0.7.13)
+  turbo-rails (~> 7.1)
   view_component (~> 2.42)
   web-console
   webdrivers

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@github/time-elements": "^3.0.7",
-    "@hotwired/turbo-rails": "^7.0.0-rc.4",
+    "@hotwired/turbo-rails": "^7.0.1",
     "@rails/ujs": "^6.1.3-2",
     "autocomplete.js": "^0.37.1",
     "blacklight-frontend": "^7.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,7 +7,7 @@
   resolved "https://registry.yarnpkg.com/@github/time-elements/-/time-elements-3.1.2.tgz#cc36d7a34ff2033d7f0b216f1a724405b8fbc201"
   integrity sha512-YVtZVLBikP6I7na22kfB9PKIseISwX41MFJ7lPuNz1VVH2IR5cpRRU6F1X6kcchPChljuvMUR4OiwMWHOJQ8kQ==
 
-"@hotwired/turbo-rails@^7.0.0-rc.4":
+"@hotwired/turbo-rails@^7.0.1":
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-7.0.1.tgz#d39816eef215e83468fa306a963e7c874ffe70f7"
   integrity sha512-0cV7zG9aCzF/foidgfx6WvqKDcRKXJt2aT1fenNFywO7armGTD8S86V8U1IyUAHq+ZkIL26moc+AB40uTZt0oA==


### PR DESCRIPTION
## Why was this change made?
Keep up to date. This is the same version that h2 uses.


## How was this change tested?



## Which documentation and/or configurations were updated?



