### PR TITLE
Prevent turbo from caching the catalog show page

### DIFF
--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,5 +1,6 @@
 <% @page_title = t('blacklight.search.show.title',
   document_title: truncate(strip_tags(document_presenter(@document).html_title).html_safe, length: 50), application_name: application_name).html_safe %>
+
 <% content_for(:head) { render_link_rel_alternates } %>
 
 <%= render_document_main_content_partial %>

--- a/app/views/datastreams/edit.html.erb
+++ b/app/views/datastreams/edit.html.erb
@@ -2,7 +2,7 @@
   <% component.header { params[:id] } %>
   <% component.body do %>
     <% if can?(:manage_item, @cocina) %>
-      <%= form_tag item_datastream_path(@cocina.externalIdentifier, params[:id]), id: 'xmlEditForm', method: :patch do %>
+      <%= form_tag item_datastream_path(@cocina.externalIdentifier, params[:id]), data: { turbo: false }, id: 'xmlEditForm', method: :patch do %>
           <input type="hidden" name="id" value="<%= @cocina.externalIdentifier %>">
           <input name="dsid" id="datastream" type="hidden" value="<%= params[:id] %>">
           <div class="form-group">


### PR DESCRIPTION
## Why was this change made?

Fixes #2832

This is the best I could do for #2832. 🤷🏻‍♂️ 

Note that this commit does not fix the missing republish flash notice. @jcoyne and I think this is unrelated and probably bears more work to hotwire-ify how Argo handles flash.

## How was this change tested?

QA env

## Which documentation and/or configurations were updated?

None.

