### PR TITLE
Update turbo-rails to a released version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ gem 'rest-client'
 gem 'retries'
 gem 'ruby-prof'
 gem 'rubyzip'
-gem 'turbo-rails', '~> 7.1'
+gem 'turbo-rails', '~> 0.8.2'
 gem 'zip_tricks', '5.3.1' # 5.3.1 is required as 5.4+ breaks the download all feature
 
 # Stanford related gems

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,7 +277,7 @@ GEM
     http-cookie (1.0.4)
       domain_name (~> 0.5)
     http_logger (0.6.0)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     iso-639 (0.3.5)
@@ -543,7 +543,7 @@ GEM
     thor (1.1.0)
     trailblazer-option (0.1.1)
     ttfunk (1.4.0)
-    turbo-rails (7.1.1)
+    turbo-rails (0.8.3)
       rails (>= 6.0.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -648,7 +648,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3 (~> 1.4.2)
-  turbo-rails (~> 7.1)
+  turbo-rails (~> 0.8.2)
   view_component (~> 2.42)
   web-console
   webdrivers


### PR DESCRIPTION

## Why was this change made?

The 7.1.1 version was yanked.  See the story here: https://github.com/hotwired/turbo-rails/commit/31e19cb4b781d186bc31edaa4035b2e13a19fc3c


## How was this change tested?



## Which documentation and/or configurations were updated?



