### PR TITLE
Avoid deprecated instance variable from Blacklight

### DIFF
--- a/app/models/concerns/csv_concern.rb
+++ b/app/models/concerns/csv_concern.rb
@@ -12,12 +12,12 @@ module CsvConcern
     @params[:page] = 1
     CSV.generate(force_quotes: true) do |csv|
       csv << @fields.map { |f| f[:label] } # header
-      until @document_list.empty?
+      until @response.documents.empty?
         report_data.each do |record|
           csv << @fields.map { |f| record[f[:field]].to_s }
         end
         @params[:page] += 1
-        (@response, @document_list) = search_results(params)
+        (@response,) = search_results(params)
       end
     end
   end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -188,16 +188,16 @@ class Report
               end
     @params = params
     @params[:page] ||= 1
-    (@response, @document_list) = search_results(@params)
+    (@response,) = search_results(@params)
     @num_found = @response['response']['numFound'].to_i
   end
 
   def pids(opts = {})
     params[:page] = 1
     params[:per_page] = 100
-    (@response, @document_list) = search_results(params)
+    (@response,) = search_results(params)
     pids = []
-    until @document_list.empty?
+    until @response.documents.empty?
       report_data.each do |rec|
         if opts[:source_id].present?
           pids << rec[:druid] + "\t" + rec[:source_id_ssim]
@@ -212,14 +212,14 @@ class Report
         end
       end
       params[:page] += 1
-      (@response, @document_list) = search_results(params)
+      (@response,) = search_results(params)
     end
 
     pids
   end
 
   def report_data
-    docs_to_records(@document_list)
+    docs_to_records(@response.documents)
   end
 
   private

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -138,13 +138,16 @@ RSpec.describe Report, type: :model do
     end
 
     it 'returns druids and source ids' do
-      doc = SolrDocument.new(id: 'druid:qq613vj0238', source_id_ssim: 'sul:36105011952764')
+      doc = { id: 'druid:qq613vj0238', source_id_ssim: 'sul:36105011952764' }
       service = instance_double(Blacklight::SearchService)
       allow(Blacklight::SearchService).to receive(:new).and_return(service)
       allow(service).to receive(:search_results).and_return(
-        [{ 'response' => { 'numFound' => '1' } }, [doc]],
-        [{ 'response' => { 'numFound' => '1' } }, [doc]],
-        [{ 'response' => { 'numFound' => '1' } }, []]
+        Blacklight::Solr::Response.new({ 'response' => { 'numFound' => '1', 'docs' => [doc] } },
+                                       {}, blacklight_config: CatalogController.blacklight_config),
+        Blacklight::Solr::Response.new({ 'response' => { 'numFound' => '1', 'docs' => [doc] } },
+                                       {}, blacklight_config: CatalogController.blacklight_config),
+        Blacklight::Solr::Response.new({ 'response' => { 'numFound' => '1', 'docs' => [] } },
+                                       {}, blacklight_config: CatalogController.blacklight_config)
       )
 
       expect(described_class.new(


### PR DESCRIPTION


## Why was this change made?

This will make it possible to upgrade blacklight to 8.x

## How was this change tested?



## Which documentation and/or configurations were updated?



