### PR TITLE
Update blacklight-frontend to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@hotwired/turbo-rails": "^7.0.1",
     "@rails/ujs": "^6.1.3-2",
     "autocomplete.js": "^0.37.1",
-    "blacklight-frontend": "7.20.1",
+    "blacklight-frontend": "^7.20.2",
     "blacklight-hierarchy": "5.1.0",
     "bootstrap": "^4.6.1",
     "bs-custom-file-input": "^1.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -79,20 +79,20 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-blacklight-frontend@7.20.1:
-  version "7.20.1"
-  resolved "https://registry.yarnpkg.com/blacklight-frontend/-/blacklight-frontend-7.20.1.tgz#48e1fb993eea9a463af02970d3216846bf0f3156"
-  integrity sha512-i4VIw1vlUp+vXFezlYOpngWMuD+jK7c869ygYHjNI/uvUf076OdA3E3kfdJ2LWBxWaJ5r7EG9+k2cvnWnJFXWQ==
+blacklight-frontend@>=7.1.0-alpha:
+  version "7.21.1"
+  resolved "https://registry.yarnpkg.com/blacklight-frontend/-/blacklight-frontend-7.21.1.tgz#7af64c1618bba493d03de9eef413810d31e00917"
+  integrity sha512-KrwzinCYMVZEr9inC/dbuKc1UsOoF8qD948Bwjr1hmHNwA0pEt7zysBBYJKSN5lVJJSYrFf68LxjuInsGEUHJQ==
   dependencies:
     bloodhound-js "^1.2.3"
     bootstrap ">=4.3.1 <6.0.0"
     jquery "^3.5.1"
     typeahead.js "^0.11.1"
 
-blacklight-frontend@>=7.1.0-alpha:
-  version "7.21.1"
-  resolved "https://registry.yarnpkg.com/blacklight-frontend/-/blacklight-frontend-7.21.1.tgz#7af64c1618bba493d03de9eef413810d31e00917"
-  integrity sha512-KrwzinCYMVZEr9inC/dbuKc1UsOoF8qD948Bwjr1hmHNwA0pEt7zysBBYJKSN5lVJJSYrFf68LxjuInsGEUHJQ==
+blacklight-frontend@^7.20.2:
+  version "7.21.2"
+  resolved "https://registry.yarnpkg.com/blacklight-frontend/-/blacklight-frontend-7.21.2.tgz#2ae71f11c8ea41689c450ecf38a98b2e12e237b5"
+  integrity sha512-lWTwTHh3qgZtyo1ijI56KIqfLlAfdW8AUWU8IKgwyqNqt+NPDYIHLW1BBwcqFV0E7Erml9vJ6GzXlkogyKWQLg==
   dependencies:
     bloodhound-js "^1.2.3"
     bootstrap ">=4.3.1 <6.0.0"


### PR DESCRIPTION


## Why was this change made?
It no longer causes a problem with Blacklight.activate()


## How was this change tested?



## Which documentation and/or configurations were updated?



