### PR TITLE
Don't underline links

### DIFF
--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -20,6 +20,7 @@ $success: $barley-corn;
 // Links
 $link-color: $bright-blue;
 $link-hover-color: $blue;
+$link-decoration: none; // no underline
 
 // Navbar
 $navbar-dark-color: $white;


### PR DESCRIPTION
## Why was this change made?
Bootstrap 5 by default underlines all links, this makes it look like BS 4.


## How was this change tested?



## Which documentation and/or configurations were updated?



