### PR TITLE
Turn on pointer events for the tag facet

### DIFF
--- a/app/components/lazy_tag_facet_component.html.erb
+++ b/app/components/lazy_tag_facet_component.html.erb
@@ -1,7 +1,7 @@
 <turbo-frame id="tag-facet" src="<%= lazy_tag_facet_catalog_path(helpers.search_state.params_for_search)%>" target="_top">
   <div class="card facet-limit blacklight-exploded_tag_ssim">
     <h3 class="card-header p-0 facet-field-heading" id="facet-exploded_tag_ssim-header">
-      <button type="button" disabled style="cursor: wait" class="btn btn-block p-2 text-left collapse-toggle collapsed" aria-expanded="false">
+      <button type="button" disabled style="pointer-events: auto; cursor: wait" class="btn w-100 d-block btn-block p-2 text-start collapse-toggle collapsed" aria-expanded="false">
         Tag
       </button>
     </h3>


### PR DESCRIPTION

## Why was this change made?
Bootstrap 5 removes pointer events from disabled inputs, so this overrides this.  This also upgrades the class for alignment to BS5



## How was this change tested?



## Which documentation and/or configurations were updated?



