### PR TITLE
Use the correct header for retrieving a token

### DIFF
--- a/app/javascript/controllers/tokens.js
+++ b/app/javascript/controllers/tokens.js
@@ -4,12 +4,11 @@ export default class extends Controller {
   static targets = [ "output", "result", "button" ]
 
   fetchToken(event) {
-    const headers = {}
-    headers[Blacklight.csrfParam()] = Blacklight.csrfToken()
-
     fetch(this.data.get("url"), {
       method: 'POST',
-      headers
+      headers: {
+        "X-CSRF-Token": Blacklight.csrfToken(),
+      }
     }).then(response => response.text())
       .then(token => {
         this.buttonTarget.style.display = "none"


### PR DESCRIPTION


## Why was this change made?
csrfParm is an appropriate form field name, not a header


## How was this change tested?



## Which documentation and/or configurations were updated?



