### PR TITLE
Stop rendering remote js.

### DIFF
--- a/app/assets/stylesheets/workflow_grid.scss
+++ b/app/assets/stylesheets/workflow_grid.scss
@@ -18,6 +18,14 @@
   }
 }
 
-.errors a {
-  @extend .text-danger;
+// reset button
+.errors {
+  form {
+    display: inline-block;
+  }
+
+  .btn {
+    @extend .p-0;
+    @extend .text-danger;
+  }
 }

--- a/app/components/workflow_table_process_component.rb
+++ b/app/components/workflow_table_process_component.rb
@@ -69,7 +69,7 @@ class WorkflowTableProcessComponent < ApplicationComponent
                                reset_step: process
                              )
     # rubocop:disable Rails/OutputSafety
-    raw ' | ' + link_to('reset', report_reset_path(new_params), remote: true, method: :post)
+    raw ' | ' + button_to('reset', report_reset_path(new_params), class: 'btn btn-link')
     # rubocop:enable Rails/OutputSafety
   end
 

--- a/app/views/report/reset.js.erb
+++ b/app/views/report/reset.js.erb
@@ -1,1 +1,0 @@
-alert('<%=@ids.size%> objects were reset back to waiting for <%=@workflow%>:<%=@step%>.  It may take a few seconds to update.')

--- a/spec/components/workflow_table_process_component_spec.rb
+++ b/spec/components/workflow_table_process_component_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe WorkflowTableProcessComponent, type: :component do
         let(:body) { render_inline(component) }
 
         it 'has a link' do
-          expect(body.css('a[data-remote="true"][rel="nofollow"][data-method="post"]', text: 'reset')).to be_present
+          expect(body.css('.btn.btn-link', text: 'reset')).to be_present
         end
       end
     end

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -157,12 +157,9 @@ RSpec.describe ReportController, type: :controller do
         allow(Report).to receive(:new).and_return(report)
       end
 
-      it 'sets instance variables and calls update workflow service' do
+      it 'calls update workflow service' do
         post :reset, xhr: true, params: { reset_workflow: workflow, reset_step: step, q: 'Cephalopods' } # has single match
-        expect(assigns(:workflow)).to eq workflow
-        expect(assigns(:step)).to eq step
-        expect(assigns(:ids)).to eq(%w[xb482ww9999])
-        expect(response).to have_http_status(:ok)
+        expect(response).to redirect_to(report_workflow_grid_path)
         expect(workflow_client).to have_received(:update_status)
           .with(druid: 'druid:xb482ww9999', workflow: workflow, process: step, status: 'waiting')
       end
@@ -176,12 +173,9 @@ RSpec.describe ReportController, type: :controller do
         allow(Report).to receive(:new).and_return(report)
       end
 
-      it 'sets instance variables and calls update workflow service' do
+      it 'calls update workflow service' do
         post :reset, xhr: true, params: { reset_workflow: workflow, reset_step: step, q: 'Cephalopods' } # has single match
-        expect(assigns(:workflow)).to eq workflow
-        expect(assigns(:step)).to eq step
-        expect(assigns(:ids)).to eq(%w[xb482ww9999])
-        expect(response).to have_http_status(:ok)
+        expect(response).to redirect_to(report_workflow_grid_path)
         expect(controller.current_ability).to have_received(:can_update_workflow?).with('waiting', cocina_model)
         expect(workflow_client).to have_received(:update_status)
           .with(druid: 'druid:xb482ww9999', workflow: workflow, process: step, status: 'waiting')
@@ -198,10 +192,7 @@ RSpec.describe ReportController, type: :controller do
 
       it 'does not call update workflow service' do
         post :reset, xhr: true, params: { reset_workflow: workflow, reset_step: step, q: 'Cephalopods' } # has single match
-        expect(assigns(:workflow)).to eq workflow
-        expect(assigns(:step)).to eq step
-        expect(assigns(:ids)).to eq(%w[xb482ww9999])
-        expect(response).to have_http_status(:ok)
+        expect(response).to redirect_to(report_workflow_grid_path)
         expect(controller.current_ability).to have_received(:can_update_workflow?).with('waiting', cocina_model)
         expect(workflow_client).not_to have_received(:update_status)
       end


### PR DESCRIPTION


## Why was this change made?
This fixes a problem created when we removed rails-ujs.  This method of rendering remote js is deprecated in rails, so I replaced it with a simple redirect + flash message


## How was this change tested?



## Which documentation and/or configurations were updated?



