### PR TITLE
Add spacing for buttons after bootstrap 5 upgrade

### DIFF
--- a/app/assets/stylesheets/argo.scss
+++ b/app/assets/stylesheets/argo.scss
@@ -114,6 +114,9 @@ legend {
 .bulk-buttons-row {
   margin-top: 16px;
   margin-bottom: 16px;
+  .btn {
+    margin-top: 0.5em;
+  }
 }
 
 #column_selector {


### PR DESCRIPTION
## Why was this change made?
Fixes #2892

<img width="760" alt="Screen Shot 2021-12-13 at 1 22 04 PM" src="https://user-images.githubusercontent.com/92044/145874801-2dc44ee6-d5d4-4c50-ac2c-53e98c76014f.png">

## How was this change tested?



## Which documentation and/or configurations were updated?



