### PR TITLE
Update APO registration form to use bootstrap 5 form layout

### DIFF
--- a/app/javascript/modules/permission_add.js
+++ b/app/javascript/modules/permission_add.js
@@ -18,19 +18,22 @@ export default class {
       newEl.innerHTML = '<legend class="col-sm-3">Add group<legend>'
 
       var div = document.createElement('div')
-      div.className = "col-sm-9 form-inline"
-      div.innerHTML = '<input id="permissionName" class="form-control" placeholder="Group name"/>' +
-          '<select id="permissionRole" class="form-control"><option value="manage">Manage</option><option value="view">View</option></select>'
+      div.className = "col-sm-9 row"
+      div.innerHTML = `<div class="col-lg-6"><input id="permissionName" class="form-control" placeholder="Group name"></div>
+          <div class="col-lg-5">
+            <select id="permissionRole" class="form-control"><option value="manage">Manage</option><option value="view">View</option></select>
+          </div>
+          <div class="col-lg-1">
+            <button class="btn btn-secondary">Add</button>
+          </div>
+          `
 
-      var button = document.createElement('button')
-      button.innerHTML = 'Add'
-      button.className = 'btn btn-secondary'
+      var button = div.querySelector('button')
       button.addEventListener('click', (event) => {
           event.preventDefault()
           this.parent.add({name: document.getElementById('permissionName').value, type: "group", access: document.getElementById('permissionRole').value}, )
       })
 
-      div.appendChild(button)
       newEl.appendChild(div)
       return newEl
     }


### PR DESCRIPTION
## Why was this change made?
Fixes #2890

<img width="871" alt="Screen Shot 2021-12-13 at 1 35 04 PM" src="https://user-images.githubusercontent.com/92044/145877807-24fa7361-0e84-4ef5-bb9a-d7523f5eb863.png">

## How was this change tested?



## Which documentation and/or configurations were updated?



