### PR TITLE
Restore functionality for collection checking

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -48,8 +48,8 @@ class CollectionsController < ApplicationController
   def collection_exists?(title:, catkey:)
     return false unless title || catkey
 
-    query = '_query_:"{!raw f=has_model_ssim}info:fedora/afmodel:Dor_Collection"'
-    query += " AND title_ssi:\"#{title}\"" if title
+    query = "_query_:\"{!raw f=#{SolrDocument::FIELD_OBJECT_TYPE}}collection\""
+    query += " AND #{SolrDocument::FIELD_LABEL}:\"#{title}\"" if title
     query += " AND identifier_ssim:\"catkey:#{params[:catkey]}\"" if catkey
 
     blacklight_config = CatalogController.blacklight_config

--- a/app/javascript/argo.js
+++ b/app/javascript/argo.js
@@ -12,34 +12,6 @@ import {initializeReport} from './modules/report'
 
 require('@github/time-elements')
 
-function pathTo(path) {
-  var root = $('body').attr('data-application-root') || '';
-  return(root + path);
-}
-
-// Provide warnings when creating a collection.
-function collectionExistsWarning(warningElem, field, value) {
-    var client = new XMLHttpRequest();
-    client.onreadystatechange = function() {
-        if (this.readyState == 4 && this.status == 200) {
-            if (this.responseText == 'true') {
-                warningElem.style.display = "block";
-            } else {
-                warningElem.style.display = "none";
-            }
-        }
-    };
-    client.open("GET", '/collections/exists?' + field + '=' + value, true);
-    client.send();
-}
-$(document).on('keyup', '#collection_title', function(e) {
-    collectionExistsWarning(document.getElementById('collection_title_warning'), 'title', e.target.value);
-});
-
-$(document).on('keyup', '#collection_catkey', function(e) {
-    collectionExistsWarning(document.getElementById('collection_catkey_warning'), 'catkey', e.target.value);
-});
-
 export default class Argo {
     initialize() {
         this.tagsAutocomplete()

--- a/app/javascript/controllers/collection_editor.js
+++ b/app/javascript/controllers/collection_editor.js
@@ -1,11 +1,29 @@
 import { Controller } from 'stimulus'
 
 export default class extends Controller {
+  static targets = [ "titleWarning", "catkeyWarning" ]
+
   toggle(event) {
     $('.collection_div').hide()
     var reveal
     if (reveal = $(event.target).data('reveal')) {
       $(`#${reveal}`).show();
     }
+  }
+
+  checkTitle(event) {
+    fetch(`/collections/exists?title=${event.target.value}`).
+      then(resp => resp.json()).
+      then(data => {
+        this.titleWarningTarget.hidden = !data
+      })
+  }
+
+  checkCatkey(event) {
+    fetch(`/collections/exists?catkey=${event.target.value}`).
+      then(resp => resp.json()).
+      then(data => {
+        this.catkeyWarningTarget.hidden = !data
+      })
   }
 }

--- a/app/views/collections/new.html.erb
+++ b/app/views/collections/new.html.erb
@@ -21,8 +21,8 @@
             <label for="collection_title">
               Collection Title
             </label>
-            <%= text_field_tag 'collection_title', nil, class: 'form-control' %>
-            <span id="collection_title_warning" class="alert alert-warning" style="display: none">Collection with this title already exists.</span>
+            <%= text_field_tag 'collection_title', nil, class: 'form-control', data: { action: 'collection-editor#checkTitle' } %>
+            <div data-collection-editor-target="titleWarning" class="mt-2 alert alert-warning" hidden>Collection with this title already exists.</div>
           </div>
           <div class="mb-3">
             <label for="collection_abstract">
@@ -42,8 +42,8 @@
             <label for="collection_catkey">
               Collection Catkey
             </label>
-            <%= text_field_tag 'collection_catkey', nil, class: 'form-control' %>
-            <span id="collection_catkey_warning" class="alert alert-warning" style="display: none">Collection with this catkey already exists.</span>
+            <%= text_field_tag 'collection_catkey', nil, class: 'form-control', data: { action: 'collection-editor#checkCatkey' } %>
+            <span data-collection-editor-target="catkeyWarning" class="mt-2 alert alert-warning" hidden>Collection with this catkey already exists.</span>
           </div>
           <div class="mb-3">
             <label for="collection_rights_catkey">

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe CollectionsController do
         }
         expect(response.body).to eq('true')
         expect(solr_client).to have_received(:get).with('select', params: a_hash_including(
-          q: '_query_:"{!raw f=has_model_ssim}info:fedora/afmodel:Dor_Collection" AND title_ssi:"foo"'
+          q: '_query_:"{!raw f=objectType_ssim}collection" AND obj_label_tesim:"foo"'
         ))
       end
     end
@@ -110,7 +110,7 @@ RSpec.describe CollectionsController do
         }
         expect(response.body).to eq('true')
         expect(solr_client).to have_received(:get).with('select', params: a_hash_including(
-          q: '_query_:"{!raw f=has_model_ssim}info:fedora/afmodel:Dor_Collection" AND identifier_ssim:"catkey:123"'
+          q: '_query_:"{!raw f=objectType_ssim}collection" AND identifier_ssim:"catkey:123"'
         ))
       end
     end
@@ -136,7 +136,7 @@ RSpec.describe CollectionsController do
         }
         expect(response.body).to eq('true')
         expect(solr_client).to have_received(:get).with('select', params: a_hash_including(
-          q: '_query_:"{!raw f=has_model_ssim}info:fedora/afmodel:Dor_Collection" AND title_ssi:"foo" AND identifier_ssim:"catkey:123"'
+          q: '_query_:"{!raw f=objectType_ssim}collection" AND obj_label_tesim:"foo" AND identifier_ssim:"catkey:123"'
         ))
       end
     end

--- a/spec/search_builders/argo/date_field_queries_spec.rb
+++ b/spec/search_builders/argo/date_field_queries_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe Argo::DateFieldQueries do
       end
 
       it 'does not affect non-date queries' do
-        blacklight_params = { 'f' => { title_ssi: ['hello'] } }
-        solr_params = { fq: ['{!term f=title_ssi}hello'] }
+        blacklight_params = { 'f' => { obj_label_tesim: ['hello'] } }
+        solr_params = { fq: ['{!term f=obj_label_tesim}hello'] }
         expect(subject).to receive(:blacklight_params)
           .twice.and_return(blacklight_params)
         subject.add_date_field_queries(solr_params)
-        expect(solr_params).to eq fq: ['{!term f=title_ssi}hello']
+        expect(solr_params).to eq fq: ['{!term f=obj_label_tesim}hello']
       end
     end
   end


### PR DESCRIPTION


## Why was this change made?
This was depending on a solr field that we don't have in the index.  This change also future proofs against moving away from Fedora 3 since we don't use the fedora object model solr field


## How was this change tested?



## Which documentation and/or configurations were updated?



