### PR TITLE
Remove unnecessary imports

### DIFF
--- a/app/javascript/argo.js
+++ b/app/javascript/argo.js
@@ -1,11 +1,6 @@
 import ItemCollection from './modules/item_collection'
-import './modules/permission_add'
-import './modules/permission_grant'
-import './modules/permission_list'
-import './modules/sharing'
 import TagsAutocomplete from './modules/tags_autocomplete'
 import ProjectAutocomplete from './modules/project_autocomplete'
-
 import Form from './modules/apo_form'
 import {gridContext} from './registration/grid'
 import {initializeReport} from './modules/report'


### PR DESCRIPTION
## Why was this change made?

These are imported in the app/javascript/modulesapo_form.js, and there's no reason to import them again.

## How was this change tested?



## Which documentation and/or configurations were updated?



