### PR TITLE
Create a document component for the first page

### DIFF
--- a/app/components/document_component.html.erb
+++ b/app/components/document_component.html.erb
@@ -1,0 +1,24 @@
+<%= content_tag @component,
+  id: @id,
+  data: {
+    'document-id': @document.id.to_s.parameterize,
+    'document-counter': @counter,
+  },
+  itemscope: true,
+  itemtype: @document.itemtype,
+  class: classes.flatten.join(' ') do %>
+
+  <%= helpers.render_document_heading @document, tag: :h1 %>
+  <%= render 'full_view_links_default', document: @document %>
+  <%= render 'show_thumbnail', document: @document %>
+  <%= render Blacklight::DocumentMetadataComponent.new(
+      fields: @presenter.field_presenters,
+      show: true
+    ) %>
+  <%= render 'datastreams_default', document: @document %>
+  <%= render 'events_default', document: @document %>
+  <%= render 'cocina_default', document: @document %>
+  <%= render 'history_default', document: @document %>
+  <%= render 'contents_default', document: @document %>
+  <%= render 'techmd_default', document: @document %>
+<% end %>

--- a/app/components/document_component.rb
+++ b/app/components/document_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class DocumentComponent < Blacklight::DocumentComponent
+  def initialize(document: nil, **kwargs)
+    super
+  end
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -198,7 +198,7 @@ class CatalogController < ApplicationController
     # Configure document actions framework
     config.index.document_actions.delete(:bookmark)
 
-    config.show.partials = %w[show_header full_view_links show_thumbnail show datastreams events cocina history contents techmd]
+    config.show.document_component = DocumentComponent
   end
 
   def index


### PR DESCRIPTION


## Why was this change made?

This makes it clearer where the content is coming from and makes it easier to migrate to BL 8, as some of the templates we were using no longer exist

## How was this change tested?



## Which documentation and/or configurations were updated?



