### PR TITLE
Avoid a deprecation warning in blacklight

### DIFF
--- a/app/components/document_component.html.erb
+++ b/app/components/document_component.html.erb
@@ -7,7 +7,7 @@
   itemscope: true,
   itemtype: @document.itemtype,
   class: 'document document-component' do %>
-  <%= helpers.render_document_heading @document, tag: :h1 %>
+  <%= title %>
   <%= render 'full_view_links_default', document: @document %>
   <%= render 'show_thumbnail', document: @document %>
   <%= render Blacklight::DocumentMetadataComponent.new(


### PR DESCRIPTION
## Why was this change made?
```
DEPRECATION WARNING: render_document_heading is deprecated and will be removed from a future release (Removed without replacement).
```


## How was this change tested?



## Which documentation and/or configurations were updated?



