### PR TITLE
Replace registration job access selection with CocinaDroAccess

### DIFF
--- a/app/services/registration_csv_converter.rb
+++ b/app/services/registration_csv_converter.rb
@@ -52,7 +52,7 @@ class RegistrationCsvConverter
     structural = {}
     structural[:isMemberOf] = [row['Collection']] if row['Collection']
     model_params[:structural] = structural
-    model_params[:access] = access(row['Rights']) if row.fetch('Rights') != 'default'
+    model_params[:access] = CocinaDroAccess.from_form_value(row['Rights']).value_or(nil)
     model_params[:administrative][:partOfProject] = row['Project Name'] if row['Project Name'].present?
 
     tags = []
@@ -84,28 +84,6 @@ class RegistrationCsvConverter
       Cocina::Models::Vocab.book
     else
       Cocina::Models::Vocab.object
-    end
-  end
-
-  # @param [String] the rights representation from the form
-  # @return [Hash<Symbol,String>] a hash representing the Access subschema of the Cocina model
-  def access(rights)
-    if rights.end_with?('-nd') || %w[dark citation-only].include?(rights)
-      {
-        access: rights.delete_suffix('-nd'),
-        download: 'none'
-      }
-    elsif rights.start_with?('loc:')
-      {
-        access: 'location-based',
-        readLocation: rights.delete_prefix('loc:'),
-        download: 'location-based'
-      }
-    else
-      {
-        access: rights,
-        download: rights
-      }
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Fixes #2944 

The bulk registration job had its own code for setting the access hash that did not match the registration form. This causes a validation failure by not including the required controlledDigitalLending related values when required.

A future refactor may rename/update the CocinaDroAccess method for clarity.

## How was this change tested?



## Which documentation and/or configurations were updated?



