### PR TITLE
Only the catalog controller show page should have a container class

### DIFF
--- a/app/helpers/argo_helper.rb
+++ b/app/helpers/argo_helper.rb
@@ -9,7 +9,7 @@ module ArgoHelper
   def container_classes
     return super if controller_name == 'apo'
 
-    action_name == 'show' ? 'container' : 'container-fluid'
+    action_name == 'show' && controller_name == 'catalog' ? 'container' : 'container-fluid'
   end
 
   def render_thumbnail_helper(doc, thumb_class = '', thumb_alt = '', thumb_style = 'max-width:240px;max-height:240px;')


### PR DESCRIPTION
All others (like registration) should remain container-fluid. 

## Why was this change made?

This was caused by a regression in https://github.com/sul-dlss/argo/commit/50914bfe579b5212e9a0a92a3aaa1ff0c2db2a0a#diff-f7572e813105da402ff889a50f513c883352daa760f926b589f93cf93dc75eefR12

## How was this change tested?



## Which documentation and/or configurations were updated?



