### PR TITLE
The open/close widget opens a modal

### DIFF
--- a/app/components/open_close_component.rb
+++ b/app/components/open_close_component.rb
@@ -13,6 +13,7 @@ class OpenCloseComponent < ApplicationComponent
             hidden: true,
             data: {
               controller: 'open-close',
+              action: 'click->open-close#open',
               open_close_url_value: workflow_service_closeable_path(id)
             }
   end
@@ -24,6 +25,7 @@ class OpenCloseComponent < ApplicationComponent
             hidden: true,
             data: {
               controller: 'open-close',
+              action: 'click->open-close#open',
               open_close_url_value: workflow_service_openable_path(id)
             }
   end

--- a/app/javascript/controllers/open_close_controller.js
+++ b/app/javascript/controllers/open_close_controller.js
@@ -10,4 +10,16 @@ export default class extends Controller {
            this.element.hidden = value == 'false'
         })
     }
+
+    // TODO: This same code is in button.js Perhaps it can be extracted?
+    open(event) {
+      event.preventDefault()
+      const href = this.element.getAttribute('href')
+      const element = document.getElementById('edit-modal')
+      const instance = bootstrap.Modal.getOrCreateInstance(element)
+      instance.show()
+      const modal = document.querySelector('#edit-modal .modal-content')
+      // Target is _top so that we can navigate to a new page when the form submission is successful
+      modal.innerHTML = `<turbo-frame id="modal-frame" src="${href}" target="_top"></turbo-frame>`
+    }
 }


### PR DESCRIPTION


## Why was this change made?
This fixes a regression introduced when the open_close_controller was created


## How was this change tested?



## Which documentation and/or configurations were updated?



