### PR TITLE
Update ruby version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Argo is the administrative interface to the Stanford Digital Repository.
 ### System Requirements
 
 1. Install Docker
-2. Install Ruby 2.7.1
+2. Install Ruby 3.0.3
 
 ### Check Out the Code
 


### PR DESCRIPTION
## Why was this change made?

App is using ruby 3.0.3 but README says to install ruby 2.7.1

## How was this change tested?



## Which documentation and/or configurations were updated?



