### PR TITLE
Upgrade to the latest mysql2 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,6 +115,5 @@ group :deployment do
 end
 
 group :production do
-  # mysql 0.5.3 is not compatible with the version of MySQL we are using (5.1)
-  gem 'mysql2', '< 0.5.3'
+  gem 'mysql2', '~> 0.5'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,7 +328,7 @@ GEM
       stanford-mods (~> 2.1)
     msgpack (1.4.2)
     multipart-post (2.1.1)
-    mysql2 (0.5.2)
+    mysql2 (0.5.3)
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
     net-ssh (6.1.0)
@@ -600,7 +600,7 @@ DEPENDENCIES
   listen (~> 3.2)
   lograge
   mods_display
-  mysql2 (< 0.5.3)
+  mysql2 (~> 0.5)
   newrelic_rpm
   nokogiri (~> 1.12)
   okcomputer


### PR DESCRIPTION
We are no longer on this ancient version of mysql2

## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



