### PR TITLE
Update Dockerfile base image to ruby 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.1-alpine
+FROM ruby:3.0.3-alpine
 
 RUN apk add --update --no-cache \
   build-base \


### PR DESCRIPTION
## Why was this change made?

App now runs ruby 3.0.3 so Dockerfile should be in sync.

## How was this change tested?

Built web container locally and ran tests.

## Which documentation and/or configurations were updated?



