### PR TITLE
Show an inactive SearchWorks button when the item is not released

### DIFF
--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -24,6 +24,12 @@
     width: $button-width;
     @extend .btn;
     @extend .btn-outline-primary;
+
+    &.disabled {
+      color: $btn-link-disabled-color;
+      border-color: $btn-link-disabled-color;
+      opacity: $btn-disabled-opacity;
+    }
   }
 
   .blacklight-item {

--- a/app/components/external_links_component.html.erb
+++ b/app/components/external_links_component.html.erb
@@ -4,9 +4,7 @@
     <%= link_to 'MODS', descriptive_item_metadata_path(@document.id), class: 'external-link-button', data: { blacklight_modal: 'trigger' } %>
   </li>
   <li class="nav-item"><%= purl_link %></li>
-  <% if released_to_searchworks? %>
-    <li class="nav-item"><%= searchworks_link %></li>
-  <% end %>
+  <li class="nav-item"><%= searchworks_link %></li>
   <li class="nav-item"><%= dor_link %></li>
   <li class="nav-item"><%= foxml_link %></li>
   <li class="nav-item"><%= solr_link %></li>

--- a/app/components/external_links_component.rb
+++ b/app/components/external_links_component.rb
@@ -18,6 +18,8 @@ class ExternalLinksComponent < ViewComponent::Base
   end
 
   def searchworks_link
+    return tag.span('SearchWorks', class: 'external-link-button disabled btn') unless released_to_searchworks?
+
     id = document.catkey.presence || document.druid
     url = Kernel.format(Settings.searchworks_url, id: id)
     link_to 'SearchWorks', url, target: '_blank', rel: 'noopener', class: 'external-link-button'


### PR DESCRIPTION


## Why was this change made?

This corresponds to Astrid's designs https://projects.invisionapp.com/share/ZR1072MLCMEW#/screens/445123823


## How was this change tested?

<img width="962" alt="Screen Shot 2022-01-13 at 3 59 09 PM" src="https://user-images.githubusercontent.com/92044/149415653-4c437c86-23f6-4384-ba3d-109aaf9cb7d4.png">

## Which documentation and/or configurations were updated?



