### PR TITLE
Remove FoXML export from the external links

### DIFF
--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -1,5 +1,6 @@
 .show-document {
   $button-width: 11rem;
+  $external-link-button-width: 9rem;
 
   .argo-show-btn-group {
     .btn {
@@ -21,7 +22,7 @@
   .external-link-button {
     margin-right: .5rem;
     margin-bottom: .5rem;
-    width: $button-width;
+    width: $external-link-button-width;
     @extend .btn;
     @extend .btn-outline-primary;
 

--- a/app/components/external_links_component.html.erb
+++ b/app/components/external_links_component.html.erb
@@ -1,15 +1,10 @@
 <h3 class="button-header">View in new window</h3>
 <ul class="nav flex">
-  <li class="nav-item">
-    <%= link_to 'MODS', descriptive_item_metadata_path(@document.id), class: 'external-link-button', data: { blacklight_modal: 'trigger' } %>
-  </li>
+  <li class="nav-item"><%= mods_link %></li>
   <li class="nav-item"><%= purl_link %></li>
   <li class="nav-item"><%= searchworks_link %></li>
-  <li class="nav-item"><%= dor_link %></li>
-  <li class="nav-item"><%= foxml_link %></li>
-  <li class="nav-item"><%= solr_link %></li>
   <li class="nav-item"><%= cocina_link %></li>
-  <li class="nav-item">
-    <%= link_to 'Dublin Core', full_dc_item_metadata_path(@document.id), title: 'Dublin Core (derived from MODS)', class: 'external-link-button', data: { blacklight_modal: 'trigger' } %>
-  </li>
+  <li class="nav-item"><%= solr_link %></li>
+  <li class="nav-item"><%= dublin_core_link %></li>
+  <li class="nav-item"><%= dor_link %></li>
 </ul>

--- a/app/components/external_links_component.rb
+++ b/app/components/external_links_component.rb
@@ -25,11 +25,6 @@ class ExternalLinksComponent < ViewComponent::Base
     link_to 'SearchWorks', url, target: '_blank', rel: 'noopener', class: 'external-link-button'
   end
 
-  def foxml_link
-    url = File.join(fedora_url_without_credentials, "objects/#{document.id}/export?context=archive")
-    link_to 'FoXML', url, target: '_blank', rel: 'noopener', class: 'external-link-button'
-  end
-
   def solr_link
     link_to 'Solr document', solr_document_path(document, format: :json),
             target: '_blank', rel: 'noopener', class: 'external-link-button'
@@ -38,6 +33,19 @@ class ExternalLinksComponent < ViewComponent::Base
   def cocina_link
     link_to 'Cocina model', item_path(document, format: :json),
             target: '_blank', rel: 'noopener', class: 'external-link-button'
+  end
+
+  def dublin_core_link
+    link_to 'Dublin Core', full_dc_item_metadata_path(document.id),
+            title: 'Dublin Core (derived from MODS)',
+            class: 'external-link-button',
+            data: { blacklight_modal: 'trigger' }
+  end
+
+  def mods_link
+    link_to 'MODS', descriptive_item_metadata_path(document.id),
+            class: 'external-link-button',
+            data: { blacklight_modal: 'trigger' }
   end
 
   def released_to_searchworks?


### PR DESCRIPTION


## Why was this change made?
Resize and reorder the lin
<img width="930" alt="Screen Shot 2022-01-13 at 6 48 10 PM" src="https://user-images.githubusercontent.com/92044/149432035-1a3708c8-21ce-40e8-9c2a-73725b9dded7.png">
ks to align with the mockup


## How was this change tested?



## Which documentation and/or configurations were updated?



