### PR TITLE
Expand and collapse cocina in place

### DIFF
--- a/app/javascript/controllers/json_renderer.js
+++ b/app/javascript/controllers/json_renderer.js
@@ -5,7 +5,15 @@ export default class extends Controller {
   static targets = ['cocina', 'section']
 
   connect() {
-    const cocina = JSON.parse(this.cocinaTarget.innerText)
-    this.sectionTarget.appendChild(renderjson.set_show_to_level(1)(cocina))
+    this.cocina = JSON.parse(this.cocinaTarget.innerText)
+    this.collapse()
+  }
+
+  expand() {
+    this.sectionTarget.replaceChildren(renderjson.set_show_to_level('all')(this.cocina))
+  }
+
+  collapse() {
+    this.sectionTarget.replaceChildren(renderjson.set_show_to_level(1)(this.cocina))
   }
 }

--- a/app/views/catalog/_cocina_default.html.erb
+++ b/app/views/catalog/_cocina_default.html.erb
@@ -6,10 +6,15 @@
   </h2>
   <div id="document-cocina-section" class="accordion-collapse collapse" aria-labelledby="document-cocina-heading">
     <div class="accordion-body" data-controller="json-renderer">
+      <div>
+        <a class="btn btn-secondary " data-action="json-renderer#expand">Expand</a>
+        <a class="btn btn-secondary " data-action="json-renderer#collapse">Collapse</a>
+      </div>
 
       <script type="application/json" data-json-renderer-target="cocina">
         <%= @cocina.to_json.html_safe %>
       </script>
+
       <div class="detail" data-json-renderer-target="section"></div>
     </div>
   </div>


### PR DESCRIPTION
Fixes #2618 (again)

## Why was this change made?

The previous impl allowed users to expand and collapse individual nodes, and as a user, I expect to see widgets for collapse-all and expand-all. So I added it. Note that I chatted with @andrewjbtw and he wants the "View Cocina in New Window" button to remain even with this in place as a means for easy copy/paste of large cocina structures.

## How was this change tested?

![Peek 2022-01-13 13-48](https://user-images.githubusercontent.com/131982/149555206-2bd57323-9eba-41bd-8c93-7c25b8767583.gif)

Locally. Clicked the buttons and watched the JS console.

## Which documentation and/or configurations were updated?

None

