### PR TITLE
move manage embargo from a button to a link in the embargo component

### DIFF
--- a/app/components/show_embargo_component.html.erb
+++ b/app/components/show_embargo_component.html.erb
@@ -1,3 +1,3 @@
 <div class='embargo-panel text-white bg-dark fs-5 p-2 my-2'>
-  Embargoed until <%= l embargo_release_date, format: :long %>
+  Embargoed until <%= l embargo_release_date, format: :long %> <%= edit_embargo %>
 </div>

--- a/app/components/show_embargo_component.rb
+++ b/app/components/show_embargo_component.rb
@@ -5,9 +5,16 @@ class ShowEmbargoComponent < ApplicationComponent
     @solr_document = solr_document
   end
 
-  delegate :embargoed?, :embargo_release_date, to: :@solr_document
+  delegate :id, :embargoed?, :embargo_release_date, to: :@solr_document
 
   def render?
     embargoed? && embargo_release_date.present?
+  end
+
+  def edit_embargo
+    link_to '✎', edit_item_embargo_path(id),
+            class: 'text-white',
+            aria: { label: 'Manage embargo' },
+            data: { controller: 'button', action: 'click->button#open' }
   end
 end

--- a/app/components/sidebar_controls_component.html.erb
+++ b/app/components/sidebar_controls_component.html.erb
@@ -1,4 +1,4 @@
-<div class='argo-show-btn-group'>
+<div class="argo-show-btn-group">
   <h3 class="button-header">Actions</h3>
   <% if admin_policy? %>
     <%= edit_apo %>
@@ -11,5 +11,5 @@
   <%= purge_button %>
   <%= refresh_metadata if symphony_record? %>
   <%= manage_release %>
-  <%= embargo %>
+  <%= create_embargo %>
 </div>

--- a/app/components/sidebar_controls_component.rb
+++ b/app/components/sidebar_controls_component.rb
@@ -47,14 +47,10 @@ class SidebarControlsComponent < ApplicationComponent
     render ActionButton.new(url: item_manage_release_path(pid), label: 'Manage release')
   end
 
-  def embargo
-    return unless item?
+  def create_embargo
+    return if !item? || embargoed?
 
-    if embargoed?
-      render ActionButton.new(url: edit_item_embargo_path(pid), label: 'Manage embargo')
-    else
-      render ActionButton.new(url: new_item_embargo_path(pid), label: 'Create embargo')
-    end
+    render ActionButton.new(url: new_item_embargo_path(pid), label: 'Create embargo')
   end
 
   def edit_apo

--- a/spec/components/show_embargo_component_spec.rb
+++ b/spec/components/show_embargo_component_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ShowEmbargoComponent, type: :component do
   context 'embargoed with release date' do
     let(:document) do
       SolrDocument.new(
-        id: 1,
+        id: 'druid:kv840xx0000',
         SolrDocument::FIELD_EMBARGO_STATUS => ['embargoed'],
         SolrDocument::FIELD_EMBARGO_RELEASE_DATE => ['24/02/2259']
       )
@@ -20,6 +20,8 @@ RSpec.describe ShowEmbargoComponent, type: :component do
 
     it 'displays release date' do
       expect(rendered.to_html).to include 'Embargoed until February 24, 2259'
+      link = rendered.css("a[href='/items/druid:kv840xx0000/embargo/edit']")
+      expect(link.attr('aria-label').value).to eq 'Manage embargo'
     end
   end
 

--- a/spec/components/sidebar_controls_component_spec.rb
+++ b/spec/components/sidebar_controls_component_spec.rb
@@ -42,12 +42,6 @@ RSpec.describe SidebarControlsComponent, type: :component do
         expect(rendered.css('a').size).to eq 6
       end
 
-      it 'only includes the embargo update button if the user is an admin and the object is embargoed' do
-        allow(doc).to receive(:embargoed?).and_return(true)
-        expect(rendered.css("a[href='/items/druid:kv840xx0000/embargo/edit']").inner_text).to eq 'Manage embargo'
-        expect(rendered.css('a').size).to eq 6
-      end
-
       context "with a user that can't manage the object" do
         let(:manager) { false }
 


### PR DESCRIPTION

## Why was this change made?
Per the design mockups.
Ref #2960



## How was this change tested?



## Which documentation and/or configurations were updated?



