### PR TITLE
Update lock icons to use something easier to distinguish

### DIFF
--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -41,7 +41,8 @@
     width: 2rem;
     float: left;
     .btn {
-      font-size: xx-large;
+      font-size: x-large;
+      color: $color-cardinal-red;
     }
   }
 

--- a/app/components/open_close_component.rb
+++ b/app/components/open_close_component.rb
@@ -7,7 +7,7 @@ class OpenCloseComponent < ApplicationComponent
   end
 
   def close_button
-    link_to '🔓', close_ui_item_versions_path(item_id: id),
+    link_to close_ui_item_versions_path(item_id: id),
             title: 'Close Version',
             class: 'btn',
             hidden: true,
@@ -15,11 +15,13 @@ class OpenCloseComponent < ApplicationComponent
               controller: 'open-close',
               action: 'click->open-close#open',
               open_close_url_value: workflow_service_closeable_path(id)
-            }
+            } do
+      tag.span class: 'bi-unlock-fill'
+    end
   end
 
   def open_button
-    link_to '🔒', open_ui_item_versions_path(item_id: id),
+    link_to open_ui_item_versions_path(item_id: id),
             title: 'Open for modification',
             class: 'btn',
             hidden: true,
@@ -27,7 +29,9 @@ class OpenCloseComponent < ApplicationComponent
               controller: 'open-close',
               action: 'click->open-close#open',
               open_close_url_value: workflow_service_openable_path(id)
-            }
+            } do
+      tag.span class: 'bi-lock-fill'
+    end
   end
 
   attr_reader :solr_document


### PR DESCRIPTION


## Why was this change made?

Fixes #2969

## How was this change tested?

<img width="278" alt="Screen Shot 2022-01-14 at 2 38 44 PM" src="https://user-images.githubusercontent.com/92044/149582064-cd8bb7f6-92cc-445f-a9cd-c772a66084e8.png">


## Which documentation and/or configurations were updated?



