### PR TITLE
Switch to using registered_date

### DIFF
--- a/app/components/details_component.html.erb
+++ b/app/components/details_component.html.erb
@@ -32,7 +32,7 @@
       <tr>
         <th class="col-3" scope="row">Created</th>
         <td>
-            <%= created_date %>
+            <%= registered_date %>
         </td>
       </tr>
 

--- a/app/components/details_component.rb
+++ b/app/components/details_component.rb
@@ -47,7 +47,7 @@ class DetailsComponent < ApplicationComponent
             end
   end
 
-  delegate :id, :object_type, :content_type, :source_id, :created_date,
+  delegate :id, :object_type, :content_type, :source_id, :registered_date,
            :preservation_size, :catkey_id, :item?, :collection?,
            to: :@solr_document
 


### PR DESCRIPTION

## Why was this change made?
The created_date field comes from the originInfo in MODS.  Most records don't have this set.
Fixes #2965



## How was this change tested?



## Which documentation and/or configurations were updated?



