### PR TITLE
Localize the created date on the details component

### DIFF
--- a/app/components/details_component.html.erb
+++ b/app/components/details_component.html.erb
@@ -34,7 +34,7 @@
       <tr>
         <th class="col-3" scope="row">Created</th>
         <td>
-            <%= registered_date %>
+            <%= l registered_date, format: :long if registered_date %>
         </td>
       </tr>
 

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -45,7 +45,7 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
   attribute :embargo_release_date, Blacklight::Types::Date, FIELD_EMBARGO_RELEASE_DATE
   attribute :first_shelved_image, Blacklight::Types::String, :first_shelved_image_ss
 
-  attribute :registered_date, Blacklight::Types::Array, FIELD_REGISTERED_DATE
+  attribute :registered_date, Blacklight::Types::Date, FIELD_REGISTERED_DATE
   attribute :accessioned_date, Blacklight::Types::Array, FIELD_LAST_ACCESSIONED_DATE
   attribute :published_date, Blacklight::Types::Array, FIELD_LAST_PUBLISHED_DATE
   attribute :submitted_date, Blacklight::Types::Array, FIELD_LAST_SUBMITTED_DATE

--- a/spec/components/details_component_spec.rb
+++ b/spec/components/details_component_spec.rb
@@ -5,12 +5,14 @@ require 'rails_helper'
 RSpec.describe DetailsComponent, type: :component do
   let(:component) { described_class.new(solr_document: doc) }
   let(:rendered) { render_inline(component) }
+  let(:doc) do
+    SolrDocument.new('id' => 'druid:kv840xx0000',
+                     SolrDocument::FIELD_REGISTERED_DATE => ['2012-04-05T01:00:04.148Z'],
+                     SolrDocument::FIELD_OBJECT_TYPE => object_type)
+  end
 
   context 'with a DRO' do
-    let(:doc) do
-      SolrDocument.new('id' => 'druid:kv840xx0000',
-                       SolrDocument::FIELD_OBJECT_TYPE => 'item')
-    end
+    let(:object_type) { 'item' }
 
     it 'creates a edit buttons' do
       expect(rendered.css("a[aria-label='Change source id']")).to be_present
@@ -24,10 +26,7 @@ RSpec.describe DetailsComponent, type: :component do
   end
 
   context 'with a Collection' do
-    let(:doc) do
-      SolrDocument.new('id' => 'druid:kv840xx0000',
-                       SolrDocument::FIELD_OBJECT_TYPE => 'collection')
-    end
+    let(:object_type) { 'collection' }
 
     it 'creates a edit buttons' do
       expect(rendered.css("a[aria-label='Change source id']")).not_to be_present
@@ -38,10 +37,7 @@ RSpec.describe DetailsComponent, type: :component do
   end
 
   context 'with an AdminPolicy' do
-    let(:doc) do
-      SolrDocument.new('id' => 'druid:kv840xx0000',
-                       SolrDocument::FIELD_OBJECT_TYPE => 'adminPolicy')
-    end
+    let(:object_type) { 'adminPolicy' }
 
     it 'renders the appropriate buttons' do
       expect(rendered.css("a[aria-label='Change source id']")).not_to be_present

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe SolrDocument, type: :model do
     end
 
     it 'returns date' do
-      expect(document.registered_date).to match_array(single_date)
+      expect(document.registered_date).to eq Date.parse('2012-04-05T01:00:04.148Z')
     end
   end
 


### PR DESCRIPTION
## Why was this change made?



## How was this change tested?

Before:
<img width="477" alt="Screen Shot 2022-01-20 at 11 37 28 AM" src="https://user-images.githubusercontent.com/92044/150392073-b253a54f-ba5e-4ea4-b0d4-c0a11cbf0db4.png">

After:
<img width="331" alt="Screen Shot 2022-01-20 at 11 39 13 AM" src="https://user-images.githubusercontent.com/92044/150392331-bcc07c7c-86f9-43f5-817c-489b475f1bec.png">



## Which documentation and/or configurations were updated?



