### PR TITLE
Prevent edits to rights statement fields when object is not opened or…

### DIFF
--- a/app/components/overview_component.html.erb
+++ b/app/components/overview_component.html.erb
@@ -46,8 +46,10 @@
           <td>
             <turbo-frame id="edit_copyright">
               <%= copyright %>
-              <%= link_to edit_copyright_item_path(id: id), aria: { label: 'Edit copyright' } do %>
-                <span class="bi-pencil"></span>
+              <% if allows_modification? %>
+                <%= link_to edit_copyright_item_path(id: id), aria: { label: 'Edit copyright' } do %>
+                  <span class="bi-pencil"></span>
+                <% end %>
               <% end %>
             </turbo-frame>
           </td>
@@ -56,12 +58,14 @@
         <tr>
           <th class="col-3" scope="row">License</th>
           <td>
-              <turbo-frame id="edit_license">
-                <%= license %>
+            <turbo-frame id="edit_license">
+              <%= license %>
+              <% if allows_modification? %>
                 <%= link_to edit_license_item_path(id: id), aria: { label: 'Edit license' } do %>
                   <span class="bi-pencil"></span>
                 <% end %>
-              </turbo-frame>
+              <% end %>
+            </turbo-frame>
           </td>
         </tr>
 
@@ -70,8 +74,10 @@
           <td>
             <turbo-frame id="edit_use_statement">
               <%= use_statement %>
-              <%= link_to edit_use_statement_item_path(id: id), aria: { label: 'Edit use and reproduction' } do %>
-                <span class="bi-pencil"></span>
+              <% if allows_modification? %>
+                <%= link_to edit_use_statement_item_path(id: id), aria: { label: 'Edit use and reproduction' } do %>
+                  <span class="bi-pencil"></span>
+                <% end %>
               <% end %>
             </turbo-frame>
           </td>

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -14,10 +14,12 @@ class ItemsController < ApplicationController
 
   before_action :enforce_versioning, only: %i[
     add_collection set_collection remove_collection
+    edit_copyright edit_license edit_use_statement
     source_id
     refresh_metadata
     set_rights
     set_governing_apo
+    update
   ]
 
   rescue_from Dor::Services::Client::UnexpectedResponse do |exception|

--- a/app/services/state_service.rb
+++ b/app/services/state_service.rb
@@ -9,8 +9,10 @@ class StateService
   end
 
   def allows_modification?
-    !client.lifecycle(druid: pid, milestone_name: 'submitted') ||
-      client.active_lifecycle(druid: pid, milestone_name: 'opened', version: version)
+    return @allows_modification unless @allows_modification.nil?
+
+    @allows_modification = !client.lifecycle(druid: pid, milestone_name: 'submitted') ||
+                           client.active_lifecycle(druid: pid, milestone_name: 'opened', version: version)
   end
 
   private

--- a/spec/components/overview_component_spec.rb
+++ b/spec/components/overview_component_spec.rb
@@ -5,25 +5,25 @@ require 'rails_helper'
 RSpec.describe OverviewComponent, type: :component do
   let(:component) { described_class.new(solr_document: doc) }
   let(:rendered) { render_inline(component) }
-  let(:state_service) { instance_double(StateService, allows_modification?: true) }
+  let(:allows_modification) { true }
+  let(:state_service) { instance_double(StateService, allows_modification?: allows_modification) }
   let(:edit_collection_button) { rendered.css("a[aria-label='Edit collections']") }
+  let(:edit_copyright_button) { rendered.css("a[aria-label='Edit copyright']") }
+  let(:edit_license_button) { rendered.css("a[aria-label='Edit license']") }
+  let(:edit_use_statement_button) { rendered.css("a[aria-label='Edit use and reproduction']") }
 
   before do
     allow(StateService).to receive(:new).and_return(state_service)
   end
 
   context 'with a DRO' do
+    let(:doc) do
+      SolrDocument.new('id' => 'druid:kv840xx0000',
+                       SolrDocument::FIELD_OBJECT_TYPE => 'item')
+    end
+
     context 'without a license set' do
-      let(:doc) do
-        SolrDocument.new('id' => 'druid:kv840xx0000',
-                         SolrDocument::FIELD_OBJECT_TYPE => 'item')
-      end
-
-      it 'creates a edit buttons' do
-        expect(rendered.css("a[aria-label='Set governing APO']")).to be_present
-        expect(rendered.css("a[aria-label='Set rights']")).to be_present
-        expect(edit_collection_button).to be_present
-
+      it 'shows empty field defaults' do
         expect(rendered.to_html).to include 'Not entered'
         expect(rendered.to_html).to include 'No license'
       end
@@ -38,6 +38,32 @@ RSpec.describe OverviewComponent, type: :component do
 
       it 'shows the full license text' do
         expect(rendered.to_html).to include 'Attribution-NonCommercial Share Alike 4.0 International'
+      end
+    end
+
+    context 'when allows_modification is true' do
+      it 'creates a edit buttons' do
+        expect(rendered.css("a[aria-label='Set governing APO']")).to be_present
+        expect(rendered.css("a[aria-label='Set rights']")).to be_present
+
+        expect(edit_collection_button).to be_present
+        expect(edit_copyright_button).to be_present
+        expect(edit_license_button).to be_present
+        expect(edit_use_statement_button).to be_present
+      end
+    end
+
+    context 'when allows_modification is false' do
+      let(:allows_modification) { false }
+
+      it 'creates some edit buttons' do
+        expect(rendered.css("a[aria-label='Set governing APO']")).to be_present
+        expect(rendered.css("a[aria-label='Set rights']")).to be_present
+
+        expect(edit_collection_button).to be_present
+        expect(edit_copyright_button).not_to be_present
+        expect(edit_license_button).not_to be_present
+        expect(edit_use_statement_button).not_to be_present
       end
     end
   end

--- a/spec/features/item_catkey_change_spec.rb
+++ b/spec/features/item_catkey_change_spec.rb
@@ -77,7 +77,6 @@ RSpec.describe 'Item catkey change' do
       expect(page).to have_css '.alert.alert-info', text: 'Catkey for ' \
         "#{druid} has been updated!"
       expect(Argo::Indexer).to have_received(:reindex_pid_remotely)
-      expect(state_service).to have_received(:allows_modification?).exactly(3).times
     end
   end
 end

--- a/spec/features/item_source_id_change_spec.rb
+++ b/spec/features/item_source_id_change_spec.rb
@@ -76,7 +76,6 @@ RSpec.describe 'Item source id change' do
       expect(page).to have_css '.alert.alert-info', text: 'Source Id for ' \
         "#{druid} has been updated!"
       expect(Argo::Indexer).to have_received(:reindex_pid_remotely)
-      expect(state_service).to have_received(:allows_modification?).exactly(3).times
     end
   end
 end


### PR DESCRIPTION
… registered



## Why was this change made?
Fixes #3028


## How was this change tested?



## Which documentation and/or configurations were updated?



