### PR TITLE
Display the file level access

### DIFF
--- a/app/components/contents/file_component.html.erb
+++ b/app/components/contents/file_component.html.erb
@@ -11,4 +11,6 @@
   <td class="ps-4"><%= tag :span, class: 'bi-check' if publish %></td>
   <td class="ps-4"><%= tag :span, class: 'bi-check' if shelve %></td>
   <td class="ps-4"><%= tag :span, class: 'bi-check' if sdrPreserve %></td>
+  <td><%= view_access %></td>
+  <td><%= download_access %></td>
 </tr>

--- a/app/components/contents/file_component.rb
+++ b/app/components/contents/file_component.rb
@@ -17,6 +17,14 @@ module Contents
     delegate :access, :administrative, :filename, :hasMimeType, :size, :externalIdentifier, to: :file
     delegate :publish, :shelve, :sdrPreserve, to: :administrative
 
+    def view_access
+      access.access.capitalize
+    end
+
+    def download_access
+      access.download.capitalize
+    end
+
     def link_attrs
       { item_id: object_id, id: filename }
     end

--- a/app/components/contents/resource_component.html.erb
+++ b/app/components/contents/resource_component.html.erb
@@ -16,6 +16,8 @@
         <th>Publish</th>
         <th>Shelve</th>
         <th>Preserve</th>
+        <th>View</th>
+        <th>Download</th>
       </tr>
 
     <%= render Contents::FileComponent.with_collection(files, object_id: object_id, viewable: viewable?) %>

--- a/spec/components/contents/file_component_spec.rb
+++ b/spec/components/contents/file_component_spec.rb
@@ -15,11 +15,13 @@ RSpec.describe Contents::FileComponent, type: :component do
                     administrative: admin)
   end
 
-  let(:access) { instance_double(Cocina::Models::FileAccess, access: 'world') }
+  let(:access) { instance_double(Cocina::Models::FileAccess, access: 'world', download: 'stanford') }
   let(:admin) { instance_double(Cocina::Models::FileAdministrative, sdrPreserve: true, publish: true, shelve: true) }
 
   it 'renders the component' do
     expect(rendered.css('a[href="/items/druid:kb487gt5106/files?id=0220_MLK_Kids_Gadson_459-25.tif"]').to_html)
       .to include('0220_MLK_Kids_Gadson_459-25.tif')
+    expect(rendered.to_html).to include 'World'
+    expect(rendered.to_html).to include 'Stanford'
   end
 end


### PR DESCRIPTION
## Why was this change made?


Fixes #3033
## How was this change tested?
Tested on QA:

<img width="1308" alt="Screen Shot 2022-02-02 at 9 07 18 AM" src="https://user-images.githubusercontent.com/92044/152180458-944a363e-32ff-4dec-bd83-0f75edfe2b98.png">


## Which documentation and/or configurations were updated?



