### PR TITLE
Surface errors from applying APO default access in the UI

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -202,7 +202,9 @@ class ItemsController < ApplicationController
   def apply_apo_defaults
     Dor::Services::Client.object(@cocina.externalIdentifier).apply_admin_policy_defaults
     reindex
-    render status: :ok, plain: 'Defaults applied.'
+    render status: :ok, plain: 'APO defaults applied.'
+  rescue Dor::Services::Client::UnexpectedResponse => e
+    render status: :bad_request, plain: "APO defaults could not be applied: #{e.message}"
   end
 
   def set_governing_apo

--- a/spec/requests/apply_apo_defaults_spec.rb
+++ b/spec/requests/apply_apo_defaults_spec.rb
@@ -27,10 +27,26 @@ RSpec.describe 'Apply APO defaults' do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
   end
 
-  it 'applies the defaults' do
-    post '/items/druid:123/apply_apo_defaults'
-    expect(object_client).to have_received(:apply_admin_policy_defaults)
-    expect(Argo::Indexer).to have_received(:reindex_pid_remotely).with(pid)
-    expect(response).to be_successful
+  context 'when request succeeds' do
+    it 'applies the defaults' do
+      post '/items/druid:123/apply_apo_defaults'
+      expect(object_client).to have_received(:apply_admin_policy_defaults).once
+      expect(Argo::Indexer).to have_received(:reindex_pid_remotely).with(pid)
+      expect(response).to be_successful
+    end
+  end
+
+  context 'when request errors' do
+    before do
+      allow(object_client).to receive(:apply_admin_policy_defaults).and_raise(Dor::Services::Client::UnexpectedResponse)
+    end
+
+    it 'renders an error message' do
+      post '/items/druid:123/apply_apo_defaults'
+      expect(object_client).to have_received(:apply_admin_policy_defaults).once
+      expect(Argo::Indexer).not_to have_received(:reindex_pid_remotely)
+      expect(response).not_to be_successful
+      expect(response).to have_http_status(:bad_request)
+    end
   end
 end


### PR DESCRIPTION
Connects to #3019

## Why was this change made?

To make it clearer to the user which bulk update operations failed and which succeeded.

## How was this change tested?

🤷🏻‍♂️ 

## Which documentation and/or configurations were updated?

None

