### PR TITLE
show workflow errors on item page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -639,4 +639,4 @@ DEPENDENCIES
   zip_tricks (= 5.3.1)
 
 BUNDLED WITH
-   2.3.4
+   2.3.6

--- a/app/components/show/admin_policy_component.html.erb
+++ b/app/components/show/admin_policy_component.html.erb
@@ -7,7 +7,7 @@
   </div>
 </div>
 
-<%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
+<%= render Show::WorkflowErrorComponent.new(document: document) %>
 
 <div class="row mt-5">
   <div class="col-md-6">

--- a/app/components/show/admin_policy_component.html.erb
+++ b/app/components/show/admin_policy_component.html.erb
@@ -7,6 +7,8 @@
   </div>
 </div>
 
+<%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
+
 <div class="row mt-5">
   <div class="col-md-6">
     <%= render OverviewComponent.new(presenter: presenter) %>

--- a/app/components/show/collection_component.html.erb
+++ b/app/components/show/collection_component.html.erb
@@ -7,7 +7,7 @@
   </div>
 </div>
 
-<%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
+<%= render Show::WorkflowErrorComponent.new(document: document) %>
 
 <div class="row mt-5">
   <div class="col-md-6">

--- a/app/components/show/collection_component.html.erb
+++ b/app/components/show/collection_component.html.erb
@@ -7,6 +7,8 @@
   </div>
 </div>
 
+<%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
+
 <div class="row mt-5">
   <div class="col-md-6">
     <%= render OverviewComponent.new(presenter: presenter) %>

--- a/app/components/show/item_component.html.erb
+++ b/app/components/show/item_component.html.erb
@@ -18,6 +18,8 @@
   </div>
 </div>
 
+<%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
+
 <div class="row mt-5">
   <div class="col-md-6">
     <%= render OverviewComponent.new(presenter: presenter) %>

--- a/app/components/show/item_component.html.erb
+++ b/app/components/show/item_component.html.erb
@@ -18,7 +18,7 @@
   </div>
 </div>
 
-<%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
+<%= render Show::WorkflowErrorComponent.new(document: document) %>
 
 <div class="row mt-5">
   <div class="col-md-6">

--- a/app/components/show/workflow_error_component.html.erb
+++ b/app/components/show/workflow_error_component.html.erb
@@ -1,0 +1,3 @@
+<div class="alert alert-danger" role="alert">
+    Error: <%= workflow_errors %>
+</div>

--- a/app/components/show/workflow_error_component.rb
+++ b/app/components/show/workflow_error_component.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Show
+  class WorkflowErrorComponent < ApplicationComponent
+    def initialize(document:)
+      @document = document
+    end
+
+    attr_reader :document
+
+    delegate :blacklight_config, :value_for_wf_error, to: :helpers
+
+    def workflow_errors
+      field_config = blacklight_config.show_fields_for(:show).fetch(SolrDocument::FIELD_WORKFLOW_ERRORS)
+      Blacklight::FieldPresenter.new(self, document, field_config).render
+    end
+
+    def render?
+      document[SolrDocument::FIELD_WORKFLOW_ERRORS]
+    end
+  end
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -43,8 +43,8 @@ class CatalogController < ApplicationController
     config.add_index_field 'identifier_tesim',                label: 'IDs', helper_method: :value_for_identifier_tesim
     config.add_index_field SolrDocument::FIELD_RELEASED_TO,   label: 'Released to'
     config.add_index_field 'status_ssi',                      label: 'Status'
-    config.add_index_field 'wf_error_ssim',                   label: 'Error', helper_method: :value_for_wf_error
-    config.add_index_field 'rights_descriptions_ssim',        label: 'Access Rights'
+    config.add_index_field SolrDocument::FIELD_WORKFLOW_ERRORS, label: 'Error', helper_method: :value_for_wf_error
+    config.add_index_field 'rights_descriptions_ssim', label: 'Access Rights'
 
     config.add_show_field 'project_tag_ssim',                label: 'Project',           link_to_facet: true
     config.add_show_field 'tag_ssim',                        label: 'Tags',              link_to_facet: true
@@ -207,6 +207,10 @@ class CatalogController < ApplicationController
 
     @cocina = maybe_load_cocina(params[:id])
     flash[:alert] = 'Warning: this object cannot currently be represented in the Cocina model.' if @cocina.instance_of?(NilModel)
+    if @document[SolrDocument::FIELD_WORKFLOW_ERRORS]
+      flash[:error] =
+        "Error: #{helpers.value_for_wf_error(document: @document, field: SolrDocument::FIELD_WORKFLOW_ERRORS)}"
+    end
 
     authorize! :view_metadata, @cocina
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -48,6 +48,7 @@ class CatalogController < ApplicationController
 
     config.add_show_field 'project_tag_ssim',                label: 'Project',           link_to_facet: true
     config.add_show_field 'tag_ssim',                        label: 'Tags',              link_to_facet: true
+    config.add_show_field SolrDocument::FIELD_WORKFLOW_ERRORS, label: 'Error', helper_method: :value_for_wf_error
 
     # exploded_tag_ssim indexes all tag prefixes (see IdentityMetadataDS#to_solr for a more exact
     # description), whereas tag_ssim only indexes whole tags.  we want to facet on exploded_tag_ssim
@@ -207,10 +208,6 @@ class CatalogController < ApplicationController
 
     @cocina = maybe_load_cocina(params[:id])
     flash[:alert] = 'Warning: this object cannot currently be represented in the Cocina model.' if @cocina.instance_of?(NilModel)
-    if @document[SolrDocument::FIELD_WORKFLOW_ERRORS]
-      flash[:error] =
-        "Error: #{helpers.value_for_wf_error(document: @document, field: SolrDocument::FIELD_WORKFLOW_ERRORS)}"
-    end
 
     authorize! :view_metadata, @cocina
 

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -37,6 +37,7 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
   FIELD_TAGS                      = 'tag_ssim'
   FIELD_SOURCE_ID                 = 'source_id_ssim'
   FIELD_BARCODE_ID                = 'barcode_id_ssim'
+  FIELD_WORKFLOW_ERRORS           = 'wf_error_ssim'
 
   attribute :object_type, Blacklight::Types::String, FIELD_OBJECT_TYPE
   attribute :content_type, Blacklight::Types::String, FIELD_CONTENT_TYPE

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -28,7 +28,7 @@
   <main id="main-container" class="<%= container_classes %>" role="main" aria-label="<%= t('blacklight.main.aria.main_container') %>">
     <%= content_for(:container_header) %>
 
-    <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
+    <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' unless params[:id] && current_page?(solr_document_path)%>
 
     <div class="row">
       <%= content_for?(:content) ? yield(:content) : yield %>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -28,7 +28,7 @@
   <main id="main-container" class="<%= container_classes %>" role="main" aria-label="<%= t('blacklight.main.aria.main_container') %>">
     <%= content_for(:container_header) %>
 
-    <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' unless params[:id] && current_page?(solr_document_path)%>
+    <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
 
     <div class="row">
       <%= content_for?(:content) ? yield(:content) : yield %>

--- a/spec/helpers/value_helper_spec.rb
+++ b/spec/helpers/value_helper_spec.rb
@@ -85,10 +85,10 @@ RSpec.describe ValueHelper do
   describe '#value_for_wf_error' do
     let(:document_attributes) do
       {
-        'wf_error_ssim' => ['accessionWF:technical-metadata:401 Unauthorized']
+        SolrDocument::FIELD_WORKFLOW_ERRORS => ['accessionWF:technical-metadata:401 Unauthorized']
       }
     end
-    let(:args) { { document: document, field: 'wf_error_ssim' } }
+    let(:args) { { document: document, field: SolrDocument::FIELD_WORKFLOW_ERRORS } }
 
     it 'returns a formatted wf error message' do
       expect(helper.value_for_wf_error(**args)).to eq 'technical-metadata : 401 Unauthorized'


### PR DESCRIPTION
## Why was this change made?

Fixes #3027 - show workflow errors in alert dialog box on item/collection/apo pages below buttons and above details, all other alerts/errors/notices are last as is in same location as before

![Screen Shot 2022-02-02 at 3 59 42 PM](https://user-images.githubusercontent.com/47137/152258011-8fc8c276-1d78-4a3d-a7ae-0f5debde812d.png)

## How was this change tested?

Localhost browser, existing tests


## Which documentation and/or configurations were updated?



