### PR TITLE
allow paging to work when using rails console in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,6 +150,7 @@ services:
       - SETTINGS__DOR_SERVICES__TOKEN=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJGb28ifQ.-BVfLTW9Q1_ZQEsGv4tuzGLs5rESN7LgdtEwUltnKv4
       - SETTINGS__ENABLE_STOMP=false
       - SETTINGS__REDIS__HOSTNAME=redis
+      - PAGER='more'
     depends_on:
       - db
       - redis


### PR DESCRIPTION
## Why was this change made?

The default pager (`less`) is not available in the docker container which will throw errors if you do this: ` docker compose run workflow rails c` to get to the rails console and then have a lot of output.  This disables the less pager for the workflow container.

## How was this change tested?

localhost

## Which documentation and/or configurations were updated?



