### PR TITLE
Add error handling for turbo-frames

### DIFF
--- a/app/views/items/error.html.erb
+++ b/app/views/items/error.html.erb
@@ -1,0 +1,1 @@
+<turbo-frame id="<%= request.headers['Turbo-Frame'] %>"><%= message %></turbo-frame>

--- a/app/views/layouts/catalog_result.html.erb
+++ b/app/views/layouts/catalog_result.html.erb
@@ -4,5 +4,4 @@
     <%= yield %>
   </section>
 <% end %>
-
 <%= render template: 'layouts/blacklight/base' %>

--- a/spec/requests/item_update_spec.rb
+++ b/spec/requests/item_update_spec.rb
@@ -113,5 +113,15 @@ RSpec.describe 'Set the properties for an item' do
         expect(response.code).to eq('303')
       end
     end
+
+    context 'when there is an error' do
+      it 'draws the error' do
+        allow(object_client).to receive(:update).and_raise(Dor::Services::Client::BadRequestError, '({"errors":[{"detail":"broken"}]})')
+        patch "/items/#{pid}", params: { item: { barcode: 'invalid' } }, headers: { 'Turbo-Frame' => 'barcode' }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include '<turbo-frame id="barcode">Unable to retrieve the cocina model: broken</turbo-frame>'
+      end
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Errors were not being displayed.

## How was this change tested?



## Which documentation and/or configurations were updated?



