### PR TITLE
hide upload CSV button if the object is locked

### DIFF
--- a/app/components/contents_component.html.erb
+++ b/app/components/contents_component.html.erb
@@ -8,8 +8,10 @@
     <div class="accordion-body" data-controller="structural">
       <div class="mb-3">
         <%= render DownloadAllButtonComponent.new(document: @document) %>
-        <%= button_tag class: 'btn btn-link float-end', data: { action: 'click->structural#open' } do %>
-          <span class="bi-upload"></span> Upload CSV
+        <% if allows_modification? %>
+          <%= button_tag class: 'btn btn-link float-end', data: { action: 'click->structural#open' } do %>
+            <span class="bi-upload"></span> Upload CSV
+          <% end %>
         <% end %>
         <%= link_to item_structure_path(@document, format: :csv), download: true, class: 'btn btn-link float-end' do %>
           <span class="bi-download"></span> Download CSV

--- a/app/components/contents_component.rb
+++ b/app/components/contents_component.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class ContentsComponent < ApplicationComponent
-  def initialize(cocina:, document:, state_service:)
-    @cocina = cocina
-    @document = document
-    @state_service = state_service
+  def initialize(presenter:)
+    @document = presenter.document
+    @cocina = presenter.cocina
+    @state_service = presenter.state_service
   end
 
   def render?

--- a/app/components/contents_component.rb
+++ b/app/components/contents_component.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 class ContentsComponent < ApplicationComponent
-  def initialize(cocina:, document:)
+  def initialize(cocina:, document:, state_service:)
     @cocina = cocina
     @document = document
+    @state_service = state_service
   end
 
   def render?
     @cocina.respond_to?(:structural)
   end
+
+  delegate :allows_modification?, to: :@state_service
 end

--- a/app/components/show/item_component.html.erb
+++ b/app/components/show/item_component.html.erb
@@ -34,6 +34,6 @@
   <%= render 'events_default', document: document %>
   <%= render 'cocina_default', document: document %>
   <%= render 'history_default', document: document %>
-  <%= render ContentsComponent.new(cocina: cocina, document: document) %>
+  <%= render ContentsComponent.new(cocina: cocina, document: document, state_service: state_service) %>
   <%= render TechmdComponent.new(result: techmd) %>
 </div>

--- a/app/components/show/item_component.html.erb
+++ b/app/components/show/item_component.html.erb
@@ -34,6 +34,6 @@
   <%= render 'events_default', document: document %>
   <%= render 'cocina_default', document: document %>
   <%= render 'history_default', document: document %>
-  <%= render ContentsComponent.new(cocina: cocina, document: document, state_service: state_service) %>
+  <%= render ContentsComponent.new(presenter: presenter) %>
   <%= render TechmdComponent.new(result: techmd) %>
 </div>

--- a/app/components/show/item_component.rb
+++ b/app/components/show/item_component.rb
@@ -9,5 +9,6 @@ module Show
     attr_reader :presenter
 
     delegate :document, :cocina, :techmd, to: :presenter
+    delegate :state_service, to: :@presenter
   end
 end

--- a/app/controllers/structures_controller.rb
+++ b/app/controllers/structures_controller.rb
@@ -29,7 +29,7 @@ class StructuresController < ApplicationController
         redirect_to solr_document_path(@cocina.externalIdentifier), flash: { error: status.failure.join('\n') }
       end
     else
-      redirect_to solr_document_path(@cocina.externalIdentifier), status: :not_acceptable, flash: { error: 'Updates not allowed on this object.' }
+      redirect_to solr_document_path(@cocina.externalIdentifier), flash: { error: 'Updates not allowed on this object.' }
     end
   end
 

--- a/app/controllers/structures_controller.rb
+++ b/app/controllers/structures_controller.rb
@@ -29,7 +29,7 @@ class StructuresController < ApplicationController
         redirect_to solr_document_path(@cocina.externalIdentifier), flash: { error: status.failure.join('\n') }
       end
     else
-      redirect_to solr_document_path(@cocina.externalIdentifier), flash: { error: 'Updates not allowed on this object.' }
+      redirect_to solr_document_path(@cocina.externalIdentifier), status: :not_acceptable, flash: { error: 'Updates not allowed on this object.' }
     end
   end
 

--- a/app/controllers/structures_controller.rb
+++ b/app/controllers/structures_controller.rb
@@ -18,13 +18,18 @@ class StructuresController < ApplicationController
   def update
     authorize! :manage_item, @cocina
 
-    status = StructureUpdater.from_csv(@cocina, params[:csv].read)
+    state_service = StateService.new(@cocina.externalIdentifier, version: @cocina.version)
+    if state_service.allows_modification?
+      status = StructureUpdater.from_csv(@cocina, params[:csv].read)
 
-    if status.success?
-      object_client.update(params: @cocina.new(structural: status.value!))
-      redirect_to solr_document_path(@cocina.externalIdentifier), status: :see_other, notice: 'Structural metadata updated'
+      if status.success?
+        object_client.update(params: @cocina.new(structural: status.value!))
+        redirect_to solr_document_path(@cocina.externalIdentifier), status: :see_other, notice: 'Structural metadata updated'
+      else
+        redirect_to solr_document_path(@cocina.externalIdentifier), flash: { error: status.failure.join('\n') }
+      end
     else
-      redirect_to solr_document_path(@cocina.externalIdentifier), flash: { error: status.failure.join('\n') }
+      redirect_to solr_document_path(@cocina.externalIdentifier), flash: { error: 'Updates not allowed on this object.' }
     end
   end
 

--- a/spec/components/contents_component_spec.rb
+++ b/spec/components/contents_component_spec.rb
@@ -3,9 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe ContentsComponent, type: :component do
-  let(:component) do
-    described_class.new(document: solr_doc, cocina: cocina, state_service: state_service)
-  end
+  let(:presenter) { instance_double(ArgoShowPresenter, document: solr_doc, cocina: cocina, state_service: state_service) }
+  let(:component) { described_class.new(presenter: presenter) }
   let(:state_service) { instance_double(StateService, allows_modification?: allows_modification) }
 
   let(:rendered) { render_inline(component) }

--- a/spec/components/contents_component_spec.rb
+++ b/spec/components/contents_component_spec.rb
@@ -4,8 +4,9 @@ require 'rails_helper'
 
 RSpec.describe ContentsComponent, type: :component do
   let(:component) do
-    described_class.new(document: solr_doc, cocina: cocina)
+    described_class.new(document: solr_doc, cocina: cocina, state_service: state_service)
   end
+  let(:state_service) { instance_double(StateService, allows_modification?: allows_modification) }
 
   let(:rendered) { render_inline(component) }
 
@@ -103,9 +104,25 @@ RSpec.describe ContentsComponent, type: :component do
       allow(controller).to receive(:can?).and_return(true)
     end
 
-    it 'shows multiple external files' do
-      expect(rendered.css('a[href="/items/druid:bg954kx8787/files?id=image.jpg"]').to_html).to include('image.jpg')
-      expect(rendered.css('a[href="/items/druid:bg954kx8787/files?id=image.jp2"]').to_html).to include('image.jp2')
+    context 'with unlocked object' do
+      let(:allows_modification) { true }
+
+      it 'shows multiple external files' do
+        expect(rendered.css('a[href="/items/druid:bg954kx8787/files?id=image.jpg"]').to_html).to include('image.jpg')
+        expect(rendered.css('a[href="/items/druid:bg954kx8787/files?id=image.jp2"]').to_html).to include('image.jp2')
+      end
+
+      it 'shows Upload CSV button' do
+        expect(rendered.css('.bi-upload')).to be_present
+      end
+    end
+
+    context 'with locked object' do
+      let(:allows_modification) { false }
+
+      it 'hides Upload CSV button' do
+        expect(rendered.css('.bi-upload')).not_to be_present
+      end
     end
   end
 end

--- a/spec/controllers/structures_controller_spec.rb
+++ b/spec/controllers/structures_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe StructuresController do
         put :update, params: { item_id: pid, csv: file }
         expect(StructureUpdater).to have_received(:from_csv)
         expect(object_client).to have_received(:update)
-        expect(response).to have_http_status :see_other
+        expect(response).to have_http_status :redirect
       end
     end
 
@@ -54,7 +54,8 @@ RSpec.describe StructuresController do
         put :update, params: { item_id: pid, csv: file }
         expect(StructureUpdater).not_to have_received(:from_csv)
         expect(object_client).not_to have_received(:update)
-        expect(response).to have_http_status :not_acceptable
+        expect(response).to have_http_status :redirect
+        expect(flash[:error]).to eq 'Updates not allowed on this object.'
       end
     end
   end

--- a/spec/controllers/structures_controller_spec.rb
+++ b/spec/controllers/structures_controller_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StructuresController do
+  let(:user) { create(:user) }
+  let(:pid) { 'druid:bc123df4567' }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+  let(:state_service) { instance_double(StateService) }
+  let(:successful_update) { double(success?: true, value!: nil) }
+  let(:file) { fixture_file_upload('structure-upload.csv') }
+  let(:cocina_model) do
+    Cocina::Models.build({
+                           'label' => 'My Item',
+                           'version' => 1,
+                           'type' => Cocina::Models::Vocab.object,
+                           'externalIdentifier' => pid,
+                           'access' => {},
+                           'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+                           'structural' => {},
+                           'identification' => {}
+                         })
+  end
+
+  before do
+    sign_in user
+    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+    allow(controller).to receive(:authorize!).and_return(true)
+    allow(StateService).to receive(:new).and_return(state_service)
+    allow(StructureUpdater).to receive(:from_csv).and_return(successful_update)
+    allow(object_client).to receive(:update)
+  end
+
+  describe '#update' do
+    context 'object is unlocked' do
+      before do
+        allow(state_service).to receive(:allows_modification?).and_return(true)
+      end
+
+      it 'is successful' do
+        put :update, params: { item_id: pid, csv: file }
+        expect(StructureUpdater).to have_received(:from_csv)
+        expect(object_client).to have_received(:update)
+        expect(response).to have_http_status :see_other
+      end
+    end
+
+    context 'object is locked' do
+      before do
+        allow(state_service).to receive(:allows_modification?).and_return(false)
+      end
+
+      it 'is not allowed' do
+        put :update, params: { item_id: pid, csv: file }
+        expect(StructureUpdater).not_to have_received(:from_csv)
+        expect(object_client).not_to have_received(:update)
+        expect(response).to have_http_status :not_acceptable
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

Fixes #3062 - hide upload csv button if object is locked (does not allow modifications)

## How was this change tested?

- Updated component test
- New structure controller test 

## Which documentation and/or configurations were updated?



