### PR TITLE
help-block in bootstrap 3 becomes form-text in bootstrap 4/5

### DIFF
--- a/app/components/manage_release/collection_form_component.html.erb
+++ b/app/components/manage_release/collection_form_component.html.erb
@@ -25,7 +25,7 @@
       </label>
     </div>
   </div>
-  <p class='help-block'>* Any members that have their own overriding release information will not be affected</p>
+  <p class='form-text'>* Any members that have their own overriding release information will not be affected</p>
   <div class='mb-3'>
     <%= manage_release_fields.select :to, Constants::RELEASE_TARGETS, {}, class: 'form-select' %>
   </div>

--- a/app/views/bulk_actions/forms/_manage_release_form.html.erb
+++ b/app/views/bulk_actions/forms/_manage_release_form.html.erb
@@ -20,4 +20,4 @@
   <%= manage_release_fields.hidden_field('what', value: 'self') %>
   <%= manage_release_fields.hidden_field('who', value: current_user.sunetid) %>
 <% end %>
-<span class='help-block'>* for items this overrides any collection release instructions; for a collection this releases the collection object itself, not its members</span>
+<span class='form-text'>* for items this overrides any collection release instructions; for a collection this releases the collection object itself, not its members</span>

--- a/app/views/catkeys/_edit.html.erb
+++ b/app/views/catkeys/_edit.html.erb
@@ -2,7 +2,7 @@
   <div class="mb-3">
     <%= f.label :catkey %>
     <%= f.text_field :catkey, class: 'form-control' %>
-    <p class='help-block'>
+    <p class='form-text'>
     </p>
   </div>
   <button class="btn btn-primary">Update</button>

--- a/app/views/items/_source_id_ui.html.erb
+++ b/app/views/items/_source_id_ui.html.erb
@@ -1,7 +1,7 @@
 <%= form_tag source_id_item_path(@cocina.externalIdentifier) do %>
   <div class="mb-3">
     <input class="form-control" name="new_id" id="new_id" type="text" value="<%= @cocina.identification.sourceId %>">
-    <p class='help-block'>
+    <p class='form-text'>
       <em>entries should be of the form</em> source:value
     </p>
   </div>

--- a/spec/views/items/_source_id_ui.html.erb_spec.rb
+++ b/spec/views/items/_source_id_ui.html.erb_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'items/_source_id_ui.html.erb' do
     render
     expect(rendered)
       .to have_css 'form input.form-control[value="source id"]'
-    expect(rendered).to have_css 'p.help-block'
+    expect(rendered).to have_css 'p.form-text'
     expect(rendered).to have_css 'button.btn.btn-primary', text: 'Update'
   end
 end


### PR DESCRIPTION
## Why was this change made?

See https://getbootstrap.com/docs/4.5/components/forms/#help-text

## How was this change tested?



## Which documentation and/or configurations were updated?



