### PR TITLE
Keep tmp/pids in git for Argo to start

### DIFF
--- a/tmp/.gitignore
+++ b/tmp/.gitignore
@@ -1,4 +1,10 @@
 # Ignore everything in this directory
-*
+/*
+
 # Except this file
-!.gitignore
+!/.gitignore
+
+# And the pids directory needed for Argo to start
+!/pids
+/pids/*
+!/pids/.gitkeep


### PR DESCRIPTION
## Why was this change made?

If you try to `docker-compose up -d` without a `tmp/pids` argo_web_1
will exit with:

```
/usr/local/bundle/gems/puma-5.6.1/lib/puma/launcher.rb:248:in `write': No such file or directory @ rb_sysopen - tmp/pids/server.pid (Errno::ENOENT)
```

This commit keeps `tmp/pids/` by adding `tmp/pids/.gitkeep`. The `tmp/.gitignore` was modified
to allow this but still ignore everything else.

## How was this change tested?

Testing locally with `docker compose up -d`

## Which documentation and/or configurations were updated?

None.
