### PR TITLE
Use the citation as the thumbnail label

### DIFF
--- a/app/components/show/item/thumbnail_component.html.erb
+++ b/app/components/show/item/thumbnail_component.html.erb
@@ -1,0 +1,13 @@
+<% if document.thumbnail_url %>
+  <%= image_tag document.thumbnail_url, style: 'max-width:240px; max-height:240px;' %>
+<% else %>
+  <svg style="text-anchor: middle" width="240" height="240" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Responsive image" focusable="false">
+    <title>Placeholder</title>
+    <rect width="100%" height="100%" fill="#868e96"></rect>
+    <foreignObject x="10" y="10" width="220" height="220">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; height: 100%; justify-content: center; align-items: center;">
+        <p xmlns="http://www.w3.org/1999/xhtml"><%= placeholder_text %></p>
+      </div>
+    </foreignObject>
+  </svg>
+<% end %>

--- a/app/components/show/item/thumbnail_component.rb
+++ b/app/components/show/item/thumbnail_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Show
+  module Item
+    class ThumbnailComponent < ApplicationComponent
+      def initialize(document:)
+        @document = document
+      end
+
+      attr_reader :document
+
+      def placeholder_text
+        truncate(CitationPresenter.new(document, italicize: false).render, length: 246, omission: '…')
+      end
+    end
+  end
+end

--- a/app/components/show/item_component.html.erb
+++ b/app/components/show/item_component.html.erb
@@ -2,15 +2,7 @@
 
 <div class="row">
   <div class="col-md-3">
-    <% if document.thumbnail_url %>
-      <%= image_tag document.thumbnail_url, style: 'max-width:240px; max-height:240px;' %>
-    <% else %>
-      <svg style="text-anchor: middle" width="240" height="240" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Responsive image" focusable="false">
-        <title>Placeholder</title>
-        <rect width="100%" height="100%" fill="#868e96"></rect>
-        <text x="50%" y="50%" fill="#dee2e6" dy=".3em"><%= document.label %></text>
-      </svg>
-    <% end %>
+    <%= render Show::Item::ThumbnailComponent.new(document: document) %>
   </div>
   <div class="col-md-9">
     <%= render ExternalLinksComponent.new(document: document) %>

--- a/app/presenters/citation_presenter.rb
+++ b/app/presenters/citation_presenter.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
 class CitationPresenter
-  def initialize(document)
+  def initialize(document, italicize: true)
     @document = document
+    @italicize = italicize
   end
 
   def render
     result = ''
     result += "#{author} " if author.present?
-    result += "<em>#{title}</em>" if title.present?
+    if title.present?
+      result += @italicize ? "<em>#{title}</em>" : title
+    end
     origin_info = [publisher, place, mods_created_date].compact.join(', ')
     result += ": #{origin_info}" if origin_info.present?
     result.html_safe

--- a/spec/components/show/item/thumbnail_component_spec.rb
+++ b/spec/components/show/item/thumbnail_component_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Show::Item::ThumbnailComponent, type: :component do
+  let(:component) { described_class.new(document: document) }
+  let(:rendered) { render_inline(component) }
+
+  let(:document) do
+    SolrDocument.new('id' => 'druid:kv840xx0000',
+                     SolrDocument::FIELD_TITLE => title)
+  end
+
+  context 'without a thumbnail_url and a long title' do
+    let(:title) do
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dolor mauris, ' \
+        'tincidunt ut elementum sollicitudin, luctus sit amet quam. Interdum et ' \
+        'malesuada fames ac ante ipsum primis in faucibus.  Proin maximus, urna id ' \
+        'gravida sodales, dui ex ullamcorper ante, vestibulum consectetur odio arcu ' \
+        'mattis dolor. '
+    end
+
+    it 'truncates the title' do
+      expect(rendered.to_html).to include 'gravida sodales, dui ex…'
+    end
+  end
+end


### PR DESCRIPTION

## Why was this change made?
Fixes #3084
Fixes #3059 


## How was this change tested?

<img width="1385" alt="Screen Shot 2022-02-09 at 2 57 56 PM" src="https://user-images.githubusercontent.com/92044/153288838-275d4d55-4183-4511-8b8a-c151716bad55.png">

<img width="1419" alt="Screen Shot 2022-02-09 at 2 58 21 PM" src="https://user-images.githubusercontent.com/92044/153288900-4e486028-be4c-436a-962d-0a968fec3e51.png">


## Which documentation and/or configurations were updated?



