### PR TITLE
Remove resource part of item link

### DIFF
--- a/app/components/contents/external_file_component.html.erb
+++ b/app/components/contents/external_file_component.html.erb
@@ -4,9 +4,7 @@
       <span class="label">
         External File
       </span>
-      <%= filename %>
-      (from item '<%= link_to druid, solr_document_path(druid) %>',
-       resource '<%= resource_id %>')
+      (from item '<%= link_to druid, solr_document_path(druid) %>')
     </li>
   </ul>
 </li>

--- a/app/components/contents/external_file_component.rb
+++ b/app/components/contents/external_file_component.rb
@@ -4,15 +4,12 @@ module Contents
   # Displays external files for a virtual object
   # e.g. https://argo.stanford.edu/view/druid:tm280sk2404
   class ExternalFileComponent < ViewComponent::Base
-    def initialize(external_file:)
-      @resource_id, @filename = external_file.split('/')
+    with_collection_parameter :druid
+
+    def initialize(druid:)
+      @druid = druid
     end
 
-    attr_reader :resource_id, :filename
-
-    def druid
-      druid, = resource_id.split('_')
-      "druid:#{druid}"
-    end
+    attr_reader :druid
   end
 end

--- a/spec/components/contents/external_file_component_spec.rb
+++ b/spec/components/contents/external_file_component_spec.rb
@@ -3,18 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe Contents::ExternalFileComponent, type: :component do
-  let(:component) { described_class.new(external_file: id) }
+  let(:component) { described_class.new(druid: id) }
   let(:rendered) { render_inline(component) }
-  let(:id) { 'kg748gk9672_1/1642a.jp2' }
+  let(:id) { 'druid:bf746ns6287' }
 
   it 'renders the component' do
     expect(rendered.css('li').to_html)
-      .to include '1642a.jp2'
+      .to include 'druid:bf746ns6287'
 
     expect(rendered.css('li a').to_html)
-      .to eq '<a href="/view/druid:kg748gk9672">druid:kg748gk9672</a>'
-
-    expect(rendered.css('li').to_html)
-      .to include "resource 'kg748gk9672_1'"
+      .to eq '<a href="/view/druid:bf746ns6287">druid:bf746ns6287</a>'
   end
 end


### PR DESCRIPTION
## Why was this change made?

Cocina now only has the druid for the structural members, so we can only display those. This change removes the "resource" portion and only displays an "item" link.

## How was this change tested?

I viewed the contentMetadata for [druid:bf746ns6287](https://argo-stage.stanford.edu/view/druid:bf746ns6287) in my dev environment and the changes worked.

I also ran:

    bundle exec rspec spec/components/contents/external_file_component_spec.rb

@andrewjbtw tested in QA as well.

The full suite of tests unfortunately do not run reliably in my dev environment.

## Which documentation and/or configurations were updated?

Closes #3088 