### PR TITLE
Update named containers to start up all needed services

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ CI runs a series of steps;  this the sequence to do it locally, along with some 
 
 2. **Start up the docker services needed for testing**
 
-    Once everything has been successfully pulled, start up the docker services needed for testing
+    Once everything has been successfully pulled, start up the docker services needed for testing (all but the web container)
 
     ```
-    docker-compose up -d dor-services-app dor-indexing-app techmd
+    docker-compose up -d sdr-api techmd
     ```
 
     You should do the following to make sure all the services are up:


### PR DESCRIPTION
## Why was this change made?

So I/we no longer need to read the docker-compose when trying to find the shortest way to spin up all containers but the web one.

## How was this change tested?

It's a README change.

## Which documentation and/or configurations were updated?

README

