### PR TITLE
Spiff up virtual object UI experience

### DIFF
--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -8,7 +8,7 @@
   }
 
   .object-type {
-    width: 11rem;
+    width: 15rem;
     height: 2.4rem;
 
     &.object-type-apo {
@@ -19,6 +19,9 @@
     }
     &.object-type-item {
       background-color: $illuminating-light;
+    }
+    &.object-type-virtual-object {
+      background-color: $bay-light;
     }
   }
 

--- a/app/assets/stylesheets/sul_variables.scss
+++ b/app/assets/stylesheets/sul_variables.scss
@@ -9,4 +9,5 @@ $sonic-silver: #767674; // "60% black" in Stanford brand identity
 $illuminating-light: #ffe781;
 $sky-light: #67afd2;
 $fog: #dad7cb;
+$bay-light: #8ab8a7;
 $white: #fff;

--- a/app/components/document_title_component.html.erb
+++ b/app/components/document_title_component.html.erb
@@ -5,7 +5,7 @@
     <%= title -%>
   <% end %>
 
-  <div class="object-type object-type-<%= object_type %> fw-bold text-center text-uppercase rounded-pill fs-4 mt-2 float-end">
-    <%= object_type %>
+  <div class="object-type object-type-<%= object_type_class %> fw-bold text-center text-uppercase rounded-pill fs-4 mt-2 float-end">
+    <%= object_type_label %>
   </div>
 </header>

--- a/app/components/document_title_component.rb
+++ b/app/components/document_title_component.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 
 class DocumentTitleComponent < Blacklight::DocumentTitleComponent
-  def object_type
-    @document.object_type == 'adminPolicy' ? 'apo' : @document.object_type
+  def object_type_label
+    return 'apo' if @document.admin_policy?
+    return 'virtual object' if @document.virtual_object?
+
+    @document.object_type
+  end
+
+  def object_type_class
+    object_type_label.tr(' ', '-')
   end
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -114,6 +114,12 @@ class CatalogController < ApplicationController
     # common method since search results and reports all do the same configuration
     add_common_date_facet_fields_to_config! config
 
+    config.add_facet_field SolrDocument::FIELD_CONSTITUENTS, label: 'Virtual Objects', home: false,
+                                                             component: true,
+                                                             query: {
+                                                               has_constituents: { label: 'Virtual Objects', fq: "#{SolrDocument::FIELD_CONSTITUENTS}:*" }
+                                                             }
+
     # This will help us find records that need to be fixed before we can move to cocina.
     config.add_facet_field 'data_quality_ssim', label: 'Data Quality', home: false, component: true
 

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -39,6 +39,7 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
   FIELD_SOURCE_ID                 = 'source_id_ssim'
   FIELD_BARCODE_ID                = 'barcode_id_ssim'
   FIELD_WORKFLOW_ERRORS           = 'wf_error_ssim'
+  FIELD_CONSTITUENTS              = 'has_constituents_ssim'
 
   attribute :object_type, Blacklight::Types::String, FIELD_OBJECT_TYPE
   attribute :content_type, Blacklight::Types::String, FIELD_CONTENT_TYPE
@@ -75,6 +76,7 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
   attribute :source_id, Blacklight::Types::String, FIELD_SOURCE_ID
   attribute :barcode, Blacklight::Types::String, FIELD_BARCODE_ID
   attribute :tags, Blacklight::Types::Array, FIELD_TAGS
+  attribute :constituents, Blacklight::Types::Array, FIELD_CONSTITUENTS
 
   # self.unique_key = 'id'
 
@@ -116,6 +118,12 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
 
   def item?
     object_type == 'item'
+  end
+
+  def virtual_object?
+    return false unless item?
+
+    constituents&.any?
   end
 
   def collection?

--- a/spec/components/document_title_component_spec.rb
+++ b/spec/components/document_title_component_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DocumentTitleComponent, type: :component do
+  subject(:component) { described_class.new(presenter: presenter, document: document) }
+
+  let(:ability_mock) { instance_double(Ability, can?: true) }
+  let(:document) do
+    instance_double(
+      SolrDocument,
+      id: 'druid:ab123cd3445',
+      admin_policy?: admin_policy,
+      virtual_object?: virtual_object,
+      object_type: object_type
+    )
+  end
+  let(:presenter) { instance_double(ArgoShowPresenter, document: document, cocina: nil) }
+  let(:rendered) { render_inline(component) }
+
+  before do
+    allow(component).to receive(:helpers).and_return(ability_mock)
+    allow(component).to receive(:title).and_return('Dummy Title')
+  end
+
+  context 'with an APO' do
+    let(:admin_policy) { true }
+    let(:virtual_object) { false }
+    let(:object_type) { 'adminPolicy' }
+
+    it 'renders the expected object type label' do
+      expect(rendered.css('div.object-type').first.text.strip).to eq('apo')
+    end
+
+    it 'renders the expected object type class' do
+      expect(rendered.css('div.object-type').first.classes).to include('object-type-apo')
+    end
+  end
+
+  context 'with an agreement' do
+    let(:admin_policy) { false }
+    let(:virtual_object) { false }
+    let(:object_type) { 'agreement' }
+
+    it 'renders the expected object type label' do
+      expect(rendered.css('div.object-type').first.text.strip).to eq('agreement')
+    end
+
+    it 'renders the expected object type class' do
+      expect(rendered.css('div.object-type').first.classes).to include('object-type-agreement')
+    end
+  end
+
+  context 'with a collection' do
+    let(:admin_policy) { false }
+    let(:virtual_object) { false }
+    let(:object_type) { 'collection' }
+
+    it 'renders the expected object type label' do
+      expect(rendered.css('div.object-type').first.text.strip).to eq('collection')
+    end
+
+    it 'renders the expected object type class' do
+      expect(rendered.css('div.object-type').first.classes).to include('object-type-collection')
+    end
+  end
+
+  context 'with an item' do
+    let(:admin_policy) { false }
+    let(:virtual_object) { false }
+    let(:object_type) { 'item' }
+
+    it 'renders the expected object type label' do
+      expect(rendered.css('div.object-type').first.text.strip).to eq('item')
+    end
+
+    it 'renders the expected object type class' do
+      expect(rendered.css('div.object-type').first.classes).to include('object-type-item')
+    end
+  end
+
+  context 'with a virtual object' do
+    let(:admin_policy) { false }
+    let(:virtual_object) { true }
+    let(:object_type) { 'item' }
+
+    it 'renders the expected object type label' do
+      expect(rendered.css('div.object-type').first.text.strip).to eq('virtual object')
+    end
+
+    it 'renders the expected object type class' do
+      expect(rendered.css('div.object-type').first.classes).to include('object-type-virtual-object')
+    end
+  end
+end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -58,6 +58,42 @@ RSpec.describe SolrDocument, type: :model do
     end
   end
 
+  describe '#constituents' do
+    context 'when field present' do
+      let(:constituents) { ['druid:item1', 'druid:item2'] }
+      let(:document_attributes) do
+        {
+          SolrDocument::FIELD_CONSTITUENTS => constituents,
+          SolrDocument::FIELD_OBJECT_TYPE => ['item']
+        }
+      end
+
+      it 'returns the constituents' do
+        expect(document.constituents).to eq(constituents)
+      end
+
+      it 'knows it is a virtual object' do
+        expect(document).to be_virtual_object
+      end
+    end
+
+    context 'when field not present' do
+      let(:document_attributes) do
+        {
+          SolrDocument::FIELD_OBJECT_TYPE => ['item']
+        }
+      end
+
+      it 'returns nil' do
+        expect(document.constituents).to be_empty
+      end
+
+      it 'knows it is not a virtual object' do
+        expect(document).not_to be_virtual_object
+      end
+    end
+  end
+
   describe '#title' do
     subject(:title) { document.title }
 


### PR DESCRIPTION
## Why was this change made?

Improve the virtual object experience for users by:

1. Adding a facet to find all virtual objects; and
2. Rendering a pill on the show page to let users know they're looking at a virtual object

### Facet UI

Yes, there's only one virtual object in QA. Happy to take suggestions for how to label these better. @andrewjbtw. Both the collapsible heading *and* the link could both say `Virtual Objects` for instance? 🤷🏻‍♂️ 

![Screenshot from 2022-02-14 16-25-27](https://user-images.githubusercontent.com/131982/153969608-fca600e6-5827-4e46-84a3-4784a6657346.png)

### Show Page

![Screenshot from 2022-02-14 16-24-51](https://user-images.githubusercontent.com/131982/153969617-a62240aa-a857-45e5-aecb-31a775af8718.png)

## How was this change tested?

CI, QA


## Which documentation and/or configurations were updated?

None
