### PR TITLE
Reorder controls

### DIFF
--- a/app/components/show/controls_component.html.erb
+++ b/app/components/show/controls_component.html.erb
@@ -9,7 +9,7 @@
     <%= purge_button %>
   <% else %>
     <%= reindex_button %>
-    <%= add_workflow_button %>
+    <%= manage_release %>
     <div class="dropdown d-inline-block">
       <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">
         Manage PURL
@@ -29,9 +29,9 @@
                         } %></li>
       </ul>
     </div>
+    <%= add_workflow_button %>
     <%= purge_button %>
     <%= refresh_metadata if symphony_record? %>
-    <%= manage_release %>
     <%= create_embargo %>
   <% end %>
 </div>


### PR DESCRIPTION

## Why was this change made?

Move embargo to the end as it's only used by items. This makes the positions more stable between collections and items.

Fixes #3119


## How was this change tested?



## Which documentation and/or configurations were updated?



