### PR TITLE
Require description when closing a version

### DIFF
--- a/app/views/versions/_close_ui.html.erb
+++ b/app/views/versions/_close_ui.html.erb
@@ -18,7 +18,7 @@
     </div>
     <div class='mb-3'>
       <label for="description">Version description</label><br>
-      <textarea id="description" name="description" class='form-control'><%= @description %></textarea>
+      <textarea id="description" name="description" class="form-control" required="true"><%= @description %></textarea>
     </div>
     <button type='submit' class='btn btn-primary'>
       Close Version


### PR DESCRIPTION
## Why was this change made?

Let the browser ensure that a description has been provided when closing a version.

## How was this change tested?

Using my dev environment I tested closing version before and after the change, with and without a description.

## Which documentation and/or configurations were updated?
