### PR TITLE
remove default object rights from display

### DIFF
--- a/app/components/show/apo/default_object_rights_component.html.erb
+++ b/app/components/show/apo/default_object_rights_component.html.erb
@@ -1,12 +1,6 @@
 <table class="table table-sm mb-5 caption-header">
     <caption>Default object rights</caption>
     <tbody>
-      <tr>
-        <th class="col-3" scope="row">Access rights</th>
-        <td>
-            <%= access_rights %>
-        </td>
-      </tr>
 
       <tr>
         <th class="col-3" scope="row">Copyright</th>

--- a/app/components/show/apo/default_object_rights_component.rb
+++ b/app/components/show/apo/default_object_rights_component.rb
@@ -9,10 +9,6 @@ module Show
         @default_access = @presenter.cocina.administrative.defaultAccess
       end
 
-      def access_rights
-        @default_access.access
-      end
-
       def copyright
         @default_access.copyright || 'None'
       end


### PR DESCRIPTION
## Why was this change made?

So we can release Argo while we continue working on #3121.

Default object rights will be added back when we can display the expected value.

## How was this change tested?

Localhost


## Which documentation and/or configurations were updated?



