### PR TITLE
add back default access rights display for APOs

### DIFF
--- a/app/components/show/apo/default_object_rights_component.html.erb
+++ b/app/components/show/apo/default_object_rights_component.html.erb
@@ -1,6 +1,12 @@
 <table class="table table-sm mb-5 caption-header">
     <caption>Default object rights</caption>
     <tbody>
+      <tr>
+        <th class="col-3" scope="row">Access rights</th>
+        <td>
+            <%= access_rights %>
+        </td>
+      </tr>
 
       <tr>
         <th class="col-3" scope="row">Copyright</th>

--- a/app/components/show/apo/default_object_rights_component.rb
+++ b/app/components/show/apo/default_object_rights_component.rb
@@ -9,6 +9,10 @@ module Show
         @default_access = @presenter.cocina.administrative.defaultAccess
       end
 
+      def access_rights
+        @presenter.document.default_access_rights
+      end
+
       def copyright
         @default_access.copyright || 'None'
       end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -30,6 +30,7 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
   FIELD_CURRENT_VERSION           = 'current_version_isi'
   FIELD_STATUS                    = 'status_ssi'
   FIELD_ACCESS_RIGHTS             = 'rights_descriptions_ssim'
+  FIELD_DEFAULT_ACCESS_RIGHTS     = 'default_rights_descriptions_ssim'
   FIELD_COPYRIGHT                 = 'copyright_ssim'
   FIELD_USE_STATEMENT             = 'use_statement_ssim'
   FIELD_LICENSE                   = 'use_license_machine_ssi'
@@ -66,6 +67,7 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
   attribute :mods_created_date, Blacklight::Types::String, FIELD_MODS_CREATED_DATE
   attribute :status, Blacklight::Types::String, FIELD_STATUS
   attribute :access_rights, Blacklight::Types::String, FIELD_ACCESS_RIGHTS
+  attribute :default_access_rights, Blacklight::Types::String, FIELD_DEFAULT_ACCESS_RIGHTS
   attribute :copyright, Blacklight::Types::String, FIELD_COPYRIGHT
   attribute :use_statement, Blacklight::Types::String, FIELD_USE_STATEMENT
   attribute :license, Blacklight::Types::String, FIELD_LICENSE

--- a/spec/components/show/apo/default_object_rights_component_spec.rb
+++ b/spec/components/show/apo/default_object_rights_component_spec.rb
@@ -3,13 +3,40 @@
 require 'rails_helper'
 
 RSpec.describe Show::Apo::DefaultObjectRightsComponent, type: :component do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:component) { described_class.new(presenter: presenter) }
+  let(:presenter) { instance_double(ArgoShowPresenter, document: doc, cocina: cocina) }
+  let(:cocina) do
+    Cocina::Models::AdminPolicy.new(externalIdentifier: 'druid:bb663yf7144',
+                                    type: Cocina::Models::Vocab.admin_policy,
+                                    label: 'An APO',
+                                    version: 1,
+                                    administrative: {
+                                      hasAdminPolicy: 'druid:hv992ry2431',
+                                      hasAgreement: 'druid:hp308wm0436',
+                                      defaultAccess: {
+                                        access: 'location-based',
+                                        download: 'location-based',
+                                        readLocation: 'spec',
+                                        useAndReproductionStatement: 'Use and reproduction statement.',
+                                        copyright: 'This is the copyright.',
+                                        license: 'A license goes here.'
+                                      }
+                                    })
+  end
+  let(:doc) do
+    SolrDocument.new('id' => 'druid:bb663yf7144',
+                     SolrDocument::FIELD_OBJECT_TYPE => 'adminPolicy',
+                     SolrDocument::FIELD_DEFAULT_ACCESS_RIGHTS => 'location - spec')
+  end
+  let(:rendered) { render_inline(component) }
 
-  # it "renders something useful" do
-  #   expect(
-  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
-  #   ).to include(
-  #     "Hello, components!"
-  #   )
-  # end
+  it 'shows the copyright, license, use statement and default access rights' do
+    # these come from the cocina model:
+    expect(rendered.to_html).to include 'Use and reproduction statement.'
+    expect(rendered.to_html).to include 'This is the copyright.'
+    expect(rendered.to_html).to include 'A license goes here.'
+
+    # this comes from the solr document:
+    expect(rendered.to_html).to include 'location - spec'
+  end
 end


### PR DESCRIPTION
## Why was this change made?

Fixes #3121 - show the default access rights for APOs in a consistent way to that shown for items (by showing what is in the newly indexed solr documents for APOs)

See https://github.com/sul-dlss/dor_indexing_app/pull/754 for new indexing work this depends on

~~Note: HOLD until the new indexing code above is deployed, and APOs re-indexed for this to show correctly (note: it should not break if Argo is deployed before this occurs, but the display of default object rights will be blank until then).~~

## How was this change tested?

Localhost browser

## Which documentation and/or configurations were updated?



