### PR TITLE
improve contrast of placeholder image

### DIFF
--- a/app/components/show/item/thumbnail_component.html.erb
+++ b/app/components/show/item/thumbnail_component.html.erb
@@ -3,7 +3,7 @@
 <% else %>
   <svg style="text-anchor: middle" width="240" height="240" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Responsive image" focusable="false">
     <title>Placeholder</title>
-    <rect width="100%" height="100%" fill="#868e96"></rect>
+    <rect width="100%" height="100%" stroke="#000000" stroke-width="4" fill="#eeeeee"></rect>
     <foreignObject x="10" y="10" width="220" height="220">
       <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; height: 100%; justify-content: center; align-items: center;">
         <p xmlns="http://www.w3.org/1999/xhtml"><%= placeholder_text %></p>


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3125 - improve contrast of placeholder.

Dark grey fill to very light grey fill (to set of from page just a bit), and a solid black border.

Example:
![Screen Shot 2022-02-18 at 1 58 41 PM](https://user-images.githubusercontent.com/47137/154767010-1691fca2-4ac5-495e-8a7a-69a2ec7e4ead.png)


## How was this change tested? 🤨

Localhost browser

