### PR TITLE
Prompt temporarily when deploying to production

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -4,3 +4,10 @@ server 'argo-prod-01.stanford.edu', user: 'lyberadmin', roles: %w[web db app wor
 server 'argo-prod-02.stanford.edu', user: 'lyberadmin', roles: %w[web db app worker]
 
 Capistrano::OneTimeKey.generate_one_time_key!
+
+# During the early 2022 work cycle, Andrew would like to ship release notes to users in advance of deploys to prod
+before 'deploy:starting', :andrew_approval do
+  ask :confirmation, 'Did Andrew approve this deployment to prod? If so, type "Andrew" to confirm'
+
+  raise 'Canceling the deployment' unless fetch(:confirmation) == 'Andrew'
+end


### PR DESCRIPTION


## Why was this change made? 🤔

We hope this will help remind us that we don't want to deploy user-facing changes in advance of release notes being shared with users.

## How was this change tested? 🤨

Patched it in (another codebase), ran deploy, got the prompt.