### PR TITLE
Agreement page tweaks

### DIFF
--- a/app/components/show/agreement/details_component.html.erb
+++ b/app/components/show/agreement/details_component.html.erb
@@ -37,13 +37,6 @@
       </tr>
 
       <tr>
-        <th class="col-3" scope="row">Released to</th>
-        <td>
-            <%= released_to %>
-        </td>
-      </tr>
-
-      <tr>
         <th class="col-3" scope="row">Preservation size</th>
         <td>
             <%= number_to_human_size(preservation_size) %>

--- a/app/components/show/agreement/details_component.rb
+++ b/app/components/show/agreement/details_component.rb
@@ -11,10 +11,6 @@ module Show
 
       delegate :object_type, :created_date, :preservation_size, to: :@solr_document
       delegate :state_service, to: :@presenter
-
-      def released_to
-        @solr_document.released_to.presence&.to_sentence || 'Not released'
-      end
     end
   end
 end

--- a/app/components/show/controls_component.html.erb
+++ b/app/components/show/controls_component.html.erb
@@ -9,7 +9,9 @@
     <%= purge_button %>
   <% else %>
     <%= reindex_button %>
-    <%= manage_release %>
+    <% unless agreement? %>
+      <%= manage_release %>
+    <% end %>
     <div class="dropdown d-inline-block">
       <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">
         Manage PURL

--- a/app/components/show/controls_component.rb
+++ b/app/components/show/controls_component.rb
@@ -40,7 +40,7 @@ module Show
       doc.catkey_id.present?
     end
 
-    delegate :admin_policy?, :item?, :embargoed?, to: :doc
+    delegate :admin_policy?, :agreement?, :item?, :embargoed?, to: :doc
 
     private
 


### PR DESCRIPTION
## Why was this change made? 🤔

Closes #3112 -- there was cruft in the Agreement page.

### After

Note "Manage release" button is gone, and "Released to" is no longer in Details table.

![image](https://user-images.githubusercontent.com/96775/155592102-46385113-2392-4c27-a507-6bdf45a9c003.png)

### Before

![image](https://user-images.githubusercontent.com/96775/155592268-304ec8be-7c18-46fd-828f-6f60107c4a8f.png)


## How was this change tested? 🤨

As JCoyne points out, it is difficult to test for the absence of something.  These changes only affect the Argo display on the Agreeement change, and proof is in what the eye beholds?  (Per images above)

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on that repo to fix anything this change breaks. ⚡


