### PR TITLE
object show: list all indexed rights for objects with complex rights combinations

### DIFF
--- a/app/components/show/access_rights_component.html.erb
+++ b/app/components/show/access_rights_component.html.erb
@@ -1,4 +1,4 @@
-<%= access_rights %>
+<%= access_rights.to_sentence %>
 <% if allows_modification? && !admin_policy? %>
   <%= link_to rights_item_path(id: id),
               aria: { label: 'Set rights' },

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -66,7 +66,7 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
   attribute :publisher, Blacklight::Types::String, FIELD_PUBLISHER
   attribute :mods_created_date, Blacklight::Types::String, FIELD_MODS_CREATED_DATE
   attribute :status, Blacklight::Types::String, FIELD_STATUS
-  attribute :access_rights, Blacklight::Types::String, FIELD_ACCESS_RIGHTS
+  attribute :access_rights, Blacklight::Types::Array, FIELD_ACCESS_RIGHTS
   attribute :default_access_rights, Blacklight::Types::String, FIELD_DEFAULT_ACCESS_RIGHTS
   attribute :copyright, Blacklight::Types::String, FIELD_COPYRIGHT
   attribute :use_statement, Blacklight::Types::String, FIELD_USE_STATEMENT

--- a/spec/features/item_view_metadata_spec.rb
+++ b/spec/features/item_view_metadata_spec.rb
@@ -186,6 +186,7 @@ RSpec.describe 'Item view', js: true do
           SolrDocument::FIELD_OBJECT_TYPE => 'item',
           content_type_ssim: 'image',
           status_ssi: 'v1 Unknown Status',
+          rights_descriptions_ssim: %w[world dark],
           SolrDocument::FIELD_APO_ID => 'info:fedora/druid:ww057qx5555',
           SolrDocument::FIELD_APO_TITLE => 'Stanford University Libraries - Special Collections',
           project_tag_ssim: 'Fuller Slides',
@@ -210,6 +211,8 @@ RSpec.describe 'Item view', js: true do
           expect(page).to have_css 'th', text: 'Admin policy'
           expect(page).to have_css 'td a', text: 'Stanford University Libraries - Special Collections'
           expect(page).to have_css 'th', text: 'Status'
+          expect(page).to have_css 'th', text: 'Access rights'
+          expect(page).to have_css 'td', text: 'world and dark'
           expect(page).to have_css 'td', text: 'v1 Unknown Status'
         end
 


### PR DESCRIPTION
## Why was this change made? 🤔

fixes #3146

i wasn't sure if there was a better or more idiomatic way to do this, happy to change if so.

## How was this change tested? 🤨

- [x] unit tests
- [x] manually on laptop instance

in search results (desired display behavior for reference):
<img width="539" alt="Screen Shot 2022-02-24 at 11 44 15 PM" src="https://user-images.githubusercontent.com/7741604/155676006-2dd64ade-a067-4734-b624-f4a4ef40f9e8.png">

on show page before fix:
<img width="650" alt="Screen Shot 2022-02-24 at 11 45 04 PM" src="https://user-images.githubusercontent.com/7741604/155676166-014a2e12-c63d-4a9c-bc74-8ff1bb1474cf.png">

on show page after fix:
<img width="646" alt="Screen Shot 2022-02-24 at 11 45 32 PM" src="https://user-images.githubusercontent.com/7741604/155676304-3a8b8a38-7104-4b12-a23f-e8c8a07956e5.png">


⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

n/a

⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on that repo to fix anything this change breaks. ⚡

- [ ] integration test
