### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,14 +90,6 @@ If you want to run background jobs, which are necessary for spreadsheet bulk upl
 docker compose run web sidekiq start
 ```
 
-Alternatively, you can also just immediately run any new jobs with interactive output visible
-(and then quit the job worker).  This is useful for debugging and can also be used with "byebug"
-to stop execution in the middle of an activejob for inspection:
-
-```
-docker compose run web bin/rake jobs:workoff
-```
-
 Note, if you update the Gemfile or Gemfile.lock, you will need to rebuild the web docker container.
 
 ```
@@ -120,6 +112,7 @@ docker compose run --service-ports web
 ```
 
 This will allow you to view rails output in real-time.  You can also add 'byebug' inline in your code to pause for inspection on the console.
+
 
 ### Note
 


### PR DESCRIPTION

## Why was this change made? 🤔
`jobs:workoff` rake task does not exist. Removing reference to clarify README.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on that repo to fix anything this change breaks. ⚡


