### PR TITLE
Set content type bulk action

### DIFF
--- a/app/components/bulk_actions_form_component.html.erb
+++ b/app/components/bulk_actions_form_component.html.erb
@@ -163,6 +163,15 @@
           <%= render 'bulk_actions/forms/set_license_and_rights_statements_form', f: f, license_options: @form.license_options %>
         </div>
 
+        <div role='tabpanel', class='tab-pane', id='SetContentTypeJob'>
+          <div class="mb-3">
+            <span class='help-block'>
+              Set content type
+            </span>
+          </div>
+          <%= render 'bulk_actions/forms/set_content_type_form', f: f %> 
+        </div>
+
         <div role='tabpanel' class='tab-pane' id='ManageEmbargoesJob'>
           <div class="mb-3">
             <span class='help-block'>

--- a/app/components/bulk_actions_form_component.rb
+++ b/app/components/bulk_actions_form_component.rb
@@ -34,7 +34,8 @@ class BulkActionsFormComponent < ApplicationComponent
         ['Update governing APO', 'SetGoverningApoJob'],
         ['Edit Catkeys and Barcodes', 'SetCatkeysAndBarcodesJob'],
         ['Edit License and Rights Statements', 'SetLicenseAndRightsStatementsJob'],
-        ['Refresh MODS', 'RefreshModsJob']
+        ['Refresh MODS', 'RefreshModsJob'],
+        ['Set Content Type', 'SetContentTypeJob']
       ]],
       ['Modify objects (via CSV)', [
         ['Create virtual object(s)', 'CreateVirtualObjectsJob'],

--- a/app/controllers/bulk_actions_controller.rb
+++ b/app/controllers/bulk_actions_controller.rb
@@ -20,7 +20,6 @@ class BulkActionsController < ApplicationController
   def create
     # Since the groups aren't persisted, we need to pass them here.
     @form = BulkActionForm.new(BulkAction.new(user: current_user), groups: current_user.groups)
-
     if @form.validate(bulk_action_params) && @form.save
       flash[:notice] = 'Bulk action was successfully created.'
       redirect_to action: :index
@@ -73,7 +72,11 @@ class BulkActionsController < ApplicationController
         license license_option
         use_statement use_statement_option
       ],
-      manage_embargo: [:csv_file]
+      manage_embargo: [:csv_file],
+      set_content_type: %i[
+        current_resource_type
+        new_content_type new_resource_type
+      ]
     )
   end
 end

--- a/app/controllers/content_types_controller.rb
+++ b/app/controllers/content_types_controller.rb
@@ -19,15 +19,9 @@ class ContentTypesController < ApplicationController
     return render_error('Invalid new content type.') unless valid_content_type?
 
     object_client.update(params: @cocina_object.new(cocina_update_attributes))
-    Argo::Indexer.reindex_pid_remotely(@cocina_object.externalIdentifier) unless params[:bulk]
+    Argo::Indexer.reindex_pid_remotely(@cocina_object.externalIdentifier)
 
-    respond_to do |format|
-      if params[:bulk]
-        format.html { render plain: 'Content type updated.' }
-      else
-        format.any { redirect_to solr_document_path(params[:item_id]), notice: 'Content type updated!' }
-      end
-    end
+    redirect_to solr_document_path(params[:item_id]), notice: 'Content type updated!'
   end
 
   private

--- a/app/forms/bulk_action_form.rb
+++ b/app/forms/bulk_action_form.rb
@@ -8,6 +8,7 @@ class BulkActionForm < BaseForm
     set_source_ids_csv prepare register_druids
     create_virtual_objects import_tags
     set_license_and_rights_statements manage_embargo
+    set_content_type
   ].freeze
 
   def initialize(model, groups:)

--- a/app/javascript/bulk.js
+++ b/app/javascript/bulk.js
@@ -29,15 +29,6 @@ function process_patch(druids, action_url, req_params, success_string) {
 	process_request(druids, action_url, 'PATCH', req_params, success_string, show_buttons, show_buttons);
 }
 
-function set_content_type(druids){
-	var params={
-		'new_content_type': document.getElementById('new_content_type').value,
-		'new_resource_type': document.getElementById('new_resource_type').value,
-		'old_resource_type': document.getElementById('old_resource_type').value
-	}
-	process_patch(druids, set_content_type_url, params, "Updated");
-}
-
 function fetch_pids_txt() {
 	return document.getElementById('pids').value.trim();
 }
@@ -240,7 +231,6 @@ document.addEventListener("turbo:load", () => {
   $('#get_druids').on('click', get_druids)
 	$('#paste-druids-button').on('click', () => $('#pid_list').show(400))
 	$('#set-object-rights-button').on('click', () => $('#rights').show(400))
-	$('#set-content-type-button').on('click', () => $('#content_type').show(400))
 	$('#set-collection-button').on('click', () => $('#set_collection').show(400))
 
   $('#show_tags').on('click', () => {
@@ -251,11 +241,6 @@ document.addEventListener("turbo:load", () => {
 	$('#confirm-set-collection-button').on('click', () => {
 		fetch_druids(set_collection)
 		$('#set_collection').hide(400)
-	})
-
-	$('#confirm-set-content-type-button').on('click', () => {
-		fetch_druids(set_content_type)
-		$('#content_type').hide(400)
 	})
 
   $('#set_tags').on('click', () => {

--- a/app/javascript/bulk.js
+++ b/app/javascript/bulk.js
@@ -25,10 +25,6 @@ function process_post(druids, action_url, req_params, success_string) {
 	process_request(druids, action_url, 'POST', req_params, success_string, show_buttons, show_buttons);
 }
 
-function process_patch(druids, action_url, req_params, success_string) {
-	process_request(druids, action_url, 'PATCH', req_params, success_string, show_buttons, show_buttons);
-}
-
 function fetch_pids_txt() {
 	return document.getElementById('pids').value.trim();
 }

--- a/app/jobs/set_content_type_job.rb
+++ b/app/jobs/set_content_type_job.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/CyclomaticComplexity
+# job to set new content type and resource type
+class SetContentTypeJob < GenericJob
+  def perform(bulk_action_id, params)
+    super
+
+    # types are the label for content types, e.g. book (ltr)
+    @current_resource_type = params[:set_content_type][:current_resource_type]
+    @new_content_type = params[:set_content_type][:new_content_type]
+    @new_resource_type = params[:set_content_type][:new_resource_type]
+
+    with_bulk_action_log do |log_buffer|
+      log_buffer.puts("#{Time.current} Starting #{self.class} for BulkAction #{bulk_action_id}")
+      raise StandardError, 'Must provide values for types.' if @current_resource_type.blank? && @new_resource_type.blank? && @new_content_type.blank?
+      raise StandardError, 'Must provide a new content type when changing resource type.' if @new_content_type.blank? && @new_resource_type.present?
+
+      update_druid_count
+
+      pids.each do |current_druid|
+        log_buffer.puts("#{Time.current} #{self.class}: Attempting #{current_druid} (bulk_action.id=#{bulk_action_id})")
+        set_content_type(current_druid, log_buffer)
+      end
+
+      log_buffer.puts("#{Time.current} Finished #{self.class} for BulkAction #{bulk_action_id}")
+    rescue StandardError => e
+      log_buffer.puts "#{Time.current} #{self.class}: Error with form values provided: #{e.message}"
+    end
+  end
+  # rubocop:enable Metrics/CyclomaticComplexity
+
+  private
+
+  attr_reader :current_resource_type, :new_content_type, :new_resource_type
+
+  def set_content_type(current_druid, log_buffer)
+    object_client = Dor::Services::Client.object(current_druid)
+    cocina_object = object_client.find
+
+    return unless verify_access(cocina_object, log_buffer)
+
+    # use dor services client to pass a hash for structural metadata and update the cocina object
+    begin
+      state_service = StateService.new(cocina_object.externalIdentifier, version: cocina_object.version)
+      raise StandardError, 'Object cannot be modified in its current state.' unless state_service.allows_modification?
+
+      object_client.update(params: cocina_object.new(cocina_update_attributes(cocina_object)))
+      Argo::Indexer.reindex_pid_remotely(cocina_object.externalIdentifier)
+      log_buffer.puts("#{Time.current} #{self.class}: Successfully updated content type of #{current_druid} (bulk_action.id=#{bulk_action.id})")
+      bulk_action.increment(:druid_count_success).save
+    rescue StandardError => e
+      log_buffer.puts "#{Time.current} #{self.class}: Unexpected error for #{current_druid}: (bulk_action.id=#{bulk_action.id}): #{e.message}"
+      bulk_action.increment(:druid_count_fail).save
+    end
+  end
+
+  def verify_access(cocina_object, log_buffer)
+    return true if ability.can?(:manage_item, cocina_object)
+
+    log_buffer.puts("#{Time.current} Not authorized for #{cocina_object.externalIdentifier}")
+    bulk_action.increment(:druid_count_fail).save
+    false
+  end
+
+  def cocina_update_attributes(cocina_object)
+    {}.tap do |attributes|
+      attributes[:type] = Constants::CONTENT_TYPES[@new_content_type]
+      attributes[:structural] = if resource_types_should_change?(cocina_object)
+                                  structural_with_resource_type_changes(cocina_object)
+                                else
+                                  cocina_object.structural.new(hasMemberOrders: member_orders)
+                                end
+    end
+  end
+
+  # If the new content type is a book, we need to set the viewing direction attribute in the cocina model
+  def member_orders
+    return [] unless @new_content_type.start_with?('book')
+
+    viewing_direction = if @new_content_type == 'book (ltr)'
+                          'left-to-right'
+                        else
+                          'right-to-left'
+                        end
+    [{ viewingDirection: viewing_direction }]
+  end
+
+  def structural_with_resource_type_changes(cocina_object)
+    cocina_object.structural.new(
+      hasMemberOrders: member_orders,
+      contains: cocina_object.structural.contains.map do |resource|
+        next resource unless resource.type == Constants::RESOURCE_TYPES[@current_resource_type]
+
+        resource.new(type: Constants::RESOURCE_TYPES[@new_resource_type])
+      end
+    )
+  end
+
+  def resource_types_should_change?(cocina_object)
+    Array(cocina_object.structural.contains).map(&:type).any? { |resource_type| resource_type == Constants::RESOURCE_TYPES[@current_resource_type] }
+  end
+end

--- a/app/jobs/set_content_type_job.rb
+++ b/app/jobs/set_content_type_job.rb
@@ -38,6 +38,13 @@ class SetContentTypeJob < GenericJob
     object_client = Dor::Services::Client.object(current_druid)
     cocina_object = object_client.find
 
+    # collections, APOs, and agreements do not have content types
+    if [Cocina::Models::ObjectType.collection, Cocina::Models::ObjectType.admin_policy].include? cocina_object.type
+      log_buffer.puts "#{Time.current} #{self.class}: Could not update content type for #{current_druid}: object is a #{cocina_object.type}"
+      bulk_action.increment(:druid_count_fail).save
+      return
+    end
+
     return unless verify_access(cocina_object, log_buffer)
 
     # use dor services client to pass a hash for structural metadata and update the cocina object

--- a/app/models/bulk_action.rb
+++ b/app/models/bulk_action.rb
@@ -27,6 +27,7 @@ class BulkAction < ApplicationRecord
                      RegisterDruidsJob
                      SetLicenseAndRightsStatementsJob
                      SetSourceIdsCsvJob
+                     SetContentTypeJob
                      ManageEmbargoesJob]
             }
 

--- a/app/services/bulk_action_persister.rb
+++ b/app/services/bulk_action_persister.rb
@@ -24,7 +24,7 @@ class BulkActionPersister
 
   delegate :pids, :add_workflow, :manage_release, :set_governing_apo,
            :set_catkeys_and_barcodes, :groups, :prepare, :create_virtual_objects,
-           :import_tags, :set_license_and_rights_statements,
+           :import_tags, :set_license_and_rights_statements, :set_content_type,
            to: :bulk_action_form
 
   delegate :id, :file, :output_directory, to: :bulk_action
@@ -64,6 +64,7 @@ class BulkActionPersister
       set_catkeys_and_barcodes: set_catkeys_and_barcodes,
       set_governing_apo: set_governing_apo,
       set_license_and_rights_statements: set_license_and_rights_statements,
+      set_content_type: set_content_type,
       prepare: prepare,
       csv_file: bulk_action_form.csv_as_string,
       groups: groups

--- a/app/views/bulk_actions/forms/_set_content_type_form.html.erb
+++ b/app/views/bulk_actions/forms/_set_content_type_form.html.erb
@@ -1,0 +1,26 @@
+<% f.fields_for :set_content_type do |set_content_type_fields| %>
+  <div class='mb-3'>
+    
+    <p>The suggested mappings for content type to resource type are:</p>
+    <ul>
+      <li>File: file</li>
+      <li>Image: image</li>
+      <li>Book: page</li>
+      <li>Map: image</li>
+      <li>Document: document</li>
+    </ul>
+    
+    <% current_resource_types = [['none', '']] + Constants::RESOURCE_TYPES.keys
+      new_content_types = [['none', '']] + Constants::CONTENT_TYPES.keys
+      new_resource_types = [['none', '']] + Constants::RESOURCE_TYPES.keys %>
+
+    <%= set_content_type_fields.label :current_resource_type, 'Current resource type' %>
+    <%= set_content_type_fields.select :current_resource_type, current_resource_types, {}, class: 'form-select' %>
+   
+    <%= set_content_type_fields.label :new_content_type, 'New content type' %>
+    <%= set_content_type_fields.select :new_content_type, new_content_types, {}, class: 'form-select' %>
+     
+    <%= set_content_type_fields.label :new_resource_type, 'New resource type' %>
+    <%= set_content_type_fields.select :new_resource_type, new_resource_types, {}, class: 'form-select' %>
+  </div>
+<% end %>

--- a/app/views/report/bulk.html.erb
+++ b/app/views/report/bulk.html.erb
@@ -12,7 +12,6 @@ function catalog_url(element)
   url=url.replace(/xxxxxxxxx/g,element);
   return url;
 }
-set_content_type_url='<%= item_content_type_url(item_id: 'druid:xxxxxxxxx', bulk: 'true') %>'
 set_rights_url='<%= set_rights_item_path(id: 'druid:xxxxxxxxx', bulk: 'true') %>'
 set_collection_url='<%= set_collection_item_path(id: 'druid:xxxxxxxxx', bulk: 'true') %>'
 tags_url='<%= tags_bulk_item_path(id: 'druid:xxxxxxxxx', bulk: 'true') %>'
@@ -62,7 +61,6 @@ ul li{
         <button class="btn btn-primary btn-block" id="set-object-rights-button">Set object rights</button>
       </div>
       <div class="col-sm-2">
-        <button class="btn btn-primary btn-block" id="set-content-type-button">Set content type</button>
         <button class="btn btn-primary btn-block" id="set-collection-button">Set collection</button>
       </div>
     </div>

--- a/spec/controllers/content_types_controller_spec.rb
+++ b/spec/controllers/content_types_controller_spec.rb
@@ -197,14 +197,6 @@ RSpec.describe ContentTypesController, type: :controller do
           expect(Argo::Indexer).not_to have_received(:reindex_pid_remotely)
         end
       end
-
-      context 'when a batch process' do
-        it 'is successful' do
-          patch :update, params: { item_id: pid, new_content_type: 'media', bulk: true }
-          expect(response).to be_successful
-          expect(Argo::Indexer).not_to have_received(:reindex_pid_remotely)
-        end
-      end
     end
 
     context 'without access' do

--- a/spec/features/bulk_screen_spec.rb
+++ b/spec/features/bulk_screen_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe 'Bulk actions view', js: true do
     end
 
     expect(page).to have_button('Set object rights', disabled: false)
-    expect(page).to have_button('Set content type', disabled: false)
     expect(page).to have_button('Set collection', disabled: false)
   end
 end

--- a/spec/jobs/set_content_type_job_spec.rb
+++ b/spec/jobs/set_content_type_job_spec.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SetContentTypeJob, type: :job do
+  let(:pids) { ['druid:bb111cc2222', 'druid:cc111dd2233'] }
+  let(:groups) { [] }
+  let(:bulk_action) do
+    create(
+      :bulk_action,
+      action_type: 'SetContentTypeJob'
+    )
+  end
+  let(:params) do
+    {
+      pids: [pids[0]],
+      set_content_type: {
+        current_resource_type: 'image',
+        new_content_type: 'book (ltr)',
+        new_resource_type: 'page'
+      }
+    }
+  end
+  let(:user) { bulk_action.user }
+  let(:cocina1) do
+    Cocina::Models.build({
+                           'label' => 'My Book Item',
+                           'version' => 2,
+                           'type' => Cocina::Models::Vocab.book,
+                           'externalIdentifier' => pids[0],
+                           'description' => {
+                             title: [{ value: 'my dro' }],
+                             purl: 'https://purl.stanford.edu/bc234fg5678'
+                           },
+                           'access' => {},
+                           'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+                           'structural' => { contains: [{ type: 'http://cocina.sul.stanford.edu/models/resources/page.jsonld',
+                                                          label: 'Book page',
+                                                          version: 1,
+                                                          externalIdentifier: 'abc123456' },
+                                                        { type: 'http://cocina.sul.stanford.edu/models/resources/image.jsonld',
+                                                          label: 'Book page 2',
+                                                          version: 1,
+                                                          externalIdentifier: 'abc789012' }] },
+                           'identification' => {}
+                         })
+  end
+  let(:cocina2) do
+    Cocina::Models.build({
+                           'label' => 'My Map Item',
+                           'version' => 3,
+                           'type' => Cocina::Models::Vocab.image,
+                           'externalIdentifier' => pids[1],
+                           'description' => {
+                             title: [{ value: 'my dro' }],
+                             purl: 'https://purl.stanford.edu/bc234fg5678'
+                           },
+                           'access' => {},
+                           'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+                           'structural' => { contains: [{ type: 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
+                                                          label: 'Map label',
+                                                          version: 1,
+                                                          externalIdentifier: 'xyz012345' }] },
+                           'identification' => {}
+                         })
+  end
+
+  let(:object_client1) { instance_double(Dor::Services::Client::Object, find: cocina1) }
+  let(:object_client2) { instance_double(Dor::Services::Client::Object, find: cocina2) }
+
+  let(:state_service) { instance_double(StateService, allows_modification?: true) }
+  let(:buffer) { StringIO.new }
+
+  before do
+    allow(subject).to receive(:bulk_action).and_return(bulk_action)
+    allow(subject).to receive(:with_bulk_action_log).and_yield(buffer)
+    allow(subject.ability).to receive(:can?).and_return(true)
+    allow(StateService).to receive(:new).and_return(state_service)
+    allow(Dor::Services::Client).to receive(:object).with(pids[0]).and_return(object_client1)
+    allow(Dor::Services::Client).to receive(:object).with(pids[1]).and_return(object_client2)
+    allow(object_client1).to receive(:update)
+    allow(object_client2).to receive(:update)
+    allow(Argo::Indexer).to receive(:reindex_pid_remotely)
+  end
+
+  context 'when book object with image and page resource types' do
+    it 'changes the resource with image type to page type and logs success' do
+      subject.perform(bulk_action.id, params)
+      expect(object_client1).to have_received(:update)
+        .with(
+          params: a_cocina_object_with_types(
+            resource_types: [Cocina::Models::Vocab::Resources.page, Cocina::Models::Vocab::Resources.image]
+          )
+        )
+      expect(buffer.string).to include "Successfully updated content type of #{pids[0]} (bulk_action.id=#{bulk_action.id})"
+    end
+  end
+
+  context 'when object resource types and content type are requested to change' do
+    let(:params) do
+      {
+        pids: [pids[1]],
+        set_content_type: {
+          current_resource_type: 'file',
+          new_content_type: 'map',
+          new_resource_type: 'image'
+        }
+      }
+    end
+
+    it 'changes the content type to map and resource type' do
+      subject.perform(bulk_action.id, params)
+      expect(object_client2).to have_received(:update)
+        .with(
+          params: a_cocina_object_with_types(
+            content_type: Cocina::Models::Vocab.map,
+            resource_types: [Cocina::Models::Vocab::Resources.page, Cocina::Models::Vocab::Resources.image]
+          )
+        )
+    end
+  end
+
+  context 'when new content type is book (rtl)' do
+    let(:params) do
+      {
+        pids: [pids[0]],
+        set_content_type: {
+          current_resource_type: 'page',
+          new_content_type: 'book (rtl)',
+          new_resource_type: 'page'
+        }
+      }
+    end
+
+    it 'sets the viewing direction' do
+      subject.perform(bulk_action.id, params)
+      expect(object_client1).to have_received(:update)
+        .with(
+          params: a_cocina_object_with_types(
+            content_type: Cocina::Models::Vocab.book,
+            viewing_direction: 'right-to-left'
+          )
+        )
+    end
+  end
+
+  context 'when a new resource type is provided but not a new content type' do
+    let(:params) do
+      {
+        pids: [pids[0]],
+        set_content_type: {
+          current_resource_type: '',
+          new_content_type: '',
+          new_resource_type: 'page'
+        }
+      }
+    end
+
+    it 'logs an error' do
+      subject.perform(bulk_action.id, params)
+      expect(buffer.string).to include 'Must provide a new content type when changing resource type.'
+      expect(object_client1).not_to have_received(:update)
+    end
+  end
+
+  context 'when a no types are entered in the form' do
+    let(:params) do
+      {
+        pids: [pids[0]],
+        set_content_type: {
+          current_resource_type: '',
+          new_content_type: '',
+          new_resource_type: ''
+        }
+      }
+    end
+
+    it 'logs an error' do
+      subject.perform(bulk_action.id, params)
+      expect(buffer.string).to include 'Must provide values for types.'
+      expect(object_client1).not_to have_received(:update)
+    end
+  end
+
+  context 'without structural metadata' do
+    let(:structural) { {} }
+    let(:params) do
+      {
+        pids: [pids[0]],
+        set_content_type: {
+          current_resource_type: '',
+          new_content_type: 'map',
+          new_resource_type: ''
+        }
+      }
+    end
+
+    it 'changes the content type only' do
+      subject.perform(bulk_action.id, params)
+      expect(object_client1).to have_received(:update)
+        .with(params: a_cocina_object_with_types(content_type: Cocina::Models::Vocab.map))
+    end
+  end
+
+  context 'when modification is not allowed' do
+    let(:state_service) { instance_double(StateService, allows_modification?: false) }
+
+    it 'does not update and logs an error' do
+      subject.perform(bulk_action.id, params)
+      expect(object_client2).not_to have_received(:update)
+      expect(buffer.string).to include 'Object cannot be modified in its current state.'
+    end
+  end
+
+  context 'when not authorized to manage object' do
+    before do
+      allow(subject.ability).to receive(:can?).and_return(false)
+    end
+
+    it 'does not update and logs "not authorized"' do
+      subject.perform(bulk_action.id, params)
+      expect(buffer.string).to include 'Not authorized'
+      expect(object_client1).not_to have_received(:update)
+    end
+  end
+end

--- a/spec/jobs/set_content_type_job_spec.rb
+++ b/spec/jobs/set_content_type_job_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe SetContentTypeJob, type: :job do
-  let(:pids) { ['druid:bb111cc2222', 'druid:cc111dd2233'] }
+  let(:pids) { ['druid:bb111cc2222', 'druid:cc111dd2233', 'druid:ff123gg4567'] }
   let(:groups) { [] }
   let(:bulk_action) do
     create(
@@ -24,49 +24,64 @@ RSpec.describe SetContentTypeJob, type: :job do
   let(:user) { bulk_action.user }
   let(:cocina1) do
     Cocina::Models.build({
-                           'label' => 'My Book Item',
-                           'version' => 2,
-                           'type' => Cocina::Models::Vocab.book,
-                           'externalIdentifier' => pids[0],
-                           'description' => {
+                           label: 'My Book Item',
+                           version: 2,
+                           type: Cocina::Models::ObjectType.book,
+                           externalIdentifier: pids[0],
+                           description: {
                              title: [{ value: 'my dro' }],
                              purl: 'https://purl.stanford.edu/bc234fg5678'
                            },
-                           'access' => {},
-                           'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
-                           'structural' => { contains: [{ type: 'http://cocina.sul.stanford.edu/models/resources/page.jsonld',
-                                                          label: 'Book page',
-                                                          version: 1,
-                                                          externalIdentifier: 'abc123456' },
-                                                        { type: 'http://cocina.sul.stanford.edu/models/resources/image.jsonld',
-                                                          label: 'Book page 2',
-                                                          version: 1,
-                                                          externalIdentifier: 'abc789012' }] },
-                           'identification' => {}
+                           access: {},
+                           administrative: { hasAdminPolicy: 'druid:cg532dg5405' },
+                           structural: { contains: [{ type: Cocina::Models::FileSetType.page,
+                                                      label: 'Book page',
+                                                      version: 1,
+                                                      externalIdentifier: 'abc123456' },
+                                                    { type: Cocina::Models::FileSetType.image,
+                                                      label: 'Book page 2',
+                                                      version: 1,
+                                                      externalIdentifier: 'abc789012' }] },
+                           identification: {}
                          })
   end
   let(:cocina2) do
     Cocina::Models.build({
-                           'label' => 'My Map Item',
-                           'version' => 3,
-                           'type' => Cocina::Models::Vocab.image,
-                           'externalIdentifier' => pids[1],
-                           'description' => {
+                           label: 'My Map Item',
+                           version: 3,
+                           type: Cocina::Models::ObjectType.image,
+                           externalIdentifier: pids[1],
+                           description: {
                              title: [{ value: 'my dro' }],
                              purl: 'https://purl.stanford.edu/bc234fg5678'
                            },
-                           'access' => {},
-                           'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
-                           'structural' => { contains: [{ type: 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
-                                                          label: 'Map label',
-                                                          version: 1,
-                                                          externalIdentifier: 'xyz012345' }] },
-                           'identification' => {}
+                           access: {},
+                           administrative: { hasAdminPolicy: 'druid:cg532dg5405' },
+                           structural: { contains: [{ type: Cocina::Models::FileSetType.file,
+                                                      label: 'Map label',
+                                                      version: 1,
+                                                      externalIdentifier: 'xyz012345' }] },
+                           identification: {}
+                         })
+  end
+  let(:cocina3) do
+    Cocina::Models.build({
+                           label: 'My Collection',
+                           version: 1,
+                           type: Cocina::Models::ObjectType.collection,
+                           externalIdentifier: pids[2],
+                           description: {
+                             title: [{ value: 'my collection' }],
+                             purl: 'https://purl.stanford.edu/bc234fg5678'
+                           },
+                           access: {},
+                           administrative: { hasAdminPolicy: 'druid:cg532dg5405' }
                          })
   end
 
   let(:object_client1) { instance_double(Dor::Services::Client::Object, find: cocina1) }
   let(:object_client2) { instance_double(Dor::Services::Client::Object, find: cocina2) }
+  let(:object_client3) { instance_double(Dor::Services::Client::Object, find: cocina3) }
 
   let(:state_service) { instance_double(StateService, allows_modification?: true) }
   let(:buffer) { StringIO.new }
@@ -78,8 +93,10 @@ RSpec.describe SetContentTypeJob, type: :job do
     allow(StateService).to receive(:new).and_return(state_service)
     allow(Dor::Services::Client).to receive(:object).with(pids[0]).and_return(object_client1)
     allow(Dor::Services::Client).to receive(:object).with(pids[1]).and_return(object_client2)
+    allow(Dor::Services::Client).to receive(:object).with(pids[2]).and_return(object_client3)
     allow(object_client1).to receive(:update)
     allow(object_client2).to receive(:update)
+    allow(object_client3).to receive(:update)
     allow(Argo::Indexer).to receive(:reindex_pid_remotely)
   end
 
@@ -89,7 +106,7 @@ RSpec.describe SetContentTypeJob, type: :job do
       expect(object_client1).to have_received(:update)
         .with(
           params: a_cocina_object_with_types(
-            resource_types: [Cocina::Models::Vocab::Resources.page, Cocina::Models::Vocab::Resources.image]
+            resource_types: [Cocina::Models::FileSetType.page, Cocina::Models::FileSetType.image]
           )
         )
       expect(buffer.string).to include "Successfully updated content type of #{pids[0]} (bulk_action.id=#{bulk_action.id})"
@@ -113,8 +130,8 @@ RSpec.describe SetContentTypeJob, type: :job do
       expect(object_client2).to have_received(:update)
         .with(
           params: a_cocina_object_with_types(
-            content_type: Cocina::Models::Vocab.map,
-            resource_types: [Cocina::Models::Vocab::Resources.page, Cocina::Models::Vocab::Resources.image]
+            content_type: Cocina::Models::ObjectType.map,
+            resource_types: [Cocina::Models::FileSetType.page, Cocina::Models::FileSetType.image]
           )
         )
     end
@@ -137,7 +154,7 @@ RSpec.describe SetContentTypeJob, type: :job do
       expect(object_client1).to have_received(:update)
         .with(
           params: a_cocina_object_with_types(
-            content_type: Cocina::Models::Vocab.book,
+            content_type: Cocina::Models::ObjectType.book,
             viewing_direction: 'right-to-left'
           )
         )
@@ -198,7 +215,7 @@ RSpec.describe SetContentTypeJob, type: :job do
     it 'changes the content type only' do
       subject.perform(bulk_action.id, params)
       expect(object_client1).to have_received(:update)
-        .with(params: a_cocina_object_with_types(content_type: Cocina::Models::Vocab.map))
+        .with(params: a_cocina_object_with_types(content_type: Cocina::Models::ObjectType.map))
     end
   end
 
@@ -221,6 +238,25 @@ RSpec.describe SetContentTypeJob, type: :job do
       subject.perform(bulk_action.id, params)
       expect(buffer.string).to include 'Not authorized'
       expect(object_client1).not_to have_received(:update)
+    end
+  end
+
+  context 'when druid is for a collection' do
+    let(:params) do
+      {
+        pids: ['druid:ff123gg4567'],
+        set_content_type: {
+          current_resource_type: '',
+          new_content_type: 'media',
+          new_resource_type: ''
+        }
+      }
+    end
+
+    it 'does not update and logs an error' do
+      subject.perform(bulk_action.id, params)
+      expect(buffer.string).to include 'Could not update content type'
+      expect(object_client3).not_to have_received(:update)
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Fixes #2031: Moves set content type bulk action to a bulk job. 

## How was this change tested? 🤨
Needs review by @andrewjbtw. Note question in the issue (#2031) about how I moved the label for current resource type to a place different than it is in the design. 

The tests I added seem rather long, so I'd welcome ideas on how to improve them if anyone agrees and has ideas. 

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on that repo to fix anything this change breaks. ⚡
