### PR TITLE
add apply APO defaults button for items and collections

### DIFF
--- a/app/components/action_button.rb
+++ b/app/components/action_button.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-# Draws a blue button in the side menu
+# Draws a red button on the item detail page
 class ActionButton < ApplicationComponent
   # @param [Hash] properties the button properties
-  def initialize(label:, url:, method: nil, confirm: nil, new_page: nil, check_url: nil, disabled: nil)
+  def initialize(label:, url:, method: nil, confirm: nil, open_modal: false, check_url: nil, disabled: nil)
     @label = label
     @url = url
     @method = method
     @confirm = confirm
-    @new_page = new_page
+    @open_modal = open_modal
     @check_url = check_url
     @disabled = disabled
   end
@@ -22,7 +22,7 @@ class ActionButton < ApplicationComponent
       if confirm
         # :confirm trumps :blacklight_modal, because :blacklight_modal would negate :confirm by firing the ajax request regardless of the user's decision
         data[:turbo_confirm] = confirm
-      elsif !new_page
+      elsif open_modal
         data[:action] = 'click->button#open'
       end
       data[:button_check_url_value] = check_url if check_url
@@ -31,5 +31,5 @@ class ActionButton < ApplicationComponent
     end
   end
 
-  attr_reader :label, :confirm, :new_page, :check_url, :url, :disabled, :method
+  attr_reader :label, :confirm, :open_modal, :check_url, :url, :disabled, :method
 end

--- a/app/components/action_button.rb
+++ b/app/components/action_button.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Draws a red button on the item detail page
+# Draws button on the item detail page
 class ActionButton < ApplicationComponent
   # @param [Hash] properties the button properties
   def initialize(label:, url:, method: nil, confirm: nil, open_modal: false, check_url: nil, disabled: nil)

--- a/app/components/show/controls_component.html.erb
+++ b/app/components/show/controls_component.html.erb
@@ -33,6 +33,7 @@
     </div>
     <%= add_workflow_button %>
     <%= purge_button %>
+    <%= apply_apo_defaults %>
     <%= refresh_metadata if symphony_record? %>
     <%= create_embargo %>
   <% end %>

--- a/app/components/show/controls_component.rb
+++ b/app/components/show/controls_component.rb
@@ -40,29 +40,41 @@ module Show
       doc.catkey_id.present?
     end
 
-    delegate :admin_policy?, :agreement?, :item?, :embargoed?, to: :doc
+    delegate :admin_policy?, :agreement?, :item?, :collection?, :embargoed?, to: :doc
 
     private
 
     def manage_release
-      render ActionButton.new(url: item_manage_release_path(pid), label: 'Manage release')
+      render ActionButton.new(url: item_manage_release_path(pid), label: 'Manage release', open_modal: true)
+    end
+
+    def apply_apo_defaults
+      return unless item? || collection?
+
+      render ActionButton.new(
+        url: apply_apo_defaults_item_path(id: pid),
+        method: 'post',
+        label: 'Apply APO defaults',
+        disabled: !state_service.allows_modification?
+      )
     end
 
     def create_embargo
       return if !item? || embargoed?
 
-      render ActionButton.new(url: new_item_embargo_path(pid), label: 'Create embargo')
+      render ActionButton.new(url: new_item_embargo_path(pid), label: 'Create embargo', open_modal: true)
     end
 
     def edit_apo
       render ActionButton.new(
-        url: edit_apo_path(pid), label: 'Edit APO', new_page: true
+        url: edit_apo_path(pid), label: 'Edit APO'
       )
     end
 
     def create_collection
       render ActionButton.new(
-        url: new_apo_collection_path(apo_id: pid), label: 'Create Collection'
+        url: new_apo_collection_path(apo_id: pid), label: 'Create Collection',
+        open_modal: true
       )
     end
 
@@ -71,7 +83,6 @@ module Show
         url: refresh_metadata_item_path(id: pid),
         method: 'post',
         label: 'Refresh descMetadata',
-        new_page: true,
         disabled: !state_service.allows_modification?
       )
     end
@@ -79,14 +90,13 @@ module Show
     def reindex_button
       render ActionButton.new(
         url: dor_reindex_path(pid: pid),
-        label: 'Reindex',
-        new_page: true
+        label: 'Reindex'
       )
     end
 
     def add_workflow_button
       render ActionButton.new(
-        url: new_item_workflow_path(item_id: pid), label: 'Add workflow'
+        url: new_item_workflow_path(item_id: pid), label: 'Add workflow', open_modal: true
       )
     end
 
@@ -94,7 +104,6 @@ module Show
       render ActionButton.new(
         url: purge_item_path(id: pid),
         label: 'Purge',
-        new_page: true,
         method: 'delete',
         confirm: 'This object will be permanently purged from DOR. This action cannot be undone. Are you sure?',
         disabled: !registered_only?

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -228,7 +228,12 @@ class ItemsController < ApplicationController
       end
     end
   rescue Dor::Services::Client::UnexpectedResponse => e
-    render status: :bad_request, plain: "APO defaults could not be applied: #{e.message}"
+    error_message = "APO defaults could not be applied: #{e.message}"
+    if params[:bulk]
+      render status: :bad_request, plain: error_message
+    else
+      format.any { redirect_to solr_document_path(params[:id]), flash: { error: error_message } }
+    end
   end
 
   def set_governing_apo

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -220,7 +220,13 @@ class ItemsController < ApplicationController
   def apply_apo_defaults
     Dor::Services::Client.object(@cocina.externalIdentifier).apply_admin_policy_defaults
     reindex
-    render status: :ok, plain: 'APO defaults applied.'
+    respond_to do |format|
+      if params[:bulk]
+        format.html { render status: :ok, plain: 'APO defaults applied.' }
+      else
+        format.any { redirect_to solr_document_path(params[:id]), notice: 'APO defaults applied!' }
+      end
+    end
   rescue Dor::Services::Client::UnexpectedResponse => e
     render status: :bad_request, plain: "APO defaults could not be applied: #{e.message}"
   end

--- a/spec/components/show/controls_component_spec.rb
+++ b/spec/components/show/controls_component_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe Show::ControlsComponent, type: :component do
       expect(rendered.css("a.disabled[data-turbo-confirm][data-turbo-method='delete'][href='/items/druid:kv840xx0000/purge']").inner_text).to eq 'Purge'
       expect(page).to have_link 'Manage release', href: '/items/druid:kv840xx0000/manage_release'
       expect(page).to have_link 'Create embargo', href: '/items/druid:kv840xx0000/embargo/new'
-      expect(rendered.css('a').size).to eq 7
+      expect(rendered.css("a[data-turbo-method='post'][href='/items/druid:kv840xx0000/apply_apo_defaults']").inner_text).to eq 'Apply APO defaults'
+      expect(rendered.css('a').size).to eq 8
     end
 
     context "with a user that can't manage the object" do
@@ -53,9 +54,9 @@ RSpec.describe Show::ControlsComponent, type: :component do
     context 'when the item has a catkey' do
       let(:catkey) { 'catkey:1234567' }
 
-      it 'includes the refresh descMetadata button' do
+      it 'includes the refresh descMetadata button and the correct count of actions' do
         expect(rendered.css("a[href='/items/druid:kv840xx0000/refresh_metadata']").inner_text).to eq 'Refresh descMetadata'
-        expect(rendered.css('a').size).to eq 8
+        expect(rendered.css('a').size).to eq 9
       end
     end
   end
@@ -78,6 +79,7 @@ RSpec.describe Show::ControlsComponent, type: :component do
       expect(page).to have_link 'Purge', href: '/items/druid:zt570qh4444/purge'
       expect(page).to have_link 'Upload MODS', href: '/apos/druid:zt570qh4444/bulk_jobs'
       expect(rendered.css("a.disabled[data-turbo-confirm][data-turbo-method='delete']").inner_text).to eq 'Purge'
+      expect(rendered.css("a[data-turbo-method='post'][href='/items/druid:zt570qh4444/apply_apo_defaults']").size).to eq 0 # no apply APO defaults for APOs
       expect(page).not_to have_link 'Republish'
       expect(page).not_to have_link 'Manage release'
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3041 - Add an Apply APO Defaults button that is shown for items and collections

~~HOLD Pending testing on QA~~
~~Note: Testing currently blocked by https://github.com/sul-dlss/dor-services-app/issues/3648 and https://github.com/sul-dlss/argo/issues/3185~~

## How was this change tested? 🤨

Localhost browser, and updated component and request specs

Integration tests passed on QA

⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on that repo to fix anything this change breaks. ⚡


