### PR TITLE
disallow setting or editing embargo for locked objects

### DIFF
--- a/app/components/show/admin_policy_component.html.erb
+++ b/app/components/show/admin_policy_component.html.erb
@@ -1,4 +1,4 @@
-<%= render ShowEmbargoComponent.new(solr_document: document) %>
+<%= render ShowEmbargoComponent.new(presenter: presenter) %>
 
 <div class="row">
   <div class="col">

--- a/app/components/show/agreement_component.html.erb
+++ b/app/components/show/agreement_component.html.erb
@@ -1,4 +1,4 @@
-<%= render ShowEmbargoComponent.new(solr_document: document) %>
+<%= render ShowEmbargoComponent.new(presenter: presenter) %>
 
 <div class="row">
   <div class="col">

--- a/app/components/show/collection_component.html.erb
+++ b/app/components/show/collection_component.html.erb
@@ -1,4 +1,4 @@
-<%= render ShowEmbargoComponent.new(solr_document: document) %>
+<%= render ShowEmbargoComponent.new(presenter: presenter) %>
 
 <div class="row">
   <div class="col">

--- a/app/components/show/controls_component.rb
+++ b/app/components/show/controls_component.rb
@@ -62,7 +62,7 @@ module Show
     def create_embargo
       return if !item? || embargoed?
 
-      render ActionButton.new(url: new_item_embargo_path(pid), label: 'Create embargo', open_modal: true)
+      render ActionButton.new(url: new_item_embargo_path(pid), label: 'Create embargo', open_modal: true, disabled: !state_service.allows_modification?)
     end
 
     def edit_apo

--- a/app/components/show/item_component.html.erb
+++ b/app/components/show/item_component.html.erb
@@ -1,4 +1,4 @@
-<%= render ShowEmbargoComponent.new(solr_document: document) %>
+<%= render ShowEmbargoComponent.new(presenter: presenter) %>
 
 <div class="row">
   <div class="col-md-3">

--- a/app/components/show_embargo_component.rb
+++ b/app/components/show_embargo_component.rb
@@ -1,17 +1,21 @@
 # frozen_string_literal: true
 
 class ShowEmbargoComponent < ApplicationComponent
-  def initialize(solr_document:)
-    @solr_document = solr_document
+  def initialize(presenter:)
+    @solr_document = presenter.document
+    @state_service = presenter.state_service
   end
 
   delegate :id, :embargoed?, :embargo_release_date, to: :@solr_document
+  delegate :allows_modification?, to: :@state_service
 
   def render?
     embargoed? && embargo_release_date.present?
   end
 
   def edit_embargo
+    return unless allows_modification?
+
     link_to edit_item_embargo_path(id),
             class: 'text-white',
             aria: { label: 'Manage embargo' },


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3132 - disallow setting or editing an embargo when an object is in a state where it cannot be modified (i.e. version needs to be opened)

## How was this change tested? 🤨

Localhost and updated tests 

⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on that repo to fix anything this change breaks. ⚡


