### PR TITLE
Show registration workflows on APO page

### DIFF
--- a/app/components/show/apo/overview_component.html.erb
+++ b/app/components/show/apo/overview_component.html.erb
@@ -21,5 +21,12 @@
           <%= render Show::AccessRightsComponent.new(document: @solr_document, state_service: state_service) %>
         </td>
       </tr>
+
+      <tr>
+        <th class="col-3" scope="row">Registration workflow</th>
+        <td>
+          <%= registration_workflow %>
+        </td>
+      </tr>      
     </tbody>
   </table>

--- a/app/components/show/apo/overview_component.rb
+++ b/app/components/show/apo/overview_component.rb
@@ -7,6 +7,11 @@ module Show
       def initialize(presenter:)
         @presenter = presenter
         @solr_document = presenter.document
+        @registration_workflow = presenter.cocina.administrative.registrationWorkflow
+      end
+
+      def registration_workflow
+        @registration_workflow.present? ? @registration_workflow.join(', ') : 'None'
       end
 
       delegate :id, :status, to: :@solr_document

--- a/spec/components/show/apo/overview_component_spec.rb
+++ b/spec/components/show/apo/overview_component_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Show::Apo::OverviewComponent, type: :component do
                                     administrative: {
                                       hasAdminPolicy: 'druid:hv992ry2431',
                                       hasAgreement: 'druid:hp308wm0436',
-                                      defaultAccess: { access: 'world', download: 'world' }
+                                      defaultAccess: { access: 'world', download: 'world' },
+                                      registrationWorkflow: %w[registrationWF goobiWF]
                                     })
   end
   let(:rendered) { render_inline(component) }
@@ -25,9 +26,32 @@ RSpec.describe Show::Apo::OverviewComponent, type: :component do
                      SolrDocument::FIELD_OBJECT_TYPE => 'adminPolicy')
   end
 
-  it 'renders the appropriate fields' do
-    expect(rendered.to_html).to include 'DRUID'
-    expect(rendered.to_html).to include 'Status'
-    expect(rendered.to_html).to include 'Access rights'
+  context 'when showing an APO including registration workflows' do
+    it 'renders the appropriate fields' do
+      expect(rendered.to_html).to include 'DRUID'
+      expect(rendered.to_html).to include 'Status'
+      expect(rendered.to_html).to include 'Access rights'
+      expect(rendered.to_html).to include 'Registration workflow'
+      expect(rendered.to_html).to include 'registrationWF, goobiWF'
+    end
+  end
+
+  context 'when the APO has no registration workflow' do
+    let(:cocina) do
+      Cocina::Models::AdminPolicy.new(externalIdentifier: 'druid:bc234fg5678',
+                                      type: Cocina::Models::Vocab.admin_policy,
+                                      label: '',
+                                      version: 1,
+                                      administrative: {
+                                        hasAdminPolicy: 'druid:hv992ry2431',
+                                        hasAgreement: 'druid:hp308wm0436',
+                                        defaultAccess: { access: 'world', download: 'world' },
+                                        registrationWorkflow: []
+                                      })
+    end
+
+    it 'renders "None"' do
+      expect(rendered.css('tr:last-child').to_html).to include 'None'
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Fixes #3100 to display APO registration workflow(s) in the Overview component. 

## How was this change tested? 🤨
Added specs. Deployed to QA and confirmed that one, multiple, or 'None' workflows appear. To be reviewed by @andrewjbtw. 

![Screen Shot 2022-03-04 at 4 02 42 PM](https://user-images.githubusercontent.com/1619369/156841261-343b6f07-9980-404f-a18f-1b13f57a6a44.png)

![Screen Shot 2022-03-07 at 10 28 34 AM](https://user-images.githubusercontent.com/1619369/157065823-2b1402a5-cb0e-4a99-bc13-9082bc908a41.png)


⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on that repo to fix anything this change breaks. ⚡


