### PR TITLE
Adds maintenance page.

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -28,6 +28,7 @@ install_plugin Capistrano::SCM::Git
 
 require 'capistrano/bundler'
 require 'capistrano/honeybadger'
+require 'capistrano/maintenance'
 require 'capistrano/passenger'
 require 'capistrano/rails'
 require 'dlss/capistrano'

--- a/Gemfile
+++ b/Gemfile
@@ -120,6 +120,7 @@ group :test do
 end
 
 group :deployment do
+  gem 'capistrano-maintenance', '~> 1.2', require: false
   gem 'capistrano-passenger'
   gem 'capistrano-rails'
   gem 'dlss-capistrano', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,8 @@ GEM
       capistrano-bundler (>= 1.4)
     capistrano-bundler (2.0.1)
       capistrano (~> 3.1)
+    capistrano-maintenance (1.2.1)
+      capistrano (>= 3.0)
     capistrano-one_time_key (0.1.0)
       capistrano (~> 3.0)
     capistrano-passenger (0.2.1)
@@ -591,6 +593,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   cancancan
+  capistrano-maintenance (~> 1.2)
   capistrano-passenger
   capistrano-rails
   capybara


### PR DESCRIPTION
closes #3180

## Why was this change made? 🤔
So that Argo can be put in maintenance mode.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on that repo to fix anything this change breaks. ⚡

QA

![image](https://user-images.githubusercontent.com/588335/162831701-7dc030b4-4405-48d9-bf1d-391086a44a4b.png)

