### PR TITLE
Rights bulk action

### DIFF
--- a/app/components/bulk_actions_form_component.html.erb
+++ b/app/components/bulk_actions_form_component.html.erb
@@ -180,6 +180,15 @@
           <%= render 'bulk_actions/forms/set_content_type_form', f: f %>
         </div>
 
+        <div role="tabpanel" class="tab-pane" id="SetRightsJob">
+          <div class="mb-3">
+            <span class="help-block">
+              Edit rights
+            </span>
+          </div>
+          <%= render 'bulk_actions/forms/set_rights_form', f: f, rights_options: @form.rights_options %>
+        </div>
+
         <div role='tabpanel' class='tab-pane' id='ManageEmbargoesJob'>
           <div class="mb-3">
             <span class='help-block'>

--- a/app/components/bulk_actions_form_component.rb
+++ b/app/components/bulk_actions_form_component.rb
@@ -35,7 +35,8 @@ class BulkActionsFormComponent < ApplicationComponent
         ['Edit License and Rights Statements', 'SetLicenseAndRightsStatementsJob'],
         ['Refresh MODS', 'RefreshModsJob'],
         ['Set Content Type', 'SetContentTypeJob'],
-        ['Set Collection', 'SetCollectionJob']
+        ['Set Collection', 'SetCollectionJob'],
+        ['Set object rights', 'SetRightsJob']
       ]],
       ['Modify objects (via CSV)', [
         ['Create virtual object(s)', 'CreateVirtualObjectsJob'],

--- a/app/controllers/bulk_actions_controller.rb
+++ b/app/controllers/bulk_actions_controller.rb
@@ -76,7 +76,8 @@ class BulkActionsController < ApplicationController
         current_resource_type
         new_content_type new_resource_type
       ],
-      set_collection: [:new_collection_id]
+      set_collection: [:new_collection_id],
+      set_rights: [:rights]
     )
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -143,23 +143,14 @@ class ItemsController < ApplicationController
     redirect_to solr_document_path(params[:id]), flash: { error: "#{user_begin}: #{e.message}. #{user_end}" }
   end
 
-  # This is called from the item page and from the bulk (synchronous) update page
   def set_rights
     # Item may be a Collection or a DRO
     form_type = @cocina.collection? ? CollectionRightsForm : DroRightsForm
     form = form_type.new(@cocina)
-    # The bulk form always uses `dro_rights_form` as the key
-    form_key = params[:bulk] ? DroRightsForm.model_name.param_key : form.model_name.param_key
+    form_key = form.model_name.param_key
     form.validate(params[form_key])
     form.save
-
-    respond_to do |format|
-      if params[:bulk]
-        format.html { render status: :ok, plain: 'Rights updated.' }
-      else
-        format.any { redirect_to solr_document_path(params[:id]), notice: 'Rights updated!' }
-      end
-    end
+    redirect_to solr_document_path(params[:id]), notice: 'Rights updated!'
   rescue ArgumentError
     render status: :bad_request, plain: 'Invalid new rights setting.'
   end

--- a/app/forms/bulk_action_form.rb
+++ b/app/forms/bulk_action_form.rb
@@ -8,7 +8,7 @@ class BulkActionForm < BaseForm
     set_source_ids_csv prepare register_druids
     create_virtual_objects import_tags
     set_license_and_rights_statements manage_embargo
-    set_content_type set_collection
+    set_content_type set_collection set_rights
   ].freeze
 
   def initialize(model, groups:)
@@ -55,6 +55,10 @@ class BulkActionForm < BaseForm
   def license_options
     [['-- No license --', '']] +
       options_for_use_license_type
+  end
+
+  def rights_options
+    Constants::REGISTRATION_RIGHTS_OPTIONS
   end
 
   private

--- a/app/javascript/bulk.js
+++ b/app/javascript/bulk.js
@@ -77,11 +77,6 @@ function fetch_druids(fun) {
 	}
 }
 
-function set_rights(druids){
-	var params = { 'dro_rights_form[rights]': document.getElementById('rights_select').value }
-	process_post(druids, set_rights_url, params, "Updated");
-}
-
 function get_druids() {
 	var log = document.getElementById('pids');
 	$('#pid_list').show(400);
@@ -137,12 +132,5 @@ function error_handler(xhr, status, err, object_link, index, after) {
 document.addEventListener("turbo:load", () => {
   $('#get_druids').on('click', get_druids)
 	$('#paste-druids-button').on('click', () => $('#pid_list').show(400))
-	$('#set-object-rights-button').on('click', () => $('#rights').show(400))
-
-	$('#rights_button').on('click', () => {
-			fetch_druids(set_rights)
-			$('#rights').hide(400)
-	})
-
 	$('#stop').on('click', () => stop_all())
 })

--- a/app/jobs/set_rights_job.rb
+++ b/app/jobs/set_rights_job.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+##
+# Job to update rights for objects
+class SetRightsJob < GenericJob
+  ##
+  # A job that allows a user to update the rights for a list of druids
+  # @param [Integer] bulk_action_id GlobalID for a BulkAction object
+  # @param [Hash] params additional parameters that an Argo job may need
+  def perform(bulk_action_id, params)
+    super
+
+    @new_rights = params[:set_rights][:rights]
+
+    with_bulk_action_log do |log|
+      log.puts("#{Time.current} Starting SetRightsJob for BulkAction #{bulk_action_id}")
+      raise StandardError, 'Must provide rights' if @new_rights.blank?
+
+      update_druid_count
+
+      pids.each do |druid|
+        log.puts("#{Time.current} #{self.class}: Attempting #{druid} (bulk_action.id=#{bulk_action_id})")
+        set_rights(druid, log)
+      end
+      log.puts("#{Time.current} Finished SetRightsJob for BulkAction #{bulk_action_id}")
+    end
+  end
+
+  private
+
+  def set_rights(druid, log)
+    object_client = Dor::Services::Client.object(druid)
+    cocina_object = object_client.find
+    return unless verify_access(cocina_object, log)
+
+    # use dor services client to update the access
+    begin
+      state_service = StateService.new(druid, version: cocina_object.version)
+      raise StandardError, 'Object cannot be modified in its current state.' unless state_service.allows_modification?
+
+      form_type = cocina_object.collection? ? CollectionRightsForm : DroRightsForm
+      form = form_type.new(cocina_object)
+      form.validate(rights: @new_rights)
+      form.save
+
+      log.puts("#{Time.current} #{self.class}: Successfully updated rights of #{druid} (bulk_action.id=#{bulk_action.id})")
+      bulk_action.increment(:druid_count_success).save
+    rescue StandardError => e
+      log.puts("#{Time.current} SetRights failed #{e.class} #{e.message}")
+      bulk_action.increment(:druid_count_fail).save
+    end
+  end
+
+  def verify_access(cocina_object, log)
+    return true if ability.can?(:manage_item, cocina_object)
+
+    log.puts("#{Time.current} Not authorized for #{cocina_object.externalIdentifier}")
+    bulk_action.increment(:druid_count_fail).save
+    false
+  end
+end

--- a/app/models/bulk_action.rb
+++ b/app/models/bulk_action.rb
@@ -29,7 +29,8 @@ class BulkAction < ApplicationRecord
                      SetSourceIdsCsvJob
                      SetContentTypeJob
                      ManageEmbargoesJob
-                     SetCollectionJob]
+                     SetCollectionJob
+                     SetRightsJob]
             }
 
   before_destroy :remove_output_directory

--- a/app/services/bulk_action_persister.rb
+++ b/app/services/bulk_action_persister.rb
@@ -25,7 +25,7 @@ class BulkActionPersister
   delegate :pids, :add_workflow, :manage_release, :set_governing_apo,
            :set_catkeys_and_barcodes, :groups, :prepare, :create_virtual_objects,
            :import_tags, :set_license_and_rights_statements, :set_content_type,
-           :set_collection,
+           :set_collection, :set_rights,
            to: :bulk_action_form
 
   delegate :id, :file, :output_directory, to: :bulk_action
@@ -67,6 +67,7 @@ class BulkActionPersister
       set_governing_apo: set_governing_apo,
       set_license_and_rights_statements: set_license_and_rights_statements,
       set_content_type: set_content_type,
+      set_rights: set_rights,
       prepare: prepare,
       csv_file: bulk_action_form.csv_as_string,
       groups: groups

--- a/app/views/bulk_actions/forms/_set_rights_form.html.erb
+++ b/app/views/bulk_actions/forms/_set_rights_form.html.erb
@@ -1,0 +1,5 @@
+<% f.fields_for :set_rights do |set_rights| %>
+  <div class='mb-3'>
+    <%= set_rights.select(:rights, rights_options) %>
+  </div>
+<% end %>

--- a/app/views/report/bulk.html.erb
+++ b/app/views/report/bulk.html.erb
@@ -12,7 +12,6 @@ function catalog_url(element)
   url=url.replace(/xxxxxxxxx/g,element);
   return url;
 }
-set_rights_url='<%= set_rights_item_path(id: 'druid:xxxxxxxxx', bulk: 'true') %>'
 </script>
 
 <style>
@@ -51,17 +50,6 @@ ul li{
     <label for="pids">Bulk actions will be performed on this list of druids. Modify the list or paste a list of druids here to operate on them instead.</label>
     <textarea id="pids" name="pids" class="form-control" rows="8"></textarea>
   </div>
-
-  <div id="buttons">
-    <div class="row">
-      <div class="col-sm-12"><strong>Options that require versioning</strong></div>
-    </div>
-    <div class="row bulk-buttons-row">
-      <div class="col-sm-2">
-        <button class="btn btn-primary btn-block" id="set-object-rights-button">Set object rights</button>
-      </div>
-    </div>
-  </div>
 </div>
 
 <br>
@@ -86,12 +74,6 @@ ul li{
     <%= select_tag :new_resource_type, options_for_select(new_resource_types) %><br>
     <button class="btn btn-primary" id="confirm-set-content-type-button">Set content types</button>
   </p>
-</div>
-
-<div class="bulk_operation" id="rights" name="rights">
-  <h1>Set object rights</h1>
-  <%= select_tag :rights_select, options_for_select(Constants::REGISTRATION_RIGHTS_OPTIONS) %>
-  <button class="btn btn-primary" id="rights_button" name="rights_button">Set rights</button>
 </div>
 <button class="btn btn-primary stop_button" id="stop" style="display:none" name="stop">Stop</button>
 

--- a/spec/features/bulk_screen_spec.rb
+++ b/spec/features/bulk_screen_spec.rb
@@ -37,7 +37,5 @@ RSpec.describe 'Bulk actions view', js: true do
       # Test that the textarea was populated from a search
       expect(page).to have_content 'druid:zt570qh4444'
     end
-
-    expect(page).to have_button('Set object rights', disabled: false)
   end
 end

--- a/spec/jobs/set_rights_job_spec.rb
+++ b/spec/jobs/set_rights_job_spec.rb
@@ -1,0 +1,251 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SetRightsJob, type: :job do
+  let(:pids) { ['druid:bb111cc2222', 'druid:cc111dd2233'] }
+  let(:groups) { [] }
+
+  let(:bulk_action) do
+    create(
+      :bulk_action,
+      action_type: 'SetRightsJob'
+    )
+  end
+
+  let(:user) { bulk_action.user }
+
+  let(:cocina1) do
+    Cocina::Models::DRO.new(
+      {
+        label: 'Stanford Item',
+        version: 2,
+        type: Cocina::Models::ObjectType.book,
+        description: {
+          title: [{ value: 'Stanford Item' }],
+          purl: "https://purl.stanford.edu/#{pids[0]}"
+        },
+        externalIdentifier: pids[0],
+        access: {
+          view: 'stanford',
+          download: 'stanford'
+        },
+        administrative: { hasAdminPolicy: 'druid:cg532dg5405' },
+        structural: {
+          contains: [
+            {
+              type: Cocina::Models::FileSetType.page,
+              label: 'Book page',
+              version: 1,
+              externalIdentifier: 'abc123456',
+              structural: {
+                contains: [
+                  {
+                    filename: 'p1.jpg',
+                    externalIdentifier: 'abc123456',
+                    label: 'p1.jpg',
+                    type: Cocina::Models::ObjectType.file,
+                    version: 1,
+                    administrative: {
+                      publish: true,
+                      sdrPreserve: true,
+                      shelve: true
+                    },
+                    hasMessageDigests: [],
+                    access: {
+                      view: 'stanford',
+                      download: 'stanford'
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              type: Cocina::Models::FileSetType.image,
+              label: 'Book page 2',
+              version: 1,
+              externalIdentifier: 'abc789012',
+              structural: {
+                contains: [
+                  {
+                    filename: 'p2.jpg',
+                    externalIdentifier: 'abc123456',
+                    label: 'p2.jpg',
+                    type: Cocina::Models::ObjectType.file,
+                    version: 1,
+                    administrative: {
+                      publish: true,
+                      sdrPreserve: true,
+                      shelve: true
+                    },
+                    hasMessageDigests: [],
+                    access: {
+                      view: 'stanford',
+                      download: 'stanford'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        identification: {}
+      }
+    )
+  end
+
+  let(:cocina2) do
+    Cocina::Models::DRO.new(
+      {
+        label: 'World Item',
+        version: 3,
+        type: Cocina::Models::ObjectType.image,
+        description: {
+          title: [{ value: 'World Item' }],
+          purl: "https://purl.stanford.edu/#{pids[1]}"
+        },
+        externalIdentifier: pids[1],
+        access: {
+          view: 'world',
+          download: 'world'
+        },
+        administrative: { 'hasAdminPolicy' => 'druid:cg532dg5405' },
+        structural: {
+          contains: [
+            {
+              type: Cocina::Models::FileSetType.page,
+              label: 'Book page',
+              version: 1,
+              externalIdentifier: 'abc123456',
+              structural: {
+                contains: [
+                  {
+                    filename: 'p1.jpg',
+                    externalIdentifier: 'abc123456',
+                    label: 'p1.jpg',
+                    type: Cocina::Models::ObjectType.file,
+                    version: 1,
+                    administrative: {
+                      publish: true,
+                      sdrPreserve: true,
+                      shelve: true
+                    },
+                    hasMessageDigests: [],
+                    access: {
+                      view: 'stanford',
+                      download: 'stanford'
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              type: Cocina::Models::FileSetType.image,
+              label: 'Book page 2',
+              version: 1,
+              externalIdentifier: 'abc789012',
+              structural: {
+                contains: [
+                  {
+                    filename: 'p2.jpg',
+                    externalIdentifier: 'abc789012',
+                    label: 'p2.jpg',
+                    type: Cocina::Models::ObjectType.file,
+                    version: 1,
+                    administrative: {
+                      publish: true,
+                      sdrPreserve: true,
+                      shelve: true
+                    },
+                    hasMessageDigests: [],
+                    access: {
+                      view: 'stanford',
+                      download: 'stanford'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        identification: {}
+      }
+    )
+  end
+
+  let(:object_client1) { instance_double(Dor::Services::Client::Object, find: cocina1) }
+  let(:object_client2) { instance_double(Dor::Services::Client::Object, find: cocina2) }
+
+  let(:state_service) { instance_double(StateService, allows_modification?: true) }
+  let(:buffer) { StringIO.new }
+
+  before do
+    allow(subject).to receive(:bulk_action).and_return(bulk_action)
+    allow(subject).to receive(:with_bulk_action_log).and_yield(buffer)
+    allow(subject.ability).to receive(:can?).and_return(true)
+    allow(StateService).to receive(:new).and_return(state_service)
+    allow(Dor::Services::Client).to receive(:object).with(pids[0]).and_return(object_client1)
+    allow(Dor::Services::Client).to receive(:object).with(pids[1]).and_return(object_client2)
+    allow(object_client1).to receive(:update)
+    allow(object_client2).to receive(:update)
+    allow(Argo::Indexer).to receive(:reindex_pid_remotely)
+  end
+
+  context 'when updating one object' do
+    let(:params) do
+      {
+        pids: [pids[0]],
+        set_rights: {
+          rights: 'world'
+        }
+      }
+    end
+
+    it 'changes access to world and logs success' do
+      subject.perform(bulk_action.id, params)
+      expect(object_client1).to have_received(:update)
+        .with(
+          params: a_cocina_object_with_access(
+            view: 'world',
+            download: 'world'
+          )
+        )
+      expect(object_client2).not_to have_received(:update)
+      expect(buffer.string).to include "Successfully updated rights of #{pids[0]} (bulk_action.id=#{bulk_action.id})"
+    end
+  end
+
+  context 'when updating two objects' do
+    let(:params) do
+      {
+        pids: pids,
+        set_rights: {
+          rights: 'world'
+        }
+      }
+    end
+
+    it 'changes access to world and logs success' do
+      subject.perform(bulk_action.id, params)
+
+      expect(object_client1).to have_received(:update)
+        .with(
+          params: a_cocina_object_with_access(
+            view: 'world',
+            download: 'world'
+          )
+        )
+
+      expect(object_client2).to have_received(:update)
+        .with(
+          params: a_cocina_object_with_access(
+            view: 'world',
+            download: 'world'
+          )
+        )
+
+      expect(buffer.string).to include "Successfully updated rights of #{pids[0]} (bulk_action.id=#{bulk_action.id})"
+      expect(buffer.string).to include "Successfully updated rights of #{pids[1]} (bulk_action.id=#{bulk_action.id})"
+    end
+  end
+end

--- a/spec/requests/set_rights_spec.rb
+++ b/spec/requests/set_rights_spec.rb
@@ -416,26 +416,6 @@ RSpec.describe 'Set rights for an object' do
           expect(Argo::Indexer).to have_received(:reindex_pid_remotely).with(pid)
         end
       end
-
-      context 'when a bulk request' do
-        let(:updated_model) do
-          cocina_model.new(
-            {
-              'access' => {
-                'view' => 'dark'
-              }
-            }
-          )
-        end
-
-        it 'sets the access' do
-          post "/items/#{pid}/set_rights", params: { bulk: true, dro_rights_form: { rights: 'dark' } }
-          expect(response).to have_http_status(:ok)
-          expect(object_client).to have_received(:update)
-            .with(params: updated_model)
-          expect(Argo::Indexer).to have_received(:reindex_pid_remotely).with(pid)
-        end
-      end
     end
 
     context "when the cocina model isn't found" do


### PR DESCRIPTION
## Why was this change made? 🤔

Argo users would like to be able to update object rights as an asynchronous Bulk Action similar to how they do with synchronous Bulk Updates.

Closes #2030

## How was this change tested? 🤨

I tested in my dev environment and on QA. See below for the more thorough testing that @andrewjbtw did. And some initial problems that were fixed.

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on that repo to fix anything this change breaks. ⚡


