### PR TITLE
ensure blank structural CSVs are allowed in argo

### DIFF
--- a/app/services/structure_updater.rb
+++ b/app/services/structure_updater.rb
@@ -4,6 +4,7 @@
 # So an upload CSV that lists a file not already present should be rejected.
 # At present, the CSV update only supports changing settings,
 # changing the order of resources, or removing content.
+# You can remove all content by leaving the file blank (except header).
 class StructureUpdater
   include Dry::Monads[:result]
 
@@ -21,7 +22,7 @@ class StructureUpdater
   attr_reader :model, :csv, :errors
 
   # @return [Bool] true if there are no problems
-  def validate
+  def valid?
     @errors = []
     # 1. Ensure all files in the csv are present in the existing object
     csv.each.with_index(2) do |row, index|
@@ -59,7 +60,7 @@ class StructureUpdater
 
   # @return [Maybe] success if there are no problems
   def from_csv
-    return Failure(errors) unless validate
+    return Failure(errors) unless valid?
 
     fileset_attributes = {}
     # Which files go in which filesets

--- a/spec/services/structure_updater_spec.rb
+++ b/spec/services/structure_updater_spec.rb
@@ -260,6 +260,19 @@ RSpec.describe StructureUpdater do
     end
   end
 
+  context 'with a blank csv file with just a header row' do
+    let(:csv) do
+      <<~CSV
+        resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_access,rights_download,mimetype,role
+      CSV
+    end
+
+    it 'validates and clears the fileset' do
+      new_filesets = result.value!.contains
+      expect(new_filesets).to eq []
+    end
+  end
+
   context 'with invalid csv' do
     let(:csv) do
       <<~CSV


### PR DESCRIPTION
## Why was this change made? 🤔

Part of #3181 - it turns out that you can upload a blank structural CSV and it sets the changeset to an empty array, which seems fine.  So this not working must be an issue in DSA.  Just adding a test to confirm the call to DSA is made correctly in Argo.

## How was this change tested? 🤨

Added a new test