### PR TITLE
bulk actions: use search params instead of search history to get druids

### DIFF
--- a/app/components/bulk_actions_form_component.html.erb
+++ b/app/components/bulk_actions_form_component.html.erb
@@ -168,7 +168,7 @@
     </div>
 
     <div data-bulk-actions-target="commonFields" >
-     <% unless search_params.blank? %>
+     <% if search_state.has_constraints? %>
         <button class='btn btn-primary' data-action="click->bulk-actions#populateDruids">
           Populate with previous search
         </button>

--- a/app/components/bulk_actions_form_component.html.erb
+++ b/app/components/bulk_actions_form_component.html.erb
@@ -62,7 +62,7 @@
             Deletes unpublished DOR objects
           </span>
         </div>
-        
+
         <div role='tabpanel' class='tab-pane' id='AddWorkflowJob'>
           <span class='help-block'>
             Starts a workflow for individual objects.
@@ -168,11 +168,10 @@
     </div>
 
     <div data-bulk-actions-target="commonFields" >
-      <% if @last_search %>
+     <% unless search_params.blank? %>
         <button class='btn btn-primary' data-action="click->bulk-actions#populateDruids">
           Populate with previous search
         </button>
-        <small><%= @last_search.query_params.except('controller', 'action') %></small>
       <% end %>
       <div class='mb-3'>
         <label>Druids to perform bulk action on</label>

--- a/app/components/bulk_actions_form_component.rb
+++ b/app/components/bulk_actions_form_component.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 class BulkActionsFormComponent < ApplicationComponent
-  def initialize(form:, last_search:)
+  attr_reader :search_params
+
+  def initialize(form:, search_params:)
     @form = form
-    @last_search = last_search
+    @search_params = search_params
   end
 
   ##
@@ -13,9 +15,9 @@ class BulkActionsFormComponent < ApplicationComponent
   # @param [Blacklight::Search, nil]
   # @return [Hash]
   def search_of_pids
-    return '' if @last_search.blank?
+    return '' if search_params.blank?
 
-    @last_search.query_params.merge('pids_only' => true)
+    search_params.merge('pids_only' => true)
   end
 
   def action_types

--- a/app/components/bulk_actions_form_component.rb
+++ b/app/components/bulk_actions_form_component.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
 class BulkActionsFormComponent < ApplicationComponent
-  attr_reader :search_params
-
-  def initialize(form:, search_params:)
+  def initialize(form:)
     @form = form
-    @search_params = search_params
   end
 
   ##
@@ -15,9 +12,9 @@ class BulkActionsFormComponent < ApplicationComponent
   # @param [Blacklight::Search, nil]
   # @return [Hash]
   def search_of_pids
-    return '' if search_params.blank?
+    return '' unless search_state.has_constraints?
 
-    search_params.merge('pids_only' => true)
+    search_state.params_for_search('pids_only' => true)
   end
 
   def action_types

--- a/app/controllers/bulk_actions_controller.rb
+++ b/app/controllers/bulk_actions_controller.rb
@@ -13,7 +13,6 @@ class BulkActionsController < ApplicationController
   # GET /bulk_actions/new
   def new
     @form = BulkActionForm.new(BulkAction.new, groups: current_user.groups)
-    @last_search = session[:search].present? ? searches_from_history.find(session[:search]['id']) : nil
   end
 
   # POST /bulk_actions

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,10 +5,6 @@ module ApplicationHelper
     'Argo'
   end
 
-  def search_params
-    params.except(:controller, :action).permit!
-  end
-
   def location_to_send_search_form
     return report_path if report_view?
     return report_workflow_grid_path if workflow_grid_view?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,6 +5,10 @@ module ApplicationHelper
     'Argo'
   end
 
+  def search_params
+    params.except(:controller, :action).permit!
+  end
+
   def location_to_send_search_form
     return report_path if report_view?
     return report_workflow_grid_path if workflow_grid_view?

--- a/app/views/bulk_actions/index.html.erb
+++ b/app/views/bulk_actions/index.html.erb
@@ -3,7 +3,7 @@
   <h1>Bulk Actions</h1>
   <div class="row">
     <div class="col-md-10">
-      <%= link_to 'New Bulk Action', new_bulk_action_path, class: 'btn btn-primary' %>
+      <%= link_to 'New Bulk Action', send(:new_bulk_action_path, search_params), class: 'btn btn-primary' %>
     </div>
     <div class="col-md-2">
       <%= link_back_to_catalog label: 'Back to search', class: 'btn btn-default' %>

--- a/app/views/bulk_actions/index.html.erb
+++ b/app/views/bulk_actions/index.html.erb
@@ -3,7 +3,7 @@
   <h1>Bulk Actions</h1>
   <div class="row">
     <div class="col-md-10">
-      <%= link_to 'New Bulk Action', send(:new_bulk_action_path, search_params), class: 'btn btn-primary' %>
+      <%= link_to 'New Bulk Action', new_bulk_action_path(search_state.to_h), class: 'btn btn-primary' %>
     </div>
     <div class="col-md-2">
       <%= link_back_to_catalog label: 'Back to search', class: 'btn btn-default' %>

--- a/app/views/bulk_actions/new.html.erb
+++ b/app/views/bulk_actions/new.html.erb
@@ -1,2 +1,1 @@
-<%= render BulkActionsFormComponent.new(form: @form, last_search: @last_search) %>
-
+<%= render BulkActionsFormComponent.new(form: @form, search_params: search_params) %>

--- a/app/views/bulk_actions/new.html.erb
+++ b/app/views/bulk_actions/new.html.erb
@@ -1,1 +1,1 @@
-<%= render BulkActionsFormComponent.new(form: @form, search_params: search_params) %>
+<%= render BulkActionsFormComponent.new(form: @form) %>

--- a/app/views/catalog/_bulk_action_button.html.erb
+++ b/app/views/catalog/_bulk_action_button.html.erb
@@ -1,3 +1,3 @@
 <div class='btn-group'>
-  <%= link_to 'Bulk Actions', send(:bulk_actions_path, search_params), class: 'btn btn-outline-secondary', type: 'button' %>
+  <%= link_to 'Bulk Actions', bulk_actions_path(search_state.to_h), class: 'btn btn-outline-secondary', type: 'button' %>
 </div>

--- a/app/views/catalog/_bulk_action_button.html.erb
+++ b/app/views/catalog/_bulk_action_button.html.erb
@@ -1,3 +1,3 @@
 <div class='btn-group'>
-  <%= link_to 'Bulk Actions', bulk_actions_path, class: 'btn btn-outline-secondary', type: 'button' %>
+  <%= link_to 'Bulk Actions', send(:bulk_actions_path, search_params), class: 'btn btn-outline-secondary', type: 'button' %>
 </div>

--- a/app/views/catalog/_bulk_update_view_button.html.erb
+++ b/app/views/catalog/_bulk_update_view_button.html.erb
@@ -1,3 +1,3 @@
 <div id='bulk-update-button' class='btn-group'>
-  <%= link_to 'Bulk Update', send(:report_bulk_url, search_params), class: 'btn btn-outline-secondary', type: 'button', id: 'bulk_update_view' %>
+  <%= link_to 'Bulk Update', report_bulk_url(search_state.to_h), class: 'btn btn-outline-secondary', type: 'button', id: 'bulk_update_view' %>
 </div>

--- a/app/views/catalog/_bulk_update_view_button.html.erb
+++ b/app/views/catalog/_bulk_update_view_button.html.erb
@@ -1,4 +1,3 @@
 <div id='bulk-update-button' class='btn-group'>
-  <% cleaned_params = params.except(:controller, :action).permit! %>
-  <%= link_to 'Bulk Update', send(:report_bulk_url, cleaned_params), class: 'btn btn-outline-secondary', type: 'button', id: 'bulk_update_view' %>
+  <%= link_to 'Bulk Update', send(:report_bulk_url, search_params), class: 'btn btn-outline-secondary', type: 'button', id: 'bulk_update_view' %>
 </div>

--- a/app/views/report/bulk.html.erb
+++ b/app/views/report/bulk.html.erb
@@ -43,7 +43,7 @@ ul li{
 
 <h1>Bulk update operations</h1>
 
-<% unless search_params.blank? %>
+<% if search_state.has_constraints? %>
   <button class="btn btn-primary" id="get_druids" name="get_druids">Get druids from search</button>
 <% end %>
 <button class="btn btn-primary" id="paste-druids-button">Paste a druid list</button>

--- a/app/views/report/bulk.html.erb
+++ b/app/views/report/bulk.html.erb
@@ -43,7 +43,9 @@ ul li{
 
 <h1>Bulk update operations</h1>
 
-<button class="btn btn-primary" id="get_druids" name="get_druids">Get druids from search</button>
+<% unless search_params.blank? %>
+  <button class="btn btn-primary" id="get_druids" name="get_druids">Get druids from search</button>
+<% end %>
 <button class="btn btn-primary" id="paste-druids-button">Paste a druid list</button>
 
 <div id="pid_list" name="pid_list" style="display:none;" class="bulk_operation">

--- a/spec/components/bulk_actions_form_component_spec.rb
+++ b/spec/components/bulk_actions_form_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe BulkActionsFormComponent, type: :component do
-  subject(:instance) { described_class.new(form: bulk_action_form, last_search: last_search) }
+  subject(:instance) { described_class.new(form: bulk_action_form, search_params: search_params) }
 
   let(:bulk_action_form) { BulkActionForm.new(build(:bulk_action), groups: []) }
 
@@ -11,7 +11,20 @@ RSpec.describe BulkActionsFormComponent, type: :component do
 
   describe '#search_of_pids' do
     context "when last search isn't present" do
-      let(:last_search) { nil }
+      let(:search_params) { {} }
+
+      it 'returns an empty string' do
+        expect(instance.search_of_pids).to eq ''
+      end
+
+      it 'does not render a populate from previous search button' do
+        render_inline(subject)
+        expect(page).not_to have_button 'Populate with previous search'
+      end
+    end
+
+    context 'when last search is nil' do
+      let(:search_params) { nil }
 
       it 'returns an empty string' do
         expect(instance.search_of_pids).to eq ''
@@ -24,11 +37,7 @@ RSpec.describe BulkActionsFormComponent, type: :component do
     end
 
     context 'when a Blacklight::Search is present' do
-      let(:last_search) do
-        Search.new.tap do |search|
-          search.query_params = { q: 'cool catz' }
-        end
-      end
+      let(:search_params) { { q: 'cool catz' } }
 
       it 'adds a pids_only param' do
         expect(instance.search_of_pids).to include(q: 'cool catz', 'pids_only' => true)

--- a/spec/components/bulk_actions_form_component_spec.rb
+++ b/spec/components/bulk_actions_form_component_spec.rb
@@ -3,26 +3,18 @@
 require 'rails_helper'
 
 RSpec.describe BulkActionsFormComponent, type: :component do
-  subject(:instance) { described_class.new(form: bulk_action_form, search_params: search_params) }
+  subject(:instance) { described_class.new(form: bulk_action_form) }
 
   let(:bulk_action_form) { BulkActionForm.new(build(:bulk_action), groups: []) }
+  let(:blacklight_config) { Blacklight::Configuration.new }
+  let(:search_state) { Blacklight::SearchState.new(search_params, blacklight_config) }
 
-  before { allow(controller).to receive(:current_user).and_return(build(:user)) }
+  before do
+    allow(controller).to receive(:current_user).and_return(build(:user))
+    allow(subject).to receive(:search_state).and_return(search_state)
+  end
 
   describe '#search_of_pids' do
-    context "when last search isn't present" do
-      let(:search_params) { {} }
-
-      it 'returns an empty string' do
-        expect(instance.search_of_pids).to eq ''
-      end
-
-      it 'does not render a populate from previous search button' do
-        render_inline(subject)
-        expect(page).not_to have_button 'Populate with previous search'
-      end
-    end
-
     context 'when last search is nil' do
       let(:search_params) { nil }
 

--- a/spec/controllers/bulk_actions_controller_spec.rb
+++ b/spec/controllers/bulk_actions_controller_spec.rb
@@ -31,23 +31,6 @@ RSpec.describe BulkActionsController do
       expect(assigns(:form)).not_to be_nil
     end
 
-    describe 'assigns @last_search' do
-      it 'with no session[:search]' do
-        expect(request.session[:search]).to be_nil
-        get :new
-        expect(assigns(:last_search)).to be_nil
-      end
-
-      it 'with last session[:search]' do
-        Search.create
-        request.session[:search] = { 'id' => 1 }
-        all_searches = Search.all
-        expect(all_searches).to receive(:find).with(1)
-        expect(subject).to receive(:searches_from_history).and_return all_searches
-        get :new
-      end
-    end
-
     it 'has a 200 status code' do
       get :new
       expect(response.status).to eq 200

--- a/spec/features/bulk_desc_metadata_download_spec.rb
+++ b/spec/features/bulk_desc_metadata_download_spec.rb
@@ -9,14 +9,23 @@ RSpec.describe 'Bulk Descriptive Metadata Download' do
     sign_in current_user
   end
 
-  it 'New page has a populate druids div with last search' do
+  it 'New page has a populate druids button and div with last search' do
     visit search_catalog_path q: 'stanford'
     click_link 'Bulk Actions'
     expect(page).to have_css 'h1', text: 'Bulk Actions'
     click_link 'New Bulk Action'
     expect(page).to have_css 'h1', text: 'New Bulk Action'
-    expect(page).to have_css 'form[data-bulk-actions-populate-url-value="/catalog?action=index&' \
-      'controller=catalog&pids_only=true&q=stanford"]'
+    expect(page).to have_button 'Populate with previous search'
+    expect(page).to have_css 'form[data-bulk-actions-populate-url-value="/catalog?pids_only=true&q=stanford"]'
+  end
+
+  it 'New page does not have a populate druids button if no search params provided' do
+    visit root_path
+    click_link 'Bulk Actions'
+    expect(page).to have_css 'h1', text: 'Bulk Actions'
+    click_link 'New Bulk Action'
+    expect(page).to have_css 'h1', text: 'New Bulk Action'
+    expect(page).not_to have_button 'Populate with previous search'
   end
 
   it 'Creates a new jobs' do

--- a/spec/features/bulk_screen_spec.rb
+++ b/spec/features/bulk_screen_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe 'Bulk actions view', js: true do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
   end
 
-  it 'basic page renders ok' do
-    visit report_bulk_path
+  it 'basic page renders ok with get druids from search page' do
+    visit report_bulk_path({ q: 'druid:zt570qh4444' })
 
     expect(page).to have_css('h1', text: 'Bulk update operations')
     expect(page).to have_button 'Paste a druid list', disabled: false

--- a/spec/features/report_view_spec.rb
+++ b/spec/features/report_view_spec.rb
@@ -41,14 +41,14 @@ RSpec.describe 'Report view' do
 
     let(:workflow_client) { instance_double(Dor::Workflow::Client, workflow_templates: []) }
 
-    it 'returns a page with no get druids from previous search link' do
+    it 'shows page without the "get druids from search" button when no search params are available' do
       visit '/report/bulk'
       expect(page).to have_content('Bulk update operations')
       expect(page).not_to have_css('.btn-primary', text: 'Get druids from search') # no previous search params, so no get druids button
       expect(page).to have_css('.btn-primary', text: 'Paste a druid list')
     end
 
-    it 'returns a page with a get druids from previous search link' do
+    it 'shows page with the "get druids from search" button when search params are available' do
       visit '/report/bulk?q=search'
       expect(page).to have_content('Bulk update operations')
       expect(page).to have_css('.btn-primary', text: 'Get druids from search')

--- a/spec/features/report_view_spec.rb
+++ b/spec/features/report_view_spec.rb
@@ -41,8 +41,15 @@ RSpec.describe 'Report view' do
 
     let(:workflow_client) { instance_double(Dor::Workflow::Client, workflow_templates: []) }
 
-    it 'returns a page with the expected elements' do
+    it 'returns a page with no get druids from previous search link' do
       visit '/report/bulk'
+      expect(page).to have_content('Bulk update operations')
+      expect(page).not_to have_css('.btn-primary', text: 'Get druids from search') # no previous search params, so no get druids button
+      expect(page).to have_css('.btn-primary', text: 'Paste a druid list')
+    end
+
+    it 'returns a page with a get druids from previous search link' do
+      visit '/report/bulk?q=search'
       expect(page).to have_content('Bulk update operations')
       expect(page).to have_css('.btn-primary', text: 'Get druids from search')
       expect(page).to have_css('.btn-primary', text: 'Paste a druid list')

--- a/spec/views/bulk_actions/new.html.erb_spec.rb
+++ b/spec/views/bulk_actions/new.html.erb_spec.rb
@@ -5,12 +5,15 @@ require 'rails_helper'
 RSpec.describe 'bulk_actions/new.html.erb' do
   let(:user_groups) { %w[dlss-developers top-secret-clearance] }
   let(:apo_list) { [['APO 1', 'druid:123'], ['APO 2', 'druid:234']] }
+  let(:query_params) { { q: 'testing' } }
+  let(:blacklight_config) { Blacklight::Configuration.new }
+  let(:search_state) { Blacklight::SearchState.new(query_params, blacklight_config) }
 
   before do
     @form = BulkActionForm.new(create(:bulk_action), groups: user_groups)
     allow(view).to receive(:current_user).and_return(double(sunetid: 'esnowden', groups: user_groups))
     allow(view).to receive(:apo_list).with(user_groups).and_return(apo_list)
-
+    allow(view).to receive(:search_state).and_return(search_state)
     render
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Another attempt to fix #2792 

This does a few things:

- for bulk actions, it uses the search parameters in the query to determine if a previous search is available to get druids from (the same mechanism currently used for bulk update) instead of using the blacklight search history from cookie storage
- if no search parameters are available, it hides the "Populate with previous search" button on the New Bulk Action page
- if no search parameters are available, it hides the "Get druids from search " button on the Bulk Update page
- it stops showing the previous search from history in small text next to that button (as it is no longer relevant)

The net result is that unless you use the "Bulk Update" or "Bulk Action" buttons above the search results, you will not get those "get druid list" buttons (i.e. if you use the links in the top navigation to get to bulk update or bulk action, you will have to paste druids in).

This should fix any issues with search history getting confused between tabs, browser windows, etc.

## How was this change tested? 🤨

Localhost brower, and updated tests