### PR TITLE
Add the tab for refreshing metadata

### DIFF
--- a/app/components/bulk_actions_form_component.html.erb
+++ b/app/components/bulk_actions_form_component.html.erb
@@ -62,7 +62,7 @@
             Deletes unpublished DOR objects
           </span>
         </div>
-        
+
         <div role='tabpanel' class='tab-pane' id='AddWorkflowJob'>
           <span class='help-block'>
             Starts a workflow for individual objects.
@@ -163,13 +163,21 @@
           <%= render 'bulk_actions/forms/set_license_and_rights_statements_form', f: f, license_options: @form.license_options %>
         </div>
 
+        <div role='tabpanel' class='tab-pane' id='RefreshModsJob'>
+          <div class="mb-3">
+            <span class='help-block'>
+              Refresh metadata from the catalog
+            </span>
+          </div>
+        </div>
+
         <div role='tabpanel', class='tab-pane', id='SetContentTypeJob'>
           <div class="mb-3">
             <span class='help-block'>
               Set content type
             </span>
           </div>
-          <%= render 'bulk_actions/forms/set_content_type_form', f: f %> 
+          <%= render 'bulk_actions/forms/set_content_type_form', f: f %>
         </div>
 
         <div role='tabpanel' class='tab-pane' id='ManageEmbargoesJob'>


### PR DESCRIPTION


## Why was this change made? 🤔
This fixes a problem in the stimulus where it was raising 'oldTab is null'
<img width="386" alt="Screen Shot 2022-03-10 at 3 13 17 PM" src="https://user-images.githubusercontent.com/92044/157757510-5e8248aa-484d-4725-8c32-2272bcc4b7c9.png">


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on that repo to fix anything this change breaks. ⚡


