### PR TITLE
Rails-ujs is no longer necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
     "@github/time-elements": "^3.0.7",
     "@hotwired/turbo-rails": "^7.0.1",
     "@popperjs/core": "^2.10.2",
-    "@rails/ujs": "^6.1.3-2",
     "autocomplete.js": "^0.37.1",
     "blacklight-frontend": "^7.20.2",
     "blacklight-hierarchy": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,11 +30,6 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.0.2.tgz#69a6d999f4087e0537dd38fe0963db1f4305d650"
   integrity sha512-G26maXW1Kx0LxQdmNNuNjQlRO/QlXNr3QfuwKiOKb5FZQGYe2OwtHTGXBAjSoiu4dW36XYMT/+L1Wo1Yov4ZXA==
 
-"@rails/ujs@^6.1.3-2":
-  version "6.1.5"
-  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-6.1.5.tgz#bb1afddd0d771f00924f44b21634969e329532e1"
-  integrity sha512-Ir4yd2fdDldWIghavPr874copVKf6OOoecKHZiFRlPtm38tFvhyxr+ywzNieXGwolF9JQe3D5GrM8ejkzUgh5Q==
-
 "@stimulus/core@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@stimulus/core/-/core-2.0.0.tgz#140c85318d6a8a8210c0faf182223b8459348877"


### PR DESCRIPTION


## Why was this change made? 🤔

turbo-rails handles all the same functionality

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on that repo to fix anything this change breaks. ⚡


