### PR TITLE
Move spec for reindexing to a request spec

### DIFF
--- a/spec/requests/reindex_spec.rb
+++ b/spec/requests/reindex_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe DorController, type: :controller do
+RSpec.describe 'Reindexing', type: :request do
   let(:druid) { 'druid:aa111bb2222' }
 
   before do
@@ -10,19 +10,23 @@ RSpec.describe DorController, type: :controller do
   end
 
   describe 'reindex' do
+    before do
+      allow(Argo::Indexer).to receive(:reindex_pid_remotely)
+    end
+
     context 'from a show page' do
       it 'redirects to show page and set flash notice on success' do
-        expect(Argo::Indexer).to receive(:reindex_pid_remotely).with(druid)
-        get :reindex, params: { pid: druid }
+        get "/dor/reindex/#{druid}"
         expect(flash[:notice]).to eq "Successfully updated index for #{druid}"
         expect(response).to have_http_status(:found)
         expect(response).to redirect_to(solr_document_path(druid))
+        expect(Argo::Indexer).to have_received(:reindex_pid_remotely).with(druid)
       end
 
       it 'redirects to show page and sets flash error on failure' do
-        expect(Argo::Indexer).to receive(:reindex_pid_remotely).with(druid).and_raise(Argo::Exceptions::ReindexError)
+        allow(Argo::Indexer).to receive(:reindex_pid_remotely).and_raise(Argo::Exceptions::ReindexError)
         expect(Rails.logger).to receive(:error).with(/Failed to update index for #{druid}/)
-        get :reindex, params: { pid: druid }
+        get "/dor/reindex/#{druid}"
         expect(flash[:error]).to eq "Failed to update index for #{druid}"
         expect(response).to have_http_status(:found)
         expect(response).to redirect_to(solr_document_path(druid))


### PR DESCRIPTION


## Why was this change made? 🤔
Controller specs are deprecated


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


