### PR TITLE
Move workflow grid test to a request spec

### DIFF
--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -22,14 +22,6 @@ RSpec.describe ReportController, type: :controller do
       allow(controller.current_user).to receive(:admin?).and_return(true)
     end
 
-    describe '#workflow_grid' do
-      it 'works' do
-        get :workflow_grid
-        expect(response).to have_http_status(:ok)
-        expect(response).to render_template('workflow_grid')
-      end
-    end
-
     describe '#data' do
       before do
         allow(Report).to receive(:new).and_return(report)

--- a/spec/requests/display_workflow_grid_spec.rb
+++ b/spec/requests/display_workflow_grid_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'The workflow grid', type: :request do
+  let(:user) { create(:user) }
+
+  context 'as an admin' do
+    before do
+      sign_in user, groups: ['sdr:administrator-role']
+    end
+
+    it 'works' do
+      get '/report/workflow_grid'
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template('workflow_grid')
+    end
+  end
+end


### PR DESCRIPTION


## Why was this change made? 🤔
Controlller tests are deprecated


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


