### PR TITLE
Move close version spec to a request spec

### DIFF
--- a/spec/controllers/versions_controller_spec.rb
+++ b/spec/controllers/versions_controller_spec.rb
@@ -62,33 +62,4 @@ RSpec.describe VersionsController, type: :controller do
       end
     end
   end
-
-  describe '#close' do
-    context 'when they have manage_item access' do
-      before do
-        allow(controller).to receive(:authorize!).and_return(true)
-      end
-
-      let(:object_service) { instance_double(Dor::Services::Client::Object, version: version_service, find: cocina_model) }
-      let(:version_service) { instance_double(Dor::Services::Client::ObjectVersion, close: true) }
-
-      it 'calls dor-services to close the version' do
-        expect(Argo::Indexer).to receive(:reindex_pid_remotely)
-
-        get :close, params: { item_id: pid, significance: 'major', description: 'something' }
-        expect(flash[:notice]).to eq "Version 2 of #{pid} has been closed!"
-        expect(version_service).to have_received(:close).with(description: 'something', significance: 'major', user_name: user.to_s)
-      end
-    end
-
-    context 'without manage access' do
-      let(:object_service) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
-
-      it 'returns a 403' do
-        allow(controller).to receive(:authorize!).with(:manage_item, Cocina::Models::DRO).and_raise(CanCan::AccessDenied)
-        get :close, params: { item_id: pid }
-        expect(response.code).to eq('403')
-      end
-    end
-  end
 end

--- a/spec/requests/close_version_spec.rb
+++ b/spec/requests/close_version_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Close a version', type: :request do
+  let(:pid) { 'druid:bc123df4567' }
+  let(:user) { create(:user) }
+  let(:object_service) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+  let(:cocina_model) do
+    Cocina::Models.build({
+                           'label' => 'My Item',
+                           'version' => 2,
+                           'type' => Cocina::Models::ObjectType.object,
+                           'externalIdentifier' => pid,
+                           'description' => {
+                             'title' => [{ 'value' => 'My Item' }],
+                             'purl' => "https://purl.stanford.edu/#{pid.delete_prefix('druid:')}"
+                           },
+                           'access' => {},
+                           'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
+                           'structural' => {},
+                           'identification' => {}
+                         })
+  end
+
+  before do
+    allow(Argo::Indexer).to receive(:reindex_pid_remotely)
+    allow(Dor::Services::Client).to receive(:object).and_return(object_service)
+  end
+
+  context 'when they have manage_item access' do
+    before do
+      sign_in user, groups: ['sdr:administrator-role']
+    end
+
+    let(:object_service) { instance_double(Dor::Services::Client::Object, version: version_service, find: cocina_model) }
+    let(:version_service) { instance_double(Dor::Services::Client::ObjectVersion, close: true) }
+
+    it 'calls dor-services to close the version' do
+      expect(Argo::Indexer).to receive(:reindex_pid_remotely)
+      post "/items/#{pid}/versions/close", params: { significance: 'major', description: 'something' }
+      expect(flash[:notice]).to eq "Version 2 of #{pid} has been closed!"
+      expect(version_service).to have_received(:close).with(description: 'something', significance: 'major', user_name: user.to_s)
+    end
+  end
+
+  context 'without manage access' do
+    before do
+      sign_in user, groups: []
+    end
+
+    let(:object_service) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+
+    it 'returns a 403' do
+      post "/items/#{pid}/versions/close"
+      expect(response.code).to eq('403')
+    end
+  end
+end


### PR DESCRIPTION


## Why was this change made? 🤔
Controller specs are deprecated


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


