### PR TITLE
Remove rails-controller-testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,6 @@ group :test, :development do
   gem 'factory_bot_rails'
   gem 'http_logger', require: false # Change this to `true` to see all http requests logged
   gem 'pry-remote' # allows you to attach remote session to pry
-  gem 'rails-controller-testing'
   gem 'rspec-rails', '~> 5.0'
   gem 'rubocop', '~> 1.24', require: false
   gem 'rubocop-rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -414,10 +414,6 @@ GEM
       activesupport (= 7.0.2.3)
       bundler (>= 1.15.0)
       railties (= 7.0.2.3)
-    rails-controller-testing (1.0.5)
-      actionpack (>= 5.0.1.rc1)
-      actionview (>= 5.0.1.rc1)
-      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -628,7 +624,6 @@ DEPENDENCIES
   puma (~> 5.5)
   rack-mini-profiler
   rails (~> 7.0.2)
-  rails-controller-testing
   rake
   reform-rails
   retries

--- a/spec/requests/bulk_action_spec.rb
+++ b/spec/requests/bulk_action_spec.rb
@@ -12,11 +12,12 @@ RSpec.describe 'BulkActionsController' do
   end
 
   describe 'GET index' do
-    it 'assigns @bulk_actions from current_user' do
-      create(:bulk_action, user_id: current_user.id + 1) # Not current_user's
-      b_action = create(:bulk_action, user: current_user)
+    it 'lists the BulkActions from current_user' do
+      create(:bulk_action, user_id: current_user.id + 1, description: 'not mine') # Not current_user's
+      create(:bulk_action, user: current_user, description: 'Belongs to me')
       get '/bulk_actions'
-      expect(assigns(:bulk_actions)).to eq [b_action]
+      expect(response.body).to include 'Belongs to me'
+      expect(response.body).not_to include 'not mine'
     end
 
     it 'has a 200 status code' do
@@ -26,11 +27,6 @@ RSpec.describe 'BulkActionsController' do
   end
 
   describe 'GET new' do
-    it 'assigns @form' do
-      get '/bulk_actions/new'
-      expect(assigns(:form)).not_to be_nil
-    end
-
     it 'has a 200 status code' do
       get '/bulk_actions/new'
       expect(response.status).to eq 200
@@ -59,7 +55,7 @@ RSpec.describe 'BulkActionsController' do
 
         it 'renders new' do
           post '/bulk_actions', params: { bulk_action: { action_type: 'GenericJob' } }
-          expect(response).to render_template('new')
+          expect(response.body).to include 'New Bulk Action'
         end
       end
     end

--- a/spec/requests/display_workflow_grid_spec.rb
+++ b/spec/requests/display_workflow_grid_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'The workflow grid', type: :request do
     it 'works' do
       get '/report/workflow_grid'
       expect(response).to have_http_status(:ok)
-      expect(response).to render_template('workflow_grid')
+      expect(response.body).to include 'workflow-grid'
     end
   end
 end

--- a/spec/requests/files_spec.rb
+++ b/spec/requests/files_spec.rb
@@ -144,9 +144,7 @@ RSpec.describe 'Files', type: :request do
       it 'is successful' do
         get "/items/#{pid}/files?id=M1090_S15_B01_F07_0106.jp2"
         expect(response).to have_http_status(:ok)
-        expect(assigns(:has_been_accessioned)).to be true
-        expect(assigns(:last_accessioned_version)).to eq '7'
-        expect(assigns(:file)).to eq file
+        expect(response.body).to include '/items/druid:bc123df4567/files/M1090_S15_B01_F07_0106.jp2/preserved?version=7'
       end
     end
 

--- a/spec/requests/manage_descriptive_metadata_jobs_spec.rb
+++ b/spec/requests/manage_descriptive_metadata_jobs_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Manage bulk descriptive metadata jobs for an APO' do
       it 'is successful' do
         get "/apos/#{apo_id}/bulk_jobs/#{time}/log"
         expect(response).to be_successful
-        expect(assigns[:user_log]).to be_kind_of UserLog
+        expect(response.body).to include '2016-04-21'
       end
     end
 

--- a/spec/requests/workflow_service_spec.rb
+++ b/spec/requests/workflow_service_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe 'WorkflowServiceController', type: :request do
       it 'returns true' do
         get "/workflow_service/#{pid}/published"
 
-        expect(assigns(:status)).to be true
         expect(response.body).to eq 'true'
       end
     end
@@ -47,7 +46,6 @@ RSpec.describe 'WorkflowServiceController', type: :request do
       it 'returns false' do
         get "/workflow_service/#{pid}/published"
 
-        expect(assigns(:status)).to be false
         expect(response.body).to eq 'false'
       end
     end
@@ -57,18 +55,18 @@ RSpec.describe 'WorkflowServiceController', type: :request do
     context 'when locked' do
       before { allow(state_service).to receive(:object_state).and_return(:lock) }
 
-      it 'returns true' do
+      it 'returns the lock' do
         get "/workflow_service/#{pid}/lock"
-        expect(response).to render_template('lock')
+        expect(response.body).to include 'Unlock to make changes to this object'
       end
     end
 
     context 'when unlocked' do
       before { allow(state_service).to receive(:object_state).and_return(:unlock) }
 
-      it 'returns false' do
+      it 'returns the unlock' do
         get "/workflow_service/#{pid}/lock"
-        expect(response).to render_template('unlock')
+        expect(response.body).to include 'Close Version'
       end
     end
   end

--- a/spec/requests/workflows_spec.rb
+++ b/spec/requests/workflows_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'WorkflowsController', type: :request do
 
     it 'renders the template with no layout' do
       get "/items/#{pid}/workflows/new"
-      expect(response).to render_template(layout: false)
+      expect(response.body).to start_with('<turbo-frame')
     end
   end
 
@@ -164,7 +164,7 @@ RSpec.describe 'WorkflowsController', type: :request do
     it 'fetches the workflow history' do
       get "/items/#{pid}/workflows/history"
       expect(response).to have_http_status(:ok)
-      expect(assigns[:history_xml]).to eq xml
+      expect(response.body).to include '<span style="color:#070;font-weight:bold">&lt;xml</span><span style="color:#070;font-weight:bold">/&gt;</span>'
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔

This dependency is no longer needed.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


