### PR TITLE
Use Request#media_type rather than Request#content_type

### DIFF
--- a/app/controllers/dor/objects_controller.rb
+++ b/app/controllers/dor/objects_controller.rb
@@ -24,7 +24,7 @@ class Dor::ObjectsController < ApplicationController
   end
 
   def munge_parameters
-    case request.content_type
+    case request.media_type
     when 'application/xml', 'text/xml'
       merge_params(Hash.from_xml(request.body.read))
     when 'application/json', 'text/json'


### PR DESCRIPTION


## Why was this change made? 🤔
The latter will be the unparsed header in Rails 7.1, which is not what we want


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


