### PR TITLE
Avoid a deprecation warning by calling Date#to_fs

### DIFF
--- a/app/models/item_change_set.rb
+++ b/app/models/item_change_set.rb
@@ -44,7 +44,7 @@ class ItemChangeSet < ApplicationChangeSet
 
   def setup_embargo_properties!
     embargo = model.access.embargo
-    self.embargo_release_date = embargo.releaseDate.to_date.to_s(:default)
+    self.embargo_release_date = embargo.releaseDate.to_date.to_fs(:default)
     self.embargo_access = if embargo.view == 'location-based'
                             "loc:#{embargo.location}"
                           elsif embargo.download == 'none' && embargo.view.in?(%w[stanford world])


### PR DESCRIPTION
## Why was this change made? 🤔
It was previously complaining about `Date#to_s` with a format being deprecated.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


