### PR TITLE
Hide empty descriptive elements in displayed Cocina JSON

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -395,3 +395,5 @@ RSpec/BeEq: # new in 2.9.0
   Enabled: true
 RSpec/BeNil: # new in 2.9.0
   Enabled: true
+Style/NestedFileDirname: # new in 1.26
+  Enabled: true

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -78,7 +78,7 @@ class ItemsController < ApplicationController
     authorize! :view_metadata, @cocina
 
     respond_to do |format|
-      format.json { render json: @cocina }
+      format.json { render json: CocinaHashPresenter.new(cocina_object: @cocina).render }
     end
   end
 

--- a/app/models/nil_model.rb
+++ b/app/models/nil_model.rb
@@ -28,6 +28,10 @@ class NilModel
     false
   end
 
+  def to_h
+    {}
+  end
+
   # This stands in for the administrative metadata
   class NilAdministrative
     # rubocop:disable Naming/MethodName

--- a/app/presenters/cocina_hash_presenter.rb
+++ b/app/presenters/cocina_hash_presenter.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Filters empty descriptive elements from Cocina object and return as a hash
+#
+# Why a hash?
+#
+# 1. If a Cocina object is returned, the empty descriptive elements will be present.
+# 2. A hash is easier to work with (compare against, etc.) than a JSON string, and
+#    it's super easy to coerce a hash into other data structures, so it gives us
+#    flexibility.
+class CocinaHashPresenter
+  def initialize(cocina_object:)
+    @cocina_object_hash = cocina_object.to_h
+  end
+
+  def render
+    return cocina_object_hash unless cocina_object_hash[:description]
+
+    cocina_object_hash.tap do |hash|
+      hash[:description] = DeepCompactBlank.run(enumerable: hash[:description])
+      # If other presentation tweaks are needed, they can live here.
+    end
+  end
+
+  private
+
+  attr_reader :cocina_object_hash
+end

--- a/app/services/deep_compact_blank.rb
+++ b/app/services/deep_compact_blank.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Recursively compact enumerables of blank values
+class DeepCompactBlank
+  def self.run(enumerable:)
+    new(enumerable: enumerable).run
+  end
+
+  def initialize(enumerable:)
+    @enumerable = enumerable
+  end
+
+  def run
+    return enumerable unless enumerable.respond_to?(:compact_blank)
+
+    enumerable
+      .compact_blank
+      .public_send(enumerable.is_a?(Hash) ? :transform_values : :map) { |value| self.class.run(enumerable: value) }
+  end
+
+  private
+
+  attr_reader :enumerable
+end

--- a/app/views/catalog/_cocina_default.html.erb
+++ b/app/views/catalog/_cocina_default.html.erb
@@ -16,7 +16,7 @@
         </a>
 
       <script type="application/json" data-json-renderer-target="cocina">
-        <%= @cocina.to_json.html_safe %>
+        <%= CocinaHashPresenter.new(cocina_object: @cocina).render.to_json.html_safe %>
       </script>
 
       <div class="detail" data-json-renderer-target="section"></div>

--- a/spec/presenters/cocina_hash_presenter_spec.rb
+++ b/spec/presenters/cocina_hash_presenter_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CocinaHashPresenter do
+  subject(:presenter) { described_class.new(cocina_object: cocina_object) }
+
+  describe '#render' do
+    subject(:rendered) { presenter.render }
+
+    context 'when cocina object lacks descriptive metadata' do
+      let(:cocina_object) do
+        Cocina::Models::AdminPolicy.new(
+          type: Cocina::Models::ObjectType.admin_policy,
+          externalIdentifier: 'druid:zt570qh4444',
+          version: 1,
+          administrative: {
+            hasAdminPolicy: 'druid:hv992ry2431',
+            hasAgreement: 'druid:hp308wm0436',
+            accessTemplate: {}
+          },
+          label: 'My title'
+        )
+      end
+
+      it 'returns the object untouched as a hash' do
+        expect(rendered).to eq(cocina_object.to_h)
+      end
+    end
+
+    context 'when cocina object has descriptive metadata' do
+      let(:cocina_object) do
+        Cocina::Models::Collection.new(
+          type: Cocina::Models::ObjectType.collection,
+          externalIdentifier: 'druid:zt570qh4444',
+          version: 1,
+          administrative: { hasAdminPolicy: 'druid:hv992ry2431' },
+          label: 'My title',
+          description: {
+            title: [
+              { value: 'My title' }
+            ],
+            purl: 'https://purl.stanford.edu/zt570qh4444'
+          },
+          access: {}
+        )
+      end
+
+      # NOTE: You might not see an empty e.g. `structuredValue` array above, but it's there in the instance
+      it 'removes empty descriptive elements' do
+        expect(rendered).to eq(cocinaVersion: '0.69.2',
+                               type: 'https://cocina.sul.stanford.edu/models/collection',
+                               externalIdentifier: 'druid:zt570qh4444',
+                               label: 'My title',
+                               version: 1,
+                               access: {
+                                 view: 'dark'
+                               },
+                               administrative: {
+                                 hasAdminPolicy: 'druid:hv992ry2431',
+                                 releaseTags: []
+                               },
+                               description: {
+                                 title: [
+                                   { value: 'My title' }
+                                 ],
+                                 purl: 'https://purl.stanford.edu/zt570qh4444'
+                               })
+      end
+    end
+  end
+end

--- a/spec/services/deep_compact_blank_spec.rb
+++ b/spec/services/deep_compact_blank_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DeepCompactBlank do
+  subject(:compacted) { described_class.run(enumerable: enumerable) }
+
+  describe '.run' do
+    context 'with a string' do
+      let(:enumerable) { 'foobar' }
+
+      it 'returns the value unchanged' do
+        expect(compacted).to eq(enumerable)
+      end
+    end
+
+    context 'with an empty array' do
+      let(:enumerable) { [] }
+
+      it 'returns the value unchanged' do
+        expect(compacted).to eq(enumerable)
+      end
+    end
+
+    context 'with an empty hash' do
+      let(:enumerable) { {} }
+
+      it 'returns the value unchanged' do
+        expect(compacted).to eq(enumerable)
+      end
+    end
+
+    context 'with deeply nested structure of hashes and arrays' do
+      let(:enumerable) do
+        {
+          foo: 'bar',
+          compact_me: [],
+          keep_me: {
+            compact_me_too: [],
+            another_keeper: [
+              {},
+              {
+                title: 'awesome',
+                nope: [],
+                container: [
+                  ok: 'stuff',
+                  byebye: []
+                ]
+              }
+            ]
+          }
+        }
+      end
+
+      it 'removes all empty hashes and arrays' do
+        expect(compacted).to eq(foo: 'bar',
+                                keep_me: {
+                                  another_keeper: [
+                                    {
+                                      title: 'awesome',
+                                      container: [
+                                        ok: 'stuff'
+                                      ]
+                                    }
+                                  ]
+                                })
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #3178

## Why was this change made? 🤔

This commit hides empty descriptive elements in Cocina JSON when displayed, both on the catalog show page and in the items show view.

This is accomplished by wrapping the Cocina::Models instance with a presenter object that collaborates with a new service class that knows how to deeply remove blank values from enumerables (hashes and arrays). We lean on the Rails built-in method, `#compact_blank`, to do the heavy lifting.

## How was this change tested? 🤨

CI + will be tested in QA
