### PR TITLE
Document call to rake test:prepare

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,17 +58,17 @@ CI runs a series of steps;  this the sequence to do it locally, along with some 
 
     You will need to have Google Chrome browser installed, as the tests use chrome for a headless browser.
 
-4. **Update javascript dependencies**
+4. **Prepare rails for testing**
 
     ```
-    yarn install
+    bin/rails test:prepare
     ```
 
 5. **Run the tests (without rubocop)**
 
-```
-bin/rake
-```
+    ```
+    bin/rake
+    ```
 
 ## Run the servers
 


### PR DESCRIPTION
## Why was this change made? 🤔

This gets the JS deps with yarn, and builds the javascript.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


