### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ CI runs a series of steps;  this the sequence to do it locally, along with some 
     bin/rails test:prepare
     ```
 
-5. **Run the tests (without rubocop)**
+5. **Run rubocop and the tests**
 
     ```
     bin/rake


### PR DESCRIPTION
The readme for running tests says "Run the tests (without rubocop)" which isn't true from my running, `bin/rake` includes rubocop.

## Why was this change made? 🤔

Simply updating the readme for accuracy.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


