### PR TITLE
Pin view_component to 2.50.0 until bug in 2.51.0 is resolved

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,8 @@ gem 'cssbundling-rails', '~> 1.1'
 gem 'jsbundling-rails', '~> 1.0'
 gem 'sprockets-rails'
 
-gem 'view_component', '~> 2.49'
+# Pinned due to: https://github.com/github/view_component/issues/1315
+gem 'view_component', '2.50.0'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -543,7 +543,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unicode-display_width (2.1.0)
-    view_component (2.51.0)
+    view_component (2.50.0)
       activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
     warden (1.2.9)
@@ -640,7 +640,7 @@ DEPENDENCIES
   sprockets-rails
   sqlite3 (~> 1.4.2)
   turbo-rails (~> 1.0)
-  view_component (~> 2.49)
+  view_component (= 2.50.0)
   web-console
   webdrivers
   webmock


### PR DESCRIPTION
## Why was this change made? 🤔

An open issue in view_component is causing a number of test failures. Until resolved, pin to the latest working version (2.50.0)

https://github.com/github/view_component/issues/1315

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


