### PR TITLE
Background jobs should not index unnecessarily

### DIFF
--- a/app/jobs/set_collection_job.rb
+++ b/app/jobs/set_collection_job.rb
@@ -39,7 +39,6 @@ class SetCollectionJob < GenericJob
     change_set = ItemChangeSet.new(cocina_object)
     change_set.validate(collection_ids: new_collection_ids)
     change_set.save
-    Argo::Indexer.reindex_pid_remotely(cocina_object.externalIdentifier)
 
     log.puts("#{Time.current} SetCollectionJob: Successfully updated #{cocina_object.externalIdentifier} (bulk_action.id=#{bulk_action.id})")
     bulk_action.increment(:druid_count_success).save

--- a/app/jobs/set_governing_apo_job.rb
+++ b/app/jobs/set_governing_apo_job.rb
@@ -37,7 +37,6 @@ class SetGoverningApoJob < GenericJob
     change_set = ItemChangeSet.new(cocina_item)
     change_set.validate(admin_policy_id: new_apo_id)
     change_set.save
-    Argo::Indexer.reindex_pid_remotely(current_druid)
 
     log.puts("#{Time.current} SetGoverningApoJob: Successfully updated #{current_druid} (bulk_action.id=#{bulk_action.id})")
     bulk_action.increment(:druid_count_success).save

--- a/spec/jobs/set_governing_apo_job_spec.rb
+++ b/spec/jobs/set_governing_apo_job_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe SetGoverningApoJob do
 
       it 'logs info about progress' do
         allow(subject).to receive(:set_governing_apo_and_index_safely)
-        allow(Argo::Indexer).to receive(:reindex_pid_remotely)
 
         subject.perform(bulk_action.id, params)
 
@@ -108,8 +107,6 @@ RSpec.describe SetGoverningApoJob do
       # assuming one is inclined to test private methods, but it also seemed reasonable to do a slightly more end-to-end
       # test of #perform, to prove that common failure cases for individual objects wouldn't fail the whole run.
       it 'increments the failure and success counts and logs status of each update' do
-        expect(Argo::Indexer).to receive(:reindex_pid_remotely)
-
         subject.perform(bulk_action.id, params)
         expect(state_service).to have_received(:allows_modification?)
         expect(object_client1).to have_received(:update).with(params: Cocina::Models::DRO)


### PR DESCRIPTION


## Why was this change made? 🤔

Typically DSA will initiate the indexing. It's harmful to the system if we reindex more than necessary

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


