### PR TITLE
Fix call to Ability#can?

### DIFF
--- a/app/jobs/set_collection_job.rb
+++ b/app/jobs/set_collection_job.rb
@@ -50,9 +50,7 @@ class SetCollectionJob < GenericJob
   def check_can_set_collection!(cocina, state_service)
     raise "#{cocina.externalIdentifier} is not open for modification" unless state_service.allows_modification?
 
-    new_collection_ids.each do |new_collection_id|
-      raise "user not authorized to move #{cocina.externalIdentifier} to #{new_collection_id}" unless ability.can?(:manage_item, cocina, new_collection_id)
-    end
+    raise "user not authorized to modify #{cocina.externalIdentifier}" unless ability.can?(:manage_item, cocina)
   end
 
   def version_message(collection_ids)


### PR DESCRIPTION


## Why was this change made? 🤔

This method doesn't do anything with the third argument. There's no need to loop over it

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


