### PR TITLE
Strip druid: prefix in structural metadata CSV

### DIFF
--- a/app/jobs/export_structural_job.rb
+++ b/app/jobs/export_structural_job.rb
@@ -16,7 +16,7 @@ class ExportStructuralJob < GenericJob
         pids.each do |druid|
           rows_for_file = item_to_rows(druid, log_buffer)
           rows_for_file.each do |row|
-            csv << [druid, *row]
+            csv << [druid.delete_prefix('druid:'), *row]
           end
         end
       end

--- a/spec/jobs/export_structural_job_spec.rb
+++ b/spec/jobs/export_structural_job_spec.rb
@@ -424,8 +424,13 @@ RSpec.describe ExportStructuralJob, type: :job do
         expect(log_buffer.string).to include "Exporting structural metadata for #{druid1}"
         expect(log_buffer.string).to include "Exporting structural metadata for #{druid2}"
         expect(File).to exist(csv_path)
-        File.open(csv_path, 'r') do |file|
-          expect(file.readlines.size).to eq 9 # one row for each file plus the headers.
+      end
+
+      it 'is valid csv and druids are prefixless' do
+        output = CSV.read(csv_path, headers: true)
+        expect(output.size).to eq 8
+        output.each do |row|
+          expect(row['druid']).not_to match(/^druid:/)
         end
       end
     end


### PR DESCRIPTION
## Why was this change made? 🤔

This is a small change to strip the "druid:" prefix from druids in the structural metadata bulk action export. The existing test has been updated to parse the CSV and make sure the druids are correct.

## How was this change tested? 🤨

Adjusted unit test to look at druid column. Ran a report with 7 items on QA.

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Closes #3292



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


