### PR TITLE
allow the search state params to pass through bulk actions

### DIFF
--- a/app/components/bulk_actions_form_component.html.erb
+++ b/app/components/bulk_actions_form_component.html.erb
@@ -2,6 +2,7 @@
   <h1>New Bulk Action</h1>
 
   <%= form_for(@form,
+               url: bulk_actions_path(search_state.params_for_search),
                data: {
                  controller: 'bulk-actions',
                  bulk_actions_populate_url_value: search_catalog_path(search_of_pids)

--- a/app/controllers/bulk_actions_controller.rb
+++ b/app/controllers/bulk_actions_controller.rb
@@ -21,7 +21,7 @@ class BulkActionsController < ApplicationController
     @form = BulkActionForm.new(BulkAction.new(user: current_user), groups: current_user.groups)
     if @form.validate(bulk_action_params) && @form.save
       flash[:notice] = 'Bulk action was successfully created.'
-      redirect_to action: :index
+      redirect_to action: :index, params: search_state.params_for_search
     else
       render :new, status: :unprocessable_entity
     end


### PR DESCRIPTION
## Why was this change made? 🤔

Now that we use query string parameters to define the previous search used for the "populate druids" button in Bulk Actions (see #3222), the previous search is lost once you submit a bulk action job.  This simply passes the existing search params on through the form submission used to create a new bulk action and then onto the redirect to create a new job.  This allows the search request to be preserved if you then create a new bulk action immediately and want to apply them to the same list of druids.

## How was this change tested? 🤨

Localhost browser.  Though I did not that it seems pass along more params than just the search related ones, and I'm not sure why.  It does work though.


