### PR TITLE
[HOLD for testing] Extract open version method to remove duplication

### DIFF
--- a/app/jobs/manage_embargoes_job.rb
+++ b/app/jobs/manage_embargoes_job.rb
@@ -42,9 +42,8 @@ class ManageEmbargoesJob < GenericJob
 
     return failure.call('Not authorized') unless ability.can?(:manage_item, cocina_object)
 
-    state_service = StateService.new(cocina_object)
     msg = "Setting embargo to #{rights_param} to be released on #{embargo_release_date_param}."
-    open_new_version(cocina_object.externalIdentifier, cocina_object.version, msg) unless state_service.allows_modification?
+    cocina_object = open_new_version(cocina_object, msg)
 
     changes = {}
     changes[:embargo_release_date] = embargo_release_date if embargo_release_date

--- a/app/jobs/set_catkeys_and_barcodes_job.rb
+++ b/app/jobs/set_catkeys_and_barcodes_job.rb
@@ -55,8 +55,7 @@ class SetCatkeysAndBarcodesJob < GenericJob
     log_update(change_set, log)
 
     begin
-      state_service = StateService.new(cocina_object)
-      open_new_version(cocina_object.externalIdentifier, cocina_object.version, version_message(change_set)) unless state_service.allows_modification?
+      open_new_version(cocina_object, version_message(change_set))
       change_set.save
 
       bulk_action.increment(:druid_count_success).save

--- a/app/jobs/set_collection_job.rb
+++ b/app/jobs/set_collection_job.rb
@@ -17,11 +17,7 @@ class SetCollectionJob < GenericJob
     with_items(params[:druids], name: 'Set collection') do |cocina_object, success, _failure|
       next failure.call('Not authorized') unless ability.can?(:manage_item, cocina_object)
 
-      state_service = StateService.new(cocina_object)
-      unless state_service.allows_modification?
-        new_version = open_new_version(cocina_object.externalIdentifier, cocina_object.version, version_message(new_collection_ids))
-        cocina_object = cocina_object.new(version: new_version.to_i)
-      end
+      cocina_object = open_new_version(cocina_object, version_message(new_collection_ids))
 
       change_set = ItemChangeSet.new(cocina_object)
       change_set.validate(collection_ids: new_collection_ids)

--- a/app/jobs/set_governing_apo_job.rb
+++ b/app/jobs/set_governing_apo_job.rb
@@ -17,8 +17,7 @@ class SetGoverningApoJob < GenericJob
     with_items(params[:druids], name: 'Set governing APO') do |cocina_item, success, failure|
       next failure.call("user not authorized to move item to #{new_apo_id}") unless ability.can?(:manage_governing_apo, cocina_item, new_apo_id)
 
-      state_service = StateService.new(cocina_item)
-      open_new_version(cocina_item.externalIdentifier, cocina_item.version, 'Set new governing APO') unless state_service.allows_modification?
+      cocina_item = open_new_version(cocina_item, 'Set new governing APO')
 
       change_set = ItemChangeSet.new(cocina_item)
       change_set.validate(admin_policy_id: new_apo_id)

--- a/app/jobs/set_source_ids_csv_job.rb
+++ b/app/jobs/set_source_ids_csv_job.rb
@@ -36,11 +36,7 @@ class SetSourceIdsCsvJob < GenericJob
       return
     end
 
-    state_service = StateService.new(cocina_object)
-    unless state_service.allows_modification?
-      new_version = open_new_version(cocina_object.externalIdentifier, cocina_object.version, version_message(source_id))
-      cocina_object = cocina_object.new(version: new_version.to_i)
-    end
+    cocina_object = open_new_version(cocina_object, version_message(source_id))
 
     change_set_class = cocina_object.collection? ? CollectionChangeSet : ItemChangeSet
     change_set = change_set_class.new(cocina_object)

--- a/spec/jobs/set_catkeys_and_barcodes_job_spec.rb
+++ b/spec/jobs/set_catkeys_and_barcodes_job_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe SetCatkeysAndBarcodesJob do
       let(:state_service) { instance_double(StateService, allows_modification?: false) }
 
       it 'updates catkey and barcode and versions objects' do
-        expect(subject).to receive(:open_new_version).with(druid, 3, "Catkey updated to #{catkeys[0]}. Barcode updated to #{barcode}.")
+        expect(subject).to receive(:open_new_version).with(item1, "Catkey updated to #{catkeys[0]}. Barcode updated to #{barcode}.").and_return(updated_model)
         subject.send(:update_catkey_and_barcode, change_set, buffer)
         expect(object_client).to have_received(:update)
           .with(params: updated_model)
@@ -191,7 +191,8 @@ RSpec.describe SetCatkeysAndBarcodesJob do
       let(:state_service) { instance_double(StateService, allows_modification?: true) }
 
       it 'updates catkey and barcode and does not version objects if not needed' do
-        expect(subject).not_to receive(:open_new_version).with(druid, 3, "Catkey updated to #{catkeys[0]}. Barcode updated to #{barcode}.")
+        expect(DorObjectWorkflowStatus).not_to receive(:new)
+        expect(VersionService).not_to receive(:open)
         subject.send(:update_catkey_and_barcode, change_set, buffer)
         expect(object_client).to have_received(:update)
           .with(params: updated_model)
@@ -216,7 +217,7 @@ RSpec.describe SetCatkeysAndBarcodesJob do
       end
 
       it 'removes catkey and barcode' do
-        expect(subject).to receive(:open_new_version).with(druid, 3, 'Catkey removed. Barcode removed.')
+        expect(subject).to receive(:open_new_version).with(item1, 'Catkey removed. Barcode removed.').and_return(updated_model)
         subject.send(:update_catkey_and_barcode, change_set, buffer)
         expect(object_client).to have_received(:update)
           .with(params: updated_model)

--- a/spec/jobs/set_governing_apo_job_spec.rb
+++ b/spec/jobs/set_governing_apo_job_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe SetGoverningApoJob do
         allow(Dor::Services::Client).to receive(:object).with(druids[0]).and_return(object_client1)
         allow(Dor::Services::Client).to receive(:object).with(druids[1]).and_raise(Dor::Services::Client::NotFoundResponse)
         allow(Dor::Services::Client).to receive(:object).with(druids[2]).and_return(object_client3)
+        allow(DorObjectWorkflowStatus).to receive(:new).and_return(instance_double(DorObjectWorkflowStatus, can_open_version?: true))
         allow(subject.ability).to receive(:can?).and_return(true, false)
       end
 

--- a/spec/jobs/set_source_ids_csv_job_spec.rb
+++ b/spec/jobs/set_source_ids_csv_job_spec.rb
@@ -80,7 +80,8 @@ RSpec.describe SetSourceIdsCsvJob do
         let(:state_service) { instance_double(StateService, allows_modification?: false) }
 
         before do
-          allow(job).to receive(:open_new_version).and_return('3')
+          allow(DorObjectWorkflowStatus).to receive(:new).and_return(instance_double(DorObjectWorkflowStatus, can_open_version?: true))
+          allow(VersionService).to receive(:open).and_return('3')
           job.perform(bulk_action.id,
                       csv_file: csv_file,
                       groups: groups,


### PR DESCRIPTION
## Why was this change made? 🤔

Closes #3163 

- [x] Updates generic_job#open_new_version to be more resuable
- [x] Updates generic_job_spec to reflect changes
- [x] Updates set_collection_job and set_collection_job_spec to use not open_new_version method
 
Draft until the following are updated:

- [x] manage_embargo_job and manage_embargo_job_spec
- [x] set_source_id_job and set_source_id_job_spec
- [x] set_catkeys_and_barcodes_job and set_catkeys_and_barcodes_job_spec
- [x] set_governing_apo_job and set_governing_apo_job_spec


## How was this change tested? 🤨

- [x] Updated unit tests.
- [ ] will run integration tests in QA (and manually test the affected jobs?)

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


