### PR TITLE
Add a way to use factories to create Cocina objects

### DIFF
--- a/spec/components/show/item/overview_component_spec.rb
+++ b/spec/components/show/item/overview_component_spec.rb
@@ -7,20 +7,7 @@ RSpec.describe Show::Item::OverviewComponent, type: :component do
   let(:presenter) { instance_double(ArgoShowPresenter, document: doc, cocina: cocina, change_set: change_set, state_service: state_service) }
   let(:change_set) { ItemChangeSet.new(cocina) }
   let(:cocina) do
-    Cocina::Models::DRO.new(externalIdentifier: 'druid:bc234fg5678',
-                            type: Cocina::Models::ObjectType.document,
-                            label: 'my dro',
-                            version: 1,
-                            description: {
-                              title: [{ value: 'my dro' }],
-                              purl: 'https://purl.stanford.edu/bc234fg5678'
-                            },
-                            access: {},
-                            identification: {},
-                            structural: {},
-                            administrative: {
-                              hasAdminPolicy: 'druid:hv992ry2431'
-                            })
+    build_for_repository(:item)
   end
   let(:rendered) { render_inline(component) }
   let(:allows_modification) { true }
@@ -46,22 +33,7 @@ RSpec.describe Show::Item::OverviewComponent, type: :component do
 
   context 'with a license set' do
     let(:cocina) do
-      Cocina::Models::DRO.new(externalIdentifier: 'druid:bc234fg5678',
-                              type: Cocina::Models::ObjectType.document,
-                              label: 'my dro',
-                              version: 1,
-                              description: {
-                                title: [{ value: 'my dro' }],
-                                purl: 'https://purl.stanford.edu/bc234fg5678'
-                              },
-                              access: {
-                                license: 'https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode'
-                              },
-                              identification: {},
-                              structural: {},
-                              administrative: {
-                                hasAdminPolicy: 'druid:hv992ry2431'
-                              })
+      build_for_repository(:item, license: 'https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode')
     end
     let(:doc) do
       SolrDocument.new('id' => 'druid:kv840xx0000',

--- a/spec/factories/apos.rb
+++ b/spec/factories/apos.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :apo, class: 'Cocina::Models::RequestAdminPolicy' do
+  factory :persisted_apo, class: 'Cocina::Models::RequestAdminPolicy' do
     initialize_with do |*_args|
       ApoMethodSender.new(
         Cocina::Models.build_request({
@@ -25,6 +25,35 @@ FactoryBot.define do
     end
 
     admin_policy_id { 'druid:hv992ry2431' }
+
+    agreement_id { 'druid:hp308wm0436' }
+
+    type { Cocina::Models::ObjectType.admin_policy }
+  end
+
+  factory :apo, class: 'Cocina::Models::AdminPolicy' do
+    initialize_with do |*_args|
+      ApoMethodSender.new(
+        Cocina::Models.build({
+                               externalIdentifier: external_identifier,
+                               type: type,
+                               label: 'test collection',
+                               version: 1,
+
+                               administrative: {
+                                 hasAdminPolicy: admin_policy_id,
+                                 hasAgreement: agreement_id,
+                                 accessTemplate: {
+                                   view: 'world',
+                                   download: 'world'
+                                 }
+                               }
+                             })
+      )
+    end
+
+    admin_policy_id { 'druid:hv992ry2431' }
+    external_identifier { 'druid:bc123df4568' }
 
     agreement_id { 'druid:hp308wm0436' }
 

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :collection, class: 'Cocina::Models::RequestCollection' do
+  factory :persisted_collection, class: 'Cocina::Models::RequestCollection' do
     initialize_with do |*_args|
       CollectionMethodSender.new(
         Cocina::Models.build_request({
@@ -24,5 +24,35 @@ FactoryBot.define do
     admin_policy_id { 'druid:hv992ry2431' }
 
     type { Cocina::Models::ObjectType.collection }
+  end
+
+  factory :collection, class: 'Cocina::Models::Collection' do
+    initialize_with do |*_args|
+      CollectionMethodSender.new(
+        Cocina::Models.build({
+                               externalIdentifier: external_identifier,
+                               type: type,
+                               label: 'test collection',
+                               version: 1,
+                               description: {
+                                 title: [{ value: title }],
+                                 purl: purl
+                               },
+                               administrative: {
+                                 hasAdminPolicy: admin_policy_id
+                               },
+                               identification: {},
+                               access: {}
+                             })
+      )
+    end
+
+    admin_policy_id { 'druid:hv992ry2431' }
+    external_identifier { 'druid:bc123df4568' }
+
+    label { 'test object' }
+    type { Cocina::Models::ObjectType.collection }
+    title { 'my collection' }
+    purl { 'https://purl.stanford.edu/bc123df4568' }
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :item, class: 'Cocina::Models::RequestDRO' do
+  factory :persisted_item, class: 'Cocina::Models::RequestDRO' do
     initialize_with do
       ItemMethodSender.new(
         Cocina::Models.build_request({
@@ -31,5 +31,36 @@ FactoryBot.define do
     factory :agreement do
       type { Cocina::Models::ObjectType.agreement }
     end
+  end
+
+  factory :item, class: 'Cocina::Models::DRO' do
+    initialize_with do
+      ItemMethodSender.new(
+        Cocina::Models.build({
+                               externalIdentifier: external_identifier,
+                               type: type,
+                               label: label,
+                               version: 1,
+                               description: {
+                                 title: [{ value: title }],
+                                 purl: purl
+                               },
+                               identification: {},
+                               administrative: {
+                                 hasAdminPolicy: admin_policy_id
+                               },
+                               access: {},
+                               structural: {}
+                             })
+      )
+    end
+
+    admin_policy_id { 'druid:hv992ry2431' }
+    external_identifier { 'druid:bc234fg5678' }
+
+    label { 'test object' }
+    type { Cocina::Models::ObjectType.object }
+    title { 'my dro' }
+    purl { 'https://purl.stanford.edu/bc234fg5678' }
   end
 end

--- a/spec/features/apo_spec.rb
+++ b/spec/features/apo_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Create an apo', js: true do
   # An Agreement object must exist to populate the dropdown on the form
   let(:agreement) { FactoryBot.create_for_repository(:agreement) }
   let!(:preexisting_collection) do
-    FactoryBot.create_for_repository(:collection,
+    FactoryBot.create_for_repository(:persisted_collection,
                                      label: 'Another type of collection',
                                      title: 'Another type of collection',
                                      admin_policy_id: agreement.administrative.hasAdminPolicy)

--- a/spec/features/edit_item_tags_spec.rb
+++ b/spec/features/edit_item_tags_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Edit administrative tags for a single item', js: true do
   let(:user) { create(:user) }
   let(:item) do
-    FactoryBot.create_for_repository(:item)
+    FactoryBot.create_for_repository(:persisted_item)
   end
 
   let(:first_new_tag) { 'cow : pig' }

--- a/spec/features/item_catkey_change_spec.rb
+++ b/spec/features/item_catkey_change_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Item catkey change' do
   end
 
   describe 'when modification is not allowed' do
-    let(:item) { FactoryBot.create_for_repository(:item) }
+    let(:item) { FactoryBot.create_for_repository(:persisted_item) }
     let(:druid) { item.externalIdentifier }
     let(:state_service) { instance_double(StateService, allows_modification?: false) }
 

--- a/spec/features/item_manage_release_spec.rb
+++ b/spec/features/item_manage_release_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Item manage release' do
                     version: version_client)
   end
   let(:item) do
-    FactoryBot.create_for_repository(:item)
+    FactoryBot.create_for_repository(:persisted_item)
   end
 
   it 'has a manage release button' do

--- a/spec/features/item_source_id_change_spec.rb
+++ b/spec/features/item_source_id_change_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Item source id change' do
   end
 
   describe 'when modification is not allowed' do
-    let(:item) { FactoryBot.create_for_repository(:item) }
+    let(:item) { FactoryBot.create_for_repository(:persisted_item) }
     let(:druid) { item.externalIdentifier }
     let(:state_service) { instance_double(StateService, allows_modification?: false) }
 

--- a/spec/features/open_and_close_a_version_spec.rb
+++ b/spec/features/open_and_close_a_version_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Open and close a version' do
   let(:item) do
-    FactoryBot.create_for_repository(:item)
+    FactoryBot.create_for_repository(:persisted_item)
   end
 
   let(:dsc) { Dor::Services::Client.object(item.externalIdentifier) }

--- a/spec/features/set_governing_apo_spec.rb
+++ b/spec/features/set_governing_apo_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 RSpec.describe 'Set governing APO' do
   let(:groups) { ['sdr:administrator-role', 'dlss:dor-admin', 'dlss:developers'] }
   let(:new_apo) do
-    FactoryBot.create_for_repository(:apo, title: 'Stanford University Libraries - Special Collections',
-                                           roles: [{ name: 'dor-apo-manager', members: [{ identifier: 'sdr:administrator-role', type: 'workgroup' }] }])
+    FactoryBot.create_for_repository(:persisted_apo, title: 'Stanford University Libraries - Special Collections',
+                                                     roles: [{ name: 'dor-apo-manager', members: [{ identifier: 'sdr:administrator-role', type: 'workgroup' }] }])
   end
 
   let(:identity_md) { instance_double(Nokogiri::XML::Document, xpath: []) }
@@ -14,7 +14,7 @@ RSpec.describe 'Set governing APO' do
 
   let(:uber_apo_id) { 'druid:hv992ry2431' }
   let(:item) do
-    FactoryBot.create_for_repository(:item, label: 'Foo', source_id: 'sauce:99', admin_policy_id: uber_apo_id, title: 'Test')
+    FactoryBot.create_for_repository(:persisted_item, label: 'Foo', source_id: 'sauce:99', admin_policy_id: uber_apo_id, title: 'Test')
   end
   let(:item_id) { item.externalIdentifier }
   let(:blacklight_config) { CatalogController.blacklight_config }

--- a/spec/requests/apo_count_spec.rb
+++ b/spec/requests/apo_count_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe 'Count the members of an apo' do
 
   describe 'counting the collection members' do
     before do
-      FactoryBot.create_for_repository(:collection)
-      FactoryBot.create_for_repository(:collection)
+      FactoryBot.create_for_repository(:persisted_collection)
+      FactoryBot.create_for_repository(:persisted_collection)
     end
 
     it 'returns the count' do
@@ -41,8 +41,8 @@ RSpec.describe 'Count the members of an apo' do
 
   describe 'counting the item members' do
     before do
-      FactoryBot.create_for_repository(:item)
-      FactoryBot.create_for_repository(:item)
+      FactoryBot.create_for_repository(:persisted_item)
+      FactoryBot.create_for_repository(:persisted_item)
     end
 
     it 'returns the count' do

--- a/spec/requests/collection_count_spec.rb
+++ b/spec/requests/collection_count_spec.rb
@@ -4,15 +4,15 @@ require 'rails_helper'
 
 RSpec.describe 'Count the members of a collection' do
   let(:user) { create(:user) }
-  let(:collection) { FactoryBot.create_for_repository(:collection) }
+  let(:collection) { FactoryBot.create_for_repository(:persisted_collection) }
   let(:rendered) do
     Capybara::Node::Simple.new(response.body)
   end
 
   before do
     sign_in user, groups: ['sdr:administrator-role']
-    FactoryBot.create_for_repository(:item, collection_id: collection.externalIdentifier)
-    FactoryBot.create_for_repository(:item, collection_id: collection.externalIdentifier)
+    FactoryBot.create_for_repository(:persisted_item, collection_id: collection.externalIdentifier)
+    FactoryBot.create_for_repository(:persisted_item, collection_id: collection.externalIdentifier)
   end
 
   it 'returns the count' do

--- a/spec/requests/view_cocina_model_spec.rb
+++ b/spec/requests/view_cocina_model_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'View Cocina model' do
 
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: item) }
   let(:item) do
-    FactoryBot.create_for_repository(:item)
+    FactoryBot.create_for_repository(:persisted_item)
   end
 
   before do

--- a/spec/services/license_and_rights_statements_setter_spec.rb
+++ b/spec/services/license_and_rights_statements_setter_spec.rb
@@ -25,20 +25,7 @@ RSpec.describe LicenseAndRightsStatementsSetter do
     let(:allows_modification) { true }
     let(:instance_args) { { copyright: copyright_statement } }
     let(:cocina_object) do
-      Cocina::Models::DRO.new(
-        externalIdentifier: 'druid:bc123df4568',
-        label: 'test',
-        type: Cocina::Models::ObjectType.object,
-        version: 1,
-        description: {
-          title: [{ value: 'test' }],
-          purl: 'https://purl.stanford.edu/bc123df4567'
-        },
-        access: {},
-        identification: {},
-        structural: {},
-        administrative: { hasAdminPolicy: 'druid:bc123df4569' }
-      )
+      build_for_repository(:item)
     end
     let(:copyright_statement) { 'the new hotness' }
     let(:fake_state_service) { instance_double(StateService, allows_modification?: allows_modification) }
@@ -92,19 +79,7 @@ RSpec.describe LicenseAndRightsStatementsSetter do
 
       context 'with a collection' do
         let(:cocina_object) do
-          Cocina::Models::Collection.new(
-            externalIdentifier: 'druid:bc123df4568',
-            label: 'test',
-            type: Cocina::Models::ObjectType.collection,
-            description: {
-              title: [{ value: 'test' }],
-              purl: 'https://purl.stanford.edu/bc123df4567'
-            },
-            version: 1,
-            identification: {},
-            access: {},
-            administrative: { hasAdminPolicy: 'druid:bc123df4569' }
-          )
+          build_for_repository(:collection)
         end
 
         it 'updates via collection change set persister' do
@@ -116,17 +91,7 @@ RSpec.describe LicenseAndRightsStatementsSetter do
 
     context 'with an unsupported object type' do
       let(:cocina_object) do
-        Cocina::Models::AdminPolicy.new(
-          externalIdentifier: 'druid:bc123df4570',
-          label: 'test',
-          type: Cocina::Models::ObjectType.admin_policy,
-          version: 1,
-          administrative: {
-            hasAdminPolicy: 'druid:bc123df4570',
-            hasAgreement: 'druid:hp308wm0436',
-            accessTemplate: { view: 'world', download: 'world' }
-          }
-        )
+        build_for_repository(:apo)
       end
 
       it 'raises' do

--- a/spec/support/build_strategy_repository_pattern.rb
+++ b/spec/support/build_strategy_repository_pattern.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class BuildStrategyForRepositoryPattern
+  def association(runner)
+    runner.run
+  end
+
+  def result(evaluation)
+    result = nil
+    evaluation.object.tap do |instance|
+      evaluation.notify(:after_build, instance)
+      evaluation.notify(:before_create, instance)
+      result = instance.cocina_model
+      evaluation.notify(:after_create, instance)
+    end
+
+    result
+  end
+end
+
+FactoryBot.register_strategy(:build_for_repository, BuildStrategyForRepositoryPattern)

--- a/spec/support/item_method_sender.rb
+++ b/spec/support/item_method_sender.rb
@@ -18,4 +18,8 @@ class ItemMethodSender
   def collection_id=(collection_id)
     @cocina_model = @cocina_model.new(structural: Cocina::Models::DROStructural.new(isMemberOf: [collection_id]))
   end
+
+  def license=(license)
+    @cocina_model = @cocina_model.new(access: @cocina_model.access.new(license: license))
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

To reduce the amount of boilerplate in tests.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


