### PR TITLE
Display image props

### DIFF
--- a/app/components/contents/file_component.html.erb
+++ b/app/components/contents/file_component.html.erb
@@ -8,6 +8,10 @@
   </td>
   <td><%= hasMimeType %></td>
   <td><%= number_to_human_size(size) %></td>
+  <% if image? %>
+    <td><%= height %></td>
+    <td><%= width %></td>
+  <% end %>
   <td><%= role %></td>
   <td class="ps-4"><%= tag :span, class: 'bi-check' if publish %></td>
   <td class="ps-4"><%= tag :span, class: 'bi-check' if shelve %></td>

--- a/app/components/contents/file_component.rb
+++ b/app/components/contents/file_component.rb
@@ -2,10 +2,11 @@
 
 module Contents
   class FileComponent < ViewComponent::Base
-    def initialize(file:, object_id:, viewable:)
+    def initialize(file:, object_id:, viewable:, image:)
       @file = file
       @object_id = object_id
       @viewable = viewable
+      @image = image
     end
 
     attr_reader :file, :object_id
@@ -14,7 +15,11 @@ module Contents
       @viewable
     end
 
-    delegate :access, :administrative, :filename, :hasMimeType, :size, :externalIdentifier, :use, to: :file
+    def image?
+      @image
+    end
+
+    delegate :access, :administrative, :filename, :hasMimeType, :size, :externalIdentifier, :use, :presentation, to: :file
     delegate :publish, :shelve, :sdrPreserve, to: :administrative
 
     def view_access
@@ -33,6 +38,20 @@ module Contents
 
     def link_attrs
       { item_id: object_id, id: filename }
+    end
+
+    def height
+      # still need to account for no presentation
+      return '' if presentation.height.blank?
+
+      "#{presentation.height} px"
+    end
+
+    def width
+      # still need to account for no presentation
+      return '' if presentation.width.blank?
+
+      "#{presentation.width} px"
     end
   end
 end

--- a/app/components/contents/file_component.rb
+++ b/app/components/contents/file_component.rb
@@ -41,15 +41,13 @@ module Contents
     end
 
     def height
-      # still need to account for no presentation
-      return '' if presentation.height.blank?
+      return '' if presentation&.height.blank?
 
       "#{presentation.height} px"
     end
 
     def width
-      # still need to account for no presentation
-      return '' if presentation.width.blank?
+      return '' if presentation&.width.blank?
 
       "#{presentation.width} px"
     end

--- a/app/components/contents/resource_component.html.erb
+++ b/app/components/contents/resource_component.html.erb
@@ -13,6 +13,10 @@
         <th>File name</th>
         <th>Type</th>
         <th>Size</th>
+        <% if image? %> 
+          <th>Height</th>
+          <th>Width</th>
+        <% end %>
         <th>Role</th>
         <th>Publish</th>
         <th>Shelve</th>
@@ -21,6 +25,6 @@
         <th>Download</th>
       </tr>
 
-    <%= render Contents::FileComponent.with_collection(files, object_id: object_id, viewable: viewable?) %>
+    <%= render Contents::FileComponent.with_collection(files, object_id: object_id, viewable: viewable?, image: image?) %>
   </table>
 </li>

--- a/app/components/contents/resource_component.rb
+++ b/app/components/contents/resource_component.rb
@@ -15,6 +15,10 @@ module Contents
       @viewable
     end
 
+    def image?
+      type == 'image'
+    end
+
     def type
       resource.type.delete_prefix('https://cocina.sul.stanford.edu/models/resources/')
     end

--- a/spec/components/contents/file_component_spec.rb
+++ b/spec/components/contents/file_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Contents::FileComponent, type: :component do
-  let(:component) { described_class.new(file: file, object_id: 'druid:kb487gt5106', viewable: true) }
+  let(:component) { described_class.new(file: file, object_id: 'druid:kb487gt5106', viewable: true, image: true) }
   let(:rendered) { render_inline(component) }
   let(:file) do
     instance_double(Cocina::Models::File,
@@ -13,11 +13,13 @@ RSpec.describe Contents::FileComponent, type: :component do
                     size: 99,
                     access: access,
                     administrative: admin,
+                    presentation: presentation,
                     use: use)
   end
 
   let(:access) { instance_double(Cocina::Models::FileAccess, view: 'world', download: 'stanford') }
   let(:admin) { instance_double(Cocina::Models::FileAdministrative, sdrPreserve: true, publish: true, shelve: true) }
+  let(:presentation) { instance_double(Cocina::Models::Presentation, height: 11_839, width: 19_380) }
   let(:use) { 'transcription' }
 
   it 'renders the component' do
@@ -26,6 +28,7 @@ RSpec.describe Contents::FileComponent, type: :component do
     expect(rendered.to_html).to include 'World'
     expect(rendered.to_html).to include 'Stanford'
     expect(rendered.to_html).to include 'Transcription'
+    expect(rendered.to_html).to include '11839 px'
   end
 
   context 'with no file use set' do

--- a/spec/components/contents/file_component_spec.rb
+++ b/spec/components/contents/file_component_spec.rb
@@ -38,4 +38,12 @@ RSpec.describe Contents::FileComponent, type: :component do
       expect(rendered.to_html).to include 'No role'
     end
   end
+
+  context 'with no presentation' do
+    let(:presentation) { nil }
+
+    it 'renders the component' do
+      expect(rendered.to_html).to include 'World'
+    end
+  end
 end

--- a/spec/components/contents/file_component_spec.rb
+++ b/spec/components/contents/file_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Contents::FileComponent, type: :component do
   let(:rendered) { render_inline(component) }
   let(:file) do
     instance_double(Cocina::Models::File,
-                    filename: '0220_MLK_Kids_Gadson_459-25.tif',
+                    filename: 'example.tif',
                     externalIdentifier: 'https://cocina.sul.stanford.edu/file/b7cdfa7a-6e1f-484b-bbb0-f9a46c40dbb4',
                     hasMimeType: 'image/tiff',
                     size: 99,
@@ -22,13 +22,15 @@ RSpec.describe Contents::FileComponent, type: :component do
   let(:presentation) { instance_double(Cocina::Models::Presentation, height: 11_839, width: 19_380) }
   let(:use) { 'transcription' }
 
-  it 'renders the component' do
-    expect(rendered.css('a[href="/items/druid:kb487gt5106/files?id=0220_MLK_Kids_Gadson_459-25.tif"]').to_html)
-      .to include('0220_MLK_Kids_Gadson_459-25.tif')
-    expect(rendered.to_html).to include 'World'
-    expect(rendered.to_html).to include 'Stanford'
-    expect(rendered.to_html).to include 'Transcription'
-    expect(rendered.to_html).to include '11839 px'
+  context 'with an image fileset' do
+    it 'renders the component' do
+      expect(rendered.css('a[href="/items/druid:kb487gt5106/files?id=example.tif"]').to_html)
+        .to include('example.tif')
+      expect(rendered.to_html).to include 'World'
+      expect(rendered.to_html).to include 'Stanford'
+      expect(rendered.to_html).to include 'Transcription'
+      expect(rendered.to_html).to include '11839 px'
+    end
   end
 
   context 'with no file use set' do
@@ -44,6 +46,15 @@ RSpec.describe Contents::FileComponent, type: :component do
 
     it 'renders the component' do
       expect(rendered.to_html).to include 'World'
+    end
+  end
+
+  context 'with a fileset that is not an image' do
+    let(:component) { described_class.new(file: file, object_id: 'druid:kb487gt5106', viewable: true, image: false) }
+
+    it 'renders the component without height' do
+      expect(rendered.to_html).to include 'World'
+      expect(rendered.to_html).not_to include '11839 px'
     end
   end
 end

--- a/spec/components/contents/resource_component_spec.rb
+++ b/spec/components/contents/resource_component_spec.rb
@@ -3,13 +3,56 @@
 require 'rails_helper'
 
 RSpec.describe Contents::ResourceComponent, type: :component do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:component) { described_class.new(resource: resource, resource_counter: 1, object_id: 'druid:kb487gt5106', viewable: true) }
+  let(:rendered) { render_inline(component) }
+  let(:resource) do
+    instance_double(Cocina::Models::FileSet,
+                    type: type,
+                    externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/bb573tm8486-bc91c072-3b0f-4338-a9b2-0f85e1b98e00',
+                    version: 3,
+                    label: 'Object 1',
+                    structural: instance_double(Cocina::Models::FileSetStructural, contains: [file]))
+  end
+  let(:file) do
+    Cocina::Models::File.new(type: Cocina::Models::ObjectType.file,
+                             filename: 'example.tif',
+                             label: 'example.tif',
+                             externalIdentifier: 'https://cocina.sul.stanford.edu/file/b7cdfa7a-6e1f-484b-bbb0-f9a46c40dbb4',
+                             hasMimeType: 'image/tiff',
+                             version: 3,
+                             access: {
+                               view: 'world',
+                               download: 'world'
+                             },
+                             administrative: {
+                               publish: true,
+                               sdrPreserve: true,
+                               shelve: true
+                             },
+                             presentation: presentation)
+  end
+  let(:type) { 'https://cocina.sul.stanford.edu/models/resources/image' }
+  let(:presentation) { { height: 11_839, width: 19_380 } }
 
-  # it "renders something useful" do
-  #   expect(
-  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
-  #   ).to include(
-  #     "Hello, components!"
-  #   )
-  # end
+  it 'renders the component' do
+    expect(rendered.to_html).to include 'Type'
+    expect(rendered.to_html).to include 'Height'
+    expect(rendered.to_html).to include 'Width'
+  end
+
+  context 'with no presentation' do
+    let(:presentation) { nil }
+
+    it 'renders the component' do
+      expect(rendered.to_html).to include 'Height'
+    end
+  end
+
+  context 'when fileset is not an image' do
+    let(:type) { 'https://cocina.sul.stanford.edu/models/resources/file' }
+
+    it 'height column does not display' do
+      expect(rendered.to_html).not_to include 'Height'
+    end
+  end
 end

--- a/spec/components/contents/resource_component_spec.rb
+++ b/spec/components/contents/resource_component_spec.rb
@@ -34,10 +34,12 @@ RSpec.describe Contents::ResourceComponent, type: :component do
   let(:type) { 'https://cocina.sul.stanford.edu/models/resources/image' }
   let(:presentation) { { height: 11_839, width: 19_380 } }
 
-  it 'renders the component' do
-    expect(rendered.to_html).to include 'Type'
-    expect(rendered.to_html).to include 'Height'
-    expect(rendered.to_html).to include 'Width'
+  context 'with an image' do
+    it 'renders the component' do
+      expect(rendered.to_html).to include 'Type'
+      expect(rendered.to_html).to include 'Height'
+      expect(rendered.to_html).to include 'Width'
+    end
   end
 
   context 'with no presentation' do


### PR DESCRIPTION
## Why was this change made? 🤔
Resolves #2925. Image height and width display for image files in the Content resources section.


## How was this change tested? 🤨
Added and ran unit tests, deployed to QA. 

When the fileset has a type of image, the Height and Width columns display:
![Screen Shot 2022-03-24 at 11 51 51 AM](https://user-images.githubusercontent.com/1619369/159959032-22ae83b3-2fe5-4d39-8683-ab4ce5dd4599.png)

When the image files do not have presentation metadata, the columns appear but values are blank. 
![Screen Shot 2022-03-24 at 11 50 58 AM](https://user-images.githubusercontent.com/1619369/159958905-e984bfcf-cf41-40d3-86f2-614ef1eeff87.png)

When the fileset is not for an image, the columns do not appear.
![Screen Shot 2022-03-24 at 11 53 33 AM](https://user-images.githubusercontent.com/1619369/159959228-97e254c0-04af-4ca5-a3e5-d50a7d12fbce.png)



⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


