### PR TITLE
Bump sdr-client to 0.74.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -492,7 +492,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    sdr-client (0.73.0)
+    sdr-client (0.74.0)
       activesupport
       cocina-models (~> 0.70.0)
       dry-monads


### PR DESCRIPTION
## Why was this change made? 🤔

To stay up-to-date with sdr-client releases.

## How was this change tested? 🤨

CI + was successfully integration tested in stage