### PR TITLE
pass search params through the bulk action create form

### DIFF
--- a/app/controllers/concerns/creates_bulk_actions.rb
+++ b/app/controllers/concerns/creates_bulk_actions.rb
@@ -15,7 +15,7 @@ module CreatesBulkActions
     if bulk_action.save
       bulk_action.enqueue_job(job_params)
 
-      redirect_to bulk_actions_path, status: :see_other, notice: success_message
+      redirect_to bulk_actions_path(Blacklight::Parameters.sanitize(search_state.to_h.except(:authenticity_token))), status: :see_other, notice: success_message
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/views/bulk_actions/_druids.html.erb
+++ b/app/views/bulk_actions/_druids.html.erb
@@ -1,5 +1,6 @@
 <div data-bulk-actions-target="commonFields">
   <% if search_state.has_constraints? %>
+    <%= render Blacklight::HiddenSearchStateComponent.new(params: Blacklight::Parameters.sanitize(search_state.to_h)) %>
     <button class='btn btn-primary' data-action="click->bulk-actions#populateDruids">
       Populate with previous search
     </button>


### PR DESCRIPTION
## Why was this change made? 🤔

Now that we use query string parameters to define the previous search used for the "populate druids" button in Bulk Actions (see #3222), the previous search is lost once you submit a bulk action job.  This simply passes the existing search params on through the form submission used to create a new bulk action and then onto the redirect to create a new job.  This allows the search request to be preserved if you then create a new bulk action immediately and want to apply them to the same list of druids.

## How was this change tested? 🤨

Localhost browser. 

