### PR TITLE
Unpin ViewComponent now that the bug introduced in 2.51.0 has been fixed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,8 +22,7 @@ gem 'cssbundling-rails', '~> 1.1'
 gem 'jsbundling-rails', '~> 1.0'
 gem 'sprockets-rails'
 
-# Pinned due to: https://github.com/github/view_component/issues/1315
-gem 'view_component', '2.50.0'
+gem 'view_component', '~> 2.52'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -543,7 +543,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unicode-display_width (2.1.0)
-    view_component (2.50.0)
+    view_component (2.52.0)
       activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
     warden (1.2.9)
@@ -640,7 +640,7 @@ DEPENDENCIES
   sprockets-rails
   sqlite3 (~> 1.4.2)
   turbo-rails (~> 1.0)
-  view_component (= 2.50.0)
+  view_component (~> 2.52)
   web-console
   webdrivers
   webmock


### PR DESCRIPTION
## Why was this change made? 🤔

No need to pin the dependency to patch-level now that the bug is fixed.

## How was this change tested? 🤨

CI
