### PR TITLE
Ordinal keys should begin at 1 rather than zero

### DIFF
--- a/app/services/description_export.rb
+++ b/app/services/description_export.rb
@@ -15,14 +15,15 @@ class DescriptionExport
     flatten(squish(description.to_h).merge('source_id' => @source_id))
   end
 
-  # Transform the COCINA datastructure into a hash structure (converting arrays to hashes with index for keys)
+  # Transform the COCINA datastructure into a hash structure by converting
+  # arrays to hashes with index (starting at 1) as the key
   def squish(source)
     return source unless source.is_a? Hash
 
     source.each_with_object({}) do |(k, value), sink|
       new_value = if value.is_a? Array
                     # Transform to hash
-                    value.each_with_object({}).with_index { |(el, acc), i| acc[i] = squish(el) }
+                    value.each_with_object({}).with_index { |(el, acc), index| acc[index + 1] = squish(el) }
                   else
                     squish(value)
                   end

--- a/spec/jobs/descriptive_metadata_export_job_spec.rb
+++ b/spec/jobs/descriptive_metadata_export_job_spec.rb
@@ -75,12 +75,12 @@ RSpec.describe DescriptiveMetadataExportJob, type: :job do
 
       it 'writes a CSV file' do
         csv = CSV.read(csv_path, headers: true)
-        expect(csv.headers).to eq ['druid', 'source_id', 'title0:value', 'purl']
+        expect(csv.headers).to eq ['druid', 'source_id', 'title1:value', 'purl']
         expect(csv[0][0]).to eq 'druid:bc123df4567'
         expect(csv[1][0]).to eq 'druid:bd123fg5678'
         expect(csv[0][1]).to eq ''
         expect(csv[1][1]).to eq 'sul:123'
-        expect(csv[1]['title0:value']).to eq 'Test DRO #2'
+        expect(csv[1]['title1:value']).to eq 'Test DRO #2'
       end
     end
   end

--- a/spec/services/description_export_spec.rb
+++ b/spec/services/description_export_spec.rb
@@ -13,6 +13,6 @@ RSpec.describe DescriptionExport do
   end
 
   it 'rectangularizes the item' do
-    expect(run).to eq('source_id' => 'sul:123', 'title0:value' => 'Stored title', 'purl' => 'https://purl.stanford.edu/zt570qh4444')
+    expect(run).to eq('source_id' => 'sul:123', 'title1:value' => 'Stored title', 'purl' => 'https://purl.stanford.edu/zt570qh4444')
   end
 end


### PR DESCRIPTION


## Why was this change made? 🤔
See https://github.com/sul-dlss/argo/pull/3339#issuecomment-1080833153


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


