### PR TITLE
Add test for virtual object CSV with no constituents.

### DIFF
--- a/spec/services/virtual_objects_csv_converter_spec.rb
+++ b/spec/services/virtual_objects_csv_converter_spec.rb
@@ -96,5 +96,20 @@ RSpec.describe VirtualObjectsCsvConverter do
         )
       end
     end
+
+    context 'with no constituents' do
+      let(:csv) { 'parent1,,' }
+
+      it 'returns empty constituents array' do
+        expect(subject.convert).to eq(
+          [
+            {
+              virtual_object_id: 'druid:parent1',
+              constituent_ids: []
+            }
+          ]
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
refs #2821

## Why was this change made? 🤔
To test the mechanism by which virtual objects will be cleared.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


