### PR TITLE
Load technical metadata lazily

### DIFF
--- a/app/components/show/agreement_component.html.erb
+++ b/app/components/show/agreement_component.html.erb
@@ -24,5 +24,5 @@
   <%= render 'cocina_default', document: document %>
   <%= render 'history_default', document: document %>
   <%= render ContentsComponent.new(presenter: presenter) %>
-  <%= render TechmdComponent.new(result: techmd) %>
+  <%= render TechmdComponent.new(view_token: view_token) %>
 </div>

--- a/app/components/show/agreement_component.rb
+++ b/app/components/show/agreement_component.rb
@@ -8,7 +8,7 @@ module Show
 
     attr_reader :presenter
 
-    delegate :document, :cocina, :techmd, to: :presenter
+    delegate :document, :cocina, :view_token, to: :presenter
     delegate :state_service, to: :@presenter
   end
 end

--- a/app/components/show/item_component.html.erb
+++ b/app/components/show/item_component.html.erb
@@ -27,5 +27,5 @@
   <%= render 'cocina_default', document: document %>
   <%= render 'history_default', document: document %>
   <%= render ContentsComponent.new(presenter: presenter) %>
-  <%= render TechmdComponent.new(result: techmd) %>
+  <%= render TechmdComponent.new(view_token: view_token) %>
 </div>

--- a/app/components/show/item_component.rb
+++ b/app/components/show/item_component.rb
@@ -8,7 +8,7 @@ module Show
 
     attr_reader :presenter
 
-    delegate :document, :cocina, :techmd, to: :presenter
+    delegate :document, :cocina, :view_token, to: :presenter
     delegate :state_service, to: :@presenter
   end
 end

--- a/app/components/techmd_component.html.erb
+++ b/app/components/techmd_component.html.erb
@@ -6,67 +6,7 @@
   </h2>
   <div id="document-techmd-section" class="accordion-collapse collapse" aria-labelledby="document-techmd-heading">
     <div class="accordion-body">
-      <% if failure? %>
-        <p>Technical Metadata connection failed: <%= failure_message %></p>
-      <% elsif !results? %>
-        <p>Technical Metadata not available</p>
-      <% else %>
-        <ul class="file-list">
-          <% results.each do | file_techmd | %>
-            <li class="file">
-              <span class="label">File</span><%= file_techmd['filename'] %>
-              <ul class="metadata-list">
-                <% file_techmd.reject { |key| %w[filename druid dro_file_parts].include?(key) }.each do |file_techmd_key, file_techmd_value| %>
-                  <li class="metadata">
-                    <span class="label"><%= file_techmd_key %></span>
-                      <% unless file_techmd_value.is_a?(Hash) %>
-                        <%= file_techmd_value %>
-                      <% else %>
-                        <ul class="metadata-list">
-                          <% file_techmd_value.each do |key, value| %>
-                            <li class="metadata">
-                              <span class="label"><%= key %></span><%= value %>
-                            </li>
-                          <% end %>
-                        </ul>
-                      <% end %>
-                  </li>
-                <% end %>
-                <% unless file_techmd['dro_file_parts'].nil? %>
-                  <li class="metadata">
-                    <span class="label">File parts</span>
-                    <ul class="file-list">
-                      <% file_techmd['dro_file_parts'].each do | file_part_techmd | %>
-                        <li class="file">
-                          <span class="label">File part</span><%= file_part_techmd['part_id'] %>
-                          <ul class="metadata-list">
-                            <% file_part_techmd.reject { |key| ['part_id'].include?(key) }.each do |file_part_techmd_key, file_part_techmd_value| %>
-                              <li class="metadata">
-                                <span class="label"><%= file_part_techmd_key %></span>
-                                <% unless file_part_techmd_value.is_a?(Hash) %>
-                                  <%= file_part_techmd_value %>
-                                <% else %>
-                                  <ul class="metadata-list">
-                                    <% file_part_techmd_value.each do |key, value| %>
-                                      <li class="metadata">
-                                        <span class="label"><%= key %></span><%= value %>
-                                      </li>
-                                    <% end %>
-                                  </ul>
-                                <% end %>
-                              </li>
-                            <% end %>
-                          </ul>
-                        </li>
-                      <% end %>
-                    </ul>
-                  </li>
-                <% end %>
-              </ul>
-            </li>
-          <% end %>
-        </ul>
-      <% end %>
+      <turbo-frame id="techmd" src="<%= item_technical_path(view_token) %>" loading="lazy"></turbo-frame>
     </div>
   </div>
 </div>

--- a/app/components/techmd_component.rb
+++ b/app/components/techmd_component.rb
@@ -1,24 +1,10 @@
 # frozen_string_literal: true
 
 class TechmdComponent < ViewComponent::Base
-  # @params [Dry::Result] result
-  def initialize(result:)
-    @wrapped_result = result
+  # @params [String] view_token
+  def initialize(view_token:)
+    @view_token = view_token
   end
 
-  attr_reader :wrapped_result
-
-  delegate :failure?, to: :wrapped_result
-
-  def failure_message
-    wrapped_result.failure
-  end
-
-  def results?
-    results.present?
-  end
-
-  def results
-    wrapped_result.value!
-  end
+  attr_reader :view_token
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -222,7 +222,13 @@ class CatalogController < ApplicationController
                                                     versions: object_client.version.inventory)
 
     @datastreams = object_client.metadata.datastreams
-    @techmd = TechmdService.techmd_for(druid: params[:id])
+
+    # If you have this token, it indicates you have view_metadata access to the object
+    @verified_token_with_expiration = Argo.verifier.generate(
+      { key: params[:id] },
+      expires_in: 1.hour,
+      purpose: :view_token
+    )
 
     respond_to do |format|
       format.html { @search_context = setup_next_and_previous_documents }

--- a/app/controllers/technicals_controller.rb
+++ b/app/controllers/technicals_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class TechnicalsController < ApplicationController
+  def show
+    @techmd = TechmdService.techmd_for(druid: decrypted_token.fetch(:key))
+  end
+
+  private
+
+  # decode the token that grants view access
+  def decrypted_token
+    Argo.verifier.verified(params[:item_id], purpose: :view_token)
+  end
+end

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -5,11 +5,11 @@ module ItemsHelper
     "#{Settings.stacks_file_url}/#{druid}/#{ERB::Util.url_encode(file_name)}"
   end
 
-  # Overriding blacklight so we can pass @techmd to the presenter
+  # Overriding blacklight so we can pass @cocina to the presenter
   def document_presenter(document)
     super.tap do |presenter|
       # rubocop:disable Rails/HelperInstanceVariable
-      presenter.techmd = @techmd if presenter.respond_to? :techmd
+      presenter.view_token = @verified_token_with_expiration if presenter.respond_to? :view_token
       if presenter.respond_to? :cocina
         presenter.cocina = @cocina
         presenter.state_service = StateService.new(document.id, version: document.current_version)

--- a/app/presenters/argo_show_presenter.rb
+++ b/app/presenters/argo_show_presenter.rb
@@ -19,5 +19,5 @@ class ArgoShowPresenter < Blacklight::ShowPresenter
 
   delegate :allows_modification?, to: :state_service
 
-  attr_accessor :techmd, :cocina, :state_service
+  attr_accessor :cocina, :view_token, :state_service
 end

--- a/app/views/technicals/show.html.erb
+++ b/app/views/technicals/show.html.erb
@@ -1,0 +1,63 @@
+<turbo-frame id="techmd">
+  <% if @techmd.failure? %>
+    <p>Technical Metadata connection failed: <%= @techmd.failure %></p>
+  <% elsif @techmd.value!.blank? %>
+    <p>Technical Metadata not available</p>
+  <% else %>
+    <ul class="file-list">
+      <% @techmd.value!.each do | file_techmd | %>
+        <li class="file">
+          <span class="label">File</span><%= file_techmd['filename'] %>
+          <ul class="metadata-list">
+            <% file_techmd.reject { |key| %w[filename druid dro_file_parts].include?(key) }.each do |file_techmd_key, file_techmd_value| %>
+              <li class="metadata">
+                <span class="label"><%= file_techmd_key %></span>
+                  <% unless file_techmd_value.is_a?(Hash) %>
+                    <%= file_techmd_value %>
+                  <% else %>
+                    <ul class="metadata-list">
+                      <% file_techmd_value.each do |key, value| %>
+                        <li class="metadata">
+                          <span class="label"><%= key %></span><%= value %>
+                        </li>
+                      <% end %>
+                    </ul>
+                  <% end %>
+              </li>
+            <% end %>
+            <% unless file_techmd['dro_file_parts'].nil? %>
+              <li class="metadata">
+                <span class="label">File parts</span>
+                <ul class="file-list">
+                  <% file_techmd['dro_file_parts'].each do | file_part_techmd | %>
+                    <li class="file">
+                      <span class="label">File part</span><%= file_part_techmd['part_id'] %>
+                      <ul class="metadata-list">
+                        <% file_part_techmd.reject { |key| ['part_id'].include?(key) }.each do |file_part_techmd_key, file_part_techmd_value| %>
+                          <li class="metadata">
+                            <span class="label"><%= file_part_techmd_key %></span>
+                            <% unless file_part_techmd_value.is_a?(Hash) %>
+                              <%= file_part_techmd_value %>
+                            <% else %>
+                              <ul class="metadata-list">
+                                <% file_part_techmd_value.each do |key, value| %>
+                                  <li class="metadata">
+                                    <span class="label"><%= key %></span><%= value %>
+                                  </li>
+                                <% end %>
+                              </ul>
+                            <% end %>
+                          </li>
+                        <% end %>
+                      </ul>
+                    </li>
+                  <% end %>
+                </ul>
+              </li>
+            <% end %>
+          </ul>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+</turbo-frame>

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,8 @@ require 'rails/all'
 Bundler.require(*Rails.groups)
 
 module Argo
+  mattr_accessor :verifier
+
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
@@ -18,6 +20,10 @@ module Argo
 
     # Configure action_dispatch to handle not found errors
     config.action_dispatch.rescue_responses['Blacklight::Exceptions::RecordNotFound'] = :not_found
+
+    config.after_initialize do |app|
+      Argo.verifier = app.message_verifier('Argo')
+    end
   end
 
   ARGO_VERSION = File.read(File.join(Rails.root, 'VERSION'))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,6 +142,7 @@ Rails.application.routes.draw do
     resource :content_type, only: %i[show update]
     resource :structure, only: %i[show update]
     resource :descriptive, only: %i[show]
+    resource :technical, only: %i[show]
     resource :serials, only: %i[edit update]
 
     resources :workflows, only: %i[new create show update] do

--- a/spec/components/techmd_component_spec.rb
+++ b/spec/components/techmd_component_spec.rb
@@ -5,31 +5,11 @@ require 'rails_helper'
 RSpec.describe TechmdComponent, type: :component do
   include Dry::Monads[:result]
 
-  subject(:component) { described_class.new(result: result) }
+  subject(:component) { described_class.new(view_token: 'skret-t0k3n') }
 
   let(:rendered) { render_inline(component) }
 
-  context 'with a failure' do
-    let(:result) { Failure('it borken!') }
-
-    it 'renders the error message' do
-      expect(rendered.css('p').to_html).to include('it borken!')
-    end
-  end
-
-  context 'with no results' do
-    let(:result) { Success([]) }
-
-    it 'renders the error message' do
-      expect(rendered.css('p').to_html).to include('Technical Metadata not available')
-    end
-  end
-
-  context 'with results' do
-    let(:result) { Success(['filename' => 'sunburst.png']) }
-
-    it 'renders something useful' do
-      expect(rendered.css('.file').to_html).to include('sunburst.png')
-    end
+  it 'renders a turbo frame' do
+    expect(rendered.css('turbo-frame').first['src']).to eq '/items/skret-t0k3n/technical'
   end
 end

--- a/spec/requests/technicals_spec.rb
+++ b/spec/requests/technicals_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Technicals', type: :request do
+  include Dry::Monads[:result]
+
+  before do
+    allow(Argo.verifier).to receive(:verified).and_return({ key: 'druid:kv840xx0000' })
+    allow(TechmdService).to receive(:techmd_for).and_return(result)
+    sign_in build(:user), groups: []
+  end
+
+  let(:rendered) do
+    Capybara::Node::Simple.new(response.body)
+  end
+
+  context 'with a failure' do
+    let(:result) { Failure('it borken!') }
+
+    it 'renders the error message' do
+      get '/items/skret-t0k3n/technical'
+      expect(rendered.find_css('p').to_html).to include('it borken!')
+    end
+  end
+
+  context 'with no results' do
+    let(:result) { Success([]) }
+
+    it 'renders the error message' do
+      get '/items/skret-t0k3n/technical'
+      expect(rendered.find_css('p').to_html).to include('Technical Metadata not available')
+    end
+  end
+
+  context 'with results' do
+    let(:result) { Success(['filename' => 'sunburst.png']) }
+
+    it 'renders something useful' do
+      get '/items/skret-t0k3n/technical'
+      expect(rendered.find_css('.file').to_html).to include('sunburst.png')
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3756

Avoid having a call to the technical metadata service block rendering of the show page.

## How was this change tested? 🤨
locally