### PR TITLE
Create a factory for a cocina object

### DIFF
--- a/lib/cocina/models/factories.rb
+++ b/lib/cocina/models/factories.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    class Factories
+      def self.build(type, attributes = {})
+        case type
+        when :dro
+          build_dro(attributes)
+        end
+      end
+
+      DRO_DEFAULTS = {
+        type: Cocina::Models::ObjectType.object,
+        id: 'druid:bc234fg5678',
+        version: 1,
+        label: 'test object',
+        title: 'test object',
+        source_id: 'sul:1234',
+        admin_policy_id: 'druid:hv992ry2431'
+      }.freeze
+
+      # rubocop:disable Metrics/ParameterLists
+      def self.build_dro_properties(type:, id:, version:, label:, title:, source_id:, admin_policy_id:, catkeys: [])
+        {
+          type: type,
+          externalIdentifier: id,
+          version: version,
+          label: label,
+          access: {},
+          administrative: { hasAdminPolicy: admin_policy_id },
+          description: {
+            title: [{ value: title }],
+            purl: "https://purl.stanford.edu/#{id.delete_prefix('druid:')}"
+          },
+          identification: {
+            sourceId: source_id
+          },
+          structural: {}
+        }.tap do |props|
+          props[:identification][:catalogLinks] = catkeys.map { |catkey| { catalog: 'symphony', catalogRecordId: catkey } } if catkeys.present?
+        end
+      end
+      # rubocop:enable Metrics/ParameterLists
+
+      def self.build_dro(attributes)
+        Cocina::Models.build(build_dro_properties(**DRO_DEFAULTS.merge(attributes)))
+      end
+    end
+  end
+end

--- a/spec/components/show/item/overview_component_spec.rb
+++ b/spec/components/show/item/overview_component_spec.rb
@@ -7,20 +7,7 @@ RSpec.describe Show::Item::OverviewComponent, type: :component do
   let(:presenter) { instance_double(ArgoShowPresenter, document: doc, cocina: cocina, change_set: change_set, state_service: state_service) }
   let(:change_set) { ItemChangeSet.new(cocina) }
   let(:cocina) do
-    Cocina::Models::DRO.new(externalIdentifier: 'druid:bc234fg5678',
-                            type: Cocina::Models::ObjectType.document,
-                            label: 'my dro',
-                            version: 1,
-                            description: {
-                              title: [{ value: 'my dro' }],
-                              purl: 'https://purl.stanford.edu/bc234fg5678'
-                            },
-                            access: {},
-                            identification: { sourceId: 'sul:1234' },
-                            structural: {},
-                            administrative: {
-                              hasAdminPolicy: 'druid:hv992ry2431'
-                            })
+    Cocina::Models::Factories.build(:dro)
   end
   let(:rendered) { render_inline(component) }
   let(:allows_modification) { true }

--- a/spec/features/item_source_id_change_spec.rb
+++ b/spec/features/item_source_id_change_spec.rb
@@ -27,23 +27,7 @@ RSpec.describe 'Item source id change' do
     let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
     let(:druid) { 'druid:kv840xx0000' }
     let(:cocina_model) do
-      Cocina::Models.build({
-                             'label' => 'My ETD',
-                             'version' => 1,
-                             'type' => Cocina::Models::ObjectType.object,
-                             'externalIdentifier' => druid,
-                             'description' => {
-                               'title' => [{ 'value' => 'My ETD' }],
-                               'purl' => "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
-                             },
-                             'access' => {
-                               'view' => 'world',
-                               'download' => 'world'
-                             },
-                             'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
-                             'structural' => {},
-                             'identification' => { sourceId: 'some:thing' }
-                           })
+      Cocina::Models::Factories.build(:dro, id: druid)
     end
     let(:state_service) { instance_double(StateService, allows_modification?: true) }
     let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }

--- a/spec/jobs/add_workflow_job_spec.rb
+++ b/spec/jobs/add_workflow_job_spec.rb
@@ -9,30 +9,10 @@ RSpec.describe AddWorkflowJob, type: :job do
   let(:user) { bulk_action.user }
 
   let(:cocina1) do
-    Cocina::Models.build({
-                           'label' => 'My Item',
-                           'version' => 2,
-                           'type' => Cocina::Models::ObjectType.object,
-                           'externalIdentifier' => druids[0],
-                           'access' => {},
-                           'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
-                           'description' => { title: [{ value: 'Stored title' }], purl: 'https://purl.stanford.edu/bb111cc2222' },
-                           'structural' => {},
-                           identification: { sourceId: 'sul:1234' }
-                         })
+    Cocina::Models::Factories.build(:dro, id: druids[0])
   end
   let(:cocina2) do
-    Cocina::Models.build({
-                           'label' => 'My Item',
-                           'version' => 3,
-                           'type' => Cocina::Models::ObjectType.object,
-                           'externalIdentifier' => druids[1],
-                           'access' => {},
-                           'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
-                           'description' => { title: [{ value: 'Stored title' }], purl: 'https://purl.stanford.edu/cc111dd2222' },
-                           'structural' => {},
-                           identification: { sourceId: 'sul:1234' }
-                         })
+    Cocina::Models::Factories.build(:dro, id: druids[1])
   end
 
   let(:object_client1) { instance_double(Dor::Services::Client::Object, find: cocina1) }

--- a/spec/jobs/apply_apo_defaults_job_spec.rb
+++ b/spec/jobs/apply_apo_defaults_job_spec.rb
@@ -8,38 +8,11 @@ RSpec.describe ApplyApoDefaultsJob, type: :job do
   let(:bulk_action) { create(:bulk_action) }
   let(:user) { bulk_action.user }
 
-  let(:identification) do
-    {
-      catalogLinks: [{ catalog: 'symphony', catalogRecordId: '123' }],
-      sourceId: 'sul:1234'
-    }
-  end
-
   let(:cocina1) do
-    Cocina::Models.build({
-                           'label' => 'My Item',
-                           'version' => 2,
-                           'type' => Cocina::Models::ObjectType.object,
-                           'externalIdentifier' => druids[0],
-                           'access' => {},
-                           'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
-                           'description' => { title: [{ value: 'Stored title' }], purl: 'https://purl.stanford.edu/bb111cc2222' },
-                           'structural' => {},
-                           'identification' => identification
-                         })
+    Cocina::Models::Factories.build(:dro, id: druids[0])
   end
   let(:cocina2) do
-    Cocina::Models.build({
-                           'label' => 'My Item',
-                           'version' => 3,
-                           'type' => Cocina::Models::ObjectType.object,
-                           'externalIdentifier' => druids[1],
-                           'access' => {},
-                           'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
-                           'description' => { title: [{ value: 'Stored title' }], purl: 'https://purl.stanford.edu/cc111dd2222' },
-                           'structural' => {},
-                           'identification' => identification
-                         })
+    Cocina::Models::Factories.build(:dro, id: druids[1])
   end
 
   let(:object_client1) { instance_double(Dor::Services::Client::Object, find: cocina1, apply_admin_policy_defaults: true) }

--- a/spec/jobs/close_version_job_spec.rb
+++ b/spec/jobs/close_version_job_spec.rb
@@ -10,36 +10,10 @@ RSpec.describe CloseVersionJob, type: :job do
   let(:bulk_action) { create(:bulk_action) }
 
   let(:item1) do
-    Cocina::Models.build({
-                           'label' => 'My Item',
-                           'version' => 1,
-                           'type' => Cocina::Models::ObjectType.object,
-                           'externalIdentifier' => druids[0],
-                           'description' => {
-                             'title' => [{ 'value' => 'My Item' }],
-                             'purl' => "https://purl.stanford.edu/#{druids[0].delete_prefix('druid:')}"
-                           },
-                           'access' => {},
-                           'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
-                           'structural' => {},
-                           identification: { sourceId: 'sul:1234' }
-                         })
+    Cocina::Models::Factories.build(:dro, id: druids[0])
   end
   let(:item2) do
-    Cocina::Models.build({
-                           'label' => 'My Item',
-                           'version' => 1,
-                           'type' => Cocina::Models::ObjectType.object,
-                           'externalIdentifier' => druids[1],
-                           'description' => {
-                             'title' => [{ 'value' => 'My Item' }],
-                             'purl' => "https://purl.stanford.edu/#{druids[1].delete_prefix('druid:')}"
-                           },
-                           'access' => {},
-                           'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
-                           'structural' => {},
-                           identification: { sourceId: 'sul:1234' }
-                         })
+    Cocina::Models::Factories.build(:dro, id: druids[1])
   end
   let(:object_client1) { instance_double(Dor::Services::Client::Object, find: item1, version: version_client) }
   let(:object_client2) { instance_double(Dor::Services::Client::Object, find: item2, version: version_client) }

--- a/spec/jobs/descriptive_metadata_export_job_spec.rb
+++ b/spec/jobs/descriptive_metadata_export_job_spec.rb
@@ -30,39 +30,11 @@ RSpec.describe DescriptiveMetadataExportJob, type: :job do
     let(:user) { instance_double(User, to_s: 'jcoyne85') }
 
     let(:item1) do
-      Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
-                              type: Cocina::Models::ObjectType.document,
-                              label: 'Test DRO',
-                              version: 1,
-                              description: {
-                                title: [{ value: 'Test DRO #1' }],
-                                purl: 'https://purl.stanford.edu/bc123df4567'
-                              },
-                              access: {},
-                              administrative: {
-                                hasAdminPolicy: 'druid:hv992ry2431'
-                              },
-                              identification: { sourceId: 'sul:4444' },
-                              structural: {})
+      Cocina::Models::Factories.build(:dro, id: 'druid:bc123df4567', source_id: 'sul:4444')
     end
 
     let(:item2) do
-      Cocina::Models::DRO.new(externalIdentifier: 'druid:bd123fg5678',
-                              type: Cocina::Models::ObjectType.document,
-                              label: 'Test DRO',
-                              version: 1,
-                              description: {
-                                title: [{ value: 'Test DRO #2' }],
-                                purl: 'https://purl.stanford.edu/bd123fg5678'
-                              },
-                              access: {},
-                              administrative: {
-                                hasAdminPolicy: 'druid:hv992ry2431'
-                              },
-                              identification: {
-                                sourceId: 'sul:123'
-                              },
-                              structural: {})
+      Cocina::Models::Factories.build(:dro, id: 'druid:bd123fg5678', title: 'Test DRO #2')
     end
 
     context 'when happy path' do
@@ -79,7 +51,7 @@ RSpec.describe DescriptiveMetadataExportJob, type: :job do
         expect(csv[0][0]).to eq 'druid:bc123df4567'
         expect(csv[1][0]).to eq 'druid:bd123fg5678'
         expect(csv[0][1]).to eq 'sul:4444'
-        expect(csv[1][1]).to eq 'sul:123'
+        expect(csv[1][1]).to eq 'sul:1234'
         expect(csv[1]['title1:value']).to eq 'Test DRO #2'
       end
     end

--- a/spec/jobs/manage_embargoes_job_spec.rb
+++ b/spec/jobs/manage_embargoes_job_spec.rb
@@ -17,52 +17,13 @@ RSpec.describe ManageEmbargoesJob do
   let(:rights) { ['world', '', 'stanford-nd'] }
   let(:buffer) { StringIO.new }
   let(:item1) do
-    Cocina::Models.build({
-                           'label' => 'My Item1',
-                           'version' => 2,
-                           'type' => Cocina::Models::ObjectType.object,
-                           'externalIdentifier' => druids[0],
-                           'description' => {
-                             'title' => [{ 'value' => 'My Item1' }],
-                             'purl' => "https://purl.stanford.edu/#{druids[0].delete_prefix('druid:')}"
-                           },
-                           'access' => {},
-                           'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
-                           'structural' => {},
-                           identification: { sourceId: 'sul:1234' }
-                         })
+    Cocina::Models::Factories.build(:dro, id: druids[0])
   end
   let(:item2) do
-    Cocina::Models.build({
-                           'label' => 'My Item2',
-                           'version' => 3,
-                           'type' => Cocina::Models::ObjectType.object,
-                           'externalIdentifier' => druids[1],
-                           'description' => {
-                             'title' => [{ 'value' => 'My Item2' }],
-                             'purl' => "https://purl.stanford.edu/#{druids[1].delete_prefix('druid:')}"
-                           },
-                           'access' => {},
-                           'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
-                           'structural' => {},
-                           identification: { sourceId: 'sul:1234' }
-                         })
+    Cocina::Models::Factories.build(:dro, id: druids[1])
   end
   let(:item3) do
-    Cocina::Models.build({
-                           'label' => 'My Item3',
-                           'version' => 3,
-                           'type' => Cocina::Models::ObjectType.object,
-                           'externalIdentifier' => druids[2],
-                           'description' => {
-                             'title' => [{ 'value' => 'My Item3' }],
-                             'purl' => "https://purl.stanford.edu/#{druids[2].delete_prefix('druid:')}"
-                           },
-                           'access' => {},
-                           'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
-                           'structural' => {},
-                           identification: { sourceId: 'sul:1234' }
-                         })
+    Cocina::Models::Factories.build(:dro, id: druids[2])
   end
 
   let(:csv_file) do

--- a/spec/jobs/prepare_job_spec.rb
+++ b/spec/jobs/prepare_job_spec.rb
@@ -10,36 +10,10 @@ RSpec.describe PrepareJob, type: :job do
   let(:user) { bulk_action.user }
 
   let(:cocina1) do
-    Cocina::Models.build({
-                           'label' => 'My Item',
-                           'version' => 2,
-                           'type' => Cocina::Models::ObjectType.object,
-                           'externalIdentifier' => druids[0],
-                           'description' => {
-                             'title' => [{ 'value' => 'My Item' }],
-                             'purl' => "https://purl.stanford.edu/#{druids[0].delete_prefix('druid:')}"
-                           },
-                           'access' => {},
-                           'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
-                           'structural' => {},
-                           identification: { sourceId: 'sul:1234' }
-                         })
+    Cocina::Models::Factories.build(:dro, id: druids[0])
   end
   let(:cocina2) do
-    Cocina::Models.build({
-                           'label' => 'My Item',
-                           'version' => 3,
-                           'type' => Cocina::Models::ObjectType.object,
-                           'externalIdentifier' => druids[1],
-                           'description' => {
-                             'title' => [{ 'value' => 'My Item' }],
-                             'purl' => "https://purl.stanford.edu/#{druids[1].delete_prefix('druid:')}"
-                           },
-                           'access' => {},
-                           'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
-                           'structural' => {},
-                           identification: { sourceId: 'sul:1234' }
-                         })
+    Cocina::Models::Factories.build(:dro, id: druids[1])
   end
 
   let(:object_client1) { instance_double(Dor::Services::Client::Object, find: cocina1) }

--- a/spec/jobs/purge_job_spec.rb
+++ b/spec/jobs/purge_job_spec.rb
@@ -11,36 +11,10 @@ RSpec.describe PurgeJob, type: :job do
   let(:bulk_action) { create(:bulk_action) }
 
   let(:cocina1) do
-    Cocina::Models.build({
-                           'label' => 'My Item',
-                           'version' => 2,
-                           'type' => Cocina::Models::ObjectType.object,
-                           'externalIdentifier' => druids[0],
-                           'description' => {
-                             'title' => [{ 'value' => 'My Item' }],
-                             'purl' => "https://purl.stanford.edu/#{druids[0].delete_prefix('druid:')}"
-                           },
-                           'access' => {},
-                           'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
-                           'structural' => {},
-                           identification: { sourceId: 'sul:1234' }
-                         })
+    Cocina::Models::Factories.build(:dro, id: druids[0])
   end
   let(:cocina2) do
-    Cocina::Models.build({
-                           'label' => 'My Item',
-                           'version' => 3,
-                           'type' => Cocina::Models::ObjectType.object,
-                           'externalIdentifier' => druids[1],
-                           'description' => {
-                             'title' => [{ 'value' => 'My Item' }],
-                             'purl' => "https://purl.stanford.edu/#{druids[1].delete_prefix('druid:')}"
-                           },
-                           'access' => {},
-                           'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
-                           'structural' => {},
-                           identification: { sourceId: 'sul:1234' }
-                         })
+    Cocina::Models::Factories.build(:dro, id: druids[1])
   end
 
   let(:object_client1) { instance_double(Dor::Services::Client::Object, find: cocina1) }

--- a/spec/jobs/refresh_mods_job_spec.rb
+++ b/spec/jobs/refresh_mods_job_spec.rb
@@ -8,38 +8,15 @@ RSpec.describe RefreshModsJob, type: :job do
   let(:bulk_action) { create(:bulk_action) }
   let(:user) { bulk_action.user }
 
-  let(:identification) do
-    {
-      catalogLinks: [{ catalog: 'symphony', catalogRecordId: '123' }],
-      sourceId: 'sul:1234'
-    }
+  let(:catkeys) do
+    ['123']
   end
 
   let(:cocina1) do
-    Cocina::Models.build({
-                           'label' => 'My Item',
-                           'version' => 2,
-                           'type' => Cocina::Models::ObjectType.object,
-                           'externalIdentifier' => druids[0],
-                           'access' => {},
-                           'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
-                           'structural' => {},
-                           'description' => { title: [{ value: 'Stored title' }], purl: 'https://purl.stanford.edu/bb111cc2222' },
-                           'identification' => identification
-                         })
+    Cocina::Models::Factories.build(:dro, id: druids[0], catkeys: catkeys)
   end
   let(:cocina2) do
-    Cocina::Models.build({
-                           'label' => 'My Item',
-                           'version' => 3,
-                           'type' => Cocina::Models::ObjectType.object,
-                           'externalIdentifier' => druids[1],
-                           'access' => {},
-                           'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
-                           'structural' => {},
-                           'description' => { title: [{ value: 'Stored title' }], purl: 'https://purl.stanford.edu/cc111dd2222' },
-                           'identification' => identification
-                         })
+    Cocina::Models::Factories.build(:dro, id: druids[1], catkeys: catkeys)
   end
 
   let(:object_client1) { instance_double(Dor::Services::Client::Object, find: cocina1, refresh_descriptive_metadata_from_ils: true) }
@@ -62,9 +39,7 @@ RSpec.describe RefreshModsJob, type: :job do
     let(:ability) { instance_double(Ability, can?: true) }
 
     context 'without catkey' do
-      let(:identification) do
-        { sourceId: 'sul:1234' }
-      end
+      let(:catkeys) { [] }
 
       it 'logs errors' do
         expect(logger).to have_received(:puts).with(/Starting RefreshModsJob for BulkAction/)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'cocina/rspec'
 require 'capybara/rspec'
+require 'cocina/models/factories'
 require 'equivalent-xml/rspec_matchers'
 require 'view_component/test_helpers'
 require 'webmock/rspec'

--- a/spec/requests/serials_spec.rb
+++ b/spec/requests/serials_spec.rb
@@ -7,20 +7,7 @@ RSpec.describe 'Serials', type: :request do
   let(:druid) { 'druid:dc243mg0841' }
 
   let(:cocina_model) do
-    Cocina::Models.build({
-                           'label' => 'My Serial',
-                           'version' => 1,
-                           'type' => Cocina::Models::ObjectType.object,
-                           'externalIdentifier' => druid,
-                           'description' => {
-                             'title' => [{ 'value' => 'My Serial' }],
-                             'purl' => "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
-                           },
-                           'access' => {},
-                           'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
-                           'structural' => {},
-                           identification: { sourceId: 'sul:1234' }
-                         })
+    Cocina::Models::Factories.build(:dro, id: druid, label: 'My Serial', title: 'My Serial')
   end
 
   before do
@@ -61,7 +48,7 @@ RSpec.describe 'Serials', type: :request do
                                },
                                'access' => {},
                                identification: { sourceId: 'sul:1234' },
-                               'administrative' => { 'hasAdminPolicy' => 'druid:cg532dg5405' },
+                               'administrative' => { 'hasAdminPolicy' => 'druid:hv992ry2431' },
                                'structural' => {}
                              })
       end


### PR DESCRIPTION
## Why was this change made? 🤔
Per discussion on #3323 it was agreed to first make factories for cocina models. This is a minimal implementation of a factory that is useful in a test.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


