### PR TITLE
Collapse the datastream section by default

### DIFF
--- a/app/views/catalog/_datastreams_default.html.erb
+++ b/app/views/catalog/_datastreams_default.html.erb
@@ -1,10 +1,10 @@
 <div class="accordion-item">
   <h2 class="accordion-header" id="document-datastreams-heading">
-    <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#document-datastreams-section" aria-expanded="true" aria-controls="document-datastreams-section">
+    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#document-datastreams-section" aria-expanded="false" aria-controls="document-datastreams-section">
       Datastreams
     </button>
   </h2>
-  <div id="document-datastreams-section" class="accordion-collapse collapse show" aria-labelledby="document-datastreams-heading">
+  <div id="document-datastreams-section" class="accordion-collapse collapse" aria-labelledby="document-datastreams-heading">
     <div class="accordion-body">
 
       <table class="detail">

--- a/spec/features/item_view_spec.rb
+++ b/spec/features/item_view_spec.rb
@@ -266,6 +266,7 @@ RSpec.describe 'Item view', js: true do
             expect(page).to have_css 'tr td', text: /Searchworks/
             expect(page).to have_css 'tr td', text: /pjreed/
 
+            click_button 'Datastreams' # Open the datastream accordion
             click_link 'descMetadata' # Open the datastream modal
             within '.code' do
               expect(page).to have_content '<title>Slides, IA 11, Geodesic Domes, Double Skin "Growth" House, N.C. State, 1953</title>'


### PR DESCRIPTION


## Why was this change made? 🤔

This helps to encourage users to look elsewhere for the information they need. This will assist the transition to datastreams going away.

This came up in a conversation I had with Andrew.

## How was this change tested? 🤨
Locally