### PR TITLE
add rake tasks for seed data and update readme

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Provide some default values that allow the user to login.
+# In a production like environment these are provided by the webserver/Shibboleth/LDAP
+REMOTE_USER="${REMOTE_USER:=blalbrit@stanford.edu}"
+ROLES="${ROLES:=sdr:administrator-role}"
+
+REMOTE_USER=$REMOTE_USER ROLES=$ROLES bin/rails s


### PR DESCRIPTION
## Why was this change made? 🤔

- Restructure the README to be clearer on how to do local development.
- Add a script to start the bin/rails server with appropriate env variables.
- Add rake tasks for seeding solr for local development and for creating items.

## How was this change tested? 🤨

Localhost