### PR TITLE
[SPIKE] bin/dev and docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,11 @@ RUN bundle config build.nokogiri --use-system-libraries && \
   bundle config set without 'production' && \
   bundle install
 
+RUN gem install foreman
+
 COPY package.json yarn.lock ./
 RUN yarn install
 
 COPY . .
 
-CMD ["bin/puma", "-C", "config/puma.rb", "config.ru"]
+CMD ["bin/dev"]

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: bin/rails server -p 3000
+web: bin/rails server -b 0.0.0.0 -p 3000
 js: yarn build --watch
 css: yarn build:css --watch

--- a/bin/dev
+++ b/bin/dev
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # Provide some default values that allow the user to login.
 # In a production like environment these are provided by the webserver/Shibboleth/LDAP

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
       SOLR_URL: http://solr:8983/solr/argo
     depends_on:
       - dor-indexing-app
+    # To allow yarn --watch from Procfile.dev to continue after stdin is closed
+    tty: true
 
   dor-indexing-app:
     image: suldlss/dor-indexing-app:latest


### PR DESCRIPTION
## Why was this change made? 🤔

This PR modifies the docker-compose web service to use bin/dev as an entrypoint. This means that JS and CSS assets will get compiled automatically when the files change. Hopefully it should make getting set up to develop Argo a little bit easier.

## How was this change tested? 🤨

Local development environment.

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

The docker configuration isn't used outside of development.

⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


