### PR TITLE
[refactor] Rename AdminPolicyChangeSetPersister to AdminPolicyPersister

### DIFF
--- a/app/forms/apo_form.rb
+++ b/app/forms/apo_form.rb
@@ -56,9 +56,9 @@ class ApoForm < ApplicationChangeSet
 
   def save_model
     @model = if persisted?
-               AdminPolicyChangeSetPersister.update(model, self)
+               AdminPolicyPersister.update(model, self)
              else
-               AdminPolicyChangeSetPersister.create(self)
+               AdminPolicyPersister.create(self)
              end
   end
 

--- a/app/services/admin_policy_persister.rb
+++ b/app/services/admin_policy_persister.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Writes changes on an AdminPolicy to the to the dor-services-app API
-class AdminPolicyChangeSetPersister # rubocop:disable Metrics/ClassLength
+class AdminPolicyPersister # rubocop:disable Metrics/ClassLength
   # @param [Cocina::Models::AdminPolicy] model the orignal state of the model
   # @param [ApoForm] form the values to update.
   # @return [Cocina::Models::AdminPolicy] the model with updates applied

--- a/spec/services/admin_policy_persister_spec.rb
+++ b/spec/services/admin_policy_persister_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe AdminPolicyChangeSetPersister do
+RSpec.describe AdminPolicyPersister do
   let(:fake_tags_client) { instance_double(Dor::Services::Client::AdministrativeTags, create: true) }
   let(:instance) { described_class.new(apo, change_set) }
 


### PR DESCRIPTION
## Why was this change made? 🤔
We no longer have an AdminPolicyChangeSet, so the name was a bit confusing.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


