### PR TITLE
Remove pid file when starting up rails dev server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       SETTINGS__WORKFLOW_URL: http://workflow:3000
       SETTINGS__TECH_MD_SERVICE__URL: http://techmd:3000
       SOLR_URL: http://solr:8983/solr/argo
+      # Docker doesn't allow rails server to remove PID on shutdown
+      PID_FILE: /dev/null
     depends_on:
       - dor-indexing-app
     # To allow yarn --watch from Procfile.dev to continue after stdin is closed


### PR DESCRIPTION
## Why was this change made? 🤔

If you start the containers with `docker compose up` and then stop them
with ctrl-c or a `docker compose stop` the tmp/pids/server.pid in the
working directory (shared with the docker container) is not deleted.
This means when you try to start it back up again you get an error about
the server already running.

I suspect there's a better way to do this, but this small change will remove the
server.pid before starting up `rails server`.

## How was this change tested? 🤨

Starting and stopping my local Argo Docker development environment.

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


