### PR TITLE
Don't try to set nil values on CSV imports

### DIFF
--- a/app/controllers/descriptives_controller.rb
+++ b/app/controllers/descriptives_controller.rb
@@ -10,7 +10,7 @@ class DescriptivesController < ApplicationController
   # Handle upload of the spreadsheet
   def create
     csv = CSV.read(params[:data].tempfile, headers: true)
-    mapping_result = DescriptionImport.import(description: @cocina.description, csv_row: csv.first)
+    mapping_result = DescriptionImport.import(csv_row: csv.first)
     mapping_result.either(->(description) { convert_metdata_success(description: description) },
                           ->(error) { convert_metadata_fail(error) })
   end

--- a/app/jobs/descriptive_metadata_import_job.rb
+++ b/app/jobs/descriptive_metadata_import_job.rb
@@ -18,7 +18,7 @@ class DescriptiveMetadataImportJob < GenericJob
     with_csv_items(csv, name: 'Import descriptive metadata') do |cocina_object, csv_row, success, failure|
       next failure.call('Not authorized') unless ability.can?(:manage_item, cocina_object)
 
-      DescriptionImport.import(description: cocina_object.description, csv_row: csv_row).either(
+      DescriptionImport.import(csv_row: csv_row).either(
         ->(description) { Repository.store(cocina_object.new(description: description)) && success.call('Successfully updated') },
         ->(error) { failure.call(error) }
       )

--- a/app/services/description_import.rb
+++ b/app/services/description_import.rb
@@ -3,17 +3,16 @@
 class DescriptionImport
   include Dry::Monads[:result]
 
-  def self.import(description:, csv_row:)
-    new(description: description, csv_row: csv_row).import
+  def self.import(csv_row:)
+    new(csv_row: csv_row).import
   end
 
-  def initialize(description:, csv_row:)
-    @description = description
+  def initialize(csv_row:)
     @csv_row = csv_row
   end
 
   def import
-    params = @description.to_h
+    params = {}
 
     # The source_id and druid are only there for the user to reference and should be ignored for data processing
     # druid is only on the bulk sheet
@@ -22,7 +21,7 @@ class DescriptionImport
     headers.each do |address|
       split_address = address.scan(/[[:alpha:]]+|[[:digit:]]+/)
                              .map { |item| /\d+/.match?(item) ? item.to_i - 1 : item.to_sym }
-      visit(params, split_address, @csv_row[address])
+      visit(params, split_address, @csv_row[address]) if @csv_row[address]
     end
 
     Success(Cocina::Models::Description.new(params))

--- a/spec/jobs/descriptive_metadata_import_job_spec.rb
+++ b/spec/jobs/descriptive_metadata_import_job_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe DescriptiveMetadataImportJob, type: :job do
 
   let(:csv_file) do
     [
-      'druid,source_id,title1:value',
-      [item1.externalIdentifier, item1.identification.sourceId, 'new title 1'].join(','),
-      [item2.externalIdentifier, item2.identification.sourceId, 'new title 2'].join(',')
+      'druid,source_id,title1:value,purl',
+      [item1.externalIdentifier, item1.identification.sourceId, 'new title 1', 'https://purl'].join(','),
+      [item2.externalIdentifier, item2.identification.sourceId, 'new title 2', 'https://purl'].join(',')
     ].join("\n")
   end
 
@@ -38,11 +38,11 @@ RSpec.describe DescriptiveMetadataImportJob, type: :job do
       let(:ability) { instance_double(Ability, can?: true) }
 
       let(:expected1) do
-        item1.new(description: item1.description.new(title: [{ value: 'new title 1' }]))
+        item1.new(description: item1.description.new(title: [{ value: 'new title 1' }], purl: 'https://purl'))
       end
 
       let(:expected2) do
-        item2.new(description: item2.description.new(title: [{ value: 'new title 2' }]))
+        item2.new(description: item2.description.new(title: [{ value: 'new title 2' }], purl: 'https://purl'))
       end
 
       it 'updates the descriptive metadata for each item' do


### PR DESCRIPTION
## Why was this change made? 🤔

Instead of merging the upload with the existing metadata, generate a whole new descriptive metadata for each upload.  This is how it should work per @arcadiafalcone 

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


