### PR TITLE
add rights_location, rename rights_access, add validation for location

### DIFF
--- a/app/services/structure_serializer.rb
+++ b/app/services/structure_serializer.rb
@@ -2,7 +2,7 @@
 
 class StructureSerializer
   HEADERS = %w[resource_label resource_type sequence filename file_label publish
-               shelve preserve rights_access rights_download mimetype role].freeze
+               shelve preserve rights_view rights_download rights_location mimetype role].freeze
 
   def self.as_csv(structural)
     new(structural).as_csv
@@ -27,7 +27,7 @@ class StructureSerializer
         yield [resource.label, type(resource), n, file.filename, file.label,
                to_yes_no(file.administrative.publish), to_yes_no(file.administrative.shelve),
                to_yes_no(file.administrative.sdrPreserve), file.access.view,
-               file.access.download, file.hasMimeType, file.use]
+               file.access.download, file.access.location, file.hasMimeType, file.use]
       end
     end
   end

--- a/spec/fixtures/files/bulk_upload_structural.csv
+++ b/spec/fixtures/files/bulk_upload_structural.csv
@@ -1,5 +1,5 @@
-druid,resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_access,rights_download,mimetype,role
-zp968gy7494,LOL1,image,1,jt667tw2770_00_0001.tif,jt667tw2770_00_0001.tif,no,no,yes,dark,none,image/tiff,
-zp968gy7494,LOL2,image,1,jt667tw2770_05_0001.jp2,jt667tw2770_05_0001.jp2,yes,yes,yes,dark,none,image/jp2,
-bc234fg7890,LOL3,image,1,jt667tw2770_00_0001.tif,jt667tw2770_00_0001.tif,no,no,yes,dark,none,image/tiff,
-bc234fg7890,LOL4,image,1,jt667tw2770_05_0001.jp2,jt667tw2770_05_0001.jp2,yes,yes,yes,dark,none,image/jp2,
+druid,resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
+zp968gy7494,LOL1,image,1,jt667tw2770_00_0001.tif,jt667tw2770_00_0001.tif,no,no,yes,dark,none,,image/tiff,
+zp968gy7494,LOL2,image,1,jt667tw2770_05_0001.jp2,jt667tw2770_05_0001.jp2,yes,yes,yes,dark,none,,image/jp2,
+bc234fg7890,LOL3,image,1,jt667tw2770_00_0001.tif,jt667tw2770_00_0001.tif,no,no,yes,dark,none,,image/tiff,
+bc234fg7890,LOL4,image,1,jt667tw2770_05_0001.jp2,jt667tw2770_05_0001.jp2,yes,yes,yes,dark,none,,image/jp2,

--- a/spec/fixtures/files/structure-upload.csv
+++ b/spec/fixtures/files/structure-upload.csv
@@ -1,2 +1,2 @@
-resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_access,rights_download,mimetype,role
-Item 1,https://cocina.sul.stanford.edu/models/resources/image.jsonld,1,chocolate_cake.jpg,chocolate_cake.jpg,yes,yes,yes,world,world,image/jpeg,
+resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
+Item 1,https://cocina.sul.stanford.edu/models/resources/image.jsonld,1,chocolate_cake.jpg,chocolate_cake.jpg,yes,yes,yes,world,world,,image/jpeg,

--- a/spec/services/structure_serializer_spec.rb
+++ b/spec/services/structure_serializer_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe StructureSerializer do
 
     it 'serializes to CSV' do
       expect(csv).to eq <<~CSV
-        resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_access,rights_download,mimetype,role
+        resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
       CSV
     end
   end
@@ -223,8 +223,9 @@ RSpec.describe StructureSerializer do
                         }
                       ],
                       "access": {
-                        "view": "world",
-                        "download": "world"
+                        "view": "location-based",
+                        "download": "location-based",
+                        "location": "music"
                       },
                       "administrative": {
                         "publish": true,
@@ -247,11 +248,11 @@ RSpec.describe StructureSerializer do
 
     it 'serializes to CSV' do
       expect(csv).to eq <<~CSV
-        resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_access,rights_download,mimetype,role
-        Image 1,image,1,bb045jk9908_0001.tiff,bb045jk9908_0001.tiff,no,no,yes,world,world,image/tiff,
-        Image 1,image,1,bb045jk9908_0001.jp2,bb045jk9908_0001.jp2,yes,yes,no,world,world,image/jp2,
-        Image 2,image,2,bb045jk9908_0002.tiff,bb045jk9908_0002.tiff,no,no,yes,world,world,image/tiff,
-        Image 2,image,2,bb045jk9908_0002.jp2,bb045jk9908_0002.jp2,yes,yes,no,world,world,image/jp2,
+        resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
+        Image 1,image,1,bb045jk9908_0001.tiff,bb045jk9908_0001.tiff,no,no,yes,world,world,,image/tiff,
+        Image 1,image,1,bb045jk9908_0001.jp2,bb045jk9908_0001.jp2,yes,yes,no,world,world,,image/jp2,
+        Image 2,image,2,bb045jk9908_0002.tiff,bb045jk9908_0002.tiff,no,no,yes,world,world,,image/tiff,
+        Image 2,image,2,bb045jk9908_0002.jp2,bb045jk9908_0002.jp2,yes,yes,no,location-based,location-based,music,image/jp2,
       CSV
     end
   end

--- a/spec/services/structure_updater_spec.rb
+++ b/spec/services/structure_updater_spec.rb
@@ -276,8 +276,8 @@ RSpec.describe StructureUpdater do
         'On row 2 found bb045jk_0001.tiff, which appears to be a new file',
         'On row 3 found bb045jk_0001.jp2, which appears to be a new file',
         'On row 4 found bb045jk_0002.tiff, which appears to be a new file',
-        'On row 5 found bb045jk_0002.jp2, which appears to be a new file',
-        'On row 5 found "paper", which is not a valid resource type'
+        'On row 5 found "paper", which is not a valid resource type',
+        'On row 5 found bb045jk_0002.jp2, which appears to be a new file'
       ]
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3327 - add a new `rights_location` column to structural spreadsheet and rename `rights_access` column to `rights_view`

Note: I also added an additional validation to ensure the new `rights_location` column has a value if either `rights_view` or `rights_download` contains a value of `location-based`.  

Question: is there an easy way to verify the location specified is an allowed value in the enum here: https://github.com/sul-dlss/cocina-models/blob/main/openapi.yml#L318-L324 

## How was this change tested? 🤨

Updated existing tests to show location can be set, and to account for new column and renamed column, and added a new test for location validation.
