### PR TITLE
[refactor] use load_and_authorize_resource consistently

### DIFF
--- a/app/controllers/descriptives_controller.rb
+++ b/app/controllers/descriptives_controller.rb
@@ -2,7 +2,7 @@
 
 # Download the CSV descriptive metadata
 class DescriptivesController < ApplicationController
-  before_action :load_and_authorize_cocina
+  before_action :load_and_authorize_resource
 
   # Display the form for uploading the descriptive metadata spreadsheet
   def new; end
@@ -42,7 +42,7 @@ class DescriptivesController < ApplicationController
     render :new, status: :unprocessable_entity
   end
 
-  def load_and_authorize_cocina
+  def load_and_authorize_resource
     @cocina = Repository.find(params[:item_id])
     authorize! :manage_item, @cocina
   end

--- a/app/controllers/structures_controller.rb
+++ b/app/controllers/structures_controller.rb
@@ -2,14 +2,14 @@
 
 # dispatches to the dor-services-app to (re/un)publish
 class StructuresController < ApplicationController
-  before_action :load_and_authorize_cocina, only: :update
+  before_action :load_and_authorize_resource, only: :update
   before_action :enforce_versioning, only: :update
 
   def show
     respond_to do |format|
       format.csv do
         # Download the structural spreadsheet
-        load_and_authorize_cocina
+        load_and_authorize_resource
         filename = "structure-#{Druid.new(@cocina).without_namespace}.csv"
         send_data StructureSerializer.as_csv(@cocina.structural), filename: filename
       end
@@ -21,8 +21,6 @@ class StructuresController < ApplicationController
   end
 
   def update
-    authorize! :manage_item, @cocina
-
     status = StructureUpdater.from_csv(@cocina, params[:csv].read)
 
     if status.success?
@@ -35,7 +33,7 @@ class StructuresController < ApplicationController
 
   private
 
-  def load_and_authorize_cocina
+  def load_and_authorize_resource
     @cocina = Repository.find(params[:item_id])
     authorize! :manage_item, @cocina
   end


### PR DESCRIPTION

## Why was this change made? 🤔

We were mostly using the load_and_authorize_resource, so use that consistently across all controllers
```
$ git grep load_and_authorize_cocina |wc -l
       5
$ git grep load_and_authorize_resource |wc -l
      10
```


## How was this change tested? 🤨
test suite