### PR TITLE
add support for Excel files to desc spreadsheet upload

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,9 @@ gem 'honeybadger', '~> 4.1'
 gem 'lograge'
 gem 'sidekiq', '~> 6.0'
 
+gem 'roo', '~> 2.9.0' # work with newer Excel files and other types (xlsx, ods, csv)
+gem 'roo-xls' # needed to work with legacy Excel files (xls)
+
 gem 'newrelic_rpm'
 gem 'nokogiri', '~> 1.12'
 # Prawn is used to create "tracksheets"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -448,6 +448,13 @@ GEM
       railties (>= 5.0)
     retries (0.0.5)
     rexml (3.2.5)
+    roo (2.9.0)
+      nokogiri (~> 1)
+      rubyzip (>= 1.3.0, < 3.0.0)
+    roo-xls (1.2.0)
+      nokogiri
+      roo (>= 2.0.0, < 3)
+      spreadsheet (> 0.9.0)
     rsolr (2.5.0)
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
@@ -487,6 +494,7 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
     rubocop-rspec (2.9.0)
       rubocop (~> 1.19)
+    ruby-ole (1.2.12.2)
     ruby-prof (1.4.3)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
@@ -512,6 +520,8 @@ GEM
     simplecov_json_formatter (0.1.4)
     slop (3.6.0)
     smart_properties (1.17.0)
+    spreadsheet (1.3.0)
+      ruby-ole
     sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -624,6 +634,8 @@ DEPENDENCIES
   rake
   reform-rails
   retries
+  roo (~> 2.9.0)
+  roo-xls
   rsolr
   rspec-rails (~> 5.0)
   rspec_junit_formatter

--- a/app/views/bulk_actions/descriptive_metadata_import_jobs/_new.html.erb
+++ b/app/views/bulk_actions/descriptive_metadata_import_jobs/_new.html.erb
@@ -4,10 +4,10 @@
   </span>
 
   <div class='mb-3' id="import-csv">
-    <%= f.label :csv_file, 'Upload a CSV file' %>
+    <%= f.label :uploaded_file, 'Upload a CSV or Excel file' %>
       <br>
-      <small>Each row in the CSV should start with the druid in the first field, followed by the descriptive metadata columns.</small>
-    <%= f.file_field :csv_file, class: 'form-control', accept: '.csv' %>
+      <small>Each row in the spreadsheet should start with the druid in the first field, followed by the descriptive metadata columns.</small>
+    <%= f.file_field :uploaded_file, class: 'form-control', accept: '.csv, .xls, .ods, .xlsx' %>
   </div>
   <%= render 'bulk_actions/common_fields', f: f %>
 <% end %>


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3363 - allow the user to upload ODS, XLS, XLSX as well as CSV when uploading descriptive metadata (only).  CSV is still required for all other uploads.  

Use the roo gem to open the spreadsheet, then ask it to covert to CSV ... this allows us to parse and use the CSV just as before without other code changes.

## How was this change tested? 🤨

TODO: test (both in code and in browser)
