### PR TITLE
Revert change that caused 422s in development

### DIFF
--- a/app/models/bulk_action.rb
+++ b/app/models/bulk_action.rb
@@ -3,7 +3,38 @@
 # Stores data about an asynchonous background job
 class BulkAction < ApplicationRecord
   belongs_to :user
-  validates :action_type, inclusion: { in: GenericJob.descendants.map(&:to_s) }
+  validates :action_type,
+            inclusion: {
+              in: %w[GenericJob
+                     AddWorkflowJob
+                     ApplyApoDefaultsJob
+                     DescmetadataDownloadJob
+                     DescriptiveMetadataExportJob
+                     DescriptiveMetadataImportJob
+                     ReleaseObjectJob
+                     RemoteIndexingJob
+                     PurgeJob
+                     SetGoverningApoJob
+                     SetCatkeysAndBarcodesJob
+                     SetCatkeysAndBarcodesCsvJob
+                     PrepareJob
+                     RefreshModsJob
+                     RepublishJob
+                     CloseVersionJob
+                     ChecksumReportJob
+                     CreateVirtualObjectsJob
+                     ExportTagsJob
+                     ImportTagsJob
+                     ExportStructuralJob
+                     ImportStructuralJob
+                     RegisterDruidsJob
+                     SetLicenseAndRightsStatementsJob
+                     SetSourceIdsCsvJob
+                     SetContentTypeJob
+                     ManageEmbargoesJob
+                     SetCollectionJob
+                     SetRightsJob]
+            }
 
   after_create :create_output_directory, :create_log_file
   before_destroy :remove_output_directory


### PR DESCRIPTION
## Why was this change made? 🤔
Reverts this [change](https://github.com/sul-dlss/argo/commit/9956d8e530ec1cb9739dcad1498c7dcf3c933d74#diff-53119f6275d5138e0ab2020201cb5b59268a159737c296991d49d3e0c98da2efR6) in https://github.com/sul-dlss/argo/commit/9956d8e530ec1cb9739dcad1498c7dcf3c933d74

While this change probably didn't effect production, it caused bulk actions to return 422 errors during local development. This reverts that change so that local dev and testing of bulk jobs can continue. 

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


