### PR TITLE
[refactor] Rename ability for refreshing descriptive metadata

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -104,7 +104,7 @@ class ItemsController < ApplicationController
   end
 
   def refresh_metadata
-    authorize! :manage_desc_metadata, @cocina
+    authorize! :refresh_descriptive_metadata, @cocina
 
     catkey = @cocina.identification&.catalogLinks&.find { |link| link.catalog == 'symphony' }&.catalogRecordId
     if catkey.blank?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -23,7 +23,7 @@ class Ability
     cannot :impersonate, User unless current_user.webauth_admin?
 
     if current_user.manager?
-      can %i[manage_item manage_desc_metadata manage_governing_apo view_content view_metadata],
+      can %i[manage_item refresh_descriptive_metadata manage_governing_apo view_content view_metadata],
           [NilModel, Cocina::Models::DRO, Cocina::Models::Collection]
       can :create, Cocina::Models::AdminPolicy
     end
@@ -38,12 +38,12 @@ class Ability
       can_manage_items? current_user.roles(cocina_object.administrative.hasAdminPolicy)
     end
 
-    can :manage_desc_metadata, Cocina::Models::AdminPolicy do |cocina_admin_policy|
-      can_edit_desc_metadata? current_user.roles(cocina_admin_policy.externalIdentifier)
+    can :refresh_descriptive_metadata, Cocina::Models::AdminPolicy do |cocina_admin_policy|
+      can_refresh_descriptive_metadata? current_user.roles(cocina_admin_policy.externalIdentifier)
     end
 
-    can :manage_desc_metadata, [Cocina::Models::Collection, Cocina::Models::DRO] do |cocina_object|
-      can_edit_desc_metadata? current_user.roles(cocina_object.administrative.hasAdminPolicy)
+    can :refresh_descriptive_metadata, [Cocina::Models::Collection, Cocina::Models::DRO] do |cocina_object|
+      can_refresh_descriptive_metadata? current_user.roles(cocina_object.administrative.hasAdminPolicy)
     end
 
     can :manage_governing_apo, [Cocina::Models::Collection, Cocina::Models::DRO] do |cocina_object, new_apo_id|
@@ -75,15 +75,15 @@ class Ability
   private
 
   GROUPS_WHICH_MANAGE_ITEMS = %w[dor-administrator sdr-administrator dor-apo-manager dor-apo-depositor].freeze
-  GROUPS_WHICH_EDIT_DESC_METADATA = (GROUPS_WHICH_MANAGE_ITEMS + %w[dor-apo-metadata]).freeze
+  GROUPS_WHICH_REFRESH_DESCRIPTIVE_METADATA = (GROUPS_WHICH_MANAGE_ITEMS + %w[dor-apo-metadata]).freeze
   GROUPS_WHICH_VIEW = (GROUPS_WHICH_MANAGE_ITEMS + %w[dor-viewer sdr-viewer]).freeze
 
   def can_manage_items?(roles)
     intersect roles, GROUPS_WHICH_MANAGE_ITEMS
   end
 
-  def can_edit_desc_metadata?(roles)
-    intersect roles, GROUPS_WHICH_EDIT_DESC_METADATA
+  def can_refresh_descriptive_metadata?(roles)
+    intersect roles, GROUPS_WHICH_REFRESH_DESCRIPTIVE_METADATA
   end
 
   def can_view?(roles)

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Ability do
 
     it { is_expected.to be_able_to(:manage, :everything) }
     it { is_expected.to be_able_to(:manage_item, dro) }
-    it { is_expected.to be_able_to(:manage_desc_metadata, dro) }
+    it { is_expected.to be_able_to(:refresh_descriptive_metadata, dro) }
     it { is_expected.to be_able_to(:manage_governing_apo, dro, apo_id) }
     it { is_expected.to be_able_to(:create, Cocina::Models::AdminPolicy) }
     it { is_expected.to be_able_to(:view_content, dro) }
@@ -81,7 +81,7 @@ RSpec.describe Ability do
 
     it { is_expected.not_to be_able_to(:manage, :everything) }
     it { is_expected.to be_able_to(:manage_item, dro) }
-    it { is_expected.to be_able_to(:manage_desc_metadata, dro) }
+    it { is_expected.to be_able_to(:refresh_descriptive_metadata, dro) }
 
     it { is_expected.to be_able_to(:manage_governing_apo, dro, apo_id) }
     it { is_expected.to be_able_to(:create, Cocina::Models::AdminPolicy) }
@@ -93,7 +93,7 @@ RSpec.describe Ability do
     let(:viewer) { true }
 
     it { is_expected.not_to be_able_to(:manage_item, dro) }
-    it { is_expected.not_to be_able_to(:manage_desc_metadata, dro) }
+    it { is_expected.not_to be_able_to(:refresh_descriptive_metadata, dro) }
     it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, apo_id) }
     it { is_expected.to be_able_to(:view_metadata, dro) }
@@ -105,7 +105,7 @@ RSpec.describe Ability do
 
   context 'for items without an APO' do
     it { is_expected.not_to be_able_to(:manage_item, dro) }
-    it { is_expected.not_to be_able_to(:manage_desc_metadata, dro) }
+    it { is_expected.not_to be_able_to(:refresh_descriptive_metadata, dro) }
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, apo_id) }
     it { is_expected.not_to be_able_to(:view_content, dro) }
   end
@@ -116,7 +116,7 @@ RSpec.describe Ability do
     it { is_expected.not_to be_able_to(:manage, :everything) }
     it { is_expected.to be_able_to(:manage_item, dro) }
     it { is_expected.to be_able_to(:manage_governing_apo, dro, apo_id) }
-    it { is_expected.to be_able_to(:manage_desc_metadata, dro) }
+    it { is_expected.to be_able_to(:refresh_descriptive_metadata, dro) }
     it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
 
     it { is_expected.to be_able_to(:view_metadata, dro) }
@@ -131,7 +131,7 @@ RSpec.describe Ability do
     it { is_expected.not_to be_able_to(:manage, :everything) }
     it { is_expected.not_to be_able_to(:manage_item, dro) }
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, apo_id) }
-    it { is_expected.not_to be_able_to(:manage_desc_metadata, dro) }
+    it { is_expected.not_to be_able_to(:refresh_descriptive_metadata, dro) }
     it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
 
     it { is_expected.not_to be_able_to(:view_metadata, dro) }
@@ -146,7 +146,7 @@ RSpec.describe Ability do
     it { is_expected.not_to be_able_to(:manage, :everything) }
     it { is_expected.not_to be_able_to(:manage_item, dro) }
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, apo_id) }
-    it { is_expected.to be_able_to(:manage_desc_metadata, dro) }
+    it { is_expected.to be_able_to(:refresh_descriptive_metadata, dro) }
     it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
     it { is_expected.not_to be_able_to(:view_content, dro) }
   end
@@ -157,7 +157,7 @@ RSpec.describe Ability do
     it { is_expected.not_to be_able_to(:manage, :everything) }
     it { is_expected.not_to be_able_to(:manage_item, dro) }
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, apo_id) }
-    it { is_expected.not_to be_able_to(:manage_desc_metadata, dro) }
+    it { is_expected.not_to be_able_to(:refresh_descriptive_metadata, dro) }
     it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
     it { is_expected.to be_able_to(:view_content, dro) }
   end


### PR DESCRIPTION


## Why was this change made? 🤔

'refresh' is more specific than 'manage'

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


