### PR TITLE
bulk action creation: remove bulk action form values from params passed along location URL in redirect when bulk action is created.

### DIFF
--- a/app/controllers/concerns/creates_bulk_actions.rb
+++ b/app/controllers/concerns/creates_bulk_actions.rb
@@ -15,7 +15,11 @@ module CreatesBulkActions
     if bulk_action.save
       bulk_action.enqueue_job(job_params)
 
-      redirect_to bulk_actions_path(Blacklight::Parameters.sanitize(search_state.to_h.except(:authenticity_token))), status: :see_other, notice: success_message
+      # strip the CSRF token, and the parameters that happened to be in the bulk job creation form
+      # this can be removed when this is resolved: https://github.com/projectblacklight/blacklight/issues/2683
+      search_state_subset = search_state.to_h.except(:authenticity_token, :druids, :druids_only, :description)
+      path_params = Blacklight::Parameters.sanitize(search_state_subset)
+      redirect_to bulk_actions_path(path_params), status: :see_other, notice: success_message
     else
       render :new, status: :unprocessable_entity
     end


### PR DESCRIPTION
## Why was this change made? 🤔

closes #3413 

long druid lists were causing response handling upstream from argo to throw a 500 error... because of the possibly enormous redirect `Location` header?

e.g. the apache error logs (`argo_error_ssl.log`) would report `Premature end of script headers: bulk_actions, referer` when the user received a 500 in this case (despite the app logs showing a successful 303 response to the `POST`).  note that HTTP 303 responses should have a location.  perhaps the location header in the 303 was not parseable by apache once a certain size was exceeded?

this only occurred with long druid lists.  thanks to @tallenaz yesterday for talking through where we might insert some debug logging, and @edsu today for suggesting a look at the 303 response the user gets when there's a long-ish druid list but the redirect after the bulk job succeeds in getting a 303 to the user.

i think the long druid list was actually just a holdover from the bulk job creation form, not part of the blacklight search params?

i wasn't sure whether filtering `druids_only` from the redirect URL's param list was the right thing to do.


## How was this change tested? 🤨

tested manually on QA with a search that resulted in 964 druids.

needs a new unit test? 🤷 

`main`, with 964 druid search result, reproducing the issue:
<img width="1432" alt="Screen Shot 2022-04-12 at 5 47 03 PM" src="https://user-images.githubusercontent.com/7741604/163078623-d0a6ada7-b6c8-4add-aa76-5ae8e088147f.png">

`main` with a short druid list and a successful response (the total count jumped up to 10 a moment later on page reload after the job had a chance to initialize -- note druid list in `Location`):
<img width="1438" alt="Screen Shot 2022-04-12 at 5 54 25 PM" src="https://user-images.githubusercontent.com/7741604/163078784-f597a634-5d5c-47db-8de8-95c424c366f5.png">

this branch with a 964 druid search result and a successful 303 back to the user (druid list filtered from `Location` URL):
<img width="1432" alt="Screen Shot 2022-04-12 at 5 50 12 PM" src="https://user-images.githubusercontent.com/7741604/163078903-fe47f206-2884-4821-885c-28c57be5914b.png">



⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


