### PR TITLE
Remove nil values from arrays when uploading descriptive metadata

### DIFF
--- a/app/services/description_import.rb
+++ b/app/services/description_import.rb
@@ -71,7 +71,10 @@ class DescriptionImport
 
   def compact_params(params)
     params.each do |key, value|
-      params[key].compact! if value.is_a?(Array)
+      next unless value.is_a?(Array)
+
+      params[key].compact!
+      params[key].map { |param| compact_params(param) }
     end
   end
 end

--- a/app/services/description_import.rb
+++ b/app/services/description_import.rb
@@ -24,7 +24,7 @@ class DescriptionImport
       visit(params, split_address, @csv_row[address]) if @csv_row[address]
     end
 
-    Success(Cocina::Models::Description.new(params))
+    Success(Cocina::Models::Description.new(compact_params(params)))
   rescue Cocina::Models::ValidationError => e
     Failure(e.message)
   end
@@ -66,6 +66,12 @@ class DescriptionImport
       (0...what.size).cover?(key)
     when Hash
       what.key?(key)
+    end
+  end
+
+  def compact_params(params)
+    params.each do |key, value|
+      params[key].compact! if value.is_a?(Array)
     end
   end
 end

--- a/spec/services/description_import_spec.rb
+++ b/spec/services/description_import_spec.rb
@@ -205,4 +205,42 @@ RSpec.describe DescriptionImport do
       expect(updated.value!).to eq expected
     end
   end
+
+  context 'with a csv that has varied nested values' do
+    # This case occurs when you do a bulk import of different object structures
+    let(:csv_data) do
+      <<~CSV
+        druid,source_id,purl,title1.value,contributor3.name3.parallelValue3.structuredValue1.value,contributor3.name3.parallelValue3.structuredValue1.type,contributor3.name3.parallelValue3.structuredValue2.value,contributor3.name3.parallelValue3.structuredValue2.type,contributor3.name3.parallelValue4.structuredValue1.value,contributor3.name3.parallelValue4.structuredValue1.type,contributor3.name3.parallelValue4.structuredValue2.value,contributor3.name3.parallelValue4.structuredValue2.type
+        jr825qh8124,foo2:bar2,https://purl/jr825qh8124,Title 2,Parallel 1 part 1,name,1800-1900,life dates,Parallel 2 part 1,name,marchioness,term of address
+      CSV
+    end
+    let(:csv) do
+      CSV.parse(csv_data, headers: true)
+    end
+
+    let(:expected) do
+      Cocina::Models::Description.new(
+        title: [{ value: 'Title 2' }],
+        purl: 'https://purl/jr825qh8124',
+        contributor: [
+          { name: [
+            { parallelValue: [
+              { structuredValue: [
+                { value: 'Parallel 1 part 1', type: 'name' },
+                { value: '1800-1900', type: 'life dates' }
+              ] },
+              { structuredValue: [
+                { value: 'Parallel 2 part 1', type: 'name' },
+                { value: 'marchioness', type: 'term of address' }
+              ] }
+            ] }
+          ] }
+        ]
+      )
+    end
+
+    it 'ignores the empty field' do
+      expect(updated.value!).to eq expected
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Closes #3470 

This addresses the issue where if a descriptive metadata upload spreadsheet as a record with blank values in `contributor1.*` for instance, but does have values in `contributor3.*` that creates parameters with nil values such as:

```
{
  :purl=>"https://purl.stanford.edu/jr825qh8124",
  :title=>[{:value=>"foo bar 2"}],
  :contributor=>[
    nil,
    nil,
    {:name=>[
      nil,
      nil, 
      {:parallelValue=>[
        nil,
        nil, 
        {:structuredValue=>[
          {:value=>"Parallel 1 part 1", :type=>"name"},
          {:value=>"1800-1900", :type=>"life dates"}
        ]},
        {:structuredValue=>[
          {:value=>"Parallel 2 part 1", :type=>"name"},
          {:value=>"marchioness", :type=>"term of address"}]}]}]}]
}
```

This recursively removes the nils from the parameters resulting in:

```
{
  :purl=>"https://purl.stanford.edu/jr825qh8124",
  :title=>[{:value=>"foo bar 2"}],
  :contributor=>[
    {:name=>[
      {:parallelValue=>[
        {:structuredValue=>[
          {:value=>"Parallel 1 part 1", :type=>"name"},
          {:value=>"1800-1900", :type=>"life dates"}
        ]},
        {:structuredValue=>[
          {:value=>"Parallel 2 part 1", :type=>"name"},
          {:value=>"marchioness", :type=>"term of address"}]}]}]}]
}
```

And avoiding `#/components/schemas/Contributor does not allow null values` errors.

## How was this change tested? 🤨


⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


