### PR TITLE
Close the modal when the upload is successful

### DIFF
--- a/app/views/descriptives/_form.html.erb
+++ b/app/views/descriptives/_form.html.erb
@@ -1,8 +1,10 @@
-<turbo-frame id="descriptive-form">
+<turbo-frame id="descriptive-form" target="_top">
   <% if @errors.present? %>
     <div class="alert alert-danger"><%= @errors.to_sentence %></div>
   <% end %>
-  <%= form_with url: item_descriptive_path(item_id: @cocina.externalIdentifier), method: :put, local: true, multipart: true, html: { class: 'col-lg-8 mb-5' } do |f| %>
+  <%= form_with url: item_descriptive_path(item_id: @cocina.externalIdentifier),
+               method: :put, local: true, multipart: true,
+               html: { class: 'col-lg-8 mb-5' } do |f| %>
     <div class="mb-3">
       <%= f.label :data, class: 'form-label' do %>
         Upload Cocina descriptive metadata spreadsheet for <%= @cocina.externalIdentifier %>

--- a/spec/features/upload_descriptive_metadata_spec.rb
+++ b/spec/features/upload_descriptive_metadata_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# This is an integration test (with DSA), because we need to show that the
+# data we submit from here doesn't cause a round trip to MODS error.
+RSpec.describe 'Descriptive metadata spreadsheet upload', js: true do
+  let(:user) { create(:user) }
+  # We need to set a catkey on this item, but we can't do it when it's created,
+  # because we don't have symphony running in our test environment. If you register
+  # an object with a catkey, then DSA tries to connect to symphony to get the metadata.
+  let(:item) do
+    FactoryBot.create_for_repository(:persisted_item)
+  end
+
+  let(:csv) do
+    "title1:value,purl\nmy title,https://purl.stanford.edu/#{Druid.new(item.externalIdentifier).without_namespace}\n"
+  end
+  let(:file) do
+    Tempfile.new('upload.csv').tap do |file|
+      file.write csv
+      file.close
+    end
+  end
+
+  after do
+    file.unlink
+  end
+
+  before do
+    sign_in user, groups: ['sdr:administrator-role']
+    visit solr_document_path(item.externalIdentifier)
+  end
+
+  it 'uploads descriptive' do
+    click_button 'Manage description'
+    click_link 'Upload Cocina spreadsheet'
+
+    attach_file("Upload Cocina descriptive metadata spreadsheet for #{item.externalIdentifier}", file.path)
+    click_button 'Upload'
+
+    expect(page).to have_content 'Descriptive metadata has been updated.'
+  end
+end


### PR DESCRIPTION
and catch validation errors

## Why was this change made? 🤔

Fixes #3475

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


