### PR TITLE
Download descriptive spreadsheet header re-ordering

### DIFF
--- a/app/controllers/descriptives_controller.rb
+++ b/app/controllers/descriptives_controller.rb
@@ -65,8 +65,7 @@ class DescriptivesController < ApplicationController
   def create_csv
     description = DescriptionExport.export(source_id: @cocina.identification.sourceId,
                                            description: @cocina.description)
-    headers = ['source_id'] + (description.keys - ['source_id']).sort
-
+    headers = DescriptionHeaders.create(headers: description.keys)
     CSV.generate(write_headers: true, headers: headers) do |body|
       body << description.values_at(*headers)
     end

--- a/app/jobs/descriptive_metadata_export_job.rb
+++ b/app/jobs/descriptive_metadata_export_job.rb
@@ -22,9 +22,7 @@ class DescriptiveMetadataExportJob < GenericJob
       end
 
       log_buffer.puts("#{Time.current} #{self.class}: Writing to file")
-      sort_order = %w[title contributor form event language note identifier access purl subject relatedResource adminMetadata geographic marcEncodedData valueAt]
-      headers = (headers - ['source_id']).sort
-      ordered_headers = ['source_id'] + headers.sort_by.with_index { |header, index| [sort_order.index(field_name(header)) || headers.length, index] }
+      ordered_headers = DescriptionHeaders.create(headers: headers)
 
       CSV.open(csv_download_path, 'w', write_headers: true, headers: %w[druid] + ordered_headers) do |csv|
         descriptions.each do |druid, description|
@@ -37,11 +35,6 @@ class DescriptiveMetadataExportJob < GenericJob
   end
 
   private
-
-  def field_name(key)
-    field = key.split(':').first
-    /[a-zA-Z]*/.match(field).to_s
-  end
 
   def csv_download_path
     FileUtils.mkdir_p(bulk_action.output_directory)

--- a/app/services/description_headers.rb
+++ b/app/services/description_headers.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Creates column headers for descriptive metadata exports
+class DescriptionHeaders
+  def self.create(headers:)
+    new(headers: headers).create
+  end
+
+  def initialize(headers:)
+    @headers = headers
+  end
+
+  def create
+    sort_order = %w[title contributor form event language note identifier access purl subject relatedResource adminMetadata geographic marcEncodedData valueAt]
+    updated_headers = (@headers - ['source_id']).sort
+    ['source_id'] + updated_headers.sort_by.with_index { |header, index| [sort_order.index(field_name(header)) || headers.length, index] }
+  end
+
+  private
+
+  def field_name(key)
+    /[[:alpha:]]*/.match(key)[0]
+  end
+end

--- a/spec/jobs/descriptive_metadata_export_job_spec.rb
+++ b/spec/jobs/descriptive_metadata_export_job_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe DescriptiveMetadataExportJob, type: :job do
 
       it 'writes a CSV file' do
         csv = CSV.read(csv_path, headers: true)
-        expect(csv.headers).to eq ['druid', 'source_id', 'purl', 'title1.value']
+        expect(csv.headers).to eq ['druid', 'source_id', 'title1.value', 'purl']
         expect(csv[0][0]).to eq 'druid:bc123df4567'
         expect(csv[1][0]).to eq 'druid:bd123fg5678'
         expect(csv[0][1]).to eq 'sul:4444'

--- a/spec/requests/download_descriptive_csv_spec.rb
+++ b/spec/requests/download_descriptive_csv_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Download the descriptive CSV', type: :request do
     get "/items/#{druid}/descriptive.csv"
     expect(response).to have_http_status(:ok)
     csv = CSV.parse(response.body, headers: true)
-    expect(csv.headers).to eq ['source_id', 'purl', 'title1.value']
+    expect(csv.headers).to eq ['source_id', 'title1.value', 'purl']
     expect(csv[0]['source_id']).to eq 'sul:91919'
     expect(csv[0]['title1.value']).to eq 'My ETD'
   end

--- a/spec/services/description_headers_spec.rb
+++ b/spec/services/description_headers_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DescriptionHeaders do
+  subject(:run) { described_class.create(headers: headers) }
+
+  let(:source_id) { 'sul:123' }
+  let(:headers) do
+    %w[adminMetadata.contributor1.name1.code adminMetadata.contributor1.name1.source.code adminMetadata.contributor1.role1.value adminMetadata.contributor1.type
+       adminMetadata.event1.date1.encoding.code adminMetadata.event1.date1.value adminMetadata.event1.type adminMetadata.event2.date1.encoding.code
+       adminMetadata.event2.date1.value adminMetadata.event2.type adminMetadata.identifier1.type adminMetadata.identifier1.value adminMetadata.note1.type
+       adminMetadata.note1.value contributor1.name1.structuredValue1.type contributor1.name1.structuredValue1.value contributor1.name1.structuredValue2.type
+       contributor1.name1.structuredValue2.value contributor1.status contributor1.type event1.location1.code event1.location1.source.code event1.note1.source.value
+       event1.note1.type event1.note1.value event2.date1.type event2.date1.value form1.source.value form1.type form1.value form2.source.code form2.type form2.value
+       form3.type form3.value language1.code language1.source.code note1.type note1.value note2.type note2.value purl relatedResource1.contributor1.name1.structuredValue1.type
+       relatedResource1.contributor1.name1.structuredValue1.value relatedResource1.contributor1.name1.structuredValue2.type
+       relatedResource1.contributor1.name1.structuredValue2.value relatedResource1.contributor1.type relatedResource1.title1.structuredValue1.type
+       relatedResource1.title1.structuredValue1.value relatedResource1.title1.structuredValue2.type relatedResource1.title1.structuredValue2.value subject1.source.code
+       subject1.structuredValue1.type subject1.structuredValue1.value subject1.structuredValue2.type subject1.structuredValue2.value title1.status title1.value
+       title2.structuredValue1.type title2.structuredValue1.value title2.structuredValue2.structuredValue1.type title2.structuredValue2.structuredValue1.value
+       title2.structuredValue2.structuredValue2.type title2.structuredValue2.structuredValue2.value title2.structuredValue2.type title2.type].freeze
+  end
+  let(:expected_headers) do
+    %w[source_id title1.status title1.value title2.structuredValue1.type title2.structuredValue1.value title2.structuredValue2.structuredValue1.type
+       title2.structuredValue2.structuredValue1.value title2.structuredValue2.structuredValue2.type title2.structuredValue2.structuredValue2.value
+       title2.structuredValue2.type title2.type contributor1.name1.structuredValue1.type contributor1.name1.structuredValue1.value contributor1.name1.structuredValue2.type
+       contributor1.name1.structuredValue2.value contributor1.status contributor1.type form1.source.value form1.type form1.value
+       form2.source.code form2.type form2.value form3.type form3.value event1.location1.code event1.location1.source.code event1.note1.source.value event1.note1.type
+       event1.note1.value event2.date1.type event2.date1.value language1.code language1.source.code note1.type note1.value note2.type note2.value purl subject1.source.code
+       subject1.structuredValue1.type subject1.structuredValue1.value subject1.structuredValue2.type subject1.structuredValue2.value
+       relatedResource1.contributor1.name1.structuredValue1.type relatedResource1.contributor1.name1.structuredValue1.value
+       relatedResource1.contributor1.name1.structuredValue2.type relatedResource1.contributor1.name1.structuredValue2.value relatedResource1.contributor1.type
+       relatedResource1.title1.structuredValue1.type relatedResource1.title1.structuredValue1.value relatedResource1.title1.structuredValue2.type
+       relatedResource1.title1.structuredValue2.value adminMetadata.contributor1.name1.code adminMetadata.contributor1.name1.source.code
+       adminMetadata.contributor1.role1.value adminMetadata.contributor1.type adminMetadata.event1.date1.encoding.code adminMetadata.event1.date1.value
+       adminMetadata.event1.type adminMetadata.event2.date1.encoding.code adminMetadata.event2.date1.value adminMetadata.event2.type adminMetadata.identifier1.type
+       adminMetadata.identifier1.value adminMetadata.note1.type adminMetadata.note1.value].freeze
+  end
+
+  it 'orders the headers' do
+    expect(run).to eq(expected_headers)
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔
Resolves #3399 to order columns correctly in "Download descriptive metadata spreadsheet" bulk action. 

## How was this change tested? �
Unit tests and tested on QA with all items. 

Resulting list of column headers: 
[descriptive-cols-example.txt](https://github.com/sul-dlss/argo/files/8488978/descriptive-cols-example.txt) 
Spreadsheet: 
[descriptive-example.csv](https://github.com/sul-dlss/argo/files/8488994/descriptive-example.csv)

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


