### PR TITLE
Avoid having duplicate line numbers in the error message

### DIFF
--- a/app/jobs/generic_job.rb
+++ b/app/jobs/generic_job.rb
@@ -134,7 +134,7 @@ class GenericJob < ApplicationJob
         cocina_object = Repository.find(druid)
         yield(cocina_object, csv_row, success, failure, row_num)
       rescue StandardError => e
-        failure.call("Line #{row_num}: #{name} failed #{e.class} #{e.message}")
+        failure.call("#{name} failed #{e.class} #{e.message}")
         Honeybadger.notify(e, context: { druid: druid })
       end
     end


### PR DESCRIPTION

## Why was this change made? 🤔

The failure lambda already prints the line number

## How was this change tested? 🤨

