### PR TITLE
don't show 'Manage serials' option for non-item objects

### DIFF
--- a/app/components/show/controls_component.html.erb
+++ b/app/components/show/controls_component.html.erb
@@ -46,7 +46,7 @@
         <li><%= link_to 'Upload Cocina spreadsheet', edit_item_descriptive_path(doc),
                                       class: 'dropdown-item',
                                       data: { controller: 'button', action: 'click->button#open'} %></li>
-        <% if symphony_record? %>
+        <% if symphony_record? && item? %>
           <li><%= link_to 'Manage serials', edit_item_serials_path(doc),
                                             class: 'dropdown-item',
                                             data: { controller: 'button', action: 'click->button#open'} %></li>

--- a/spec/components/show/controls_component_spec.rb
+++ b/spec/components/show/controls_component_spec.rb
@@ -118,6 +118,45 @@ RSpec.describe Show::ControlsComponent, type: :component do
     end
   end
 
+  context 'when the object is a Collection the user can manage' do
+    let(:view_collection_id) { 'druid:kv840xx0000' }
+    let(:allows_modification) { true }
+
+    let(:doc) do
+      SolrDocument.new('id' => view_collection_id,
+                       'processing_status_text_ssi' => 'not registered',
+                       SolrDocument::FIELD_OBJECT_TYPE => 'collection',
+                       SolrDocument::FIELD_CATKEY_ID => catkey,
+                       SolrDocument::FIELD_APO_ID => [governing_apo_id])
+    end
+    let(:catkey) { nil }
+
+    it 'renders the appropriate buttons' do
+      expect(page).to have_link 'Reindex', href: '/dor/reindex/druid:kv840xx0000'
+      expect(page).to have_link 'Manage release', href: '/items/druid:kv840xx0000/manage_release'
+      expect(page).to have_link 'Add workflow', href: '/items/druid:kv840xx0000/workflows/new'
+      expect(page).to have_link 'Publish'
+      expect(page).to have_link 'Unpublish'
+      expect(page).to have_text 'Manage description'
+      expect(page).to have_link 'Purge', href: '/items/druid:kv840xx0000/purge'
+      expect(page).to have_link 'Download Cocina spreadsheet', href: '/items/druid:kv840xx0000/descriptive.csv'
+      expect(page).to have_link 'Upload Cocina spreadsheet', href: '/items/druid:kv840xx0000/descriptive/edit'
+
+      expect(rendered.css('a').size).to eq 9
+    end
+
+    context 'when the collection has a catkey' do
+      let(:catkey) { 'catkey:1234567' }
+
+      it 'includes the descriptive metadata refresh button without "Manage Serials" and the correct count of actions' do
+        expect(page).to have_link 'Refresh', href: '/items/druid:kv840xx0000/refresh_metadata'
+        expect(page).not_to have_link 'Manage serials', href: '/items/druid:kv840xx0000/serials/edit'
+
+        expect(rendered.css('a').size).to eq 10
+      end
+    end
+  end
+
   describe '#registered_only?' do
     subject { component.send(:registered_only?) }
 


### PR DESCRIPTION
## Why was this change made? 🤔

"Manage serials" should not be an option in "Manage description" pulldown except for items with ckeys

collection objects with ckeys now show this:

![image](https://user-images.githubusercontent.com/96775/163455797-184122ef-353d-49cd-8b87-5af0f791220e.png)


Fixes #3460

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


