### PR TITLE
Handle errors on saving to dor-services-app

### DIFF
--- a/app/jobs/descriptive_metadata_import_job.rb
+++ b/app/jobs/descriptive_metadata_import_job.rb
@@ -18,17 +18,12 @@ class DescriptiveMetadataImportJob < GenericJob
     with_csv_items(csv, name: 'Import descriptive metadata') do |cocina_object, csv_row, success, failure|
       next failure.call('Not authorized') unless ability.can?(:update, cocina_object)
 
-      DescriptionImport.import(csv_row: csv_row).either(
-        lambda { |description|
-          begin
-            Repository.store(cocina_object.new(description: description))
-            success.call('Successfully updated')
-          rescue Cocina::Models::ValidationError => e
-            failure.call(e.message)
-          end
-        },
-        ->(error) { failure.call(error) }
-      )
+      DescriptionImport.import(csv_row: csv_row)
+                       .bind { |description| CocinaValidator.validate_and_save(cocina_object, description: description) }
+                       .either(
+                         ->(_updated) { success.call('Successfully updated') },
+                         ->(messages) { failure.call(messages) }
+                       )
     end
   end
 end

--- a/app/services/description_import.rb
+++ b/app/services/description_import.rb
@@ -26,7 +26,7 @@ class DescriptionImport
 
     Success(Cocina::Models::Description.new(compact_params(params)))
   rescue Cocina::Models::ValidationError => e
-    Failure(e.message)
+    Failure([e.message])
   end
 
   private

--- a/spec/requests/upload_descriptive_csv_spec.rb
+++ b/spec/requests/upload_descriptive_csv_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Upload the descriptive CSV' do
     end
 
     context 'when import was not successful' do
-      let(:result) { Failure("didn't map") }
+      let(:result) { Failure(["didn't map"]) }
 
       it "doesn't updates the descriptive" do
         put "/items/#{druid}/descriptive", params: { data: file }

--- a/spec/requests/upload_structural_csv_spec.rb
+++ b/spec/requests/upload_structural_csv_spec.rb
@@ -37,10 +37,24 @@ RSpec.describe 'Upload the structural CSV' do
 
         let(:result) { Success(cocina_model.structural) }
 
-        it 'updates the structure' do
-          put "/items/#{druid}/structure", params: { csv: file }
-          expect(Repository).to have_received(:store)
-          expect(response).to have_http_status(:see_other)
+        context 'when successfully saved' do
+          it 'updates the structure' do
+            put "/items/#{druid}/structure", params: { csv: file }
+            expect(Repository).to have_received(:store)
+            expect(response).to have_http_status(:see_other)
+          end
+        end
+
+        context 'when save failed' do
+          before do
+            allow(Repository).to receive(:store).and_raise(Dor::Services::Client::UnexpectedResponse)
+          end
+
+          it 'updates the structure' do
+            put "/items/#{druid}/structure", params: { csv: file }
+            expect(response).to have_http_status(:see_other)
+            expect(flash[:error]).to match 'unexpected response from dor-services-app'
+          end
         end
       end
 


### PR DESCRIPTION
Extracted a method for validate_and_save.  This is often something we do at the same time.  This helps us always handle the necessary exceptions while simplifying the controllers.

## Why was this change made? 🤔

Errors were not being handled properly, leading to an exception.


## How was this change tested? 🤨
Test suite

