### PR TITLE
[HOLD] Add a bulk action for Validating descriptive metadata uploads

### DIFF
--- a/app/components/bulk_actions_form_component.rb
+++ b/app/components/bulk_actions_form_component.rb
@@ -49,7 +49,8 @@ class BulkActionsFormComponent < ApplicationComponent
         ['Download checksum report', new_checksum_report_job_path(search_of_druids)],
         ['Download descriptive metadata spreadsheet', new_descriptive_metadata_export_job_path(search_of_druids)],
         ['Upload descriptive metadata spreadsheet', new_descriptive_metadata_import_job_path(search_of_druids)],
-        ['Download descriptive metadata (as MODS)', new_download_mods_job_path(search_of_druids)]
+        ['Download descriptive metadata (as MODS)', new_download_mods_job_path(search_of_druids)],
+        ['Validate Cocina descriptive metadata spreadsheet', new_validate_cocina_descriptive_job_path]
       ]]
     ]
   end

--- a/app/controllers/bulk_actions/validate_cocina_descriptive_jobs_controller.rb
+++ b/app/controllers/bulk_actions/validate_cocina_descriptive_jobs_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module BulkActions
+  class ValidateCocinaDescriptiveJobsController < ApplicationController
+    include CreatesBulkActions
+    self.action_type = 'ValidateCocinaDescriptiveJob'
+  end
+end

--- a/app/controllers/bulk_actions/validate_cocina_descriptive_jobs_controller.rb
+++ b/app/controllers/bulk_actions/validate_cocina_descriptive_jobs_controller.rb
@@ -4,5 +4,13 @@ module BulkActions
   class ValidateCocinaDescriptiveJobsController < ApplicationController
     include CreatesBulkActions
     self.action_type = 'ValidateCocinaDescriptiveJob'
+
+    def job_params
+      { csv_file: normalized_csv }
+    end
+
+    def normalized_csv
+      @normalized_csv ||= CsvUploadNormalizer.read(params[:csv_file].path)
+    end
   end
 end

--- a/app/jobs/validate_cocina_descriptive_job.rb
+++ b/app/jobs/validate_cocina_descriptive_job.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class ValidateCocinaDescriptiveJob < GenericJob
+  queue_as :default
+
+  ##
+  # A job that allows a user to verify that a spreadsheet for descriptive upload is valid
+  # @param [Integer] bulk_action_id GlobalID for a BulkAction object
+  # @param [Hash] params additional parameters that an Argo job may need
+  # @option params [String] :csv_file csv data to validate
+  def perform(bulk_action_id, params)
+    super
+
+    csv = CSV.parse(params[:csv_file], headers: true)
+    with_csv_items(csv, name: 'Validate Cocina descriptive metadata') do |cocina_object, csv_row, success, failure|
+      DescriptionImport.import(csv_row:)
+                       .bind { |description| CocinaValidator.validate(cocina_object, description:) }
+                       .either(
+                         ->(_validated) { success.call('Successfully validated') },
+                         ->(error) { failure.call(error) }
+                       )
+    end
+  end
+end

--- a/app/models/bulk_action.rb
+++ b/app/models/bulk_action.rb
@@ -33,7 +33,8 @@ class BulkAction < ApplicationRecord
                      SetContentTypeJob
                      ManageEmbargoesJob
                      SetCollectionJob
-                     SetRightsJob]
+                     SetRightsJob
+                     ValidateCocinaDescriptiveJob]
             }
 
   after_create :create_output_directory, :create_log_file

--- a/app/views/bulk_actions/validate_cocina_descriptive_jobs/_new.html.erb
+++ b/app/views/bulk_actions/validate_cocina_descriptive_jobs/_new.html.erb
@@ -1,0 +1,17 @@
+<%= form_with url: validate_cocina_descriptive_job_path , class: 'new_bulk_action', data: { turbo_frame: '_top' } do |f| %>
+  <span class='help-block'>
+    Upload descriptive metadata for objects.
+  </span>
+
+  <% if @errors.present? %>
+    <div class="alert alert-danger"><%= @errors.to_sentence %></div>
+  <% end %>
+
+  <div class='mb-3' id="import-csv">
+    <%= f.label :csv_file, 'Upload a CSV or Excel file' %>
+      <br>
+      <small>Each row in the spreadsheet should start with the druid in the first field, followed by the descriptive metadata columns.</small>
+    <%= f.file_field :csv_file, class: 'form-control', accept: '.csv, .xls, .ods, .xlsx' %>
+  </div>
+  <%= render 'bulk_actions/common_fields', f: f %>
+<% end %>

--- a/app/views/bulk_actions/validate_cocina_descriptive_jobs/new.html.erb
+++ b/app/views/bulk_actions/validate_cocina_descriptive_jobs/new.html.erb
@@ -1,0 +1,3 @@
+<turbo-frame id="bulk-action-form">
+  <%= render 'new' %>
+</turbo-frame>

--- a/app/views/bulk_actions/validate_cocina_descriptive_jobs/new.turbo_stream.erb
+++ b/app/views/bulk_actions/validate_cocina_descriptive_jobs/new.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.replace("bulk-action-form", partial: 'new') %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
         resource :descriptive_metadata_import_job, only: %i[new create]
         resource :download_mods_job, only: %i[new create]
         resource :checksum_report_job, only: %i[new create]
+        resource :validate_cocina_descriptive_job, only: %i[new create]
       end
     end
   end

--- a/spec/jobs/validate_cocina_descriptive_job_spec.rb
+++ b/spec/jobs/validate_cocina_descriptive_job_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ValidateCocinaDescriptiveJob, type: :job do
+  let(:bulk_action) { create(:bulk_action, action_type: described_class.to_s) }
+  let(:druids) { %w[druid:bb111cc2222 druid:cc111dd2222] }
+  let(:item1) { build(:dro, id: druids[0]) }
+  let(:item2) { build(:dro, id: druids[1]) }
+  let(:logger) { instance_double(File, puts: nil) }
+
+  before do
+    allow(BulkJobLog).to receive(:open).and_yield(logger)
+    allow(subject).to receive(:bulk_action).and_return(bulk_action)
+    allow(Repository).to receive(:find).with(druids[0]).and_return(item1)
+    allow(Repository).to receive(:find).with(druids[1]).and_return(item2)
+  end
+
+  describe '#perform' do
+    context 'with valid cocina metadata' do
+      let(:csv_file) do
+        [
+          'druid,source_id,title1:value,purl',
+          [item1.externalIdentifier, item1.identification.sourceId, 'new title 1', 'https://purl/bb111cc2222'].join(','),
+          [item2.externalIdentifier, item2.identification.sourceId, 'new title 2', 'https://purl/cc111dd2222'].join(',')
+        ].join("\n")
+      end
+
+      before do
+        subject.perform(bulk_action.id, { csv_file: })
+      end
+
+      it 'updates the descriptive metadata for each item' do
+        expect(bulk_action.druid_count_total).to eq druids.length
+        expect(bulk_action.druid_count_fail).to eq 0
+        expect(bulk_action.druid_count_success).to eq druids.length
+      end
+    end
+
+    context 'with a invalid cocina metadata' do
+      let(:csv_file) do
+        [
+          'druid,source_id,title1.structuredValue1.type,purl',
+          [item1.externalIdentifier, item1.identification.sourceId, 'new title 1', 'https://purl'].join(','),
+          [item2.externalIdentifier, item2.identification.sourceId, 'new title 2', 'https://purl'].join(',')
+        ].join("\n")
+      end
+
+      before do
+        subject.perform(bulk_action.id, { csv_file: })
+      end
+
+      it 'does not update the descriptive metadata for each item' do
+        expect(bulk_action.druid_count_total).to eq druids.length
+        expect(bulk_action.druid_count_fail).to eq druids.length
+        expect(bulk_action.druid_count_success).to eq 0
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Closes #3373 

Adds a bulk action that takes a csv/spreadsheet equivalent to the descriptive metadata upload job without committing changes to the cocina objects.


## How was this change tested? 🤨

New unit test.

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


