### PR TITLE
Fixes tests to that purl matches external identifier.

### DIFF
--- a/spec/jobs/descriptive_metadata_import_job_spec.rb
+++ b/spec/jobs/descriptive_metadata_import_job_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe DescriptiveMetadataImportJob, type: :job do
   let(:csv_file) do
     [
       'druid,source_id,title1:value,purl',
-      [item1.externalIdentifier, item1.identification.sourceId, 'new title 1', 'https://purl'].join(','),
-      [item2.externalIdentifier, item2.identification.sourceId, 'new title 2', 'https://purl'].join(',')
+      [item1.externalIdentifier, item1.identification.sourceId, 'new title 1', "https://purl.stanford.edu/#{item1.externalIdentifier.delete_prefix('druid:')}"].join(','),
+      [item2.externalIdentifier, item2.identification.sourceId, 'new title 2', "https://purl.stanford.edu/#{item2.externalIdentifier.delete_prefix('druid:')}"].join(',')
     ].join("\n")
   end
 
@@ -38,11 +38,11 @@ RSpec.describe DescriptiveMetadataImportJob, type: :job do
       let(:ability) { instance_double(Ability, can?: true) }
 
       let(:expected1) do
-        item1.new(description: item1.description.new(title: [{ value: 'new title 1' }], purl: 'https://purl'))
+        item1.new(description: item1.description.new(title: [{ value: 'new title 1' }], purl: "https://purl.stanford.edu/#{item1.externalIdentifier.delete_prefix('druid:')}"))
       end
 
       let(:expected2) do
-        item2.new(description: item2.description.new(title: [{ value: 'new title 2' }], purl: 'https://purl'))
+        item2.new(description: item2.description.new(title: [{ value: 'new title 2' }], purl: "https://purl.stanford.edu/#{item2.externalIdentifier.delete_prefix('druid:')}"))
       end
 
       it 'updates the descriptive metadata for each item' do
@@ -67,7 +67,7 @@ RSpec.describe DescriptiveMetadataImportJob, type: :job do
       let(:csv_file) do
         [
           'druid,source_id,title1.structuredValue1.type,purl',
-          [item1.externalIdentifier, item1.identification.sourceId, 'new title 1', 'https://purl'].join(',')
+          [item1.externalIdentifier, item1.identification.sourceId, 'new title 1', "https://purl.stanford.edu/#{item1.externalIdentifier.delete_prefix('druid:')}"].join(',')
         ].join("\n")
       end
       let(:ability) { instance_double(Ability, can?: true) }

--- a/spec/jobs/set_rights_job_spec.rb
+++ b/spec/jobs/set_rights_job_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe SetRightsJob, type: :job do
         type: Cocina::Models::ObjectType.book,
         description: {
           title: [{ value: 'Stanford Item' }],
-          purl: "https://purl.stanford.edu/#{druids[0]}"
+          purl: "https://purl.stanford.edu/#{druids[0].delete_prefix('druid:')}"
         },
         externalIdentifier: druids[0],
         access: {
@@ -102,7 +102,7 @@ RSpec.describe SetRightsJob, type: :job do
         type: Cocina::Models::ObjectType.image,
         description: {
           title: [{ value: 'World Item' }],
-          purl: "https://purl.stanford.edu/#{druids[1]}"
+          purl: "https://purl.stanford.edu/#{druids[1].delete_prefix('druid:')}"
         },
         externalIdentifier: druids[1],
         access: {

--- a/spec/services/license_and_rights_statements_setter_spec.rb
+++ b/spec/services/license_and_rights_statements_setter_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe LicenseAndRightsStatementsSetter do
         version: 1,
         description: {
           title: [{ value: 'test' }],
-          purl: 'https://purl.stanford.edu/bc123df4567'
+          purl: 'https://purl.stanford.edu/bc123df4568'
         },
         access: {},
         identification: { sourceId: 'sul:1234' },
@@ -98,7 +98,7 @@ RSpec.describe LicenseAndRightsStatementsSetter do
             type: Cocina::Models::ObjectType.collection,
             description: {
               title: [{ value: 'test' }],
-              purl: 'https://purl.stanford.edu/bc123df4567'
+              purl: 'https://purl.stanford.edu/bc123df4568'
             },
             version: 1,
             identification: { sourceId: 'sul:1234' },


### PR DESCRIPTION
## Why was this change made? 🤔
Prepare for forthcoming cocina models validation.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


