### PR TITLE
Continue after failure to open

### DIFF
--- a/app/jobs/prepare_job.rb
+++ b/app/jobs/prepare_job.rb
@@ -19,8 +19,8 @@ class PrepareJob < GenericJob
     description = params['version_description']
 
     with_items(params[:druids], name: 'Open version') do |cocina_object, success, failure|
-      return failure.call("State isn't openable") unless openable?(cocina_object)
-      return failure.call('Not authorized') unless ability.can?(:update, cocina_object)
+      next failure.call("State isn't openable") unless openable?(cocina_object)
+      next failure.call('Not authorized') unless ability.can?(:update, cocina_object)
 
       VersionService.open(identifier: cocina_object.externalIdentifier,
                           significance:,


### PR DESCRIPTION
## Why was this change made? 🤔

When performing an Open New Object Versions bulk action a failure to open an item should be logged and then the bulk action should continue to the next druid rather than stopping.

Fixes #3505

## How was this change tested? 🤨

Tested with two items in my dev environment, the first of which was not openable and the second which was. I confirmed that the bulk action downloadable log file reflected that the first failed to open and the second succeeded.

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


