### PR TITLE
Upgrade registration form modal to bootstrap 5

### DIFF
--- a/app/javascript/controllers/registration_controller.js
+++ b/app/javascript/controllers/registration_controller.js
@@ -168,11 +168,8 @@ export default class extends Controller {
           displayRequirements : function(text) {
             document.querySelector('#gridErrorModal .modal-body p').innerHTML = text;
 
-            // Bootstrap 5 will be like this:
-            // var myModal = new bootstrap.Modal(document.getElementById('gridErrorModal'), {})
-            // myModal.show()
-
-            $('#gridErrorModal').modal({ show: true })
+            const myModal = new bootstrap.Modal(document.getElementById('gridErrorModal'), {})
+            myModal.show()
           },
           progressDialog : function(numItems) {
             // Bootstrap 5 will be like this:


### PR DESCRIPTION


## Why was this change made? 🤔
The registration form hasn't been displaying errors properly since the bootstrap 5 upgrade


## How was this change tested? 🤨
locally