### PR TITLE
Desc metadata import job additions

### DIFF
--- a/spec/jobs/descriptive_metadata_import_job_spec.rb
+++ b/spec/jobs/descriptive_metadata_import_job_spec.rb
@@ -17,11 +17,14 @@ RSpec.describe DescriptiveMetadataImportJob, type: :job do
     ].join("\n")
   end
 
+  let(:state_service) { instance_double(StateService, allows_modification?: true) }
+
   before do
     allow(BulkJobLog).to receive(:open).and_yield(logger)
     allow(subject).to receive(:bulk_action).and_return(bulk_action)
     allow(Repository).to receive(:find).with(druids[0]).and_return(item1)
     allow(Repository).to receive(:find).with(druids[1]).and_return(item2)
+    allow(StateService).to receive(:new).and_return(state_service)
   end
 
   describe '#perform' do
@@ -49,6 +52,7 @@ RSpec.describe DescriptiveMetadataImportJob, type: :job do
         expect(bulk_action.druid_count_total).to eq druids.length
         expect(Repository).to have_received(:store).with(expected1)
         expect(Repository).to have_received(:store).with(expected2)
+        expect(state_service).to have_received(:allows_modification?).twice
       end
     end
 
@@ -84,6 +88,63 @@ RSpec.describe DescriptiveMetadataImportJob, type: :job do
         expect(bulk_action.druid_count_success).to eq 0
         expect(Repository).not_to have_received(:store)
         expect(Honeybadger).not_to have_received(:notify)
+      end
+    end
+
+    context 'when unchanged' do
+      before do
+        allow(Ability).to receive(:new).and_return(ability)
+        subject.perform(bulk_action.id, { csv_file: })
+      end
+
+      let(:ability) { instance_double(Ability, can?: true) }
+
+      let(:csv_file) do
+        [
+          'druid,source_id,title1:value,purl',
+          [item1.externalIdentifier, item1.identification.sourceId, 'test object', "https://purl.stanford.edu/#{item1.externalIdentifier.delete_prefix('druid:')}"].join(',')
+        ].join("\n")
+      end
+
+      it 'does not update the descriptive metadata' do
+        expect(bulk_action.druid_count_total).to eq 1
+        expect(bulk_action.druid_count_fail).to eq 1
+        expect(bulk_action.druid_count_success).to eq 0
+        expect(Repository).not_to have_received(:store)
+      end
+    end
+
+    context 'when not open for modification' do
+      before do
+        allow(Ability).to receive(:new).and_return(ability)
+        allow(DorObjectWorkflowStatus).to receive(:new).and_return(wf_status)
+        allow(VersionService).to receive(:open).and_return('2')
+        subject.perform(bulk_action.id, { csv_file: })
+      end
+
+      let(:csv_file) do
+        [
+          'druid,source_id,title1:value,purl',
+          [item1.externalIdentifier, item1.identification.sourceId, 'new title 1', "https://purl.stanford.edu/#{item1.externalIdentifier.delete_prefix('druid:')}"].join(',')
+        ].join("\n")
+      end
+
+      let(:ability) { instance_double(Ability, can?: true) }
+
+      let(:state_service) { instance_double(StateService, allows_modification?: false) }
+
+      let(:wf_status) { instance_double(DorObjectWorkflowStatus, can_open_version?: true) }
+
+      let(:expected1) do
+        item1.new(version: 2, description: item1.description.new(title: [{ value: 'new title 1' }], purl: "https://purl.stanford.edu/#{item1.externalIdentifier.delete_prefix('druid:')}"))
+      end
+
+      it 'updates the descriptive metadata for each item' do
+        expect(bulk_action.druid_count_total).to eq 1
+        expect(Repository).to have_received(:store).with(expected1)
+        expect(state_service).to have_received(:allows_modification?)
+        expect(VersionService).to have_received(:open).with(identifier: item1.externalIdentifier, significance: 'minor', opening_user_name: bulk_action.user.to_s,
+                                                            description: 'Descriptive metadata upload')
       end
     end
   end


### PR DESCRIPTION
closes #3522

## Why was this change made? 🤔
Per requirements, aligns with replayable spreadsheet/modsulator.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


