### PR TITLE
Moved checking object state and mutating cocina object version to gen…

### DIFF
--- a/app/jobs/manage_embargoes_job.rb
+++ b/app/jobs/manage_embargoes_job.rb
@@ -17,7 +17,7 @@ class ManageEmbargoesJob < GenericJob
     with_csv_items(csv, name: 'Embargo') do |cocina_object, csv_row, success, failure|
       return failure.call('Not authorized') unless ability.can?(:update, cocina_object)
 
-      open_version_if_needed(cocina_object)
+      cocina_object = open_new_version_if_needed(cocina_object, 'Manage embargo')
       update_embargo(cocina_object, csv_row)
         .either(
           ->(_val) { success.call('Embargo updated') },
@@ -27,12 +27,6 @@ class ManageEmbargoesJob < GenericJob
   end
 
   private
-
-  def open_version_if_needed(cocina_object)
-    state_service = StateService.new(cocina_object)
-    msg = 'Manage embargo'
-    open_new_version(cocina_object.externalIdentifier, cocina_object.version, msg) unless state_service.allows_modification?
-  end
 
   def update_embargo(cocina_object, csv_row)
     validate_required_field(csv_row).bind do

--- a/app/jobs/set_collection_job.rb
+++ b/app/jobs/set_collection_job.rb
@@ -17,11 +17,7 @@ class SetCollectionJob < GenericJob
     with_items(params[:druids], name: 'Set collection') do |cocina_object, success, _failure|
       next failure.call('Not authorized') unless ability.can?(:update, cocina_object)
 
-      state_service = StateService.new(cocina_object)
-      unless state_service.allows_modification?
-        new_version = open_new_version(cocina_object.externalIdentifier, cocina_object.version, version_message(new_collection_ids))
-        cocina_object = cocina_object.new(version: new_version.to_i)
-      end
+      cocina_object = open_new_version_if_needed(cocina_object, version_message(new_collection_ids))
 
       change_set = ItemChangeSet.new(cocina_object)
       change_set.validate(collection_ids: new_collection_ids)

--- a/app/jobs/set_governing_apo_job.rb
+++ b/app/jobs/set_governing_apo_job.rb
@@ -17,8 +17,7 @@ class SetGoverningApoJob < GenericJob
     with_items(params[:druids], name: 'Set governing APO') do |cocina_item, success, failure|
       next failure.call("user not authorized to move item to #{new_apo_id}") unless ability.can?(:manage_governing_apo, cocina_item, new_apo_id)
 
-      state_service = StateService.new(cocina_item)
-      open_new_version(cocina_item.externalIdentifier, cocina_item.version, 'Set new governing APO') unless state_service.allows_modification?
+      cocina_item = open_new_version_if_needed(cocina_item, 'Set new governing APO')
 
       change_set = ItemChangeSet.new(cocina_item)
       change_set.validate(admin_policy_id: new_apo_id)

--- a/app/jobs/set_source_ids_csv_job.rb
+++ b/app/jobs/set_source_ids_csv_job.rb
@@ -36,11 +36,7 @@ class SetSourceIdsCsvJob < GenericJob
       return
     end
 
-    state_service = StateService.new(cocina_object)
-    unless state_service.allows_modification?
-      new_version = open_new_version(cocina_object.externalIdentifier, cocina_object.version, version_message(source_id))
-      cocina_object = cocina_object.new(version: new_version.to_i)
-    end
+    cocina_object = open_new_version_if_needed(cocina_object, version_message(source_id))
 
     change_set_class = cocina_object.collection? ? CollectionChangeSet : ItemChangeSet
     change_set = change_set_class.new(cocina_object)

--- a/spec/jobs/manage_embargoes_job_spec.rb
+++ b/spec/jobs/manage_embargoes_job_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ManageEmbargoesJob do
     allow(StateService).to receive(:new).and_return(state_service)
     allow(subject.ability).to receive(:can?).and_return(true)
     allow(BulkJobLog).to receive(:open).and_yield(buffer)
-    allow(subject).to receive(:open_new_version)
+    allow(subject).to receive(:open_new_version).and_return(item1.new(version: 2), item2.new(version: 2), item3.new(version: 2))
   end
 
   describe '#perform' do

--- a/spec/jobs/set_collection_job_spec.rb
+++ b/spec/jobs/set_collection_job_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe SetCollectionJob do
       log_name: 'tmp/set_collection_job_log.txt'
     )
   end
+  let(:cocina1) do
+    build(:dro, id: druids[0])
+  end
+  let(:cocina2) do
+    build(:dro, id: druids[1])
+  end
 
   before do
     allow(subject).to receive(:bulk_action).and_return(bulk_action)
@@ -35,12 +41,6 @@ RSpec.describe SetCollectionJob do
         user:,
         new_collection_id:
       }.with_indifferent_access
-    end
-    let(:cocina1) do
-      build(:dro, id: druids[0])
-    end
-    let(:cocina2) do
-      build(:dro, id: druids[1])
     end
     let(:object_client1) { instance_double(Dor::Services::Client::Object, find: cocina1, update: true) }
     let(:object_client2) { instance_double(Dor::Services::Client::Object, find: cocina2, update: true) }
@@ -79,7 +79,7 @@ RSpec.describe SetCollectionJob do
           let(:state_service) { instance_double(StateService, allows_modification?: false) }
 
           before do
-            allow(job).to receive(:open_new_version).and_return('3')
+            allow(job).to receive(:open_new_version).and_return(cocina1.new(version: 2))
           end
 
           it 'opens a new version sets the new collection on an object' do

--- a/spec/jobs/set_source_ids_csv_job_spec.rb
+++ b/spec/jobs/set_source_ids_csv_job_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe SetSourceIdsCsvJob do
         let(:state_service) { instance_double(StateService, allows_modification?: false) }
 
         before do
-          allow(job).to receive(:open_new_version).and_return('3')
+          allow(job).to receive(:open_new_version).and_return(item1.new(version: 2), item2.new(version: 2), item3.new(version: 2))
           job.perform(bulk_action.id,
                       csv_file:,
                       groups:,


### PR DESCRIPTION
…eric_job methods.

## Why was this change made? 🤔
* Reduce code duplication
* Encourage mutation of cocina object when version changed.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


