### PR TITLE
close objects after bulk desc metadata import job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 .*.swp
 config/certs
 coverage/
-db/*.sqlite3
+db/*.sqlite3*
 examples.txt
 
 /public/assets

--- a/app/jobs/descriptive_metadata_import_job.rb
+++ b/app/jobs/descriptive_metadata_import_job.rb
@@ -22,9 +22,10 @@ class DescriptiveMetadataImportJob < GenericJob
       DescriptionImport.import(csv_row:)
                        .bind { |description| validate_changed(cocina_object, description) }
                        .bind { |description| open_version(cocina_object, description) }
-                       .bind { |description, new_cocina_object| CocinaValidator.validate_and_save(new_cocina_object, description:) }
-                       .bind { |new_cocina_object| close_version(new_cocina_object) }
-                       .either(
+                       .bind do |description, new_cocina_object|
+                         CocinaValidator.validate_and_save(new_cocina_object, description:)
+                         close_version(new_cocina_object)
+                       end.either(
                          ->(_updated) { success.call('Successfully updated') },
                          ->(messages) { failure.call(messages.to_sentence) }
                        )

--- a/app/jobs/descriptive_metadata_import_job.rb
+++ b/app/jobs/descriptive_metadata_import_job.rb
@@ -23,6 +23,7 @@ class DescriptiveMetadataImportJob < GenericJob
                        .bind { |description| validate_changed(cocina_object, description) }
                        .bind { |description| open_version(cocina_object, description) }
                        .bind { |description, new_cocina_object| CocinaValidator.validate_and_save(new_cocina_object, description:) }
+                       .bind { VersionService.close(identifier: cocina_object.externalIdentifier) }
                        .either(
                          ->(_updated) { success.call('Successfully updated') },
                          ->(messages) { failure.call(messages.to_sentence) }

--- a/app/jobs/descriptive_metadata_import_job.rb
+++ b/app/jobs/descriptive_metadata_import_job.rb
@@ -22,10 +22,9 @@ class DescriptiveMetadataImportJob < GenericJob
       DescriptionImport.import(csv_row:)
                        .bind { |description| validate_changed(cocina_object, description) }
                        .bind { |description| open_version(cocina_object, description) }
-                       .bind do |description, new_cocina_object|
-                         CocinaValidator.validate_and_save(new_cocina_object, description:)
-                         close_version(new_cocina_object)
-                       end.either(
+                       .bind { |description, new_cocina_object| validate_and_save(new_cocina_object, description) }
+                       .bind { |new_cocina_object| close_version(new_cocina_object) }
+                       .either(
                          ->(_updated) { success.call('Successfully updated') },
                          ->(messages) { failure.call(messages.to_sentence) }
                        )
@@ -46,6 +45,13 @@ class DescriptiveMetadataImportJob < GenericJob
     Success([description, cocina_object])
   rescue RuntimeError => e
     Failure([e.message])
+  end
+
+  def validate_and_save(cocina_object, description)
+    result = CocinaValidator.validate_and_save(cocina_object, description:)
+    return Success(cocina_object) if result.success?
+
+    Failure(["validate_and_save failed for #{cocina_object.externalIdentifier}"])
   end
 
   def close_version(cocina_object)

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -10,6 +10,7 @@ class Repository
     maybe_load_cocina(id)
   end
 
+  # @return [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy,NilModel] the updated cocina model instance
   # @raises [Dor::Services::Client::BadRequestError] when the server doesn't accept the request
   def self.store(cocina_object)
     object_client = Dor::Services::Client.object(cocina_object.externalIdentifier)


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3524 - close objects after running bulk desc metadata import job.  Also delete a tmp db file that was inadvertently added by #3534 and update gitignore to prevent from happening again.

Note: this will only close objects for which an update actually occurred.  It also assumes that any object updated is currently open, which now must be true (as we will open before applying update, if not already open). 


~~HOLD because:~~
~~Andrew tested and approved on May 13, but after rebasing from main I noticed one test started failing (likely due to this change: https://github.com/sul-dlss/argo/commit/686655e43c2f5149354fdcb56aece5638308e59c)~~

~~I think what is happening in that test is that the validation is failing, but the object is still getting closed, and so the final result is "success", which is probably not correct.  Not sure why it passed before.~~

## How was this change tested? 🤨

Updated tests.