### PR TITLE
use object title from solr instead of label from solr

### DIFF
--- a/app/models/track_sheet.rb
+++ b/app/models/track_sheet.rb
@@ -93,9 +93,8 @@ class TrackSheet
   # @return [Array<Array<String>>] Complex array suitable for pdf.table()
   def doc_to_table(doc)
     table_data = []
-    labels = doc[SolrDocument::FIELD_LABEL]
-    label = labels.nil? || labels.empty? ? '' : labels.first
-    label = label[0..110] + '...' if label.length > 110
+    labels = doc[SolrDocument::FIELD_TITLE]
+    label = labels.blank? ? '' : labels.first.truncate(110)
     table_data.push(['Object Label:', label])
     table_data.push(['Project Name:', doc['project_tag_ssim'].to_s]) if doc['project_tag_ssim']
 

--- a/app/models/track_sheet.rb
+++ b/app/models/track_sheet.rb
@@ -91,7 +91,8 @@ class TrackSheet
 
   # @param [Hash] doc Solr document or to_solr Hash
   # @return [Array<Array<String>>] Complex array suitable for pdf.table()
-  def doc_to_table(doc)
+  def doc_to_table(solr_doc)
+    doc = solr_doc.with_indifferent_access # solr doc always has string keys, SolrDocument::FIELDS can be strings or symbols
     table_data = []
     labels = doc[SolrDocument::FIELD_TITLE]
     label = labels.blank? ? '' : labels.first.truncate(110)

--- a/spec/models/track_sheet_spec.rb
+++ b/spec/models/track_sheet_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe TrackSheet do
 
     before do
       allow(SearchService).to receive(:query)
-        .with('id:"druid:xb482ww9999"', rows: 1)
+        .with("id:\"druid:#{druid}\"", rows: 1)
         .and_return(response)
     end
 
@@ -31,7 +31,7 @@ RSpec.describe TrackSheet do
         allow(Argo::Indexer).to receive(:reindex_druid_remotely)
 
         allow(SearchService).to receive(:query)
-          .with('id:"druid:xb482ww9999"', rows: 1)
+          .with("id:\"druid:#{druid}\"", rows: 1)
           .and_return(response, second_response)
       end
 
@@ -40,6 +40,166 @@ RSpec.describe TrackSheet do
 
       it 'reindexes and and tries again' do
         expect(call).to eq solr_doc
+      end
+    end
+  end
+
+  # NOTE: the test expectations here use "include" instead of "eq" because the tracking sheet adds a timestamp to the array, which can be flaky to test against
+  describe '#doc_to_table' do
+    subject(:call) { instance.send(:doc_to_table, solr_doc) }
+
+    let(:base_solr_doc) do
+      {
+        'obj_label_tesim' => ['bogus label'] # the fedora label
+      }
+    end
+
+    context 'normal length title' do
+      let(:solr_doc) do
+        base_solr_doc.merge(
+          {
+            'sw_display_title_tesim' => ['Correct title'] # the cocina title
+          }
+        )
+      end
+
+      it 'builds the table for the solr doc with the correct title' do
+        expect(call).to include(
+          [
+            'Object Label:',
+            'Correct title' # we get the cocina title out!
+          ]
+        )
+      end
+    end
+
+    context 'really long title' do
+      let(:solr_doc) do
+        base_solr_doc.merge(
+          {
+            'sw_display_title_tesim' => ['Stanford University. School of Engineeering Roger Howe Professorship: Stanford (Calif.), 2010-01-21.  And more stuff goes here']
+          }
+        )
+      end
+
+      it 'builds the table for the solr doc with a truncated title' do
+        expect(call).to include(
+          [
+            'Object Label:',
+            'Stanford University. School of Engineeering Roger Howe Professorship: Stanford (Calif.), 2010-01-21.  And m...'
+          ]
+        )
+      end
+    end
+
+    context 'no title' do
+      let(:solr_doc) do
+        base_solr_doc.merge({
+                              'sw_display_title_tesim' => ['']
+
+                            })
+      end
+
+      it 'builds the table for the solr doc with a blank title' do
+        expect(call).to include(
+          [
+            'Object Label:',
+            ''
+          ]
+        )
+      end
+    end
+
+    context 'with a project name' do
+      let(:solr_doc) do
+        base_solr_doc.merge(
+          {
+            'project_tag_ssim' => ['School of Engineering photograph collection']
+          }
+        )
+      end
+
+      it 'adds the project name' do
+        expect(call).to include(
+          [
+            'Project Name:',
+            '["School of Engineering photograph collection"]'
+          ]
+        )
+      end
+    end
+
+    context 'with tags' do
+      let(:solr_doc) do
+        base_solr_doc.merge(
+          {
+            'tag_ssim' => [
+              'Some : First : Tag',
+              'Some : Second : Tag',
+              'Project : Ignored'
+            ]
+          }
+        )
+      end
+
+      it 'adds the tags, ignoring a project tag' do
+        expect(call).to include(
+          [
+            'Tags:',
+            "Some : First : Tag\nSome : Second : Tag"
+          ]
+        )
+      end
+    end
+
+    context 'with a catkey' do
+      let(:solr_doc) do
+        base_solr_doc.merge({
+                              'catkey_id_ssim' => ['catkey123']
+                            })
+      end
+
+      it 'adds the catkey' do
+        expect(call).to include(
+          [
+            'Catkey:',
+            'catkey123'
+          ]
+        )
+      end
+    end
+
+    context 'with a source_id' do
+      let(:solr_doc) do
+        base_solr_doc.merge({
+                              'source_id_ssim' => ['source:123']
+                            })
+      end
+
+      it 'adds the catkey' do
+        expect(call).to include(
+          [
+            'Source ID:',
+            'source:123'
+          ]
+        )
+      end
+    end
+
+    context 'with a barcode' do
+      let(:solr_doc) do
+        base_solr_doc.merge({
+                              'barcode_id_ssim' => ['barcode123']
+                            })
+      end
+
+      it 'adds the catkey' do
+        expect(call).to include(
+          [
+            'Barcode:',
+            'barcode123'
+          ]
+        )
       end
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3547: use the same field we use to show object titles in Argo in the tracking sheets (instead of the solr field having the Fedora label).

See for the Solr field name we are indexing to: https://github.com/sul-dlss/dor_indexing_app/blob/main/app/indexers/descriptive_metadata_indexer.rb#L19

and the method used to generate (using `Cocina::Models::Builders::TitleBuilder`):

https://github.com/sul-dlss/dor_indexing_app/blob/main/app/indexers/descriptive_metadata_indexer.rb#L54

And the field name defined in Argo that we will now use in the tracking sheet to get this title: https://github.com/sul-dlss/argo/blob/main/app/models/solr_document.rb#L24


## How was this change tested? 🤨

It was not tested.


