### PR TITLE
disable/enable tracking sheet button based on registration

### DIFF
--- a/app/javascript/controllers/registration_controller.js
+++ b/app/javascript/controllers/registration_controller.js
@@ -202,6 +202,7 @@ export default class extends Controller {
         $('#data').jqGrid('setColProp','barcode_id',{ editable: edit });
         $('#data').jqGrid('setColProp','druid',{ editable: edit }); //, formatter: edit ? null : druidFormatter });
         $('#data').jqGrid('setColProp','label',{ editable: edit });
+        document.querySelector("#tracking-sheet-btn").disabled = edit;
       }
 
       stopEditing(autoSave) {

--- a/app/javascript/controllers/registration_controller.js
+++ b/app/javascript/controllers/registration_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "stimulus"
 import DorRegistration from '../registration/register'
 
 export default class extends Controller {
-  static targets = ["gridShowLabel", "textShowLabel"]
+  static targets = ["gridShowLabel", "textShowLabel", "trackingSheetButton"]
 
     connect() {
         this.rc = this.createRegistrationContext()
@@ -202,7 +202,7 @@ export default class extends Controller {
         $('#data').jqGrid('setColProp','barcode_id',{ editable: edit });
         $('#data').jqGrid('setColProp','druid',{ editable: edit }); //, formatter: edit ? null : druidFormatter });
         $('#data').jqGrid('setColProp','label',{ editable: edit });
-        document.querySelector("#tracking-sheet-btn").disabled = edit;
+        this.trackingSheetButtonTarget.disabled = edit;
       }
 
       stopEditing(autoSave) {

--- a/app/javascript/registration/grid.js
+++ b/app/javascript/registration/grid.js
@@ -3,7 +3,6 @@ export function gridContext() {
 
   var statusFormatter = function(val, opts, rowObj) {
     if (val in $t.statusIcons) {
-      console.error("hey")
       var result = '<span class="' + $t.statusIcons[val] + '" title="' +
         (rowObj.error||val)+'" aria-hidden="true"></span>';
       if (rowObj.druid) {

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -90,7 +90,7 @@
     <div class="float-end">
       <button class="btn btn-link" data-action="click->registration#resetDialog">Reset</button>
 
-      <button id="tracking-sheet-btn" disabled class="btn btn-outline-primary" data-action="click->registration#trackingSheet">
+      <button data-registration-target="trackingSheetButton" disabled class="btn btn-outline-primary" data-action="click->registration#trackingSheet">
         Tracking sheets
       </button>
     </div>

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -90,7 +90,7 @@
     <div class="float-end">
       <button class="btn btn-link" data-action="click->registration#resetDialog">Reset</button>
 
-      <button class="btn btn-outline-primary" data-action="click->registration#trackingSheet">
+      <button id="tracking-sheet-btn" disabled class="btn btn-outline-primary" data-action="click->registration#trackingSheet">
         Tracking sheets
       </button>
     </div>


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3549 - the tracking sheet button starts out disabled, and then gets enabled once registration is complete (and gets re-enabled if the user resets the form).

~~UPDATE: it starts as disabled, but it is possible for it be re-enabled when it shouldn't be ... briefly looking into a better way of enabling based on there being all successful registrations in the grid~~

## How was this change tested? 🤨

Localhost browser