### PR TITLE
Uses cocina model return from version open.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ gem 'openapi_parser', '< 1.0'
 # Stanford related gems
 gem 'blacklight', '~> 7.20'
 gem 'blacklight-hierarchy', '~> 6.0'
-gem 'dor-services-client', '~> 9.0'
+gem 'dor-services-client', '~> 10.0'
 gem 'dor-workflow-client', '~> 4.0'
 gem 'druid-tools'
 gem 'mods_display', '~> 1.0.0.alpha1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,7 +180,7 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.4.0)
-    dor-services-client (9.1.1)
+    dor-services-client (10.0.0)
       activesupport (>= 4.2, < 8)
       cocina-models (~> 0.75.0)
       deprecation
@@ -604,7 +604,7 @@ DEPENDENCIES
   devise
   devise-remote-user (~> 1.0)
   dlss-capistrano
-  dor-services-client (~> 9.0)
+  dor-services-client (~> 10.0)
   dor-workflow-client (~> 4.0)
   druid-tools
   dry-monads

--- a/app/jobs/generic_job.rb
+++ b/app/jobs/generic_job.rb
@@ -155,19 +155,24 @@ class GenericJob < ApplicationJob
     bulk_action.update(druid_count_total: count)
   end
 
-  # @returns [Cocina::Models::DRO|Collection|AdminPolicy] cocina object with the new version
+  # Opens a new minor version of the provided cocina object.
+  # @param [Cocina::Models::DROWithMetadata|CollectionWithMetadata|AdminPolicyWithMetadata]
+  # @param [String] description for new version
+  # @returns [Cocina::Models::DROWithMetadata|CollectionWithMetadata|AdminPolicyWithMetadata] cocina object with the new version
   def open_new_version(cocina_object, description)
     wf_status = DorObjectWorkflowStatus.new(cocina_object.externalIdentifier, version: cocina_object.version)
     raise 'Unable to open new version' unless wf_status.can_open_version?
 
-    new_version = VersionService.open(identifier: cocina_object.externalIdentifier,
-                                      significance: 'minor',
-                                      description:,
-                                      opening_user_name: bulk_action.user.to_s)
-    cocina_object.new(version: new_version.to_i)
+    VersionService.open(identifier: cocina_object.externalIdentifier,
+                        significance: 'minor',
+                        description:,
+                        opening_user_name: bulk_action.user.to_s)
   end
 
-  # @returns [Cocina::Models::DRO|Collection|AdminPolicy] cocina object with the new version
+  # Opens a new minor version of the provided cocina object unless the object is already open for modification.
+  # @param [Cocina::Models::DROWithMetadata|CollectionWithMetadata|AdminPolicyWithMetadata]
+  # @param [String] description for new version
+  # @returns [Cocina::Models::DROWithMetadata|CollectionWithMetadata|AdminPolicyWithMetadata] cocina object with the new/existing version
   def open_new_version_if_needed(cocina_object, description)
     state_service = StateService.new(cocina_object)
     return cocina_object if state_service.allows_modification?

--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -3,7 +3,7 @@
 # Encapsulates all version-related functionality
 class VersionService
   class << self
-    # @returns [String] the current version
+    # @returns [Cocina::Models::DROWithMetadata|CollectionWithMetadata|AdminPolicyWithMetadata] cocina object with updated version
     def open(identifier:, **options)
       new(identifier:).open(**options)
     end

--- a/spec/jobs/descriptive_metadata_import_job_spec.rb
+++ b/spec/jobs/descriptive_metadata_import_job_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe DescriptiveMetadataImportJob, type: :job do
       before do
         allow(Ability).to receive(:new).and_return(ability)
         allow(DorObjectWorkflowStatus).to receive(:new).and_return(wf_status)
-        allow(VersionService).to receive(:open).and_return('2')
+        allow(VersionService).to receive(:open).and_return(item1.new(version: 2))
         subject.perform(bulk_action.id, { csv_file: })
       end
 

--- a/spec/jobs/generic_job_spec.rb
+++ b/spec/jobs/generic_job_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe GenericJob do
     let(:log) { double('log') }
     let(:webauth) { OpenStruct.new('privgroup' => 'dorstuff', 'login' => 'someuser') }
     let(:client) { instance_double(Dor::Services::Client::Object, version: version_client) }
-    let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, open: '2') }
-    let(:cocina_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, version:, new: new_cocina_object) }
+    let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, open: new_cocina_object) }
+    let(:cocina_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, version:) }
     let(:new_cocina_object) { instance_double(Cocina::Models::DRO) }
 
     before do
@@ -78,8 +78,6 @@ RSpec.describe GenericJob do
         description: 'Set new governing APO',
         opening_user_name: subject.bulk_action.user.to_s
       )
-
-      expect(cocina_object).to have_received(:new).with(version: 2)
     end
 
     it 'does not open a new version if rejected by the workflow status' do

--- a/spec/jobs/set_license_and_rights_statements_job_spec.rb
+++ b/spec/jobs/set_license_and_rights_statements_job_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe SetLicenseAndRightsStatementsJob, type: :job do
       allow(DorObjectWorkflowStatus).to receive(:new).and_return(wf_status)
       allow(CollectionChangeSetPersister).to receive(:update)
       allow(ItemChangeSetPersister).to receive(:update)
-      allow(VersionService).to receive(:open)
+      allow(VersionService).to receive(:open).and_return(cocina_object)
       allow(StateService).to receive(:new).and_return(state_service)
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔
The cocina model returned from version open has the new version and etag. This allows correct optimistic lock handling.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


