### PR TITLE
Change SetLicenseAndRightsStatementsJob to handle *WithMetadata objects.

### DIFF
--- a/app/jobs/set_license_and_rights_statements_job.rb
+++ b/app/jobs/set_license_and_rights_statements_job.rb
@@ -46,9 +46,9 @@ class SetLicenseAndRightsStatementsJob < GenericJob
 
   def change_set_class(cocina_object)
     case cocina_object
-    when Cocina::Models::DRO
+    when Cocina::Models::DROWithMetadata
       ItemChangeSet
-    when Cocina::Models::Collection
+    when Cocina::Models::CollectionWithMetadata
       CollectionChangeSet
     end
   end

--- a/spec/jobs/set_license_and_rights_statements_job_spec.rb
+++ b/spec/jobs/set_license_and_rights_statements_job_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe SetLicenseAndRightsStatementsJob, type: :job do
       }.with_indifferent_access
     end
     let(:cocina_object) do
-      Cocina::Models::DRO.new(
+      cocina_object = Cocina::Models::DRO.new(
         externalIdentifier: 'druid:bc123df4568',
         label: 'test',
         type: Cocina::Models::ObjectType.object,
@@ -35,6 +35,7 @@ RSpec.describe SetLicenseAndRightsStatementsJob, type: :job do
         structural: {},
         administrative: { hasAdminPolicy: 'druid:bc123df4569' }
       )
+      Cocina::Models.with_metadata(cocina_object, 'abc123')
     end
     let(:copyright_statement) { 'the new hotness' }
     let(:state_service) { instance_double(StateService, allows_modification?: allows_modification) }
@@ -92,7 +93,7 @@ RSpec.describe SetLicenseAndRightsStatementsJob, type: :job do
 
       context 'with a collection' do
         let(:cocina_object) do
-          Cocina::Models::Collection.new(
+          cocina_object = Cocina::Models::Collection.new(
             externalIdentifier: 'druid:bc123df4568',
             label: 'test',
             type: Cocina::Models::ObjectType.collection,
@@ -105,6 +106,7 @@ RSpec.describe SetLicenseAndRightsStatementsJob, type: :job do
             access: {},
             administrative: { hasAdminPolicy: 'druid:bc123df4569' }
           )
+          Cocina::Models.with_metadata(cocina_object, 'abc123')
         end
 
         it 'updates via collection change set persister' do


### PR DESCRIPTION
closes #3559

## Why was this change made? 🤔
So that the job can choose the correct change set.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


