### PR TITLE
Improve cocina model stubbing for specs.

### DIFF
--- a/lib/cocina/models/factories.rb
+++ b/lib/cocina/models/factories.rb
@@ -11,13 +11,20 @@ module Cocina
       end
 
       def self.supported_type?(type)
-        %i[dro collection admin_policy].include?(type)
+        %i[dro collection admin_policy dro_with_metadata collection_with_metadata admin_policy_with_metadata].include?(type)
       end
+
+      WITH_METADATA_SUFFIX = '_with_metadata'
 
       def self.build(type, attributes = {})
         raise "Unsupported factory type #{type}" unless supported_type?(type)
 
-        public_send("build_#{type}".to_sym, attributes)
+        build_type = type.to_s.delete_suffix(WITH_METADATA_SUFFIX)
+
+        fixture = public_send("build_#{build_type}".to_sym, attributes)
+        return fixture unless type.ends_with?(WITH_METADATA_SUFFIX)
+
+        Cocina::Models.with_metadata(fixture, 'abc123')
       end
 
       DRO_DEFAULTS = {

--- a/spec/features/add_workflow_to_item_spec.rb
+++ b/spec/features/add_workflow_to_item_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Add a workflow to an item' do
                     metadata: metadata_client,
                     version: version_client)
   end
-  let(:cocina_model) { build(:dro, id: item_id) }
+  let(:cocina_model) { build(:dro_with_metadata, id: item_id) }
   let(:item_id) { 'druid:bg444xg6666' }
   let(:blacklight_config) { CatalogController.blacklight_config }
   let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }

--- a/spec/features/apo_displays_spec.rb
+++ b/spec/features/apo_displays_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Viewing an Admin policy' do
     ]
   end
   let(:cocina_model) do
-    build(:admin_policy)
+    build(:admin_policy_with_metadata)
   end
 
   let(:solr_doc) { { id: apo_druid } }

--- a/spec/features/bulk_jobs_spec.rb
+++ b/spec/features/bulk_jobs_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Bulk jobs view', js: true do
   let(:blacklight_config) { CatalogController.blacklight_config }
   let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
   let(:object_client) { instance_double(Dor::Services::Client::Object, metadata: nil) }
-  let(:cocina_model) { build(:admin_policy, id: apo_id) }
+  let(:cocina_model) { build(:admin_policy_with_metadata, id: apo_id) }
   let(:apo_id) { 'druid:hv992yv2222' }
 
   context 'on the page with the list of bulk jobs' do

--- a/spec/features/collection_manage_release_spec.rb
+++ b/spec/features/collection_manage_release_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Collection manage release' do
                     version: version_client)
   end
   let(:cocina_model) do
-    build(:collection, id: collection_id)
+    build(:collection_with_metadata, id: collection_id)
   end
   let(:uber_apo_id) { 'druid:hv992ry2431' }
   let(:collection_id) { 'druid:gg232vv1111' }

--- a/spec/features/create_collection_spec.rb
+++ b/spec/features/create_collection_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Add collection' do
   let(:solr_client) { instance_double(RSolr::Client, get: result) }
   let(:result) { { 'response' => { 'numFound' => 1 } } }
   let(:apo_id) { 'druid:vt333hq2222' }
-  let(:cocina_model) { instance_double(Cocina::Models::AdminPolicy, label: 'hey', externalIdentifier: apo_id) }
+  let(:cocina_model) { instance_double(Cocina::Models::AdminPolicyWithMetadata, label: 'hey', externalIdentifier: apo_id) }
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
 
   describe 'when collection catkey is provided', js: true do

--- a/spec/features/enable_buttons_spec.rb
+++ b/spec/features/enable_buttons_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Enable buttons' do
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
   let(:metadata_client) { instance_double(Dor::Services::Client::Metadata, datastreams: []) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: [], current: 1) }
-  let(:cocina_model) { build(:dro, id: item_id) }
+  let(:cocina_model) { build(:dro_with_metadata, id: item_id) }
   let(:object_client) do
     instance_double(Dor::Services::Client::Object,
                     find: cocina_model,

--- a/spec/features/item_catkey_change_spec.rb
+++ b/spec/features/item_catkey_change_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Item catkey change' do
     let(:blacklight_config) { CatalogController.blacklight_config }
     let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
     let(:druid) { 'druid:kv840xx0000' }
-    let(:cocina_model) { build(:dro, id: druid) }
+    let(:cocina_model) { build(:dro_with_metadata, id: druid) }
     let(:state_service) { instance_double(StateService, allows_modification?: true) }
     let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
     let(:metadata_client) { instance_double(Dor::Services::Client::Metadata, datastreams: []) }

--- a/spec/features/item_registration_spec.rb
+++ b/spec/features/item_registration_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Item registration page', js: true do
   let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
   let(:cocina_model) do
-    build(:admin_policy, registration_workflow: %w[dpgImageWF goobiWF])
+    build(:admin_policy_with_metadata, registration_workflow: %w[dpgImageWF goobiWF])
   end
 
   before do

--- a/spec/features/item_source_id_change_spec.rb
+++ b/spec/features/item_source_id_change_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Item source id change' do
     let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
     let(:druid) { 'druid:kv840xx0000' }
     let(:cocina_model) do
-      build(:dro, id: druid)
+      build(:dro_with_metadata, id: druid)
     end
     let(:state_service) { instance_double(StateService, allows_modification?: true) }
     let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }

--- a/spec/features/item_view_spec.rb
+++ b/spec/features/item_view_spec.rb
@@ -83,7 +83,10 @@ RSpec.describe 'Item view', js: true do
                           events: events_client,
                           metadata: metadata_client)
         end
-        let(:cocina_model) { Cocina::Models::DRO.new(props) }
+        let(:cocina_model) do
+          model = Cocina::Models::DRO.new(props)
+          Cocina::Models.with_metadata(model, 'abc123')
+        end
 
         let(:props) do
           {
@@ -300,7 +303,7 @@ RSpec.describe 'Item view', js: true do
   end
 
   context 'for an adminPolicy' do
-    let(:cocina_model) { instance_double(Cocina::Models::AdminPolicy, administrative:, as_json: {}) }
+    let(:cocina_model) { instance_double(Cocina::Models::AdminPolicyWithMetadata, administrative:, as_json: {}) }
     let(:administrative) { instance_double(Cocina::Models::AdminPolicyAdministrative) }
     let(:id) { 'druid:qv778ht9999' }
 

--- a/spec/forms/apo_form_spec.rb
+++ b/spec/forms/apo_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ApoForm do
   let(:search_service) { instance_double(Blacklight::SearchService) }
   let(:instance) { described_class.new(apo, search_service:) }
   let(:apo) do
-    build(:admin_policy, id: 'druid:zt570qh4444', title: 'Stored title').new(administrative:)
+    build(:admin_policy_with_metadata, id: 'druid:zt570qh4444', title: 'Stored title').new(administrative:)
   end
 
   let(:administrative) do

--- a/spec/forms/serials_form_spec.rb
+++ b/spec/forms/serials_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SerialsForm do
   let(:instance) { described_class.new(cocina_item) }
   let(:druid) { 'druid:bc123df4567' }
   let(:purl) { 'https://purl.stanford.edu/bc123df4567' }
-  let(:cocina_item) { build(:dro, id: druid).new(description:) }
+  let(:cocina_item) { build(:dro_with_metadata, id: druid).new(description:) }
 
   describe 'loading from cocina' do
     context 'when the number is before the title' do
@@ -76,7 +76,7 @@ RSpec.describe SerialsForm do
 
       context 'when part_number is set' do
         let(:expected) do
-          build(:dro, id: druid).new(description:
+          build(:dro_with_metadata, id: druid).new(description:
             {
               title: [
                 {
@@ -104,19 +104,19 @@ RSpec.describe SerialsForm do
 
       context 'when part_number2 is set' do
         let(:expected) do
-          build(:dro, id: druid).new(description: {
-                                       title: [
-                                         {
-                                           structuredValue: [
-                                             { value: 'My Serial', type: 'main title' },
-                                             { value: 'samurai', type: 'part name' },
-                                             { value: '7', type: 'part number' }
-                                           ]
-                                         }
-                                       ],
-                                       note: [{ value: 'something', type: 'date/sequential designation' }],
-                                       purl:
-                                     })
+          build(:dro_with_metadata, id: druid).new(description: {
+                                                     title: [
+                                                       {
+                                                         structuredValue: [
+                                                           { value: 'My Serial', type: 'main title' },
+                                                           { value: 'samurai', type: 'part name' },
+                                                           { value: '7', type: 'part number' }
+                                                         ]
+                                                       }
+                                                     ],
+                                                     note: [{ value: 'something', type: 'date/sequential designation' }],
+                                                     purl:
+                                                   })
         end
 
         before do
@@ -150,20 +150,20 @@ RSpec.describe SerialsForm do
 
       context 'when part_number is set' do
         let(:expected) do
-          build(:dro, id: druid).new(description: {
-                                       title: [
-                                         {
-                                           structuredValue: [
-                                             { type: 'subtitle', value: '99' },
-                                             { type: 'main title', value: 'Frog' },
-                                             { value: '7', type: 'part number' },
-                                             { value: 'samurai', type: 'part name' }
-                                           ]
-                                         }
-                                       ],
-                                       note: [{ value: 'something', type: 'date/sequential designation' }],
-                                       purl:
-                                     })
+          build(:dro_with_metadata, id: druid).new(description: {
+                                                     title: [
+                                                       {
+                                                         structuredValue: [
+                                                           { type: 'subtitle', value: '99' },
+                                                           { type: 'main title', value: 'Frog' },
+                                                           { value: '7', type: 'part number' },
+                                                           { value: 'samurai', type: 'part name' }
+                                                         ]
+                                                       }
+                                                     ],
+                                                     note: [{ value: 'something', type: 'date/sequential designation' }],
+                                                     purl:
+                                                   })
         end
 
         before do
@@ -178,20 +178,20 @@ RSpec.describe SerialsForm do
 
       context 'when part_number2 is set' do
         let(:expected) do
-          build(:dro, id: druid).new(description: {
-                                       title: [
-                                         {
-                                           structuredValue: [
-                                             { type: 'subtitle', value: '99' },
-                                             { type: 'main title', value: 'Frog' },
-                                             { value: 'samurai', type: 'part name' },
-                                             { value: '7', type: 'part number' }
-                                           ]
-                                         }
-                                       ],
-                                       note: [{ value: 'something', type: 'date/sequential designation' }],
-                                       purl:
-                                     })
+          build(:dro_with_metadata, id: druid).new(description: {
+                                                     title: [
+                                                       {
+                                                         structuredValue: [
+                                                           { type: 'subtitle', value: '99' },
+                                                           { type: 'main title', value: 'Frog' },
+                                                           { value: 'samurai', type: 'part name' },
+                                                           { value: '7', type: 'part number' }
+                                                         ]
+                                                       }
+                                                     ],
+                                                     note: [{ value: 'something', type: 'date/sequential designation' }],
+                                                     purl:
+                                                   })
         end
 
         before do

--- a/spec/jobs/add_workflow_job_spec.rb
+++ b/spec/jobs/add_workflow_job_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe AddWorkflowJob, type: :job do
   let(:user) { bulk_action.user }
 
   let(:cocina1) do
-    build(:dro, id: druids[0])
+    build(:dro_with_metadata, id: druids[0])
   end
   let(:cocina2) do
-    build(:dro, id: druids[1])
+    build(:dro_with_metadata, id: druids[1])
   end
 
   let(:object_client1) { instance_double(Dor::Services::Client::Object, find: cocina1) }

--- a/spec/jobs/apply_apo_defaults_job_spec.rb
+++ b/spec/jobs/apply_apo_defaults_job_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe ApplyApoDefaultsJob, type: :job do
   let(:user) { bulk_action.user }
 
   let(:cocina1) do
-    build(:dro, id: druids[0])
+    build(:dro_with_metadata, id: druids[0])
   end
   let(:cocina2) do
-    build(:dro, id: druids[1])
+    build(:dro_with_metadata, id: druids[1])
   end
 
   let(:object_client1) { instance_double(Dor::Services::Client::Object, find: cocina1, apply_admin_policy_defaults: true) }

--- a/spec/jobs/close_version_job_spec.rb
+++ b/spec/jobs/close_version_job_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe CloseVersionJob, type: :job do
   let(:bulk_action) { create(:bulk_action) }
 
   let(:item1) do
-    build(:dro, id: druids[0])
+    build(:dro_with_metadata, id: druids[0])
   end
   let(:item2) do
-    build(:dro, id: druids[1])
+    build(:dro_with_metadata, id: druids[1])
   end
   let(:object_client1) { instance_double(Dor::Services::Client::Object, find: item1, version: version_client) }
   let(:object_client2) { instance_double(Dor::Services::Client::Object, find: item2, version: version_client) }

--- a/spec/jobs/descmetadata_download_job_spec.rb
+++ b/spec/jobs/descmetadata_download_job_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe DescmetadataDownloadJob, type: :job do
   let(:object_client2) { instance_double(Dor::Services::Client::Object, find: cocina_model2, metadata: metadata_client2) }
   let(:metadata_client1) { instance_double(Dor::Services::Client::Metadata, mods: '<mods/>') }
   let(:metadata_client2) { instance_double(Dor::Services::Client::Metadata, mods: '<mods/>') }
-  let(:cocina_model1) { instance_double(Cocina::Models::DRO) }
-  let(:cocina_model2) { instance_double(Cocina::Models::DRO) }
+  let(:cocina_model1) { instance_double(Cocina::Models::DROWithMetadata) }
+  let(:cocina_model2) { instance_double(Cocina::Models::DROWithMetadata) }
 
   before do
     allow(Dor::Services::Client).to receive(:object).with(druid_list[0]).and_return(object_client1)

--- a/spec/jobs/descriptive_metadata_export_job_spec.rb
+++ b/spec/jobs/descriptive_metadata_export_job_spec.rb
@@ -30,11 +30,11 @@ RSpec.describe DescriptiveMetadataExportJob, type: :job do
     let(:user) { instance_double(User, to_s: 'jcoyne85') }
 
     let(:item1) do
-      build(:dro, id: 'druid:bc123df4567', source_id: 'sul:4444')
+      build(:dro_with_metadata, id: 'druid:bc123df4567', source_id: 'sul:4444')
     end
 
     let(:item2) do
-      build(:dro, id: 'druid:bd123fg5678', title: 'Test DRO #2')
+      build(:dro_with_metadata, id: 'druid:bd123fg5678', title: 'Test DRO #2')
     end
 
     context 'when happy path' do

--- a/spec/jobs/descriptive_metadata_import_job_spec.rb
+++ b/spec/jobs/descriptive_metadata_import_job_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 RSpec.describe DescriptiveMetadataImportJob, type: :job do
   let(:bulk_action) { create(:bulk_action, action_type: described_class.to_s) }
   let(:druids) { %w[druid:bb111cc2222 druid:cc111dd2222] }
-  let(:item1) { build(:dro, id: druids[0]) }
-  let(:item2) { build(:dro, id: druids[1]) }
+  let(:item1) { build(:dro_with_metadata, id: druids[0]) }
+  let(:item2) { build(:dro_with_metadata, id: druids[1]) }
   let(:logger) { instance_double(File, puts: nil) }
 
   let(:csv_file) do

--- a/spec/jobs/export_structural_job_spec.rb
+++ b/spec/jobs/export_structural_job_spec.rb
@@ -198,7 +198,8 @@ RSpec.describe ExportStructuralJob, type: :job do
     JSON
   end
   let(:obj1) do
-    Cocina::Models.build(JSON.parse(json1))
+    obj = Cocina::Models.build(JSON.parse(json1))
+    Cocina::Models.with_metadata(obj, 'abc123')
   end
   let(:json2) do
     <<~JSON
@@ -388,7 +389,8 @@ RSpec.describe ExportStructuralJob, type: :job do
     JSON
   end
   let(:obj2) do
-    Cocina::Models.build(JSON.parse(json2))
+    obj = Cocina::Models.build(JSON.parse(json2))
+    Cocina::Models.with_metadata(obj, 'abc123')
   end
 
   before do

--- a/spec/jobs/generic_job_spec.rb
+++ b/spec/jobs/generic_job_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe GenericJob do
     let(:webauth) { OpenStruct.new('privgroup' => 'dorstuff', 'login' => 'someuser') }
     let(:client) { instance_double(Dor::Services::Client::Object, version: version_client) }
     let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, open: new_cocina_object) }
-    let(:cocina_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, version:) }
-    let(:new_cocina_object) { instance_double(Cocina::Models::DRO) }
+    let(:cocina_object) { instance_double(Cocina::Models::DROWithMetadata, externalIdentifier: druid, version:) }
+    let(:new_cocina_object) { instance_double(Cocina::Models::DROWithMetadata) }
 
     before do
       allow(Dor::Services::Client).to receive(:object).and_return(client)

--- a/spec/jobs/import_structural_job_spec.rb
+++ b/spec/jobs/import_structural_job_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ImportStructuralJob, type: :job do
     let(:druid1) { 'druid:zp968gy7494' }
     let(:druid2) { 'druid:bc234fg7890' }
     let(:cocina1) do
-      build(:dro, id: druid1, version: 6, type: Cocina::Models::ObjectType.map)
+      build(:dro_with_metadata, id: druid1, version: 6, type: Cocina::Models::ObjectType.map)
         .new(structural: {
                contains: [
                  {
@@ -77,7 +77,7 @@ RSpec.describe ImportStructuralJob, type: :job do
     end
 
     let(:cocina2) do
-      build(:dro, id: druid2, version: 6, type: Cocina::Models::ObjectType.map)
+      build(:dro_with_metadata, id: druid2, version: 6, type: Cocina::Models::ObjectType.map)
         .new(structural: {
                contains: [
                  {
@@ -135,8 +135,8 @@ RSpec.describe ImportStructuralJob, type: :job do
       end
 
       it 'updates the structural for each druid' do
-        expect(object_client1).to have_received(:update).with(params: Cocina::Models::DRO)
-        expect(object_client2).to have_received(:update).with(params: Cocina::Models::DRO)
+        expect(object_client1).to have_received(:update).with(params: Cocina::Models::DROWithMetadata)
+        expect(object_client2).to have_received(:update).with(params: Cocina::Models::DROWithMetadata)
         expect(bulk_action.druid_count_total).to eq 2
         expect(bulk_action.druid_count_success).to eq 2
         expect(bulk_action.druid_count_fail).to eq 0

--- a/spec/jobs/manage_embargoes_job_spec.rb
+++ b/spec/jobs/manage_embargoes_job_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe ManageEmbargoesJob do
 
   let(:buffer) { StringIO.new }
   let(:item1) do
-    build(:dro, id: druids[0])
+    build(:dro_with_metadata, id: druids[0])
   end
   let(:item2) do
-    build(:dro, id: druids[1])
+    build(:dro_with_metadata, id: druids[1])
   end
   let(:item3) do
-    build(:dro, id: druids[2])
+    build(:dro_with_metadata, id: druids[2])
   end
 
   let(:csv_file) do

--- a/spec/jobs/open_version_job_spec.rb
+++ b/spec/jobs/open_version_job_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe OpenVersionJob, type: :job do
   let(:user) { bulk_action.user }
 
   let(:cocina1) do
-    build(:dro, id: druids[0])
+    build(:dro_with_metadata, id: druids[0])
   end
   let(:cocina2) do
-    build(:dro, id: druids[1])
+    build(:dro_with_metadata, id: druids[1])
   end
 
   let(:object_client1) { instance_double(Dor::Services::Client::Object, find: cocina1) }

--- a/spec/jobs/purge_job_spec.rb
+++ b/spec/jobs/purge_job_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe PurgeJob, type: :job do
   let(:bulk_action) { create(:bulk_action) }
 
   let(:cocina1) do
-    build(:dro, id: druids[0])
+    build(:dro_with_metadata, id: druids[0])
   end
   let(:cocina2) do
-    build(:dro, id: druids[1])
+    build(:dro_with_metadata, id: druids[1])
   end
 
   let(:object_client1) { instance_double(Dor::Services::Client::Object, find: cocina1) }

--- a/spec/jobs/refresh_mods_job_spec.rb
+++ b/spec/jobs/refresh_mods_job_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe RefreshModsJob, type: :job do
   end
 
   let(:cocina1) do
-    build(:dro, id: druids[0], catkeys:)
+    build(:dro_with_metadata, id: druids[0], catkeys:)
   end
   let(:cocina2) do
-    build(:dro, id: druids[1], catkeys:)
+    build(:dro_with_metadata, id: druids[1], catkeys:)
   end
 
   let(:object_client1) { instance_double(Dor::Services::Client::Object, find: cocina1, refresh_descriptive_metadata_from_ils: true) }

--- a/spec/jobs/register_druids_job_spec.rb
+++ b/spec/jobs/register_druids_job_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe RegisterDruidsJob, type: :job do
   end
 
   let(:model) do
-    instance_double(Cocina::Models::DRO,
+    instance_double(Cocina::Models::DROWithMetadata,
                     externalIdentifier: 'druid:123',
                     label: 'My object',
                     identification:)

--- a/spec/jobs/release_object_job_spec.rb
+++ b/spec/jobs/release_object_job_spec.rb
@@ -5,12 +5,8 @@ require 'rails_helper'
 RSpec.describe ReleaseObjectJob do
   let(:buffer) { StringIO.new }
 
-  let(:item1) do
-    Cocina::Models.with_metadata(build(:dro, id: druids[0], version: 2), 'nnan')
-  end
-  let(:item2) do
-    Cocina::Models.with_metadata(build(:dro, id: druids[1], version: 3), 'naun')
-  end
+  let(:item1) { build(:dro_with_metadata, id: druids[0], version: 2) }
+  let(:item2) { build(:dro_with_metadata, id: druids[1], version: 3) }
 
   before do
     allow(Repository).to receive(:find).with(druids[0]).and_return(item1)

--- a/spec/jobs/set_catkeys_and_barcodes_csv_job_spec.rb
+++ b/spec/jobs/set_catkeys_and_barcodes_csv_job_spec.rb
@@ -14,17 +14,17 @@ RSpec.describe SetCatkeysAndBarcodesCsvJob do
 
   # Replace catkey on this item
   let(:item1) do
-    build(:dro, id: druids[0], barcode: '36105014757519', catkeys: ['12346'])
+    build(:dro_with_metadata, id: druids[0], barcode: '36105014757519', catkeys: ['12346'])
   end
 
   # Remove catkey on this item
   let(:item2) do
-    build(:dro, id: druids[1], barcode: '36105014757510', catkeys: ['12347'])
+    build(:dro_with_metadata, id: druids[1], barcode: '36105014757510', catkeys: ['12347'])
   end
 
   # Add catkey on this item
   let(:item3) do
-    build(:dro, id: druids[2])
+    build(:dro_with_metadata, id: druids[2])
   end
 
   let(:csv_file) do

--- a/spec/jobs/set_catkeys_and_barcodes_job_spec.rb
+++ b/spec/jobs/set_catkeys_and_barcodes_job_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe SetCatkeysAndBarcodesJob do
   let(:barcodes) { ['36105014757517', '', '36105014757518'] }
   let(:buffer) { StringIO.new }
   let(:item1) do
-    build(:dro, id: druids[0], barcode: '36105014757519', catkeys: ['12346'])
+    build(:dro_with_metadata, id: druids[0], barcode: '36105014757519', catkeys: ['12346'])
   end
   let(:item2) do
-    build(:dro, id: druids[1], barcode: '36105014757510', catkeys: ['12347'])
+    build(:dro_with_metadata, id: druids[1], barcode: '36105014757510', catkeys: ['12347'])
   end
   let(:item3) do
-    build(:dro, id: druids[2])
+    build(:dro_with_metadata, id: druids[2])
   end
 
   let(:object_client1) { instance_double(Dor::Services::Client::Object, find: item1) }
@@ -101,11 +101,11 @@ RSpec.describe SetCatkeysAndBarcodesJob do
     let(:client) { double(Dor::Services::Client) }
     let(:object_client) { instance_double(Dor::Services::Client::Object, update: true) }
     let(:previous_version) do
-      build(:dro, id: druids[0], version: 3).new(identification: {
-                                                   barcode: '36105014757519',
-                                                   catalogLinks: [{ catalog: 'symphony', catalogRecordId: '12346', refresh: true }],
-                                                   sourceId: 'sul:1234'
-                                                 })
+      build(:dro_with_metadata, id: druids[0], version: 3).new(identification: {
+                                                                 barcode: '36105014757519',
+                                                                 catalogLinks: [{ catalog: 'symphony', catalogRecordId: '12346', refresh: true }],
+                                                                 sourceId: 'sul:1234'
+                                                               })
     end
 
     let(:updated_model) do

--- a/spec/jobs/set_collection_job_spec.rb
+++ b/spec/jobs/set_collection_job_spec.rb
@@ -18,10 +18,10 @@ RSpec.describe SetCollectionJob do
     )
   end
   let(:cocina1) do
-    build(:dro, id: druids[0])
+    build(:dro_with_metadata, id: druids[0])
   end
   let(:cocina2) do
-    build(:dro, id: druids[1])
+    build(:dro_with_metadata, id: druids[1])
   end
 
   before do

--- a/spec/jobs/set_content_type_job_spec.rb
+++ b/spec/jobs/set_content_type_job_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe SetContentTypeJob, type: :job do
   end
   let(:user) { bulk_action.user }
   let(:cocina1) do
-    build(:dro, id: druids[0], type: Cocina::Models::ObjectType.book)
+    build(:dro_with_metadata, id: druids[0], type: Cocina::Models::ObjectType.book)
       .new(structural: { contains: [{ type: Cocina::Models::FileSetType.page,
                                       label: 'Book page',
                                       version: 1,
@@ -35,7 +35,7 @@ RSpec.describe SetContentTypeJob, type: :job do
                                       structural: {} }] })
   end
   let(:cocina2) do
-    build(:dro, id: druids[1], type: Cocina::Models::ObjectType.image)
+    build(:dro_with_metadata, id: druids[1], type: Cocina::Models::ObjectType.image)
       .new(structural:
                       { contains: [{ type: Cocina::Models::FileSetType.file,
                                      label: 'Map label',
@@ -44,7 +44,7 @@ RSpec.describe SetContentTypeJob, type: :job do
                                      structural: {} }] })
   end
   let(:cocina3) do
-    build(:collection, id: druids[2])
+    build(:collection_with_metadata, id: druids[2])
   end
 
   let(:object_client1) { instance_double(Dor::Services::Client::Object, find: cocina1) }

--- a/spec/jobs/set_governing_apo_job_spec.rb
+++ b/spec/jobs/set_governing_apo_job_spec.rb
@@ -46,10 +46,10 @@ RSpec.describe SetGoverningApoJob do
 
     context 'when the user lacks the ability to manage an item and items are not found' do
       let(:cocina1) do
-        build(:dro, id: druids[0])
+        build(:dro_with_metadata, id: druids[0])
       end
       let(:cocina3) do
-        build(:dro, id: druids[2])
+        build(:dro_with_metadata, id: druids[2])
       end
 
       let(:object_client1) { instance_double(Dor::Services::Client::Object, find: cocina1, update: true) }
@@ -68,7 +68,7 @@ RSpec.describe SetGoverningApoJob do
       it 'increments the failure and success counts and logs status of each update' do
         subject.perform(bulk_action.id, params)
         expect(state_service).to have_received(:allows_modification?)
-        expect(object_client1).to have_received(:update).with(params: Cocina::Models::DRO)
+        expect(object_client1).to have_received(:update).with(params: Cocina::Models::DROWithMetadata)
 
         expect(bulk_action.druid_count_success).to eq 1
         expect(bulk_action.druid_count_fail).to eq 2

--- a/spec/jobs/set_license_and_rights_statements_job_spec.rb
+++ b/spec/jobs/set_license_and_rights_statements_job_spec.rb
@@ -20,23 +20,7 @@ RSpec.describe SetLicenseAndRightsStatementsJob, type: :job do
         groups:
       }.with_indifferent_access
     end
-    let(:cocina_object) do
-      cocina_object = Cocina::Models::DRO.new(
-        externalIdentifier: 'druid:bc123df4568',
-        label: 'test',
-        type: Cocina::Models::ObjectType.object,
-        version: 1,
-        description: {
-          title: [{ value: 'test' }],
-          purl: 'https://purl.stanford.edu/bc123df4568'
-        },
-        access: {},
-        identification: { sourceId: 'sul:1234' },
-        structural: {},
-        administrative: { hasAdminPolicy: 'druid:bc123df4569' }
-      )
-      Cocina::Models.with_metadata(cocina_object, 'abc123')
-    end
+    let(:cocina_object) { build(:dro_with_metadata) }
     let(:copyright_statement) { 'the new hotness' }
     let(:state_service) { instance_double(StateService, allows_modification?: allows_modification) }
     let(:wf_status) { instance_double(DorObjectWorkflowStatus, can_open_version?: true) }
@@ -92,22 +76,7 @@ RSpec.describe SetLicenseAndRightsStatementsJob, type: :job do
       end
 
       context 'with a collection' do
-        let(:cocina_object) do
-          cocina_object = Cocina::Models::Collection.new(
-            externalIdentifier: 'druid:bc123df4568',
-            label: 'test',
-            type: Cocina::Models::ObjectType.collection,
-            description: {
-              title: [{ value: 'test' }],
-              purl: 'https://purl.stanford.edu/bc123df4568'
-            },
-            version: 1,
-            identification: { sourceId: 'sul:1234' },
-            access: {},
-            administrative: { hasAdminPolicy: 'druid:bc123df4569' }
-          )
-          Cocina::Models.with_metadata(cocina_object, 'abc123')
-        end
+        let(:cocina_object) { build(:collection_with_metadata) }
 
         it 'updates via collection change set persister' do
           expect(VersionService).not_to have_received(:open)

--- a/spec/jobs/set_rights_job_spec.rb
+++ b/spec/jobs/set_rights_job_spec.rb
@@ -16,159 +16,135 @@ RSpec.describe SetRightsJob, type: :job do
   let(:user) { bulk_action.user }
 
   let(:cocina1) do
-    Cocina::Models::DRO.new(
-      {
-        label: 'Stanford Item',
-        version: 2,
-        type: Cocina::Models::ObjectType.book,
-        description: {
-          title: [{ value: 'Stanford Item' }],
-          purl: "https://purl.stanford.edu/#{druids[0].delete_prefix('druid:')}"
-        },
-        externalIdentifier: druids[0],
-        access: {
-          view: 'stanford',
-          download: 'stanford'
-        },
-        administrative: { hasAdminPolicy: 'druid:cg532dg5405' },
-        structural: {
-          contains: [
-            {
-              type: Cocina::Models::FileSetType.page,
-              label: 'Book page',
-              version: 1,
-              externalIdentifier: 'abc123456',
-              structural: {
-                contains: [
-                  {
-                    filename: 'p1.jpg',
-                    externalIdentifier: 'abc123456',
-                    label: 'p1.jpg',
-                    type: Cocina::Models::ObjectType.file,
-                    version: 1,
-                    administrative: {
-                      publish: true,
-                      sdrPreserve: true,
-                      shelve: true
-                    },
-                    hasMessageDigests: [],
-                    access: {
-                      view: 'stanford',
-                      download: 'stanford'
-                    }
+    build(:dro_with_metadata, id: druids[0]).new(
+      access: {
+        view: 'stanford',
+        download: 'stanford'
+      },
+      structural: {
+        contains: [
+          {
+            type: Cocina::Models::FileSetType.page,
+            label: 'Book page',
+            version: 1,
+            externalIdentifier: 'abc123456',
+            structural: {
+              contains: [
+                {
+                  filename: 'p1.jpg',
+                  externalIdentifier: 'abc123456',
+                  label: 'p1.jpg',
+                  type: Cocina::Models::ObjectType.file,
+                  version: 1,
+                  administrative: {
+                    publish: true,
+                    sdrPreserve: true,
+                    shelve: true
+                  },
+                  hasMessageDigests: [],
+                  access: {
+                    view: 'stanford',
+                    download: 'stanford'
                   }
-                ]
-              }
-            },
-            {
-              type: Cocina::Models::FileSetType.image,
-              label: 'Book page 2',
-              version: 1,
-              externalIdentifier: 'abc789012',
-              structural: {
-                contains: [
-                  {
-                    filename: 'p2.jpg',
-                    externalIdentifier: 'abc123456',
-                    label: 'p2.jpg',
-                    type: Cocina::Models::ObjectType.file,
-                    version: 1,
-                    administrative: {
-                      publish: true,
-                      sdrPreserve: true,
-                      shelve: true
-                    },
-                    hasMessageDigests: [],
-                    access: {
-                      view: 'stanford',
-                      download: 'stanford'
-                    }
-                  }
-                ]
-              }
+                }
+              ]
             }
-          ]
-        },
-        identification: { sourceId: 'sul:1234' }
+          },
+          {
+            type: Cocina::Models::FileSetType.image,
+            label: 'Book page 2',
+            version: 1,
+            externalIdentifier: 'abc789012',
+            structural: {
+              contains: [
+                {
+                  filename: 'p2.jpg',
+                  externalIdentifier: 'abc123456',
+                  label: 'p2.jpg',
+                  type: Cocina::Models::ObjectType.file,
+                  version: 1,
+                  administrative: {
+                    publish: true,
+                    sdrPreserve: true,
+                    shelve: true
+                  },
+                  hasMessageDigests: [],
+                  access: {
+                    view: 'stanford',
+                    download: 'stanford'
+                  }
+                }
+              ]
+            }
+          }
+        ]
       }
     )
   end
 
   let(:cocina2) do
-    Cocina::Models::DRO.new(
-      {
-        label: 'World Item',
-        version: 3,
-        type: Cocina::Models::ObjectType.image,
-        description: {
-          title: [{ value: 'World Item' }],
-          purl: "https://purl.stanford.edu/#{druids[1].delete_prefix('druid:')}"
-        },
-        externalIdentifier: druids[1],
-        access: {
-          view: 'world',
-          download: 'world'
-        },
-        administrative: { 'hasAdminPolicy' => 'druid:cg532dg5405' },
-        structural: {
-          contains: [
-            {
-              type: Cocina::Models::FileSetType.page,
-              label: 'Book page',
-              version: 1,
-              externalIdentifier: 'abc123456',
-              structural: {
-                contains: [
-                  {
-                    filename: 'p1.jpg',
-                    externalIdentifier: 'abc123456',
-                    label: 'p1.jpg',
-                    type: Cocina::Models::ObjectType.file,
-                    version: 1,
-                    administrative: {
-                      publish: true,
-                      sdrPreserve: true,
-                      shelve: true
-                    },
-                    hasMessageDigests: [],
-                    access: {
-                      view: 'stanford',
-                      download: 'stanford'
-                    }
+    build(:dro_with_metadata, id: druids[1]).new(
+      access: {
+        view: 'world',
+        download: 'world'
+      },
+      structural: {
+        contains: [
+          {
+            type: Cocina::Models::FileSetType.page,
+            label: 'Book page',
+            version: 1,
+            externalIdentifier: 'abc123456',
+            structural: {
+              contains: [
+                {
+                  filename: 'p1.jpg',
+                  externalIdentifier: 'abc123456',
+                  label: 'p1.jpg',
+                  type: Cocina::Models::ObjectType.file,
+                  version: 1,
+                  administrative: {
+                    publish: true,
+                    sdrPreserve: true,
+                    shelve: true
+                  },
+                  hasMessageDigests: [],
+                  access: {
+                    view: 'stanford',
+                    download: 'stanford'
                   }
-                ]
-              }
-            },
-            {
-              type: Cocina::Models::FileSetType.image,
-              label: 'Book page 2',
-              version: 1,
-              externalIdentifier: 'abc789012',
-              structural: {
-                contains: [
-                  {
-                    filename: 'p2.jpg',
-                    externalIdentifier: 'abc789012',
-                    label: 'p2.jpg',
-                    type: Cocina::Models::ObjectType.file,
-                    version: 1,
-                    administrative: {
-                      publish: true,
-                      sdrPreserve: true,
-                      shelve: true
-                    },
-                    hasMessageDigests: [],
-                    access: {
-                      view: 'stanford',
-                      download: 'stanford'
-                    }
-                  }
-                ]
-              }
+                }
+              ]
             }
-          ]
-        },
-        identification: { sourceId: 'sul:1234' }
+          },
+          {
+            type: Cocina::Models::FileSetType.image,
+            label: 'Book page 2',
+            version: 1,
+            externalIdentifier: 'abc789012',
+            structural: {
+              contains: [
+                {
+                  filename: 'p2.jpg',
+                  externalIdentifier: 'abc789012',
+                  label: 'p2.jpg',
+                  type: Cocina::Models::ObjectType.file,
+                  version: 1,
+                  administrative: {
+                    publish: true,
+                    sdrPreserve: true,
+                    shelve: true
+                  },
+                  hasMessageDigests: [],
+                  access: {
+                    view: 'stanford',
+                    download: 'stanford'
+                  }
+                }
+              ]
+            }
+          }
+        ]
       }
     )
   end

--- a/spec/jobs/set_source_ids_csv_job_spec.rb
+++ b/spec/jobs/set_source_ids_csv_job_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe SetSourceIdsCsvJob do
   end
   let(:log_buffer) { StringIO.new }
   let(:item1) do
-    build(:dro, id: druids[0], source_id: 'sul:36105014757519')
+    build(:dro_with_metadata, id: druids[0], source_id: 'sul:36105014757519')
   end
   let(:item2) do
-    build(:dro, id: druids[1], source_id: 'sul:36105014757510')
+    build(:dro_with_metadata, id: druids[1], source_id: 'sul:36105014757510')
   end
   let(:item3) do
-    build(:collection, id: druids[2], source_id: 'sul:1234')
+    build(:collection_with_metadata, id: druids[2], source_id: 'sul:1234')
   end
 
   let(:csv_file) do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -6,42 +6,14 @@ require 'cancan/matchers'
 RSpec.describe Ability do
   subject(:ability) { described_class.new(user) }
 
-  let(:dro) do
-    Cocina::Models::DRO.new(externalIdentifier: new_cocina_object_id,
-                            label: 'test',
-                            type: Cocina::Models::ObjectType.object,
-                            version: 1,
-                            description: {
-                              title: [{ value: 'test' }],
-                              purl: "https://purl.stanford.edu/#{new_cocina_object_id.delete_prefix('druid:')}"
-                            },
-                            access: {},
-                            identification: { sourceId: 'sul:1234' },
-                            structural: {},
-                            administrative: {
-                              hasAdminPolicy: apo_id
-                            })
-  end
+  let(:dro) { build(:dro, id: new_cocina_object_id, admin_policy_id: apo_id) }
+  let(:dro_with_metadata) { build(:dro, id: new_cocina_object_id, admin_policy_id: apo_id) }
 
-  let(:admin_policy) do
-    build(:admin_policy, id: new_cocina_object_id, admin_policy_id: apo_id)
-  end
+  let(:admin_policy) { build(:admin_policy, id: new_cocina_object_id, admin_policy_id: apo_id) }
+  let(:admin_policy_with_metadata) { build(:admin_policy, id: new_cocina_object_id, admin_policy_id: apo_id) }
 
-  let(:collection) do
-    Cocina::Models::Collection.new(externalIdentifier: new_cocina_object_id,
-                                   label: 'test',
-                                   type: Cocina::Models::ObjectType.collection,
-                                   version: 1,
-                                   description: {
-                                     title: [{ value: 'test' }],
-                                     purl: "https://purl.stanford.edu/#{new_cocina_object_id.delete_prefix('druid:')}"
-                                   },
-                                   access: {},
-                                   identification: { sourceId: 'sul:1234' },
-                                   administrative: {
-                                     hasAdminPolicy: apo_id
-                                   })
-  end
+  let(:collection) { build(:collection, id: new_cocina_object_id, admin_policy_id: apo_id) }
+  let(:collection_with_metadata) { build(:collection, id: new_cocina_object_id, admin_policy_id: apo_id) }
 
   let(:user) do
     instance_double(User,
@@ -70,8 +42,11 @@ RSpec.describe Ability do
     it { is_expected.to be_able_to(:manage, :everything) }
     it { is_expected.to be_able_to(:update, dro) }
     it { is_expected.to be_able_to(:manage_governing_apo, dro, apo_id) }
+    it { is_expected.to be_able_to(:update, dro_with_metadata) }
+    it { is_expected.to be_able_to(:manage_governing_apo, dro_with_metadata, apo_id) }
     it { is_expected.to be_able_to(:create, Cocina::Models::AdminPolicy) }
     it { is_expected.to be_able_to(:view_content, dro) }
+    it { is_expected.to be_able_to(:view_content, dro_with_metadata) }
     it { is_expected.to be_able_to(:update, :workflow) }
   end
 
@@ -80,10 +55,13 @@ RSpec.describe Ability do
 
     it { is_expected.not_to be_able_to(:manage, :everything) }
     it { is_expected.to be_able_to(:update, dro) }
+    it { is_expected.to be_able_to(:update, dro_with_metadata) }
 
     it { is_expected.to be_able_to(:manage_governing_apo, dro, apo_id) }
+    it { is_expected.to be_able_to(:manage_governing_apo, dro_with_metadata, apo_id) }
     it { is_expected.to be_able_to(:create, Cocina::Models::AdminPolicy) }
     it { is_expected.to be_able_to(:view_content, dro) }
+    it { is_expected.to be_able_to(:view_content, dro_with_metadata) }
     it { is_expected.not_to be_able_to(:update, :workflow) }
   end
 
@@ -91,19 +69,28 @@ RSpec.describe Ability do
     let(:viewer) { true }
 
     it { is_expected.not_to be_able_to(:update, dro) }
+    it { is_expected.not_to be_able_to(:update, dro_with_metadata) }
     it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, apo_id) }
+    it { is_expected.not_to be_able_to(:manage_governing_apo, dro_with_metadata, apo_id) }
     it { is_expected.to be_able_to(:view_metadata, dro) }
+    it { is_expected.to be_able_to(:view_metadata, dro_with_metadata) }
     it { is_expected.to be_able_to(:view_content, dro) }
+    it { is_expected.to be_able_to(:view_content, dro_with_metadata) }
     it { is_expected.to be_able_to(:view_metadata, admin_policy) }
+    it { is_expected.to be_able_to(:view_metadata, admin_policy_with_metadata) }
     it { is_expected.to be_able_to(:view_metadata, collection) }
+    it { is_expected.to be_able_to(:view_metadata, collection_with_metadata) }
     it { is_expected.not_to be_able_to(:update, :workflow) }
   end
 
   context 'for items without an APO' do
     it { is_expected.not_to be_able_to(:update, dro) }
+    it { is_expected.not_to be_able_to(:update, dro_with_metadata) }
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, apo_id) }
+    it { is_expected.not_to be_able_to(:manage_governing_apo, dro_with_metadata, apo_id) }
     it { is_expected.not_to be_able_to(:view_content, dro) }
+    it { is_expected.not_to be_able_to(:view_content, dro_with_metadata) }
   end
 
   context 'with the manage role on the parent APO' do
@@ -111,13 +98,19 @@ RSpec.describe Ability do
 
     it { is_expected.not_to be_able_to(:manage, :everything) }
     it { is_expected.to be_able_to(:update, dro) }
+    it { is_expected.to be_able_to(:update, dro_with_metadata) }
     it { is_expected.to be_able_to(:manage_governing_apo, dro, apo_id) }
+    it { is_expected.to be_able_to(:manage_governing_apo, dro_with_metadata, apo_id) }
     it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
 
     it { is_expected.to be_able_to(:view_metadata, dro) }
+    it { is_expected.to be_able_to(:view_metadata, dro_with_metadata) }
     it { is_expected.to be_able_to(:view_metadata, collection) }
+    it { is_expected.to be_able_to(:view_metadata, collection_with_metadata) }
     it { is_expected.to be_able_to(:view_metadata, admin_policy) }
+    it { is_expected.to be_able_to(:view_metadata, admin_policy_with_metadata) }
     it { is_expected.to be_able_to(:view_content, dro) }
+    it { is_expected.to be_able_to(:view_content, dro_with_metadata) }
   end
 
   context 'with the manage role on the cocina_object' do
@@ -125,13 +118,19 @@ RSpec.describe Ability do
 
     it { is_expected.not_to be_able_to(:manage, :everything) }
     it { is_expected.not_to be_able_to(:update, dro) }
+    it { is_expected.not_to be_able_to(:update, dro_with_metadata) }
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, apo_id) }
+    it { is_expected.not_to be_able_to(:manage_governing_apo, dro_with_metadata, apo_id) }
     it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
 
     it { is_expected.not_to be_able_to(:view_metadata, dro) }
+    it { is_expected.not_to be_able_to(:view_metadata, dro_with_metadata) }
     it { is_expected.not_to be_able_to(:view_metadata, collection) }
+    it { is_expected.not_to be_able_to(:view_metadata, collection_with_metadata) }
     it { is_expected.to be_able_to(:view_metadata, admin_policy) }
+    it { is_expected.to be_able_to(:view_metadata, admin_policy_with_metadata) }
     it { is_expected.not_to be_able_to(:view_content, dro) }
+    it { is_expected.not_to be_able_to(:view_content, dro_with_metadata) }
   end
 
   context 'with the edit role on the parent APO' do
@@ -139,9 +138,12 @@ RSpec.describe Ability do
 
     it { is_expected.not_to be_able_to(:manage, :everything) }
     it { is_expected.not_to be_able_to(:update, dro) }
+    it { is_expected.not_to be_able_to(:update, dro_with_metadata) }
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, apo_id) }
+    it { is_expected.not_to be_able_to(:manage_governing_apo, dro_with_metadata, apo_id) }
     it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
     it { is_expected.not_to be_able_to(:view_content, dro) }
+    it { is_expected.not_to be_able_to(:view_content, dro_with_metadata) }
   end
 
   context 'with the view role on the parent APO' do
@@ -149,8 +151,11 @@ RSpec.describe Ability do
 
     it { is_expected.not_to be_able_to(:manage, :everything) }
     it { is_expected.not_to be_able_to(:update, dro) }
+    it { is_expected.not_to be_able_to(:update, dro_with_metadata) }
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, apo_id) }
+    it { is_expected.not_to be_able_to(:manage_governing_apo, dro_with_metadata, apo_id) }
     it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
     it { is_expected.to be_able_to(:view_content, dro) }
+    it { is_expected.to be_able_to(:view_content, dro_with_metadata) }
   end
 end

--- a/spec/requests/apply_apo_defaults_spec.rb
+++ b/spec/requests/apply_apo_defaults_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Apply APO defaults' do
   let(:object_client) do
     instance_double(Dor::Services::Client::Object, find: cocina_model, apply_admin_policy_defaults: true)
   end
-  let(:cocina_model) { build(:dro, id: druid) }
+  let(:cocina_model) { build(:dro_with_metadata, id: druid) }
 
   before do
     sign_in user

--- a/spec/requests/close_version_spec.rb
+++ b/spec/requests/close_version_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Close a version', type: :request do
   let(:druid) { 'druid:bc123df4567' }
   let(:user) { create(:user) }
   let(:object_service) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
-  let(:cocina_model) { build(:dro, id: druid, version: 2) }
+  let(:cocina_model) { build(:dro_with_metadata, id: druid, version: 2) }
 
   before do
     allow(Argo::Indexer).to receive(:reindex_druid_remotely)

--- a/spec/requests/collection_update_spec.rb
+++ b/spec/requests/collection_update_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Set the properties for a collection' do
       sign_in user, groups: ['sdr:administrator-role']
     end
 
-    let(:cocina_model) { build(:collection, id: druid) }
+    let(:cocina_model) { build(:collection_with_metadata, id: druid) }
 
     let(:updated_model) do
       cocina_model.new(

--- a/spec/requests/create_collections_spec.rb
+++ b/spec/requests/create_collections_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Create collections' do
   describe 'show the form' do
     let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
     let(:cocina_model) do
-      build(:admin_policy)
+      build(:admin_policy_with_metadata)
     end
 
     before do
@@ -32,7 +32,7 @@ RSpec.describe 'Create collections' do
     let(:form) { instance_double(CollectionForm, validate: true, save: true, model: collection) }
     let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, update: true) }
     let(:cocina_model) do
-      build(:admin_policy)
+      build(:admin_policy_with_metadata)
     end
 
     before do

--- a/spec/requests/download_descriptive_csv_spec.rb
+++ b/spec/requests/download_descriptive_csv_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Download the descriptive CSV', type: :request do
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
 
   let(:cocina_model) do
-    build(:dro, id: druid, source_id: 'sul:91919', title: 'My ETD')
+    build(:dro_with_metadata, id: druid, source_id: 'sul:91919', title: 'My ETD')
   end
 
   before do

--- a/spec/requests/download_structural_csv_spec.rb
+++ b/spec/requests/download_structural_csv_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Download the structural CSV' do
     end
 
     let(:cocina_model) do
-      build(:dro, id: druid)
+      build(:dro_with_metadata, id: druid)
     end
 
     it 'returns the csv' do

--- a/spec/requests/edit_barcode_spec.rb
+++ b/spec/requests/edit_barcode_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Edit barcode' do
   let(:user) { create(:user) }
-  let(:cocina_model) { build(:dro, id: druid) }
+  let(:cocina_model) { build(:dro_with_metadata, id: druid) }
 
   let(:druid) { 'druid:dc243mg0841' }
 

--- a/spec/requests/edit_copyright_spec.rb
+++ b/spec/requests/edit_copyright_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Edit copyright' do
 
   describe 'display the form' do
     context 'with an item' do
-      let(:cocina_model) { build(:dro, id: druid) }
+      let(:cocina_model) { build(:dro_with_metadata, id: druid) }
 
       it 'draws the form' do
         get "/items/#{druid}/edit_copyright", headers: turbo_stream_headers
@@ -29,7 +29,7 @@ RSpec.describe 'Edit copyright' do
     end
 
     context 'with a collection' do
-      let(:cocina_model) { build(:collection, id: druid) }
+      let(:cocina_model) { build(:collection_with_metadata, id: druid) }
 
       it 'draws the form' do
         get "/items/#{druid}/edit_copyright", headers: turbo_stream_headers
@@ -40,7 +40,7 @@ RSpec.describe 'Edit copyright' do
 
   describe 'display the show view (after cancel)' do
     context 'with an item' do
-      let(:cocina_model) { build(:dro, id: druid) }
+      let(:cocina_model) { build(:dro_with_metadata, id: druid) }
 
       it 'draws the component' do
         get "/items/#{druid}/show_copyright", headers: turbo_stream_headers
@@ -50,7 +50,7 @@ RSpec.describe 'Edit copyright' do
     end
 
     context 'with a collection' do
-      let(:cocina_model) { build(:collection, id: druid) }
+      let(:cocina_model) { build(:collection_with_metadata, id: druid) }
 
       it 'draws the form' do
         get "/items/#{druid}/show_copyright", headers: turbo_stream_headers

--- a/spec/requests/edit_datastream_spec.rb
+++ b/spec/requests/edit_datastream_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Draw the edit datastream form' do
                       metadata: metadata_client)
     end
     let(:metadata_client) { instance_double(Dor::Services::Client::Metadata) }
-    let(:cocina_model) { instance_double(Cocina::Models::DRO, externalIdentifier: 'druid:bc123df4567') }
+    let(:cocina_model) { instance_double(Cocina::Models::DROWithMetadata, externalIdentifier: 'druid:bc123df4567') }
 
     before do
       allow(Dor::Services::Client).to receive(:object).and_return(object_client)

--- a/spec/requests/edit_license_spec.rb
+++ b/spec/requests/edit_license_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Edit license' do
 
   describe 'display the form' do
     context 'with an item' do
-      let(:cocina_model) { build(:dro, id: druid) }
+      let(:cocina_model) { build(:dro_with_metadata, id: druid) }
 
       it 'draws the form' do
         get "/items/#{druid}/edit_license", headers: turbo_stream_headers
@@ -28,7 +28,7 @@ RSpec.describe 'Edit license' do
     end
 
     context 'with a collection that has identification' do
-      let(:cocina_model) { build(:collection, id: druid) }
+      let(:cocina_model) { build(:collection_with_metadata, id: druid) }
 
       it 'draws the form' do
         get "/items/#{druid}/edit_license", headers: turbo_stream_headers
@@ -39,7 +39,7 @@ RSpec.describe 'Edit license' do
 
   describe 'display the show view (after cancel)' do
     context 'with an item' do
-      let(:cocina_model) { build(:dro, id: druid) }
+      let(:cocina_model) { build(:dro_with_metadata, id: druid) }
 
       it 'draws the component' do
         get "/items/#{druid}/show_license", headers: turbo_stream_headers
@@ -49,7 +49,7 @@ RSpec.describe 'Edit license' do
     end
 
     context 'with a collection' do
-      let(:cocina_model) { build(:collection, id: druid) }
+      let(:cocina_model) { build(:collection_with_metadata, id: druid) }
 
       it 'draws the component' do
         get "/items/#{druid}/show_license", headers: turbo_stream_headers

--- a/spec/requests/edit_rights_spec.rb
+++ b/spec/requests/edit_rights_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Edit rights' do
 
   describe 'display the form' do
     context 'with an item' do
-      let(:cocina_model) { build(:dro, id: druid) }
+      let(:cocina_model) { build(:dro_with_metadata, id: druid) }
 
       it 'draws the form' do
         get "/items/#{druid}/edit_rights", headers: turbo_stream_headers
@@ -28,7 +28,7 @@ RSpec.describe 'Edit rights' do
     end
 
     context 'with a collection' do
-      let(:cocina_model) { build(:collection, id: druid) }
+      let(:cocina_model) { build(:collection_with_metadata, id: druid) }
 
       it 'draws the form' do
         get "/items/#{druid}/edit_rights", headers: turbo_stream_headers
@@ -39,7 +39,7 @@ RSpec.describe 'Edit rights' do
 
   describe 'display the show view (after cancel)' do
     context 'with an item' do
-      let(:cocina_model) { build(:dro, id: druid) }
+      let(:cocina_model) { build(:dro_with_metadata, id: druid) }
 
       it 'draws the component' do
         get "/items/#{druid}/show_rights", headers: turbo_stream_headers
@@ -49,7 +49,7 @@ RSpec.describe 'Edit rights' do
     end
 
     context 'with a collection' do
-      let(:cocina_model) { build(:collection, id: druid) }
+      let(:cocina_model) { build(:collection_with_metadata, id: druid) }
 
       it 'draws the component' do
         get "/items/#{druid}/show_rights", headers: turbo_stream_headers

--- a/spec/requests/edit_use_statement_spec.rb
+++ b/spec/requests/edit_use_statement_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Edit use statement' do
 
   describe 'display the form' do
     context 'with an item' do
-      let(:cocina_model) { build(:dro, id: druid) }
+      let(:cocina_model) { build(:dro_with_metadata, id: druid) }
 
       it 'draws the form' do
         get "/items/#{druid}/edit_use_statement", headers: turbo_stream_headers
@@ -28,7 +28,7 @@ RSpec.describe 'Edit use statement' do
     end
 
     context 'with a collection' do
-      let(:cocina_model) { build(:collection, id: druid) }
+      let(:cocina_model) { build(:collection_with_metadata, id: druid) }
 
       it 'draws the form' do
         get "/items/#{druid}/edit_use_statement", headers: turbo_stream_headers
@@ -39,7 +39,7 @@ RSpec.describe 'Edit use statement' do
 
   describe 'display the show view (after cancel)' do
     context 'with an item' do
-      let(:cocina_model) { build(:dro, id: druid) }
+      let(:cocina_model) { build(:dro_with_metadata, id: druid) }
 
       it 'draws the component' do
         get "/items/#{druid}/show_use_statement", headers: turbo_stream_headers
@@ -49,7 +49,7 @@ RSpec.describe 'Edit use statement' do
     end
 
     context 'with a collection' do
-      let(:cocina_model) { build(:collection, id: druid) }
+      let(:cocina_model) { build(:collection_with_metadata, id: druid) }
 
       it 'draws the component' do
         get "/items/#{druid}/show_use_statement", headers: turbo_stream_headers

--- a/spec/requests/embargo_spec.rb
+++ b/spec/requests/embargo_spec.rb
@@ -11,15 +11,15 @@ RSpec.describe 'Set embargo for an object' do
   let(:object_service) { instance_double(Dor::Services::Client::Object, find: cocina) }
   let(:druid) { 'druid:bc123df4567' }
   let(:cocina) do
-    build(:dro, id: druid).new(access: {
-                                 'view' => 'stanford',
-                                 'download' => 'stanford',
-                                 'embargo' => {
-                                   'releaseDate' => '2040-05-05',
-                                   'view' => 'world',
-                                   'download' => 'world'
-                                 }
-                               })
+    build(:dro_with_metadata, id: druid).new(access: {
+                                               'view' => 'stanford',
+                                               'download' => 'stanford',
+                                               'embargo' => {
+                                                 'releaseDate' => '2040-05-05',
+                                                 'view' => 'world',
+                                                 'download' => 'world'
+                                               }
+                                             })
   end
 
   describe '#update' do

--- a/spec/requests/files_spec.rb
+++ b/spec/requests/files_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Files', type: :request do
   let(:druid) { 'druid:bc123df4567' }
   let(:user) { create(:user) }
   let(:cocina_model) do
-    instance_double(Cocina::Models::DRO, externalIdentifier: druid, structural:)
+    instance_double(Cocina::Models::DROWithMetadata, externalIdentifier: druid, structural:)
   end
   let(:file_set) do
     instance_double(Cocina::Models::FileSet, structural: fs_structural)

--- a/spec/requests/item_files_download_spec.rb
+++ b/spec/requests/item_files_download_spec.rb
@@ -4,7 +4,10 @@ require 'rails_helper'
 
 RSpec.describe 'Download item files' do
   let(:druid) { cocina_model.externalIdentifier }
-  let(:cocina_model) { Cocina::Models.build(cocina_params.stringify_keys) }
+  let(:cocina_model) do
+    model = Cocina::Models.build(cocina_params.stringify_keys)
+    Cocina::Models.with_metadata(model, 'abc123')
+  end
   let(:cocina_params) do
     {
       type: Cocina::Models::ObjectType.image,

--- a/spec/requests/item_update_spec.rb
+++ b/spec/requests/item_update_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Set the properties for an item' do
       sign_in user, groups: ['sdr:administrator-role']
     end
 
-    let(:cocina_model) { Cocina::Models.with_metadata(build(:dro), 'asdf') }
+    let(:cocina_model) { build(:dro_with_metadata) }
 
     context 'when barcode is passed' do
       let(:updated_model) do
@@ -122,7 +122,7 @@ RSpec.describe 'Set the properties for an item' do
 
     describe 'access rights' do
       let(:cocina_model) do
-        build(:dro).new(access: existing_access, structural: existing_structural)
+        build(:dro_with_metadata).new(access: existing_access, structural: existing_structural)
       end
 
       let(:existing_access) { { view: 'world', download: 'none' } }

--- a/spec/requests/manage_collection_membership_spec.rb
+++ b/spec/requests/manage_collection_membership_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Collection membership', type: :request do
   let(:state_service) { instance_double(StateService, allows_modification?: true) }
 
   describe 'adding a new collection' do
-    let(:cocina_collection) { build(:dro, id: druid, collection_ids:) }
+    let(:cocina_collection) { build(:dro_with_metadata, id: druid, collection_ids:) }
     let(:collection_ids) { ['druid:gg333xx4444'] }
     let(:object_service) do
       instance_double(Dor::Services::Client::Object,
@@ -29,7 +29,7 @@ RSpec.describe 'Collection membership', type: :request do
 
       context 'when collections already exist' do
         let(:expected) do
-          build(:dro, id: druid, collection_ids: ['druid:gg333xx4444', 'druid:bc555gh3434'])
+          build(:dro_with_metadata, id: druid, collection_ids: ['druid:gg333xx4444', 'druid:bc555gh3434'])
         end
 
         it 'adds a collection' do
@@ -46,7 +46,7 @@ RSpec.describe 'Collection membership', type: :request do
       end
 
       context 'when the object is not currently in a collection' do
-        let(:expected) { build(:dro, id: druid, collection_ids: ['druid:bc555gh3434']) }
+        let(:expected) { build(:dro_with_metadata, id: druid, collection_ids: ['druid:bc555gh3434']) }
         let(:collection_ids) { [] }
 
         it 'adds a collection' do
@@ -70,7 +70,7 @@ RSpec.describe 'Collection membership', type: :request do
   end
 
   describe 'removing a collection' do
-    let(:cocina) { build(:dro, id: druid, collection_ids: ['druid:gg333xx4444', 'druid:bc555gh3434']) }
+    let(:cocina) { build(:dro_with_metadata, id: druid, collection_ids: ['druid:gg333xx4444', 'druid:bc555gh3434']) }
 
     let(:object_service) do
       instance_double(Dor::Services::Client::Object,
@@ -85,7 +85,7 @@ RSpec.describe 'Collection membership', type: :request do
       end
 
       context 'when the item is a member of the collection' do
-        let(:expected) { build(:dro, id: druid, collection_ids: ['druid:gg333xx4444']) }
+        let(:expected) { build(:dro_with_metadata, id: druid, collection_ids: ['druid:gg333xx4444']) }
 
         it 'removes a collection' do
           get "/items/#{druid}/collection/delete?collection=druid:bc555gh3434"
@@ -95,7 +95,7 @@ RSpec.describe 'Collection membership', type: :request do
       end
 
       context 'when the object is not in any collections' do
-        let(:cocina) { build(:dro, id: druid) }
+        let(:cocina) { build(:dro_with_metadata, id: druid) }
 
         it 'does an update with no changes' do
           get "/items/#{druid}/collection/delete?collection=druid:bc555gh3434"

--- a/spec/requests/manage_release_spec.rb
+++ b/spec/requests/manage_release_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Draw the manage release form' do
   let(:user) { create(:user) }
   let(:druid) { 'druid:bc123df4567' }
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
-  let(:cocina_model) { build(:dro, id: druid) }
+  let(:cocina_model) { build(:dro_with_metadata, id: druid) }
 
   before do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)

--- a/spec/requests/open_version_spec.rb
+++ b/spec/requests/open_version_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Open a version', type: :request do
   let(:druid) { 'druid:bc123df4567' }
   let(:user) { create(:user) }
   let(:object_service) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
-  let(:cocina_model) { build(:dro, id: druid) }
+  let(:cocina_model) { build(:dro_with_metadata, id: druid) }
 
   before do
     allow(Argo::Indexer).to receive(:reindex_druid_remotely)

--- a/spec/requests/publish_spec.rb
+++ b/spec/requests/publish_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Publishing', type: :request do
   let(:druid) { 'druid:bc123df4567' }
   let(:object_service) { instance_double(Dor::Services::Client::Object, publish: true, find: cocina_model) }
-  let(:cocina_model) { build(:dro, id: druid) }
+  let(:cocina_model) { build(:dro_with_metadata, id: druid) }
 
   before do
     sign_in create(:user), groups: ['sdr:administrator-role']

--- a/spec/requests/purge_object_spec.rb
+++ b/spec/requests/purge_object_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Purge object', type: :request do
   let(:druid) { 'druid:bc123df4567' }
   let(:object_service) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
-  let(:cocina_model) { build(:dro, id: druid) }
+  let(:cocina_model) { build(:dro_with_metadata, id: druid) }
 
   before do
     allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_service)

--- a/spec/requests/refresh_metadata_spec.rb
+++ b/spec/requests/refresh_metadata_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Refresh metadata', type: :request do
   let(:druid) { 'druid:bc123df4567' }
   let(:state_service) { instance_double(StateService, allows_modification?: true) }
   let(:object_service) { instance_double(Dor::Services::Client::Object, refresh_metadata: true, find: cocina_model) }
-  let(:cocina_model) { build(:dro, id: druid, catkeys: ['12345']) }
+  let(:cocina_model) { build(:dro_with_metadata, id: druid, catkeys: ['12345']) }
 
   before do
     allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_service)

--- a/spec/requests/registration_spec.rb
+++ b/spec/requests/registration_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Registration', type: :request do
   let(:bare_druid) { 'bc123df4567' }
   let(:cocina_admin_policy) do
-    instance_double(Cocina::Models::AdminPolicy,
+    instance_double(Cocina::Models::AdminPolicyWithMetadata,
                     externalIdentifier: druid,
                     administrative: cocina_admin_policy_administrative)
   end
@@ -180,18 +180,14 @@ RSpec.describe 'Registration', type: :request do
   describe '#workflow_list' do
     let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
     let(:cocina_model) do
-      Cocina::Models.build({
-                             'label' => 'The APO',
-                             'version' => 1,
-                             'type' => Cocina::Models::ObjectType.admin_policy,
-                             'externalIdentifier' => apo_id,
-                             'administrative' => {
-                               hasAdminPolicy: 'druid:hv992ry2431',
-                               hasAgreement: 'druid:hp308wm0436',
-                               registrationWorkflow: ['digitizationWF', 'dpgImageWF', Settings.apo.default_workflow_option, 'goobiWF'],
-                               accessTemplate: { view: 'world', download: 'world' }
-                             }
-                           })
+      build(:admin_policy_with_metadata, id: apo_id).new(
+        administrative: {
+          hasAdminPolicy: 'druid:hv992ry2431',
+          hasAgreement: 'druid:hp308wm0436',
+          registrationWorkflow: ['digitizationWF', 'dpgImageWF', Settings.apo.default_workflow_option, 'goobiWF'],
+          accessTemplate: { view: 'world', download: 'world' }
+        }
+      )
     end
     let(:apo_id) { 'druid:zt570tx3016' }
 

--- a/spec/requests/remove_apo_collection_spec.rb
+++ b/spec/requests/remove_apo_collection_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe 'Removing a collection from the registration list', type: :reques
 
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, update: true) }
   let(:cocina_model) do
-    build(:admin_policy, collections_for_registration: ['druid:1', collection_id])
+    build(:admin_policy_with_metadata, collections_for_registration: ['druid:1', collection_id])
   end
 
   let(:expected) do
-    build(:admin_policy, collections_for_registration: ['druid:1']) # only one collection now
+    build(:admin_policy_with_metadata, collections_for_registration: ['druid:1']) # only one collection now
   end
 
   it 'calls remove_default_collection' do

--- a/spec/requests/reset_workflow_steps_spec.rb
+++ b/spec/requests/reset_workflow_steps_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Reset failed workflow steps', type: :request do
   let(:workflow_client) { instance_double(Dor::Workflow::Client, update_status: true) }
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
   let(:druid) { 'druid:xb482bw3979' }
-  let(:cocina_model) { build(:dro) }
+  let(:cocina_model) { build(:dro_with_metadata) }
 
   before do
     allow(Dor::Workflow::Client).to receive(:new).and_return(workflow_client)

--- a/spec/requests/serials_spec.rb
+++ b/spec/requests/serials_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Serials', type: :request do
   let(:druid) { 'druid:dc243mg0841' }
 
   let(:cocina_model) do
-    build(:dro, id: druid, label: 'My Serial', title: 'My Serial')
+    build(:dro_with_metadata, id: druid, label: 'My Serial', title: 'My Serial')
   end
 
   before do

--- a/spec/requests/set_catkey_spec.rb
+++ b/spec/requests/set_catkey_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Set catkey' do
   let(:druid) { 'druid:dc243mg0841' }
 
   context 'without manage content access' do
-    let(:cocina) { instance_double(Cocina::Models::DRO) }
+    let(:cocina) { instance_double(Cocina::Models::DROWithMetadata) }
     let(:object_service) { instance_double(Dor::Services::Client::Object, find: cocina) }
 
     before do
@@ -80,7 +80,7 @@ RSpec.describe 'Set catkey' do
       end
 
       context 'with an item' do
-        let(:cocina_model) { build(:dro, id: druid) }
+        let(:cocina_model) { build(:dro_with_metadata, id: druid) }
 
         it 'updates the catkey, trimming whitespace' do
           patch "/items/#{druid}/catkey", params: { catkey: { catkey: '   12345 ' } }
@@ -92,7 +92,7 @@ RSpec.describe 'Set catkey' do
       end
 
       context 'with a collection that has no existing catkeys' do
-        let(:cocina_model) { build(:collection, id: druid, source_id: 'sul:1234') }
+        let(:cocina_model) { build(:collection_with_metadata, id: druid, source_id: 'sul:1234') }
 
         it 'updates the catkey, trimming whitespace' do
           patch "/items/#{druid}/catkey", params: { catkey: { catkey: '   12345 ' } }

--- a/spec/requests/set_content_types_spec.rb
+++ b/spec/requests/set_content_types_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Set content type for an item', type: :request do
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, update: true) }
   let(:content_type) { Cocina::Models::ObjectType.image }
   let(:cocina_model) do
-    build(:dro, id: druid, type: content_type).new(structural:)
+    build(:dro_with_metadata, id: druid, type: content_type).new(structural:)
   end
   let(:contains) do
     [

--- a/spec/requests/set_governing_apo_spec.rb
+++ b/spec/requests/set_governing_apo_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Set APO for an object' do
     let(:druid) { 'druid:dc243mg0841' }
     let(:new_apo_id) { 'druid:bc123cd4567' }
     let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, update: true) }
-    let(:cocina_model) { build(:dro, id: druid) }
+    let(:cocina_model) { build(:dro_with_metadata, id: druid) }
     let(:state_service) { instance_double(StateService, allows_modification?: true) }
 
     before do
@@ -60,7 +60,7 @@ RSpec.describe 'Set APO for an object' do
     end
 
     context 'when a collection' do
-      let(:cocina_model) { build(:collection, id: druid) }
+      let(:cocina_model) { build(:collection_with_metadata, id: druid) }
       let(:updated_model) do
         cocina_model.new('administrative' => { 'hasAdminPolicy' => new_apo_id })
       end

--- a/spec/requests/set_source_id_spec.rb
+++ b/spec/requests/set_source_id_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Set source id for an object' do
     let(:user) { create(:user) }
     let(:druid) { 'druid:cc243mg0841' }
     let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, update: true) }
-    let(:cocina_model) { build(:dro, id: druid) }
+    let(:cocina_model) { build(:dro_with_metadata, id: druid) }
 
     let(:updated_model) do
       cocina_model.new(

--- a/spec/requests/structure_spec.rb
+++ b/spec/requests/structure_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Structure', type: :request do
   end
 
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_item) }
-  let(:cocina_item) { build(:dro) }
+  let(:cocina_item) { build(:dro_with_metadata) }
 
   it 'renders a turbo-frame' do
     get '/items/skret-t0k3n/structure'

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Tags', type: :request do
     let(:object_client) do
       instance_double(Dor::Services::Client::Object, find: cocina_model, administrative_tags: tags_client)
     end
-    let(:cocina_model) { build(:dro) }
+    let(:cocina_model) { build(:dro_with_metadata) }
 
     before do
       allow(Dor::Services::Client).to receive(:object).and_return(object_client)

--- a/spec/requests/unpublish_spec.rb
+++ b/spec/requests/unpublish_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Unpublishing', type: :request do
   let(:druid) { 'druid:bc123df4567' }
   let(:object_service) { instance_double(Dor::Services::Client::Object, unpublish: true, find: cocina_model) }
-  let(:cocina_model) { build(:dro, id: druid) }
+  let(:cocina_model) { build(:dro_with_metadata, id: druid) }
 
   before do
     sign_in create(:user), groups: ['sdr:administrator-role']

--- a/spec/requests/update_an_existing_admin_policy_spec.rb
+++ b/spec/requests/update_an_existing_admin_policy_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe 'Update an existing Admin Policy' do
   let(:object_client) do
     instance_double(Dor::Services::Client::Object, find: cocina_model)
   end
-  let(:cocina_model) do
-    build(:admin_policy, id: druid)
-  end
+  let(:cocina_model) { build(:admin_policy_with_metadata, id: druid) }
 
   before do
     sign_in user, groups: ['sdr:administrator-role']

--- a/spec/requests/update_datastream_spec.rb
+++ b/spec/requests/update_datastream_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Update a datastream' do
     allow(Repository).to receive(:find).and_return(cocina_model)
   end
 
-  let(:cocina_model) { build(:dro) }
+  let(:cocina_model) { build(:dro_with_metadata) }
   let(:druid) { 'druid:bc123df4567' }
   let(:user) { create(:user) }
   let(:state_service) { instance_double(StateService, allows_modification?: true) }

--- a/spec/requests/upload_descriptive_csv_spec.rb
+++ b/spec/requests/upload_descriptive_csv_spec.rb
@@ -22,22 +22,7 @@ RSpec.describe 'Upload the descriptive CSV' do
       sign_in user, groups: ['sdr:administrator-role']
     end
 
-    let(:cocina_model) do
-      Cocina::Models.build({
-                             'label' => 'My ETD',
-                             'version' => 1,
-                             'type' => Cocina::Models::ObjectType.object,
-                             'externalIdentifier' => druid,
-                             'description' => {
-                               'title' => [{ 'value' => 'My ETD' }],
-                               'purl' => "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
-                             },
-                             'access' => {},
-                             'administrative' => { hasAdminPolicy: 'druid:cg532dg5405' },
-                             'structural' => {},
-                             identification: { sourceId: 'sul:1234' }
-                           })
-    end
+    let(:cocina_model) { build(:dro_with_metadata, id: druid) }
     let(:file) { fixture_file_upload('descriptive-upload.csv') }
 
     context 'when import was successful' do

--- a/spec/requests/upload_structural_csv_spec.rb
+++ b/spec/requests/upload_structural_csv_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Upload the structural CSV' do
       sign_in user, groups: ['sdr:administrator-role']
     end
 
-    let(:cocina_model) { build(:dro) }
+    let(:cocina_model) { build(:dro_with_metadata) }
     let(:file) { fixture_file_upload('structure-upload.csv') }
 
     context 'when object is unlocked' do
@@ -60,27 +60,27 @@ RSpec.describe 'Upload the structural CSV' do
 
       context 'when the data is invalid' do
         let(:cocina_model) do
-          build(:dro).new(structural: {
-                            contains: [
-                              {
-                                externalIdentifier: 'fs1',
-                                label: 'foo',
-                                version: 1,
-                                type: Cocina::Models::FileSetType.image,
-                                structural: {
-                                  contains: [
-                                    {
-                                      externalIdentifier: 'file1',
-                                      label: 'foo',
-                                      version: 1,
-                                      type: Cocina::Models::ObjectType.file,
-                                      filename: 'chocolate_cake.jpg'
-                                    }
-                                  ]
-                                }
-                              }
-                            ]
-                          })
+          build(:dro_with_metadata).new(structural: {
+                                          contains: [
+                                            {
+                                              externalIdentifier: 'fs1',
+                                              label: 'foo',
+                                              version: 1,
+                                              type: Cocina::Models::FileSetType.image,
+                                              structural: {
+                                                contains: [
+                                                  {
+                                                    externalIdentifier: 'file1',
+                                                    label: 'foo',
+                                                    version: 1,
+                                                    type: Cocina::Models::ObjectType.file,
+                                                    filename: 'chocolate_cake.jpg'
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          ]
+                                        })
         end
 
         it 'shows an error' do

--- a/spec/requests/workflow_service_spec.rb
+++ b/spec/requests/workflow_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'WorkflowServiceController', type: :request do
   let(:user) { create(:user) }
   let(:state_service) { instance_double(StateService) }
   let(:object_service) { instance_double(Dor::Services::Client::Object, find: cocina) }
-  let(:cocina) { build(:dro) }
+  let(:cocina) { build(:dro_with_metadata) }
 
   describe 'GET published' do
     context 'when published' do

--- a/spec/requests/workflows_spec.rb
+++ b/spec/requests/workflows_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'WorkflowsController', type: :request do
     Capybara::Node::Simple.new(response.body)
   end
 
-  let(:cocina) { build(:dro, id: druid, version: 2) }
+  let(:cocina) { build(:dro_with_metadata, id: druid, version: 2) }
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina) }
 
   before do

--- a/spec/services/admin_policy_persister_spec.rb
+++ b/spec/services/admin_policy_persister_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe AdminPolicyPersister do
 
   context 'with a persisted model (update)' do
     let(:apo) do
-      build(:admin_policy, id: 'druid:zt570qh4444', admin_policy_id: 'druid:xx666zz7777')
+      build(:admin_policy_with_metadata, id: 'druid:zt570qh4444', admin_policy_id: 'druid:xx666zz7777')
     end
 
     let(:use_statement) { 'My use and reproduction statement' }
@@ -46,50 +46,53 @@ RSpec.describe AdminPolicyPersister do
     describe '#sync' do
       subject(:result) { instance.sync }
 
-      it 'sets clean APO metadata for accessTemplate' do
-        expect(result.to_h).to eq(
-          Cocina::Models::AdminPolicy.new(
-            administrative: {
-              accessTemplate: {
-                view: 'world',
-                controlledDigitalLending: false,
-                download: 'world',
-                location: nil,
-                copyright: 'My copyright statement',
-                license: 'https://creativecommons.org/licenses/by-nc/3.0/legalcode',
-                useAndReproductionStatement: 'My use and reproduction statement'
+      let(:expected) do
+        admin_policy = Cocina::Models::AdminPolicy.new(
+          administrative: {
+            accessTemplate: {
+              view: 'world',
+              controlledDigitalLending: false,
+              download: 'world',
+              location: nil,
+              copyright: 'My copyright statement',
+              license: 'https://creativecommons.org/licenses/by-nc/3.0/legalcode',
+              useAndReproductionStatement: 'My use and reproduction statement'
+            },
+            collectionsForRegistration: ['druid:zj785yp4820'],
+            hasAdminPolicy: 'druid:xx666zz7777',
+            hasAgreement: 'druid:dd327rv8888',
+            registrationWorkflow: ['registrationWF'],
+            roles: [
+              {
+                members: [
+                  { identifier: 'sdr:developer', type: 'workgroup' },
+                  { identifier: 'sdr:service-manager', type: 'workgroup' },
+                  { identifier: 'sdr:metadata-staff', type: 'workgroup' }
+                ],
+                name: 'dor-apo-manager'
               },
-              collectionsForRegistration: ['druid:zj785yp4820'],
-              hasAdminPolicy: 'druid:xx666zz7777',
-              hasAgreement: 'druid:dd327rv8888',
-              registrationWorkflow: ['registrationWF'],
-              roles: [
-                {
-                  members: [
-                    { identifier: 'sdr:developer', type: 'workgroup' },
-                    { identifier: 'sdr:service-manager', type: 'workgroup' },
-                    { identifier: 'sdr:metadata-staff', type: 'workgroup' }
-                  ],
-                  name: 'dor-apo-manager'
-                },
-                {
-                  members: [
-                    { identifier: 'sdr:justins', type: 'workgroup' }
-                  ],
-                  name: 'dor-apo-viewer'
-                }
-              ]
-            },
-            description: {
-              title: [{ value: 'My title' }],
-              purl: 'https://purl.stanford.edu/zt570qh4444'
-            },
-            externalIdentifier: 'druid:zt570qh4444',
-            label: 'My title',
-            type: Cocina::Models::ObjectType.admin_policy,
-            version: 1
-          ).to_h
+              {
+                members: [
+                  { identifier: 'sdr:justins', type: 'workgroup' }
+                ],
+                name: 'dor-apo-viewer'
+              }
+            ]
+          },
+          description: {
+            title: [{ value: 'My title' }],
+            purl: 'https://purl.stanford.edu/zt570qh4444'
+          },
+          externalIdentifier: 'druid:zt570qh4444',
+          label: 'My title',
+          type: Cocina::Models::ObjectType.admin_policy,
+          version: 1
         )
+        Cocina::Models.with_metadata(admin_policy, 'abc123')
+      end
+
+      it 'sets clean APO metadata for accessTemplate' do
+        expect(result.to_h).to eq(expected.to_h)
       end
     end
 
@@ -98,7 +101,7 @@ RSpec.describe AdminPolicyPersister do
 
       let(:object_client) { instance_double(Dor::Services::Client::Object, update: cocina_model) }
       let(:cocina_model) do
-        instance_double(Cocina::Models::DRO, externalIdentifier: 'druid:999')
+        instance_double(Cocina::Models::DROWithMetadata, externalIdentifier: 'druid:999')
       end
       let(:change_set) do
         instance_double(ApoForm,

--- a/spec/services/collection_change_set_persister_spec.rb
+++ b/spec/services/collection_change_set_persister_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CollectionChangeSetPersister do
   describe '.update' do
     let(:change_set) { instance_double(CollectionChangeSet) }
     let(:instance) { instance_double(described_class, update: nil) }
-    let(:model) { instance_double(Cocina::Models::Collection) }
+    let(:model) { instance_double(Cocina::Models::CollectionWithMetadata) }
 
     before do
       allow(described_class).to receive(:new).and_return(instance)
@@ -26,7 +26,7 @@ RSpec.describe CollectionChangeSetPersister do
     let(:change_set) { CollectionChangeSet.new(model) }
     let(:license_before) { 'https://opendatacommons.org/licenses/pddl/1-0/' }
     let(:model) do
-      Cocina::Models::Collection.new(
+      model = Cocina::Models::Collection.new(
         externalIdentifier: 'druid:bc123df4568',
         label: 'test',
         type: Cocina::Models::ObjectType.collection,
@@ -43,6 +43,7 @@ RSpec.describe CollectionChangeSetPersister do
         },
         administrative: { hasAdminPolicy: 'druid:bc123df4569' }
       )
+      Cocina::Models.with_metadata(model, 'abc123')
     end
     let(:use_statement_before) { 'My First Use Statement' }
 

--- a/spec/services/item_change_set_persister_spec.rb
+++ b/spec/services/item_change_set_persister_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ItemChangeSetPersister do
   describe '.update' do
     let(:change_set) { instance_double(ItemChangeSet) }
     let(:instance) { instance_double(described_class, update: nil) }
-    let(:model) { instance_double(Cocina::Models::DRO) }
+    let(:model) { instance_double(Cocina::Models::DROWithMetadata) }
 
     before do
       allow(described_class).to receive(:new).and_return(instance)
@@ -25,7 +25,7 @@ RSpec.describe ItemChangeSetPersister do
     end
     let(:license_before) { 'https://opendatacommons.org/licenses/pddl/1-0/' }
     let(:model) do
-      Cocina::Models::DRO.new(
+      model = Cocina::Models::DRO.new(
         externalIdentifier: 'druid:bc123df4568',
         label: 'test',
         type: Cocina::Models::ObjectType.object,
@@ -47,6 +47,7 @@ RSpec.describe ItemChangeSetPersister do
         structural: {},
         administrative: { hasAdminPolicy: 'druid:bc123df4569' }
       )
+      Cocina::Models.with_metadata(model, 'abc123')
     end
     let(:use_statement_before) { 'My First Use Statement' }
     let(:barcode_before) { '36105014757517' }
@@ -123,7 +124,7 @@ RSpec.describe ItemChangeSetPersister do
     context 'when change set has changed embargo' do
       let(:new_embargo_release_date) { '2055-07-17' }
       let(:model) do
-        Cocina::Models::DRO.new(
+        model = Cocina::Models::DRO.new(
           externalIdentifier: 'druid:bc123df4568',
           label: 'test',
           type: Cocina::Models::ObjectType.object,
@@ -144,6 +145,7 @@ RSpec.describe ItemChangeSetPersister do
           structural: {},
           administrative: { hasAdminPolicy: 'druid:bc123df4569' }
         )
+        Cocina::Models.with_metadata(model, 'abc123')
       end
 
       before do
@@ -175,7 +177,7 @@ RSpec.describe ItemChangeSetPersister do
     context 'when change set has new embargo' do
       let(:new_embargo_release_date) { '2055-07-17' }
       let(:model) do
-        Cocina::Models::DRO.new(
+        model = Cocina::Models::DRO.new(
           externalIdentifier: 'druid:bc123df4568',
           label: 'test',
           type: Cocina::Models::ObjectType.object,
@@ -195,6 +197,7 @@ RSpec.describe ItemChangeSetPersister do
           structural: {},
           administrative: { hasAdminPolicy: 'druid:bc123df4569' }
         )
+        Cocina::Models.with_metadata(model, 'abc123')
       end
 
       before do
@@ -220,7 +223,7 @@ RSpec.describe ItemChangeSetPersister do
 
     context 'when change set has one changed property and another nil' do
       let(:model) do
-        Cocina::Models::DRO.new(
+        model = Cocina::Models::DRO.new(
           externalIdentifier: 'druid:bc123df4568',
           label: 'test',
           type: Cocina::Models::ObjectType.object,
@@ -238,6 +241,7 @@ RSpec.describe ItemChangeSetPersister do
           structural: {},
           administrative: { hasAdminPolicy: 'druid:bc123df4569' }
         )
+        Cocina::Models.with_metadata(model, 'abc123')
       end
       let(:new_use_statement) { 'A Changed Use Statement' }
 


### PR DESCRIPTION
closes #3557

## Why was this change made? 🤔
Better testing. In particular:
* Mostly: Uses *WithMetadata when model is returned from Repository or dor-services-client.
* Some: Replaces creation of cocina models with factory build.
* Little: Adds tests for ability.rb.
* No: App changes

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


