### PR TITLE
Don't truncate error messages so short

### DIFF
--- a/app/controllers/datastreams_controller.rb
+++ b/app/controllers/datastreams_controller.rb
@@ -40,11 +40,11 @@ class DatastreamsController < ApplicationController
       # if the content is not well-formed xml, inform the user rather than raising an exception
       error_msg = 'The datastream could not be saved due to malformed XML.'
     rescue Dor::Services::Client::UnexpectedResponse => e
-      error_msg = e.errors.first['detail']
+      error_msg = e.errors.first['detail']&.truncate(1024) # Truncate to avoid cookie overflow. Cookies can hold 4k.
     end
 
     respond_to do |format|
-      format.any { redirect_to solr_document_path(params[:item_id]), notice: msg, flash: { error: error_msg&.truncate(254) } }
+      format.any { redirect_to solr_document_path(params[:item_id]), notice: msg, flash: { error: error_msg } }
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,8 +22,8 @@ class ItemsController < ApplicationController
   ]
 
   rescue_from Dor::Services::Client::UnexpectedResponse do |exception|
-    detail = exception.errors.first['detail']
-    message = "Unable to retrieve the cocina model: #{detail.truncate(200)}"
+    detail = exception.errors.first['detail']&.truncate(1024) # Truncate to avoid cookie overflow. Cookies can hold 4k.
+    message = "Unable to retrieve the cocina model: #{detail}"
     Honeybadger.notify(exception)
     logger.error "Error connecting to DSA: #{detail}"
     if turbo_frame_request?


### PR DESCRIPTION


## Why was this change made? 🤔
The cookie can hold up to 4k of data, so use more of that space

Fixes #3523


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


