### PR TITLE
Adjust css for the resource file table to truncate filenames

### DIFF
--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -14,12 +14,15 @@
     &.object-type-apo {
       background-color: $sky-light;
     }
+
     &.object-type-collection {
       background-color: $fog;
     }
+
     &.object-type-item {
       background-color: $illuminating-light;
     }
+
     &.object-type-virtual-object {
       background-color: $bay-light;
     }
@@ -30,6 +33,7 @@
       min-width: $button-width;
       margin-right: .5rem;
       margin-bottom: .5rem;
+
       &.small {
         @extend .small;
       }
@@ -66,6 +70,7 @@
   .open-close {
     width: 2rem;
     float: left;
+
     .btn {
       font-size: x-large;
       color: $color-cardinal-red;
@@ -85,12 +90,14 @@
       background-color: $gray-200;
       padding: 1rem;
       margin-bottom: 1rem;
+
       .dl-horizontal {
         dt {
           clear: left;
           float: left;
           width: 7rem;
         }
+
         dd {
           margin-left: 8rem;
         }
@@ -100,7 +107,8 @@
         }
 
         dd:before,
-        dd:after, {
+        dd:after,
+          {
           display: table;
           content: " ";
         }
@@ -109,10 +117,23 @@
           clear: both;
         }
       }
+
       .resource-files {
         background-color: $body-bg;
-        margin-left: 3rem;
-        width: 90%
+        margin-left: .5rem;
+        margin-right: .5rem;
+
+        tr {
+          td {
+            max-width: 30vw;
+            text-overflow: ellipsis;
+            overflow: hidden;
+
+            a {
+              white-space: nowrap;
+            }
+          }
+        }
       }
     }
   }
@@ -133,7 +154,7 @@
     @extend .header;
   }
 
-  .caption-header > caption {
+  .caption-header>caption {
     caption-side: top;
     @extend .header;
     background-color: $silver-sand;

--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -154,7 +154,7 @@
     @extend .header;
   }
 
-  .caption-header>caption {
+  .caption-header > caption {
     caption-side: top;
     @extend .header;
     background-color: $silver-sand;


### PR DESCRIPTION
## Why was this change made? 🤔

Closes #3328 

This updates the resource file table to truncate filenames. A bit of positional adjustment was required as well. This may truncate the filenames too much, which may require some additional design.


![Screen Shot 2022-04-26 at 1 45 50 PM](https://user-images.githubusercontent.com/2294288/165389354-7505e387-3460-45ab-8350-32a387dd9f35.png)


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


