### PR TITLE
[HOLD] Style disabled primary buttons as greyed out

### DIFF
--- a/app/assets/stylesheets/bootstrap-overrides.scss
+++ b/app/assets/stylesheets/bootstrap-overrides.scss
@@ -32,3 +32,10 @@
   color: $body-color;
   opacity: 1.0;
 }
+
+// Style disabled outline-primary buttons as greyed out using the `disabled` pseudo-class
+.btn-outline-primary:disabled {
+  border-color: $btn-link-disabled-color;
+  color: $btn-link-disabled-color;
+  opacity: $btn-disabled-opacity;
+}

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -16,6 +16,9 @@ $silver: #c5c5c5;
 $primary: $color-cardinal-red;
 $success: $barley-corn;
 
+// Buttons
+$btn-link-disabled-color: $sonic-silver;
+
 // Links
 $link-color: $bright-blue;
 $link-hover-color: $blue;
@@ -32,5 +35,4 @@ $accordion-button-active-bg: $sonic-silver;
 $accordion-button-focus-box-shadow: 0 0 0.25rem 0.25rem rgba($sonic-silver, 0.25);
 
 // Table
-
 $table-border-color: $silver-sand;


### PR DESCRIPTION
On HOLD until Andrew takes a look in QA and approves.

## Why was this change made? 🤔

Fixes #3577

This commit changes the appearance of all primary buttons (including outline-primary buttons) such that if they are disabled, whether via CSS class (for link-y buttons) or pseudoclass (for button-y buttons), they are greyed out, making it clear to users that they are not able to be pushed.

![Screenshot from 2022-04-26 12-40-39](https://user-images.githubusercontent.com/131982/165380051-cfb314e3-a1fa-448b-b440-945378b80b17.png)

![Screenshot from 2022-04-26 12-39-54](https://user-images.githubusercontent.com/131982/165380053-d8a60783-3fe6-4224-9bc4-9f772473669a.png)


## How was this change tested? 🤨

CI
