### PR TITLE
Render Cocina on show page without metadata

### DIFF
--- a/app/presenters/cocina_hash_presenter.rb
+++ b/app/presenters/cocina_hash_presenter.rb
@@ -9,8 +9,8 @@
 #    it's super easy to coerce a hash into other data structures, so it gives us
 #    flexibility.
 class CocinaHashPresenter
-  def initialize(cocina_object:)
-    @cocina_object_hash = cocina_object.to_h
+  def initialize(cocina_object:, without_metadata: false)
+    @cocina_object_hash = hash_from(cocina_object, without_metadata)
   end
 
   def render
@@ -25,4 +25,11 @@ class CocinaHashPresenter
   private
 
   attr_reader :cocina_object_hash
+
+  def hash_from(cocina_object, without_metadata)
+    # NOTE: NilModel does not respond to tyep and cannot be fed to `#without_metadata`
+    return Cocina::Models.without_metadata(cocina_object).to_h if without_metadata && cocina_object.respond_to?(:type)
+
+    cocina_object.to_h
+  end
 end

--- a/app/views/catalog/_cocina_default.html.erb
+++ b/app/views/catalog/_cocina_default.html.erb
@@ -16,7 +16,13 @@
         </a>
 
       <script type="application/json" data-json-renderer-target="cocina">
-        <%= CocinaHashPresenter.new(cocina_object: @cocina).render.to_json.html_safe %>
+       <%=
+       CocinaHashPresenter
+         .new(cocina_object: @cocina, without_metadata: true)
+         .render
+         .to_json
+         .html_safe
+       %>
       </script>
 
       <div class="detail" data-json-renderer-target="section"></div>

--- a/lib/cocina/models/factories.rb
+++ b/lib/cocina/models/factories.rb
@@ -119,7 +119,7 @@ module Cocina
 
       # rubocop:disable Metrics/ParameterLists
       def self.build_admin_policy_properties(type:, id:, version:, label:, title:,
-                                             admin_policy_id:, agreement_id:,
+                                             admin_policy_id:, agreement_id:, without_description: false,
                                              use_statement: nil, copyright: nil, license: nil,
                                              registration_workflow: nil, collections_for_registration: nil)
         {
@@ -145,6 +145,7 @@ module Cocina
           props[:administrative][:accessTemplate][:license] = license if license
           props[:administrative][:registrationWorkflow] = registration_workflow if registration_workflow
           props[:administrative][:collectionsForRegistration] = collections_for_registration if collections_for_registration
+          props.delete(:description) if without_description
         end
       end
       # rubocop:enable Metrics/ParameterLists

--- a/spec/presenters/cocina_hash_presenter_spec.rb
+++ b/spec/presenters/cocina_hash_presenter_spec.rb
@@ -3,24 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe CocinaHashPresenter do
-  subject(:presenter) { described_class.new(cocina_object:) }
+  subject(:presenter) { described_class.new(cocina_object:, without_metadata:) }
+
+  let(:without_metadata) { false }
 
   describe '#render' do
     subject(:rendered) { presenter.render }
 
     context 'when cocina object lacks descriptive metadata' do
       let(:cocina_object) do
-        Cocina::Models::AdminPolicy.new(
-          type: Cocina::Models::ObjectType.admin_policy,
-          externalIdentifier: 'druid:zt570qh4444',
-          version: 1,
-          administrative: {
-            hasAdminPolicy: 'druid:hv992ry2431',
-            hasAgreement: 'druid:hp308wm0436',
-            accessTemplate: {}
-          },
-          label: 'My title'
-        )
+        build(:admin_policy_with_metadata, without_description: true)
       end
 
       it 'returns the object untouched as a hash' do
@@ -28,31 +20,29 @@ RSpec.describe CocinaHashPresenter do
       end
     end
 
+    context 'without metadata' do
+      let(:cocina_object) do
+        build(:admin_policy_with_metadata, without_description: true)
+      end
+      let(:without_metadata) { true }
+
+      it 'returns the object without a lock' do
+        expect(rendered).to eq(cocina_object.to_h.except(:lock))
+      end
+    end
+
     context 'when cocina object has descriptive metadata' do
       let(:cocina_object) do
-        Cocina::Models::Collection.new(
-          type: Cocina::Models::ObjectType.collection,
-          externalIdentifier: 'druid:zt570qh4444',
-          version: 1,
-          administrative: { hasAdminPolicy: 'druid:hv992ry2431' },
-          label: 'My title',
-          description: {
-            title: [
-              { value: 'My title' }
-            ],
-            purl: 'https://purl.stanford.edu/zt570qh4444'
-          },
-          identification: { sourceId: 'sul:1234' },
-          access: {}
-        )
+        build(:collection_with_metadata)
       end
 
       # NOTE: You might not see an empty e.g. `structuredValue` array above, but it's there in the instance
       it 'removes empty descriptive elements' do
         expect(rendered).to eq(cocinaVersion: Cocina::Models::VERSION,
+                               lock: cocina_object.lock,
                                type: 'https://cocina.sul.stanford.edu/models/collection',
-                               externalIdentifier: 'druid:zt570qh4444',
-                               label: 'My title',
+                               externalIdentifier: cocina_object.externalIdentifier,
+                               label: cocina_object.label,
                                version: 1,
                                access: {
                                  view: 'dark'
@@ -62,14 +52,13 @@ RSpec.describe CocinaHashPresenter do
                                  releaseTags: []
                                },
                                identification: {
-                                 catalogLinks: [],
-                                 sourceId: 'sul:1234'
+                                 catalogLinks: []
                                },
                                description: {
                                  title: [
-                                   { value: 'My title' }
+                                   { value: cocina_object.label }
                                  ],
-                                 purl: 'https://purl.stanford.edu/zt570qh4444'
+                                 purl: cocina_object.description.purl
                                })
       end
     end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3583

This commit adds a new option to the `CocinaHashPresenter` that allows it to render a Cocina structure without metadata, and in this case it means without the lock, created timestamp, and modified timestamp. This new option is then used on the catalog show page. As part of this work, convert the CocinaHashPresenter spec to use factories instead of hand-crafted Cocina model instances and add a flag to the factories to retain past test behavior.

## How was this change tested? 🤨

CI
