### PR TITLE
Display location for location-based access.

### DIFF
--- a/app/components/contents/file_component.rb
+++ b/app/components/contents/file_component.rb
@@ -23,11 +23,19 @@ module Contents
     delegate :publish, :shelve, :sdrPreserve, to: :administrative
 
     def view_access
-      access.view.capitalize
+      if access.view == 'location-based'
+        access.location
+      else
+        access.view.capitalize
+      end
     end
 
     def download_access
-      access.download.capitalize
+      if access.download == 'location-based'
+        access.location
+      else
+        access.download.capitalize
+      end
     end
 
     def role

--- a/spec/components/contents/file_component_spec.rb
+++ b/spec/components/contents/file_component_spec.rb
@@ -57,4 +57,22 @@ RSpec.describe Contents::FileComponent, type: :component do
       expect(rendered.to_html).not_to include '11839 px'
     end
   end
+
+  context 'with location-based view' do
+    let(:access) { instance_double(Cocina::Models::FileAccess, view: 'location-based', location: 'hoover', download: 'none') }
+
+    it 'renders the view location' do
+      expect(rendered.to_html).to include 'hoover'
+      expect(rendered.to_html).to include 'None'
+    end
+  end
+
+  context 'with location-based download' do
+    let(:access) { instance_double(Cocina::Models::FileAccess, view: 'stanford', location: 'hoover', download: 'location-based') }
+
+    it 'renders the donwload location' do
+      expect(rendered.to_html).to include 'Stanford'
+      expect(rendered.to_html).to include 'hoover'
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Resolves #3574. Shows location value rather than "Location-based" in structural View and Download columns.

## How was this change tested? 🤨

Specs and integration tests. 

![Screen Shot 2022-04-27 at 8 29 14 AM](https://user-images.githubusercontent.com/1619369/165525244-94f0022b-3e97-43f9-94e6-6fb789244f7c.png)

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


