### PR TITLE
Add filesets to an object through structural metadata csv upload

### DIFF
--- a/app/services/structure_updater.rb
+++ b/app/services/structure_updater.rb
@@ -16,10 +16,9 @@ class StructureUpdater
     @model = model
     @csv = CSV.new(csv, headers: true)
     @errors = []
-    @druid = model.externalIdentifier.delete_prefix('druid:')
   end
 
-  attr_reader :model, :csv, :errors, :druid
+  attr_reader :model, :csv, :errors
 
   # @return [Bool] true if there are no problems
   def validate
@@ -115,7 +114,7 @@ class StructureUpdater
   # @param [string] label the label to inject for a new fileset
   def fileset_for(sequence, label)
     model.structural.contains[sequence.to_i - 1].presence ||
-      Cocina::Models::FileSet.new(externalIdentifier: "#{FILESET_NAMESPACE}#{druid}-#{SecureRandom.uuid}",
+      Cocina::Models::FileSet.new(externalIdentifier: "#{FILESET_NAMESPACE}#{SecureRandom.uuid}",
                                   type: Cocina::Models::FileSetType.file,
                                   label:,
                                   version: 1)

--- a/app/services/structure_updater.rb
+++ b/app/services/structure_updater.rb
@@ -100,7 +100,7 @@ class StructureUpdater
     end
 
     contains = files_by_fileset.keys.map do |sequence|
-      fileset = fileset_for(sequence, files_by_fileset[sequence].first.label)
+      fileset = fileset_for(sequence.to_i, files_by_fileset[sequence].first.label)
       attributes = fileset_attributes[sequence]
                    .merge(structural: { contains: files_by_fileset[sequence] })
       fileset.new(**attributes)
@@ -111,9 +111,9 @@ class StructureUpdater
   FILESET_NAMESPACE = 'https://cocina.sul.stanford.edu/fileset/'
 
   # @param [Integer] sequence is the index of the fileset in the import
-  # @param [string] label the label to inject for a new fileset
+  # @param [String] label the label to inject for a new fileset
   def fileset_for(sequence, label)
-    model.structural.contains[sequence.to_i - 1].presence ||
+    model.structural.contains[sequence - 1].presence ||
       Cocina::Models::FileSet.new(externalIdentifier: "#{FILESET_NAMESPACE}#{SecureRandom.uuid}",
                                   type: Cocina::Models::FileSetType.file,
                                   label:,

--- a/app/services/structure_updater.rb
+++ b/app/services/structure_updater.rb
@@ -100,13 +100,27 @@ class StructureUpdater
     end
 
     contains = files_by_fileset.keys.map do |sequence|
-      # Find the existing fileset
-      existing_fileset = model.structural.contains[sequence.to_i - 1]
+      existing_fileset = file_set(sequence, files_by_fileset[sequence].first.label)
       attributes = fileset_attributes[sequence]
                    .merge(structural: { contains: files_by_fileset[sequence] })
       existing_fileset.new(**attributes)
     end
     Success(model.structural.new(contains:))
+  end
+
+  # @param [int] sequence is the index of the fileset in the import
+  # @param [string] label the label to inject for a new fileset
+  def file_set(sequence, label)
+    model.structural.contains[sequence.to_i - 1].presence || new_file_set(label) # Cocina::Models::FileSet.new(files)
+  end
+
+  def new_file_set(label)
+    druid = model.externalIdentifier.delete_prefix('druid:')
+    fileset_id = "https://cocina.sul.stanford.edu/fileset/#{druid}-#{SecureRandom.uuid}"
+    Cocina::Models::FileSet.new(externalIdentifier: fileset_id,
+                                type: Cocina::Models::FileSetType.file,
+                                label:,
+                                version: 1)
   end
 
   # Change the short resource type into a url

--- a/app/services/structure_updater.rb
+++ b/app/services/structure_updater.rb
@@ -110,7 +110,7 @@ class StructureUpdater
 
   FILESET_NAMESPACE = 'https://cocina.sul.stanford.edu/fileset/'
 
-  # @param [int] sequence is the index of the fileset in the import
+  # @param [Integer] sequence is the index of the fileset in the import
   # @param [string] label the label to inject for a new fileset
   def fileset_for(sequence, label)
     model.structural.contains[sequence.to_i - 1].presence ||

--- a/spec/services/structure_updater_spec.rb
+++ b/spec/services/structure_updater_spec.rb
@@ -269,6 +269,53 @@ RSpec.describe StructureUpdater do
     end
   end
 
+  context 'with valid csv that adds filesets' do
+    let(:csv) do
+      <<~CSV
+        resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
+        Picture 1,object,1,bb045jk9908_0001.tiff,bb045jk9908_0001.tiff,yes,yes,yes,stanford,stanford,,image/tiff,
+        Picture 2,object,2,bb045jk9908_0001.jp2,bb045jk9908_0001.jp2,yes,yes,no,world,world,,image/jp2,
+        Picture 3,page,3,bb045jk9908_0002.tiff,bb045jk9908_0002.tiff,yes,yes,yes,stanford,stanford,,image/tiff,
+        Picture 4,page,4,bb045jk9908_0002.jp2,bb045jk9908_0002.jp2,yes,yes,no,world,world,,image/jp2,
+      CSV
+    end
+
+    it 'adds the filesets' do
+      new_filesets = result.value!.contains
+      expect(new_filesets.map(&:label)).to eq [
+        'Picture 1',
+        'Picture 2',
+        'Picture 3',
+        'Picture 4'
+      ]
+    end
+
+    it 'produces valid cocina' do
+      cocina.new(structural: result.value!)
+    end
+  end
+
+  context 'with valid csv that combines filesets' do
+    let(:csv) do
+      <<~CSV
+        resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
+        Picture 1,object,1,bb045jk9908_0001.tiff,bb045jk9908_0001.tiff,yes,yes,yes,stanford,stanford,,image/tiff,
+        Picture 1,object,1,bb045jk9908_0001.jp2,bb045jk9908_0001.jp2,yes,yes,no,world,world,,image/jp2,
+        Picture 1,page,1,bb045jk9908_0002.tiff,bb045jk9908_0002.tiff,yes,yes,yes,stanford,stanford,,image/tiff,
+        Picture 1,page,1,bb045jk9908_0002.jp2,bb045jk9908_0002.jp2,yes,yes,no,world,world,,image/jp2,
+      CSV
+    end
+
+    it 'combines the filesets' do
+      new_filesets = result.value!.contains
+      expect(new_filesets.map(&:label)).to eq ['Picture 1']
+    end
+
+    it 'produces valid cocina' do
+      cocina.new(structural: result.value!)
+    end
+  end
+
   context 'with invalid csv' do
     let(:csv) do
       <<~CSV


### PR DESCRIPTION
## Why was this change made? 🤔

Closes #3576 

With an initial (single) fileset:

<img width="1336" alt="Screen Shot 2022-04-27 at 2 19 51 PM" src="https://user-images.githubusercontent.com/2294288/165633266-4fa213f3-b472-4ab1-a129-71d540783d83.png">

The exported data will look like:

```
resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
Page 1,file,1,Health_Wellbeing_Panel_audio_GMT20220304-220000_Recording.mp4,Health_Wellbeing_Panel_audio_GMT20220304-220000_Recording.mp4,yes,no,yes,dark,none,,video/mp4,
Page 2,file,1,Health_Wellbeing_unedited_transcript_GMT20220304-220000_Recording.transcript.pdf,Health_Wellbeing_unedited_transcript_GMT20220304-220000_Recording.transcript.pdf,yes,no,yes,dark,none,,application/pdf,
Page 3,file,1,Health_Wellbeing_unedited_transcript_GMT20220304-220000_Recording.transcript.vtt,Health_Wellbeing_unedited_transcript_GMT20220304-220000_Recording.transcript.vtt,yes,no,yes,dark,none,,text/plain,
```

When the sequence is edited in the structural csv to indicate individual filesets, they will be generated:

```
resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
Page 1,file,1,Health_Wellbeing_Panel_audio_GMT20220304-220000_Recording.mp4,Health_Wellbeing_Panel_audio_GMT20220304-220000_Recording.mp4,yes,no,yes,dark,none,,video/mp4,
Page 2,file,2,Health_Wellbeing_unedited_transcript_GMT20220304-220000_Recording.transcript.pdf,Health_Wellbeing_unedited_transcript_GMT20220304-220000_Recording.transcript.pdf,yes,no,yes,dark,none,,application/pdf,
Page 3,file,3,Health_Wellbeing_unedited_transcript_GMT20220304-220000_Recording.transcript.vtt,Health_Wellbeing_unedited_transcript_GMT20220304-220000_Recording.transcript.vtt,yes,no,yes,dark,none,,text/plain,
```

<img width="1298" alt="Screen Shot 2022-04-27 at 2 20 19 PM" src="https://user-images.githubusercontent.com/2294288/165633379-4c88ab3f-6754-4e82-8211-5462bc71465e.png">



## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


