### PR TITLE
fix catkey setting bulk action

### DIFF
--- a/app/jobs/set_catkeys_and_barcodes_job.rb
+++ b/app/jobs/set_catkeys_and_barcodes_job.rb
@@ -23,7 +23,7 @@ class SetCatkeysAndBarcodesJob < GenericJob
       update_druids.each_with_index do |current_druid, i|
         cocina_object = Repository.find(current_druid)
         args = {}
-        args[:catkeys] = catkeys[i] if catkeys
+        args[:catkeys] = (catkeys[i] || []) if catkeys
         args[:barcode] = barcodes[i] if barcodes
         change_set = ItemChangeSet.new(cocina_object)
         change_set.validate(args)

--- a/app/jobs/set_catkeys_and_barcodes_job.rb
+++ b/app/jobs/set_catkeys_and_barcodes_job.rb
@@ -23,7 +23,7 @@ class SetCatkeysAndBarcodesJob < GenericJob
       update_druids.each_with_index do |current_druid, i|
         cocina_object = Repository.find(current_druid)
         args = {}
-        args[:catkeys] = (catkeys[i] || []) if catkeys
+        args[:catkeys] = Array(catkeys[i]) if catkeys
         args[:barcode] = barcodes[i] if barcodes
         change_set = ItemChangeSet.new(cocina_object)
         change_set.validate(args)


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3591 - removing catkeys via bulk action was not working (we need to send an empty array and not nil)

## How was this change tested? 🤨

- Tested job on stage
- New test to confirm we send a blank array and not nil when no catkey(s) are provided for a druid