### PR TITLE
Recognize parallel titles as valid titles.

### DIFF
--- a/app/services/description_validator.rb
+++ b/app/services/description_validator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # Validate the descriptive metadata spreadsheet
+# rubocop:disable Metrics/ClassLength
 class DescriptionValidator
   def initialize(csv, bulk_job: false)
     @csv = csv
@@ -41,10 +42,7 @@ class DescriptionValidator
   end
 
   def validate_title_headers
-    if @headers.include?('title1.value') ||
-       (@headers.exclude?('title1.value') && @headers.include?('title1.structuredValue1.type') && @headers.include?('title1.structuredValue1.value'))
-      return
-    end
+    return if title_value_header? || title_structured_value_header? || title_parallel_value_header?
 
     errors << 'Title column not found.'
   end
@@ -69,6 +67,18 @@ class DescriptionValidator
   end
 
   private
+
+  def title_value_header?
+    @headers.include?('title1.value')
+  end
+
+  def title_structured_value_header?
+    @headers.include?('title1.structuredValue1.type') && @headers.include?('title1.structuredValue1.value')
+  end
+
+  def title_parallel_value_header?
+    @headers.include?('title1.parallelValue1.value') || @headers.include?('title1.parallelValue1.structuredValue1.value')
+  end
 
   def duplicate_headers
     @headers.group_by { |e| e }.filter { |_k, v| v.count > 1 }.keys
@@ -121,3 +131,4 @@ class DescriptionValidator
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/spec/features/apo_spec.rb
+++ b/spec/features/apo_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Create an apo', js: true do
     # Shows a link to the agreement
     expect(page).to have_link 'Test Agreement',
                               href: solr_document_path(agreement.externalIdentifier),
-                              wait: 15 # This link is rendered in a turbo-frame, so wait longer than the default
+                              wait: 30 # This link is rendered in a turbo-frame, so wait longer than the default
 
     click_on 'Edit APO'
     expect(page).to have_text 'Add group' # wait for form to render

--- a/spec/services/description_validator_spec.rb
+++ b/spec/services/description_validator_spec.rb
@@ -62,6 +62,22 @@ RSpec.describe DescriptionValidator do
         end
       end
 
+      context 'with title1.parallelValue1.value column' do
+        let(:csv) { 'druid,title1.parallelValue1.value' }
+
+        it 'validates' do
+          expect(instance.valid?).to be true
+        end
+      end
+
+      context 'with title1.parallelValue1.structuredValue1.value column' do
+        let(:csv) { 'druid,title1.parallelValue1.structuredValue1.value' }
+
+        it 'validates' do
+          expect(instance.valid?).to be true
+        end
+      end
+
       context 'with headers that do not map to cocina model' do
         let(:csv) { 'druid,title1.value,title2.value,title3.value,bogus,event.contributor,event1.contributor,event1.note1.source.value' }
 


### PR DESCRIPTION
closes #3600

## Why was this change made? 🤔
Allow parallel titles, which are valid for descriptive spreadsheets.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡

Unit
