### PR TITLE
Show truncated events on show page with option to expand

### DIFF
--- a/app/javascript/controllers/expandable_snippets.js
+++ b/app/javascript/controllers/expandable_snippets.js
@@ -1,0 +1,40 @@
+import { Controller } from 'stimulus'
+
+export default class extends Controller {
+  static targets = ['snippet', 'viewLessLink', 'viewMoreLink']
+
+  static values = {
+    expanded: { type: Boolean, default: true }
+  }
+
+  connect() {
+    this.snippetLines = this.snippetTarget.innerText.split("\n")
+    this.collapse()
+  }
+
+  expand() {
+    if (!this.expandedValue && this.length > this.maxLength) {
+      this.snippetTarget.innerText = this.snippetLines.join("\n")
+      this.expandedValue = true
+      this.viewMoreLinkTarget.hidden = true
+      this.viewLessLinkTarget.hidden = false
+    }
+  }
+
+  collapse() {
+    if (this.expandedValue && this.length > this.maxLength) {
+      this.snippetTarget.innerText = this.snippetLines.slice(0, this.maxLength).join("\n")
+      this.expandedValue = false
+      this.viewMoreLinkTarget.hidden = false
+      this.viewLessLinkTarget.hidden = true
+    }
+  }
+
+  get length() {
+    return this.snippetLines.length
+  }
+
+  get maxLength() {
+    return 10
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -17,6 +17,7 @@ import ApoFormController from './apo_form_controller'
 import OpenCloseController from './open_close_controller'
 import StructuralController from './structural_controller'
 import AccessRightsController from './access_rights_controller'
+import ExpandableSnippets from './expandable_snippets'
 
 const application = Application.start()
 application.register("bulk-actions", BulkActions)
@@ -37,3 +38,4 @@ application.register("apo-form", ApoFormController)
 application.register("open-close", OpenCloseController)
 application.register("structural", StructuralController)
 application.register("access-rights", AccessRightsController)
+application.register("expandable-snippets", ExpandableSnippets)

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -5,7 +5,19 @@
     </thead>
     <tbody>
     <% @events.each do |event| %>
-      <tr><td><time-ago datetime="<%= event.timestamp %>"><%= event.timestamp %></time-ago></td><td><%= event.event_type %></td><td><pre><%= JSON.pretty_generate(event.data) %></pre></td></tr>
+      <tr>
+        <td><time-ago datetime="<%= event.timestamp %>"><%= event.timestamp %></time-ago></td>
+        <td><%= event.event_type %></td>
+        <td data-controller="expandable-snippets">
+          <pre data-expandable-snippets-target="snippet"><%= JSON.pretty_generate(event.data) %></pre>
+          <button data-expandable-snippets-target="viewMoreLink" data-action="expandable-snippets#expand" hidden type="button" class="btn btn-link">
+            View more <span class="bi-arrow-bar-down"/>
+          </a>
+          <button data-expandable-snippets-target="viewLessLink" data-action="expandable-snippets#collapse" hidden type="button" class="btn btn-link">
+            View less <span class="bi-arrow-bar-up"/>
+          </a>
+        </td>
+      </tr>
     <% end %>
     </tbody>
   </table>

--- a/spec/features/item_view_spec.rb
+++ b/spec/features/item_view_spec.rb
@@ -10,7 +10,16 @@ RSpec.describe 'Item view', js: true do
   let(:blacklight_config) { CatalogController.blacklight_config }
   let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
   let(:item_id) { 'druid:hj185xx2222' }
-  let(:event) { Dor::Services::Client::Events::Event.new(event_type: 'shelve_request_received', data: { 'host' => 'dor-services-stage.stanford.edu' }) }
+  let(:props) { {} }
+  let(:event) do
+    Dor::Services::Client::Events::Event.new(
+      event_type: 'shelve_request_received',
+      data: {
+        host: 'dor-services-stage.stanford.edu',
+        **props
+      }
+    )
+  end
   let(:datastream) { Dor::Services::Client::Metadata::Datastream.new(dsid: 'descMetadata', pid: item_id) }
   let(:metadata_client) { instance_double(Dor::Services::Client::Metadata, datastreams: [datastream]) }
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: [event]) }
@@ -268,6 +277,13 @@ RSpec.describe 'Item view', js: true do
             expect(page).to have_css 'table.table thead tr th', text: 'Release'
             expect(page).to have_css 'tr td', text: /Searchworks/
             expect(page).to have_css 'tr td', text: /pjreed/
+
+            # The following three clicks make sure events are expandable and collapsible
+            click_button 'Events'
+            within '#events' do
+              click_button 'View more'
+              click_button 'View less'
+            end
 
             click_button 'Datastreams' # Open the datastream accordion
             click_link 'descMetadata' # Open the datastream modal


### PR DESCRIPTION
~~HOLD until @andrewjbtw can take a look in QA~~

## Why was this change made? 🤔

Fixes #3575

This commit makes the show page tidier by showing only a peek into each event in the events list. This allows users to determine which events they want to see in detail.

![expandable-events](https://user-images.githubusercontent.com/131982/165986702-67f08ac6-1ad8-41c6-9b4f-8e1d9656c7e5.gif)

## How was this change tested? 🤨

CI + QA
