### PR TITLE
Changes ModsulatorJob to use cocina (instead of Mods) from equivalenc…

### DIFF
--- a/app/jobs/modsulator_job.rb
+++ b/app/jobs/modsulator_job.rb
@@ -91,14 +91,11 @@ class ModsulatorJob < ActiveJob::Base
       end
 
       begin
-        object_client = Dor::Services::Client.object(item_druid)
-        current_metadata = object_client.metadata.mods
         cocina = Repository.find(item_druid)
 
         ApplyModsMetadata.new(apo_druid: druid,
                               mods: xmldoc_node.first_element_child.to_s,
                               cocina:,
-                              existing_mods: current_metadata,
                               original_filename:,
                               ability:,
                               log:).apply

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,7 @@ module Argo
 
     config.after_initialize do |app|
       Argo.verifier = app.message_verifier('Argo')
+      Cocina::Models::Mapping::Purl.base_url = Settings.purl_url
     end
   end
 


### PR DESCRIPTION
…e and update.

closes #3604

## Why was this change made? 🤔
This allows for restoring the previous behavior of checking for description changes before versioning/updating.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, Andrew

⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


