### PR TITLE
another attempt to fix flappy spec

### DIFF
--- a/spec/features/apo_spec.rb
+++ b/spec/features/apo_spec.rb
@@ -55,10 +55,10 @@ RSpec.describe 'Create an apo', js: true do
     click_button 'Register APO'
     expect(page).to have_text 'created'
 
-    # Shows a link to the agreement
-    expect(page).to have_link 'Test Agreement',
-                              href: solr_document_path(agreement.externalIdentifier),
-                              wait: 30 # This link is rendered in a turbo-frame, so wait longer than the default
+    # Shows a link to the agreement. The agreement name is loaded by turbo-links, so pause to let it complete
+    # (capybara wait is flaky, see https://discuss.hotwired.dev/t/capybara-wait-for-ajax-replacement-for-turbo-stream-responses/2269/9)
+    sleep 3
+    expect(page).to have_link 'Test Agreement', href: solr_document_path(agreement.externalIdentifier)
 
     click_on 'Edit APO'
     expect(page).to have_text 'Add group' # wait for form to render


### PR DESCRIPTION
## Why was this change made? 🤔

Turbo links pull in the link name, which can sometimes be flappy.  This sleeps instead of waits.  1 second passed locally and failed in CI.  Trying for 3 seconds.

## How was this change tested? 🤨

Existing tests

