### PR TITLE
Display the mods title in the body of the modal

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,7 @@ gem 'blacklight-hierarchy', '~> 6.0'
 gem 'dor-services-client', '~> 10.0'
 gem 'dor-workflow-client', '~> 4.0'
 gem 'druid-tools'
-gem 'mods_display', '~> 1.0.0.alpha1'
+gem 'mods_display', '~> 1.0.0'
 gem 'okcomputer' # monitors application and its dependencies
 gem 'preservation-client', '~> 4.0'
 gem 'rsolr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -621,7 +621,7 @@ DEPENDENCIES
   jsbundling-rails (~> 1.0)
   listen (~> 3.2)
   lograge
-  mods_display (~> 1.0.0.alpha1)
+  mods_display (~> 1.0.0)
   mysql2 (~> 0.5)
   newrelic_rpm
   nokogiri (~> 1.13)

--- a/app/views/metadata/_descriptive.html.erb
+++ b/app/views/metadata/_descriptive.html.erb
@@ -1,1 +1,0 @@
-<%= @mods_display.body.html_safe %>

--- a/app/views/metadata/descriptive.html.erb
+++ b/app/views/metadata/descriptive.html.erb
@@ -1,4 +1,7 @@
 <%= render BlacklightModalComponent.new do |component| %>
-  <% component.header { @mods_display.title.first.html_safe } %>
-  <% component.body { render 'descriptive' } %>
+  <% component.header { 'View descriptive metadata' } %>
+  <% component.body do
+       render ModsDisplay::RecordComponent.new(record: @mods_display,
+                fields: [:title] + ModsDisplay::RecordComponent::DEFAULT_FIELDS - [:subTitle])
+  end %>
 <% end %>


### PR DESCRIPTION


## Why was this change made? 🤔

Previously the title was in the header.
Fixes #3615
Fixes #635

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


