### PR TITLE
Allow excel files to be uploaded for description update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,6 +117,7 @@ group :test do
   gem 'simplecov'
   gem 'webdrivers' # installs the chrome for selenium tests
   gem 'webmock', require: false
+  gem 'write_xlsx' # this is required to write an xlsx file prior to opening it with roo in tests
 end
 
 group :deployment do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -577,9 +577,14 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    write_xlsx (1.09.2)
+      rubyzip (>= 1.0.0)
+      zip-zip
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.5.4)
+    zip-zip (0.3)
+      rubyzip (>= 1.0.0)
     zip_tricks (5.3.1)
 
 PLATFORMS
@@ -660,6 +665,7 @@ DEPENDENCIES
   web-console
   webdrivers
   webmock
+  write_xlsx
   zip_tricks (= 5.3.1)
 
 BUNDLED WITH

--- a/app/controllers/descriptives_controller.rb
+++ b/app/controllers/descriptives_controller.rb
@@ -9,7 +9,7 @@ class DescriptivesController < ApplicationController
 
   # Handle upload of the spreadsheet
   def update
-    csv = CSV.read(params[:data].tempfile, headers: true)
+    csv = CSV.parse(CsvUploadNormalizer.read(params[:data].tempfile), headers: true)
     validator = DescriptionValidator.new(csv)
     if validator.valid?
       DescriptionImport.import(csv_row: csv.first)

--- a/app/views/descriptives/_form.html.erb
+++ b/app/views/descriptives/_form.html.erb
@@ -9,7 +9,7 @@
       <%= f.label :data, class: 'form-label' do %>
         Upload Cocina descriptive metadata spreadsheet for <%= @cocina.externalIdentifier %>
       <% end %>
-      <%= f.file_field :data, class: 'form-control', accept: '.csv', required: true %>
+      <%= f.file_field :data, class: 'form-control', accept: '.csv,.xlsx', required: true %>
     </div>
     <%= f.submit 'Upload', class: 'btn btn-primary' %>
   <% end %>

--- a/spec/features/upload_descriptive_metadata_spec.rb
+++ b/spec/features/upload_descriptive_metadata_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Descriptive metadata spreadsheet upload', js: true do
     "title1.value,purl\nmy title,https://purl.stanford.edu/#{Druid.new(item.externalIdentifier).without_namespace}\n"
   end
   let(:file) do
-    Tempfile.new('upload.csv').tap do |file|
+    Tempfile.new(%w[upload .csv]).tap do |file|
       file.write csv
       file.close
     end

--- a/spec/features/upload_descriptive_metadata_spec.rb
+++ b/spec/features/upload_descriptive_metadata_spec.rb
@@ -13,32 +13,65 @@ RSpec.describe 'Descriptive metadata spreadsheet upload', js: true do
     FactoryBot.create_for_repository(:persisted_item)
   end
 
-  let(:csv) do
-    "title1.value,purl\nmy title,https://purl.stanford.edu/#{Druid.new(item.externalIdentifier).without_namespace}\n"
-  end
-  let(:file) do
-    Tempfile.new(%w[upload .csv]).tap do |file|
-      file.write csv
-      file.close
-    end
+  before do
+    sign_in user, groups: ['sdr:administrator-role']
+    visit solr_document_path(item.externalIdentifier)
   end
 
   after do
     file.unlink
   end
 
-  before do
-    sign_in user, groups: ['sdr:administrator-role']
-    visit solr_document_path(item.externalIdentifier)
+  context 'with a csv file' do
+    let(:csv) do
+      "title1.value,purl\nmy title,https://purl.stanford.edu/#{Druid.new(item.externalIdentifier).without_namespace}\n"
+    end
+    let(:file) do
+      Tempfile.new(%w[upload .csv]).tap do |file|
+        file.write csv
+        file.close
+      end
+    end
+
+    it 'uploads csv descriptive' do
+      click_button 'Manage description'
+      click_link 'Upload Cocina spreadsheet'
+
+      attach_file("Upload Cocina descriptive metadata spreadsheet for #{item.externalIdentifier}", file.path)
+      click_button 'Upload'
+
+      expect(page).to have_content 'Descriptive metadata has been updated.'
+    end
   end
 
-  it 'uploads descriptive' do
-    click_button 'Manage description'
-    click_link 'Upload Cocina spreadsheet'
+  context 'with an excel file' do
+    let(:file) do
+      Tempfile.new(%w[upload .xlsx]).tap do |file|
+        # Open the temp file as an XLSX workbook
+        workbook = WriteXLSX.new(file.path)
 
-    attach_file("Upload Cocina descriptive metadata spreadsheet for #{item.externalIdentifier}", file.path)
-    click_button 'Upload'
+        # Add the initial worksheet
+        worksheet = workbook.add_worksheet
 
-    expect(page).to have_content 'Descriptive metadata has been updated.'
+        # Write our data into the sheet
+        worksheet.write('A1', 'title1.value')
+        worksheet.write('A2', 'my title from excel')
+        worksheet.write('B1', 'purl')
+        worksheet.write('B2', "https://purl.stanford.edu/#{Druid.new(item.externalIdentifier).without_namespace}")
+
+        # Close - require to avoid file curruption
+        workbook.close
+      end
+    end
+
+    it 'uploads excel descriptive' do
+      click_button 'Manage description'
+      click_link 'Upload Cocina spreadsheet'
+
+      attach_file("Upload Cocina descriptive metadata spreadsheet for #{item.externalIdentifier}", file.path)
+      click_button 'Upload'
+
+      expect(page).to have_content 'Descriptive metadata has been updated.'
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Closes #3620 by allowing `.xlsx` file extensions in the file open dialog and then uses `CsvUploadNormalizer` to parse either a CSV or Excel sheet into csv data.



## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


