### PR TITLE
Lazy-load cocina object JSON on show page

### DIFF
--- a/app/components/show/admin_policy_component.html.erb
+++ b/app/components/show/admin_policy_component.html.erb
@@ -25,6 +25,6 @@
 
 <div class="accordion">
   <%= render 'events_default', view_token: view_token %>
-  <%= render 'cocina_default', document: document %>
+  <%= render 'cocina_default', view_token: view_token %>
   <%= render 'history_default', document: document %>
 </div>

--- a/app/components/show/agreement_component.html.erb
+++ b/app/components/show/agreement_component.html.erb
@@ -21,7 +21,7 @@
 
 <div class="accordion">
   <%= render 'events_default', view_token: view_token %>
-  <%= render 'cocina_default', document: document %>
+  <%= render 'cocina_default', view_token: view_token %>
   <%= render 'history_default', document: document %>
   <%= render ContentsComponent.new(presenter: presenter) %>
   <%= render TechmdComponent.new(view_token: view_token) %>

--- a/app/components/show/collection_component.html.erb
+++ b/app/components/show/collection_component.html.erb
@@ -21,6 +21,6 @@
 
 <div class="accordion">
   <%= render 'events_default', view_token: view_token %>
-  <%= render 'cocina_default', document: document %>
+  <%= render 'cocina_default', view_token: view_token %>
   <%= render 'history_default', document: document %>
 </div>

--- a/app/components/show/item_component.html.erb
+++ b/app/components/show/item_component.html.erb
@@ -24,7 +24,7 @@
 
 <div class="accordion">
   <%= render 'events_default', view_token: view_token %>
-  <%= render 'cocina_default', document: document %>
+  <%= render 'cocina_default', view_token: view_token %>
   <%= render 'history_default', document: document %>
   <%= render ContentsComponent.new(presenter: presenter) %>
   <%= render TechmdComponent.new(view_token: view_token) %>

--- a/app/controllers/cocina_objects_controller.rb
+++ b/app/controllers/cocina_objects_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Loads and allows viewing Cocina objects
+class CocinaObjectsController < ApplicationController
+  # Lazy-load the cocina object part of the show page
+  def show
+    @cocina_object = Repository.find(decrypted_token.fetch(:key))
+  end
+
+  private
+
+  # Decode the token that grants view access
+  def decrypted_token
+    Argo.verifier.verified(params[:item_id], purpose: :view_token)
+  end
+end

--- a/app/views/catalog/_cocina_default.html.erb
+++ b/app/views/catalog/_cocina_default.html.erb
@@ -5,27 +5,9 @@
     </button>
   </h2>
   <div id="document-cocina-section" class="accordion-collapse collapse" aria-labelledby="document-cocina-heading">
-    <div class="accordion-body" data-controller="json-renderer">
-        <a class="btn btn-secondary " data-action="json-renderer#expand">
-          <span class="bi-arrows-expand"/>
-          <span>Expand</span>
-        </a>
-        <a class="btn btn-secondary " data-action="json-renderer#collapse">
-          <span class="bi-arrows-collapse"/>
-          <span>Collapse</span>
-        </a>
-
-      <script type="application/json" data-json-renderer-target="cocina">
-       <%=
-       CocinaHashPresenter
-         .new(cocina_object: @cocina, without_metadata: true)
-         .render
-         .to_json
-         .html_safe
-       %>
-      </script>
-
-      <div class="detail" data-json-renderer-target="section"></div>
+    <div class="accordion-body">
+      <turbo-frame id="cocina_object" src="<%= item_cocina_object_path(view_token) %>" loading="lazy">
+      </turbo-frame>
     </div>
   </div>
 </div>

--- a/app/views/cocina_objects/show.html.erb
+++ b/app/views/cocina_objects/show.html.erb
@@ -1,0 +1,24 @@
+<turbo-frame id="cocina_object">
+  <div data-controller="json-renderer">
+    <a class="btn btn-secondary " data-action="json-renderer#expand">
+      <span class="bi-arrows-expand"/>
+      <span>Expand</span>
+    </a>
+    <a class="btn btn-secondary " data-action="json-renderer#collapse">
+      <span class="bi-arrows-collapse"/>
+      <span>Collapse</span>
+    </a>
+
+    <script type="application/json" data-json-renderer-target="cocina">
+    <%=
+      CocinaHashPresenter
+        .new(cocina_object: @cocina_object, without_metadata: true)
+        .render
+        .to_json
+        .html_safe
+    %>
+    </script>
+
+    <div class="detail" data-json-renderer-target="section"></div>
+  </div>
+</turbo-frame>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,6 +147,7 @@ Rails.application.routes.draw do
     resource :descriptive, only: %i[show edit update]
     resource :technical, only: %i[show]
     resource :events, only: %i[show]
+    resource :cocina_object, only: %i[show]
     resource :serials, only: %i[edit update]
 
     resources :workflows, only: %i[new create show update] do

--- a/spec/requests/cocina_objects_spec.rb
+++ b/spec/requests/cocina_objects_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Cocina objects', type: :request do
+  before do
+    allow(Argo.verifier).to receive(:verified).and_return({ key: 'druid:kv840xx0000' })
+    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+    sign_in build(:user), groups: []
+  end
+
+  let(:rendered) do
+    Capybara::Node::Simple.new(response.body)
+  end
+
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_object) }
+  let(:cocina_object) { build(:dro) }
+
+  it 'renders a turbo-frame' do
+    get '/items/skret-t0k3n/cocina_object'
+    expect(response).to have_http_status(:ok)
+    expect(rendered.find_css('turbo-frame#cocina_object')).to be_present
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3626

This commit removes the burden of loading the full Cocina data structure from the show page, doing so lazily, only if the user interacts with the Cocina dropdown. This allows the show page to render more quickly. The approach taken in this commit follows similar work on lazy-loading events and technical metadata.

## How was this change tested? 🤨

CI + QA
