### PR TITLE
adjust test syntax for flaky test

### DIFF
--- a/spec/features/apo_spec.rb
+++ b/spec/features/apo_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe 'Create an apo', js: true do
     expect(page).to have_text 'created'
 
     # Shows a link to the agreement. The agreement name is loaded by turbo-links and is flaky, wait for it and scroll into view
-    sleep 3
     page.execute_script 'window.scrollTo(0,250);'
     expect(page).to have_link 'Test Agreement', href: solr_document_path(agreement.externalIdentifier)
 

--- a/spec/features/apo_spec.rb
+++ b/spec/features/apo_spec.rb
@@ -56,8 +56,10 @@ RSpec.describe 'Create an apo', js: true do
     click_button 'Register APO'
     expect(page).to have_text 'created'
 
-    # Shows a link to the agreement. The agreement name is loaded by turbo-links and is flaky, test href target instead
-    expect(page).to have_link href: solr_document_path(agreement.externalIdentifier)
+    # Shows a link to the agreement. The agreement name is loaded by turbo-links and is flaky, wait for it and scroll into view
+    sleep 3
+    page.execute_script 'window.scrollTo(0,250);'
+    expect(page).to have_link 'Test Agreement', href: solr_document_path(agreement.externalIdentifier)
 
     click_on 'Edit APO'
     expect(page).to have_text 'Add group' # wait for form to render


### PR DESCRIPTION
## Why was this change made? 🤔

Previous flaky test fix was potentially looking for nil text, which was sometimes not the case when turbo actually filled it in?  Just speculation.  This version again passes locally and in the CI branch consistently.

## How was this change tested? 🤨

Tests