### PR TITLE
fix bug where tags were not making it during registration

### DIFF
--- a/app/javascript/registration/register.js
+++ b/app/javascript/registration/register.js
@@ -41,7 +41,7 @@ export default function DorRegistration(initOpts) {
       return document.getElementById('rights').value
     },
 
-    // Grab list of tags from the form and rejects blanks
+    // Grab list of tags from the form
     tags: function() {
         return Array.from(document.querySelectorAll('[data-controller="tag-validation"]')).map((elem) => elem.value)
     },
@@ -59,7 +59,7 @@ export default function DorRegistration(initOpts) {
         'content_type': this.contentType(),
         'viewing_direction': this.viewingDirection(),
         'label' : data.label || ':auto',
-        'tag' : this.tags(),
+        'tags' : this.tags(),
         'rights' : this.rights(),
         'collection' : this.collection()
       }

--- a/spec/features/item_registration_spec.rb
+++ b/spec/features/item_registration_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'Item registration page', js: true do
       'source_id' => 'source:id1',
       'content_type' => 'https://cocina.sul.stanford.edu/models/book',
       'viewing_direction' => 'left-to-right',
-      'tag' => ['', 'tag : test', '', '', '', '', '', '', '', '', '', ''],
+      'tags' => ['', 'tag : test', '', '', '', '', '', '', '', '', '', ''],
       'workflow_id' => 'goobiWF'
     )
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3650 - tags were not making it the object because the params being sent by javascript was "tag" and the params expected by the server were "tags" (started with changes made in https://github.com/sul-dlss/argo/pull/3637 )...I normalized to "tags" , which makes more sense.

## How was this change tested? 🤨

Localhost browser.  Updated integration tests to catch this in the future: https://github.com/sul-dlss/infrastructure-integration-test/pull/426