### PR TITLE
Allows descriptive spreadsheet columns to be out of orders.

### DIFF
--- a/spec/services/description_import_spec.rb
+++ b/spec/services/description_import_spec.rb
@@ -179,6 +179,21 @@ RSpec.describe DescriptionImport do
     end
   end
 
+  context 'with a valid csv with columns out of order' do
+    let(:csv) do
+      # Reverse the columns
+      table = CSV.read(file_fixture('descriptive-upload.csv'), headers: true)
+      new_headers = table.headers.reverse
+      CSV::Table.new([], headers: new_headers).tap do |new_table|
+        new_table << new_headers.map { |header| table.first[header] }
+      end
+    end
+
+    it 'deserializes the item' do
+      expect(updated.value!).to eq expected
+    end
+  end
+
   context 'with an invalid csv' do
     let(:csv) do
       CSV.read(file_fixture('bulk_upload_structural.csv'), headers: true)


### PR DESCRIPTION
closes #3651

## Why was this change made? 🤔
Users are creative.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡

Unit
