### PR TITLE
Add a test for date_presenter to improve coverage

### DIFF
--- a/spec/presenters/date_presenter_spec.rb
+++ b/spec/presenters/date_presenter_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DatePresenter do
+  subject(:presenter) do
+    described_class.render(mock_date)
+  end
+
+  describe '#render' do
+    context 'when the date is nil' do
+      let(:mock_date) { nil }
+
+      it 'returns an empty string' do
+        expect(subject).to eq ''
+      end
+    end
+
+    context 'when the date is a valid DateTime value' do
+      let(:mock_date) { DateTime.parse('2022-05-06') }
+
+      context 'when the date is successfully translated' do
+        it 'returns an i18n translated date' do
+          expect(subject).to eq '2022-05-06 12:00AM'
+        end
+      end
+
+      context 'when the date cannot be translated' do
+        it 'rescues the StandardError and returns a date string' do
+          allow(I18n).to receive(:l).and_raise(StandardError, 'ruh roh')
+          expect(subject).to eq '2022-05-06 12:00AM'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Closes #3665 and should fix the broken builds related to this small coverage drop.

## How was this change tested? 🤨

New test.

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


