### PR TITLE
adjust catkey form to use multiple rows

### DIFF
--- a/app/controllers/catkeys_controller.rb
+++ b/app/controllers/catkeys_controller.rb
@@ -4,7 +4,7 @@ class CatkeysController < ApplicationController
   load_and_authorize_resource :cocina, parent: false, class: 'Repository', id_param: 'item_id'
 
   def edit
-    @form = catkey_form
+    @form = CatkeyForm.new(@cocina)
     @form.prepopulate!
     respond_to do |format|
       format.html { render layout: !request.xhr? }
@@ -14,29 +14,13 @@ class CatkeysController < ApplicationController
   def update
     return unless enforce_versioning
 
-    @form = catkey_form
-    if @form.validate(params[:catkey]) && @form.save(@cocina)
+    @form = CatkeyForm.new(@cocina)
+    if @form.validate(params[:catkey]) && @form.save
       Argo::Indexer.reindex_druid_remotely(@cocina.externalIdentifier)
       msg = "Catkeys for #{@cocina.externalIdentifier} have been updated!"
       redirect_to solr_document_path(@cocina.externalIdentifier, format: :html), notice: msg
     else
       render turbo_stream: turbo_stream.replace('modal-frame', partial: 'edit'), status: :unprocessable_entity
     end
-  end
-
-  private
-
-  def catkey_form
-    # fetch catkeys from object
-    object_catkeys = @cocina.identification.catalogLinks.filter_map { |catalog_link| catalog_link if catalog_link.catalog == Constants::SYMPHONY }
-
-    # form is initialized with catkeys in the object
-    catkeys = object_catkeys.map { |catkey| CatkeyForm::Row.new(value: catkey.catalogRecordId, refresh: catkey.refresh) }
-    CatkeyForm.new(
-      CatkeyForm::ModelProxy.new(
-        id: params[:item_id],
-        catkeys:
-      )
-    )
   end
 end

--- a/app/controllers/catkeys_controller.rb
+++ b/app/controllers/catkeys_controller.rb
@@ -3,15 +3,44 @@
 class CatkeysController < ApplicationController
   load_and_authorize_resource :cocina, parent: false, class: 'Repository', id_param: 'item_id'
 
-  rescue_from Dor::Services::Client::UnexpectedResponse do |exception|
-    md = /\((.*)\)/.match exception.message
-    detail = JSON.parse(md[1])['errors'].first['detail']
-    redirect_to solr_document_path(params[:item_id]),
-                flash: { error: "Unable to retrieve the cocina model: #{detail.truncate(200)}" }
+  ### classes that define a virtual catkey model object and data structure, used in form editing...persistence is in the cocina model
+  class ModelProxy
+    def initialize(id:, catkeys:)
+      @id = id # the object ID
+      @catkeys = catkeys # the array of catkey objects (defined in custom class below)
+    end
+
+    attr_reader :id, :catkeys
+
+    def to_param
+      @id
+    end
+
+    def persisted?
+      true
+    end
   end
 
+  class CatkeyRow
+    attr_accessor :value, :refresh, :id
+
+    def initialize(attrs = {})
+      @id = attrs[:value]
+      @value = attrs[:value]
+      @refresh = attrs[:refresh]
+    end
+
+    def persisted?
+      id.present?
+    end
+
+    # from https://github.com/rails/rails/blob/f95c0b7e96eb36bc3efc0c5beffbb9e84ea664e4/activerecord/lib/active_record/nested_attributes.rb#L382-L384
+    def _destroy; end
+  end
+  ###
+
   def edit
-    @change_set = CatkeyForm.new(@cocina)
+    @form = catkey_form
     respond_to do |format|
       format.html { render layout: !request.xhr? }
     end
@@ -20,18 +49,37 @@ class CatkeysController < ApplicationController
   def update
     return unless enforce_versioning
 
-    form = CatkeyForm.new(@cocina)
-    form.validate(catkey: update_params[:catkey].strip)
-    form.save
-    Argo::Indexer.reindex_druid_remotely(@cocina.externalIdentifier)
-
-    msg = "Catkey for #{@cocina.externalIdentifier} has been updated!"
-    redirect_to solr_document_path(@cocina.externalIdentifier), notice: msg
+    @form = catkey_form
+    respond_to do |format|
+      if @form.validate(params[:catkey]) && @form.save
+        Argo::Indexer.reindex_druid_remotely(@cocina.externalIdentifier)
+        msg = "Catkeys for #{@cocina.externalIdentifier} have been updated!"
+        format.html { redirect_to solr_document_path(@cocina.externalIdentifier, format: :html), notice: msg }
+      else
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace('modal-frame', partial: 'edit'), status: :unprocessable_entity
+        end
+      end
+    end
   end
 
   private
 
-  def update_params
-    params[CatkeyForm.model_name.param_key]
+  def catkey_form
+    # fetch catkeys from object
+    object_catkeys = @cocina.identification.catalogLinks.filter_map { |catalog_link| catalog_link if catalog_link.catalog == Constants::SYMPHONY }
+
+    # if there are no object catkeys, provide an initial blank row, else form is initialized with catkeys in the object
+    catkeys = if object_catkeys.size.zero?
+                [CatkeyRow.new(value: '', refresh: true)]
+              else
+                object_catkeys.map { |catkey| CatkeyRow.new(value: catkey.catalogRecordId, refresh: catkey.refresh) }
+              end
+    CatkeyForm.new(
+      ModelProxy.new(
+        id: params[:item_id],
+        catkeys:
+      )
+    )
   end
 end

--- a/app/controllers/catkeys_controller.rb
+++ b/app/controllers/catkeys_controller.rb
@@ -5,6 +5,7 @@ class CatkeysController < ApplicationController
 
   def edit
     @form = catkey_form
+    @form.prepopulate!
     respond_to do |format|
       format.html { render layout: !request.xhr? }
     end
@@ -33,12 +34,8 @@ class CatkeysController < ApplicationController
     # fetch catkeys from object
     object_catkeys = @cocina.identification.catalogLinks.filter_map { |catalog_link| catalog_link if catalog_link.catalog == Constants::SYMPHONY }
 
-    # if there are no object catkeys, provide an initial blank row, else form is initialized with catkeys in the object
-    catkeys = if object_catkeys.size.zero?
-                [CatkeyForm::Row.new(value: '', refresh: true)]
-              else
-                object_catkeys.map { |catkey| CatkeyForm::Row.new(value: catkey.catalogRecordId, refresh: catkey.refresh) }
-              end
+    # form is initialized with catkeys in the object
+    catkeys = object_catkeys.map { |catkey| CatkeyForm::Row.new(value: catkey.catalogRecordId, refresh: catkey.refresh) }
     CatkeyForm.new(
       CatkeyForm::ModelProxy.new(
         id: params[:item_id],

--- a/app/controllers/catkeys_controller.rb
+++ b/app/controllers/catkeys_controller.rb
@@ -15,16 +15,12 @@ class CatkeysController < ApplicationController
     return unless enforce_versioning
 
     @form = catkey_form
-    respond_to do |format|
-      if @form.validate(params[:catkey]) && @form.save(@cocina)
-        Argo::Indexer.reindex_druid_remotely(@cocina.externalIdentifier)
-        msg = "Catkeys for #{@cocina.externalIdentifier} have been updated!"
-        format.html { redirect_to solr_document_path(@cocina.externalIdentifier, format: :html), notice: msg }
-      else
-        format.turbo_stream do
-          render turbo_stream: turbo_stream.replace('modal-frame', partial: 'edit'), status: :unprocessable_entity
-        end
-      end
+    if @form.validate(params[:catkey]) && @form.save(@cocina)
+      Argo::Indexer.reindex_druid_remotely(@cocina.externalIdentifier)
+      msg = "Catkeys for #{@cocina.externalIdentifier} have been updated!"
+      redirect_to solr_document_path(@cocina.externalIdentifier, format: :html), notice: msg
+    else
+      render turbo_stream: turbo_stream.replace('modal-frame', partial: 'edit'), status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/catkeys_controller.rb
+++ b/app/controllers/catkeys_controller.rb
@@ -3,42 +3,6 @@
 class CatkeysController < ApplicationController
   load_and_authorize_resource :cocina, parent: false, class: 'Repository', id_param: 'item_id'
 
-  ### classes that define a virtual catkey model object and data structure, used in form editing...persistence is in the cocina model
-  class ModelProxy
-    def initialize(id:, catkeys:)
-      @id = id # the object ID
-      @catkeys = catkeys # the array of catkey objects (defined in custom class below)
-    end
-
-    attr_reader :id, :catkeys
-
-    def to_param
-      @id
-    end
-
-    def persisted?
-      true
-    end
-  end
-
-  class CatkeyRow
-    attr_accessor :value, :refresh, :id
-
-    def initialize(attrs = {})
-      @id = attrs[:value]
-      @value = attrs[:value]
-      @refresh = attrs[:refresh]
-    end
-
-    def persisted?
-      id.present?
-    end
-
-    # from https://github.com/rails/rails/blob/f95c0b7e96eb36bc3efc0c5beffbb9e84ea664e4/activerecord/lib/active_record/nested_attributes.rb#L382-L384
-    def _destroy; end
-  end
-  ###
-
   def edit
     @form = catkey_form
     respond_to do |format|
@@ -71,12 +35,12 @@ class CatkeysController < ApplicationController
 
     # if there are no object catkeys, provide an initial blank row, else form is initialized with catkeys in the object
     catkeys = if object_catkeys.size.zero?
-                [CatkeyRow.new(value: '', refresh: true)]
+                [CatkeyForm::Row.new(value: '', refresh: true)]
               else
-                object_catkeys.map { |catkey| CatkeyRow.new(value: catkey.catalogRecordId, refresh: catkey.refresh) }
+                object_catkeys.map { |catkey| CatkeyForm::Row.new(value: catkey.catalogRecordId, refresh: catkey.refresh) }
               end
     CatkeyForm.new(
-      ModelProxy.new(
+      CatkeyForm::ModelProxy.new(
         id: params[:item_id],
         catkeys:
       )

--- a/app/controllers/catkeys_controller.rb
+++ b/app/controllers/catkeys_controller.rb
@@ -16,7 +16,7 @@ class CatkeysController < ApplicationController
 
     @form = catkey_form
     respond_to do |format|
-      if @form.validate(params[:catkey]) && @form.save
+      if @form.validate(params[:catkey]) && @form.save(@cocina)
         Argo::Indexer.reindex_druid_remotely(@cocina.externalIdentifier)
         msg = "Catkeys for #{@cocina.externalIdentifier} have been updated!"
         format.html { redirect_to solr_document_path(@cocina.externalIdentifier, format: :html), notice: msg }

--- a/app/forms/catkey_form.rb
+++ b/app/forms/catkey_form.rb
@@ -16,8 +16,8 @@ class CatkeyForm < Reform::Form
   validate :catkeys_acceptable
 
   def catkeys_acceptable
-    # at most one catkey can be set to refresh == true
-    errors.add(:refresh, 'is only allowed for a single catkey.') if catkeys.count { |catkey| catkey.refresh == 'true' } > 1
+    # at most one catkey (not being deleted) can be set to refresh == true
+    errors.add(:refresh, 'is only allowed for a single catkey.') if catkeys.count { |catkey| catkey.refresh == 'true' && catkey._destroy != '1' } > 1
     # must match the expected pattern
     errors.add(:catkey, 'must be in an allowed format') if catkeys.count { |catkey| catkey.value.match(/^\d+(:\d+)*$/).nil? }.positive?
   end

--- a/app/forms/catkey_form.rb
+++ b/app/forms/catkey_form.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class CatkeyForm < Reform::Form
-  collection :catkeys, populator: lambda { |collection:, index:, **|
+  collection :catkeys, prepopulator: ->(*) { catkeys << CatkeyForm::Row.new(value: '', refresh: true) if catkeys.size.zero? },
+                       populator: lambda { |collection:, index:, **|
                                     if item = collection[index] # rubocop:disable Lint/AssignmentInCondition
                                       item
                                     else

--- a/app/forms/catkey_form.rb
+++ b/app/forms/catkey_form.rb
@@ -5,7 +5,7 @@ class CatkeyForm < Reform::Form
                                     if item = collection[index] # rubocop:disable Lint/AssignmentInCondition
                                       item
                                     else
-                                      collection.insert(index, CatkeysController::CatkeyRow.new)
+                                      collection.insert(index, CatkeyForm::Row.new)
                                     end
                                   } do
     property :value
@@ -14,6 +14,42 @@ class CatkeyForm < Reform::Form
   end
 
   validate :catkeys_acceptable
+
+  ### classes that define a virtual catkey model object and data structure, used in form editing...persistence is in the cocina model
+  class ModelProxy
+    def initialize(id:, catkeys:)
+      @id = id # the object ID
+      @catkeys = catkeys # the array of catkey objects (defined in custom class below)
+    end
+
+    attr_reader :id, :catkeys
+
+    def to_param
+      @id
+    end
+
+    def persisted?
+      true
+    end
+  end
+
+  class Row
+    attr_accessor :value, :refresh, :id
+
+    def initialize(attrs = {})
+      @id = attrs[:value]
+      @value = attrs[:value]
+      @refresh = attrs[:refresh]
+    end
+
+    def persisted?
+      id.present?
+    end
+
+    # from https://github.com/rails/rails/blob/f95c0b7e96eb36bc3efc0c5beffbb9e84ea664e4/activerecord/lib/active_record/nested_attributes.rb#L382-L384
+    def _destroy; end
+  end
+  ###
 
   def catkeys_acceptable
     # at most one catkey (not being deleted) can be set to refresh == true

--- a/app/forms/catkey_form.rb
+++ b/app/forms/catkey_form.rb
@@ -10,7 +10,7 @@ class CatkeyForm < Reform::Form
                                     end
                                   } do
     property :value
-    property :refresh
+    property :refresh # ActiveModel::Type::Boolean.new.cast('1')
     property :_destroy, virtual: true
   end
 
@@ -59,9 +59,7 @@ class CatkeyForm < Reform::Form
     errors.add(:catkey, 'must be in an allowed format') if catkeys.count { |catkey| catkey.value.match(/^\d+(:\d+)*$/).nil? }.positive?
   end
 
-  def save
-    cocina_object = Repository.find(@model.id)
-
+  def save(cocina_object)
     return false if catkeys.size.zero? # nothing submitted on the form
 
     # fetch the existing previous catkey values from the cocina object

--- a/app/forms/catkey_form.rb
+++ b/app/forms/catkey_form.rb
@@ -1,22 +1,52 @@
 # frozen_string_literal: true
 
-class CatkeyForm < ApplicationChangeSet
-  property :catkey, virtual: true
-
-  # When the object is initialized, copy the properties from the cocina model to the form:
-  def setup_properties!(_options)
-    self.catkey = Catkey.symphony_links(model).join(', ')
+class CatkeyForm < Reform::Form
+  collection :catkeys, populator: lambda { |collection:, index:, **|
+                                    if item = collection[index] # rubocop:disable Lint/AssignmentInCondition
+                                      item
+                                    else
+                                      collection.insert(index, CatkeysController::CatkeyRow.new)
+                                    end
+                                  } do
+    property :value
+    property :refresh
+    property :_destroy, virtual: true
   end
 
-  # @raises [Dor::Services::Client::BadRequestError] when the server doesn't accept the request
-  # @raises [Cocina::Models::ValidationError] when given invalid Cocina values or structures
-  def save_model
-    return unless changed?(:catkey)
+  validate :catkeys_acceptable
 
-    updated = model
-    identification_props = updated.identification.new(catalogLinks: Catkey.serialize(model, catkey.split(/\s*,\s*/)))
-    updated = updated.new(identification: identification_props)
+  def catkeys_acceptable
+    # at most one catkey can be set to refresh == true
+    errors.add(:refresh, 'is only allowed for a single catkey.') if catkeys.count { |catkey| catkey.refresh == 'true' } > 1
+    # must match the expected pattern
+    errors.add(:catkey, 'must be in an allowed format') if catkeys.count { |catkey| catkey.value.match(/^\d+(:\d+)*$/).nil? }.positive?
+  end
 
-    Repository.store(updated)
+  def save
+    cocina_object = Repository.find(@model.id)
+
+    return false if catkeys.size.zero? # nothing submitted on the form
+
+    # fetch the existing previous catkey values from the cocina object
+    existing_previous_catkeys = Catkey.new(cocina_object).previous_links
+
+    # these are all of the existing catkey values the user wants to remove (i.e. for which they clicked the trash icon)
+    removed_catkeys = catkeys.filter_map { |catkey| catkey.value if catkey._destroy == '1' }
+
+    # build an array of all previous catkeys (which includes the existing previous catkeys plus any newly removed ones)
+    updated_previous_catkeys = (existing_previous_catkeys + removed_catkeys).map do |catkey_value|
+      { catalog: Constants::PREVIOUS_CATKEY, catalogRecordId: catkey_value, refresh: false }
+    end.uniq
+
+    # build an array of submitted catkeys (i.e. for which they did NOT click the trash icon): could be unchanged, changed, or new)
+    updated_catkeys = catkeys.filter_map do |catkey|
+      { catalog: Constants::SYMPHONY, catalogRecordId: catkey.value, refresh: (catkey.refresh == 'true') } unless catkey._destroy == '1'
+    end
+
+    # now store everything in the cocina object
+    updated_object = cocina_object
+    identification_props = updated_object.identification.new(catalogLinks: updated_previous_catkeys + updated_catkeys)
+    updated_object = updated_object.new(identification: identification_props)
+    Repository.store(updated_object)
   end
 end

--- a/app/services/catkey.rb
+++ b/app/services/catkey.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class Catkey
-  SYMPHONY = 'symphony'
-  PREVIOUS_CATKEY = 'previous symphony'
-
   def self.symphony_links(model)
     new(model).symphony_links
   end
@@ -21,17 +18,17 @@ class Catkey
   # @return [Array<Hash>] a list of catalog links
   def serialize(new_catkeys)
     removed_links = symphony_links - new_catkeys
-    links = (previous_links + removed_links).map { |record_id| { catalog: PREVIOUS_CATKEY, catalogRecordId: record_id, refresh: false } }.uniq
+    links = (previous_links + removed_links).map { |record_id| { catalog: Constants::PREVIOUS_CATKEY, catalogRecordId: record_id, refresh: false } }.uniq
 
-    links + new_catkeys.map.with_index { |record_id, index| { catalog: SYMPHONY, catalogRecordId: record_id, refresh: index.zero? } }
+    links + new_catkeys.map.with_index { |record_id, index| { catalog: Constants::SYMPHONY, catalogRecordId: record_id, refresh: index.zero? } }
   end
 
   def symphony_links
-    find(SYMPHONY)
+    find(Constants::SYMPHONY)
   end
 
   def previous_links
-    find(PREVIOUS_CATKEY)
+    find(Constants::PREVIOUS_CATKEY)
   end
 
   def find(type)

--- a/app/views/catkeys/_edit.html.erb
+++ b/app/views/catkeys/_edit.html.erb
@@ -1,10 +1,43 @@
-<%= form_with model: @change_set, url: item_catkey_path(@change_set), method: :patch do |f| %>
-  <div class="mb-3">
-    <%= f.label :catkey %>
-    <%= f.text_field :catkey, class: 'form-control' %>
-    <p class='form-text'>
-      Separate multiple catkeys with commas.
-    </p>
-  </div>
-  <button class="btn btn-primary">Update</button>
+<%= render EditModalComponent.new do |component| %>
+  <% component.header { 'Manage catkey' } %>
+  <% component.body do %>
+    <div class="mb-3 row plain-container">
+      <div class="col-sm-2"></div>
+      <div class="col-sm-10 col-xl-8">
+        <strong>Catkey</strong>
+      </div>
+      <div class="col-sm-1"></div>
+    </div>
+    <%= form_with model: @form,
+                      url: item_catkey_path(@form),
+                      method: :patch,
+                      data: { controller: 'nested-form', nested_form_selector_value: '.plain-container' } do |form| %>
+
+        <% if @form.errors.full_messages.present? %>
+          <div id="error_explanation">
+            <ul>
+            <% @form.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+            </ul>
+          </div>
+        <% end %>
+
+        <template data-nested-form-target='template'>
+          <%= form.fields_for :catkeys, CatkeysController::CatkeyRow.new, child_index: 'TEMPLATE_RECORD' do |catkey_form| %>
+            <%= render 'row', form: catkey_form %>
+          <% end %>
+        </template>
+
+        <%= form.fields_for :catkeys do |catkey_form| %>
+          <%= render 'row', form: catkey_form %>
+        <% end %>
+
+        <div data-nested-form-target="add_item" class="mb-5">
+          <%= button_tag '+ Add another catkey', type: 'button', class: "col-sm-2 btn btn-outline-primary",  data: { action: "nested-form#addAssociation" } %>
+        </div>
+
+        <button class='btn btn-primary'>Update</button>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/views/catkeys/_edit.html.erb
+++ b/app/views/catkeys/_edit.html.erb
@@ -24,7 +24,7 @@
         <% end %>
 
         <template data-nested-form-target='template'>
-          <%= form.fields_for :catkeys, CatkeysController::CatkeyRow.new, child_index: 'TEMPLATE_RECORD' do |catkey_form| %>
+          <%= form.fields_for :catkeys, CatkeyForm::Row.new, child_index: 'TEMPLATE_RECORD' do |catkey_form| %>
             <%= render 'row', form: catkey_form %>
           <% end %>
         </template>

--- a/app/views/catkeys/_edit.html.erb
+++ b/app/views/catkeys/_edit.html.erb
@@ -9,7 +9,7 @@
       <div class="col-sm-1"></div>
     </div>
     <%= form_with model: @form,
-                      url: item_catkey_path(@form),
+                      url: item_catkey_path(@cocina.externalIdentifier),
                       method: :patch,
                       data: { controller: 'nested-form', nested_form_selector_value: '.plain-container' } do |form| %>
 

--- a/app/views/catkeys/_row.html.erb
+++ b/app/views/catkeys/_row.html.erb
@@ -1,0 +1,17 @@
+<div class="mb-3 row plain-container">
+  <div class="col-sm-2">
+    <%= form.select :refresh, [['Do not refresh', false], ['Refresh', true]], {}, class: 'form-select' %>
+  </div>
+  <div class="col-sm-10 col-xl-8">
+    <%= form.text_field :value, class: "form-control" %>
+  </div>
+  <div class="col-sm-1">
+    <%= button_tag type: 'button', class: 'btn', aria: { label: 'Remove' },
+     data: { action: "click->nested-form#removeAssociation",
+             plain: true } do %>
+      <span class="bi bi-trash"></span>
+    <% end %>
+    <%= form.hidden_field :_destroy %>
+    <%= form.hidden_field :id %>
+  </div>
+</div>

--- a/app/views/catkeys/_row.html.erb
+++ b/app/views/catkeys/_row.html.erb
@@ -12,6 +12,5 @@
       <span class="bi bi-trash"></span>
     <% end %>
     <%= form.hidden_field :_destroy %>
-    <%= form.hidden_field :id %>
   </div>
 </div>

--- a/app/views/catkeys/edit.html.erb
+++ b/app/views/catkeys/edit.html.erb
@@ -1,4 +1,1 @@
-<%= render EditModalComponent.new do |component| %>
-  <% component.header { 'Manage catkey' } %>
-  <% component.body { render 'edit' } %>
-<% end %>
+<%= render 'edit' %>

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -119,4 +119,7 @@ module Constants
     %w[Searchworks Searchworks],
     %w[Earthworks Earthworks]
   ].freeze
+
+  SYMPHONY = 'symphony'
+  PREVIOUS_CATKEY = 'previous symphony'
 end

--- a/spec/features/item_catkey_change_spec.rb
+++ b/spec/features/item_catkey_change_spec.rb
@@ -15,7 +15,9 @@ RSpec.describe 'Item catkey change' do
 
     it 'cannot change the catkey' do
       visit edit_item_catkey_path druid
-      fill_in 'Catkey', with: '12345'
+      within '.modal-body' do
+        find('input').set '12345'
+      end
       click_button 'Update'
       expect(page).to have_css 'body', text: 'Object cannot be modified in ' \
                                              'its current state.'
@@ -56,10 +58,13 @@ RSpec.describe 'Item catkey change' do
 
     it 'changes the catkey' do
       visit edit_item_catkey_path druid
-      fill_in 'Catkey', with: '12345, 99912'
+      within '.modal-body' do
+        find('input').set '12345'
+        find('select').set true
+      end
       click_button 'Update'
-      expect(page).to have_css '.alert.alert-info', text: 'Catkey for ' \
-                                                          "#{druid} has been updated!"
+      expect(page).to have_css '.alert.alert-info', text: 'Catkeys for ' \
+                                                          "#{druid} have been updated!"
       expect(Argo::Indexer).to have_received(:reindex_druid_remotely)
     end
   end

--- a/spec/features/update_serials_metadata_spec.rb
+++ b/spec/features/update_serials_metadata_spec.rb
@@ -20,7 +20,11 @@ RSpec.describe 'Update serials metadata', js: true do
 
   it 'edits serials' do
     click_link 'Manage catkey'
-    fill_in 'Catkey', with: '55555'
+
+    within '.modal-body' do
+      find('input').set '55555'
+      find('select').set true
+    end
     click_button 'Update'
 
     click_button 'Manage description'

--- a/spec/requests/set_catkey_spec.rb
+++ b/spec/requests/set_catkey_spec.rb
@@ -5,6 +5,9 @@ require 'rails_helper'
 RSpec.describe 'Set catkey' do
   let(:user) { create(:user) }
   let(:druid) { 'druid:dc243mg0841' }
+  let(:catkey_params) do
+    { catkey: { 'catkeys_attributes' => { '0' => { 'refresh' => 'true', 'value' => '12345', '_destroy' => '', 'id' => '12345' } } }, 'item_id' => 'druid:xc078vy7260' }
+  end
 
   context 'without manage content access' do
     let(:cocina) { instance_double(Cocina::Models::DROWithMetadata) }
@@ -16,8 +19,8 @@ RSpec.describe 'Set catkey' do
     end
 
     it 'returns a 403' do
-      patch "/items/#{druid}/catkey", params: { catkey: { catkey: '12345' } }
-
+      patch item_catkey_path(druid),
+            params: catkey_params
       expect(response.code).to eq('403')
     end
   end
@@ -35,7 +38,7 @@ RSpec.describe 'Set catkey' do
         let(:cocina_model) { build(:dro, id: druid) }
 
         it 'draws the form' do
-          get "/items/#{druid}/catkey/edit"
+          get edit_item_catkey_path druid
 
           expect(response).to be_successful
         end
@@ -45,7 +48,7 @@ RSpec.describe 'Set catkey' do
         let(:cocina_model) { build(:collection, id: druid) }
 
         it 'draws the form' do
-          get "/items/#{druid}/catkey/edit"
+          get edit_item_catkey_path druid
 
           expect(response).to be_successful
         end
@@ -55,7 +58,7 @@ RSpec.describe 'Set catkey' do
         let(:cocina_model) { build(:collection, id: druid, catkeys: ['10448742']) }
 
         it 'draws the form' do
-          get "/items/#{druid}/catkey/edit"
+          get edit_item_catkey_path druid
 
           expect(response).to be_successful
           expect(response.body).to include '10448742'
@@ -82,8 +85,8 @@ RSpec.describe 'Set catkey' do
       context 'with an item' do
         let(:cocina_model) { build(:dro_with_metadata, id: druid) }
 
-        it 'updates the catkey, trimming whitespace' do
-          patch "/items/#{druid}/catkey", params: { catkey: { catkey: '   12345 ' } }
+        it 'updates the catkey' do
+          patch "/items/#{druid}/catkey", params: catkey_params
 
           expect(object_client).to have_received(:update)
             .with(params: updated_model)
@@ -94,8 +97,8 @@ RSpec.describe 'Set catkey' do
       context 'with a collection that has no existing catkeys' do
         let(:cocina_model) { build(:collection_with_metadata, id: druid, source_id: 'sul:1234') }
 
-        it 'updates the catkey, trimming whitespace' do
-          patch "/items/#{druid}/catkey", params: { catkey: { catkey: '   12345 ' } }
+        it 'updates the catkey' do
+          patch "/items/#{druid}/catkey", params: catkey_params
 
           expect(object_client).to have_received(:update)
             .with(params: updated_model)

--- a/spec/requests/set_catkey_spec.rb
+++ b/spec/requests/set_catkey_spec.rb
@@ -8,10 +8,15 @@ RSpec.describe 'Set catkey' do
   let(:catkey_params) do
     { catkey: { 'catkeys_attributes' => { '0' => { 'refresh' => 'true', 'value' => '12345', '_destroy' => '', 'id' => '12345' } } }, 'item_id' => druid }
   end
+  let(:delete_catkey_params) do
+    { catkey: { 'catkeys_attributes' => { '0' => { 'refresh' => 'true', 'value' => '99999', '_destroy' => '1', 'id' => '99999' },
+                                          '1' => { 'refresh' => 'true', 'value' => '45678', '_destroy' => '', 'id' => '45678' } } }, 'item_id' => druid }
+  end
   let(:turbo_stream_headers) do
     { 'Accept' => "#{Mime[:turbo_stream]},#{Mime[:html]}",
       'Turbo-Frame' => 'edit_copyright' }
   end
+  let(:cocina_model) { build(:dro_with_metadata, id: druid) }
 
   context 'without manage content access' do
     let(:cocina) { instance_double(Cocina::Models::DROWithMetadata) }
@@ -23,8 +28,7 @@ RSpec.describe 'Set catkey' do
     end
 
     it 'returns a 403' do
-      patch item_catkey_path(druid),
-            params: catkey_params
+      patch item_catkey_path(druid), params: catkey_params
       expect(response.code).to eq('403')
     end
   end
@@ -86,29 +90,173 @@ RSpec.describe 'Set catkey' do
         allow(Argo::Indexer).to receive(:reindex_druid_remotely)
       end
 
-      context 'with an invalid catkey on an item' do
-        let(:cocina_model) { build(:dro_with_metadata, id: druid) }
+      context 'with invalid catkey value on an item' do
+        let(:invalid_catkey_params) do
+          { catkey: { 'catkeys_attributes' => { '0' => { 'refresh' => 'true', 'value' => 'bogus', '_destroy' => '', 'id' => 'bogus' } } }, 'item_id' => druid }
+        end
 
         it 'does not update the catkey' do
-          catkey_params[:catkey]['catkeys_attributes']['0']['value'] = 'bogus'
-
-          patch "/items/#{druid}/catkey", params: catkey_params, headers: turbo_stream_headers
+          patch item_catkey_path(druid), params: invalid_catkey_params, headers: turbo_stream_headers
 
           expect(object_client).not_to have_received(:update)
-            .with(params: updated_model)
           expect(Argo::Indexer).not_to have_received(:reindex_druid_remotely).with(druid)
           expect(response.status).to eq 422
         end
       end
 
-      context 'with an item' do
-        let(:cocina_model) { build(:dro_with_metadata, id: druid) }
+      context 'with multiple catkeys set to refresh on an item' do
+        let(:invalid_catkey_params) do
+          { catkey: { 'catkeys_attributes' => { '0' => { 'refresh' => 'true', 'value' => '12345', '_destroy' => '', 'id' => '12345' },
+                                                '1' => { 'refresh' => 'true', 'value' => '45678', '_destroy' => '', 'id' => '45678' } } }, 'item_id' => druid }
+        end
 
-        it 'updates the catkey' do
-          patch "/items/#{druid}/catkey", params: catkey_params
+        it 'does not update the catkey' do
+          patch item_catkey_path(druid), params: invalid_catkey_params, headers: turbo_stream_headers
+
+          expect(object_client).not_to have_received(:update)
+          expect(Argo::Indexer).not_to have_received(:reindex_druid_remotely).with(druid)
+          expect(response.status).to eq 422
+        end
+      end
+
+      context 'with an item that has no existing catkeys' do
+        let(:mutiple_catkey_params) do
+          { catkey: { 'catkeys_attributes' => { '0' => { 'refresh' => 'true', 'value' => '12345', '_destroy' => '', 'id' => '12345' },
+                                                '1' => { 'refresh' => 'false', 'value' => '45678', '_destroy' => '', 'id' => '45678' } } }, 'item_id' => druid }
+        end
+        let(:updated_model_multiple_catkeys) do
+          cocina_model.new(
+            {
+              identification: {
+                catalogLinks: [{ catalog: 'symphony', catalogRecordId: '12345', refresh: true },
+                               { catalog: 'symphony', catalogRecordId: '45678', refresh: false }],
+                sourceId: 'sul:1234'
+              }
+            }
+          )
+        end
+
+        it 'updates a single catkey' do
+          patch item_catkey_path(druid), params: catkey_params
 
           expect(object_client).to have_received(:update)
             .with(params: updated_model)
+          expect(Argo::Indexer).to have_received(:reindex_druid_remotely).with(druid)
+        end
+
+        it 'updates multiple catkeys' do
+          patch item_catkey_path(druid), params: mutiple_catkey_params
+
+          expect(object_client).to have_received(:update)
+            .with(params: updated_model_multiple_catkeys)
+          expect(Argo::Indexer).to have_received(:reindex_druid_remotely).with(druid)
+        end
+      end
+
+      context 'with an item that has a single existing catkey' do
+        let(:cocina_model) { build(:dro_with_metadata, id: druid, catkeys: ['99999']) }
+        let(:updated_model_deleted_catkey) do
+          cocina_model.new(
+            {
+              identification: {
+                catalogLinks: [{ catalog: 'previous symphony', catalogRecordId: '99999', refresh: false },
+                               { catalog: 'symphony', catalogRecordId: '45678', refresh: true }],
+                sourceId: 'sul:1234'
+              }
+            }
+          )
+        end
+
+        it 'updates the catkey' do
+          patch item_catkey_path(druid), params: catkey_params
+
+          expect(object_client).to have_received(:update)
+            .with(params: updated_model)
+          expect(Argo::Indexer).to have_received(:reindex_druid_remotely).with(druid)
+        end
+
+        it 'deletes the catkey, moving it to previous symphony, and then adds a new one' do
+          patch item_catkey_path(druid), params: delete_catkey_params
+
+          expect(object_client).to have_received(:update)
+            .with(params: updated_model_deleted_catkey)
+          expect(Argo::Indexer).to have_received(:reindex_druid_remotely).with(druid)
+        end
+      end
+
+      context 'with an item that has two existing catkeys' do
+        let(:cocina_model) { build(:dro_with_metadata, id: druid, catkeys: %w[99999 45678]) }
+        let(:update_catkey_params) do
+          { catkey: { 'catkeys_attributes' => { '0' => { 'refresh' => 'false', 'value' => '99999', '_destroy' => '', 'id' => '99999' },
+                                                '1' => { 'refresh' => 'true', 'value' => '45678', '_destroy' => '', 'id' => '45678' } } }, 'item_id' => druid }
+        end
+        let(:updated_model_updated_catkeys) do
+          cocina_model.new(
+            {
+              identification: {
+                catalogLinks: [{ catalog: 'symphony', catalogRecordId: '99999', refresh: false },
+                               { catalog: 'symphony', catalogRecordId: '45678', refresh: true }],
+                sourceId: 'sul:1234'
+              }
+            }
+          )
+        end
+
+        it 'swaps the refresh setting of the catkeys' do
+          expect(cocina_model.identification.catalogLinks[0].refresh).to be true # the first catkey is refresh true
+          expect(cocina_model.identification.catalogLinks[1].refresh).to be false # the second catkey is refresh false
+
+          patch item_catkey_path(druid), params: update_catkey_params
+
+          expect(object_client).to have_received(:update)
+            .with(params: updated_model_updated_catkeys) # the updated model swaps the refresh
+          expect(Argo::Indexer).to have_received(:reindex_druid_remotely).with(druid)
+        end
+      end
+
+      context 'with an item that has existing catkeys and existing previous catkeys' do
+        let(:cocina_model) { build(:dro_with_metadata, id: druid, catkeys: ['99999']) }
+        let(:updated_model_with_previous_catkey) do
+          cocina_model.new(
+            {
+              identification: {
+                catalogLinks: [{ catalog: 'previous symphony', catalogRecordId: '55555', refresh: false },
+                               { catalog: 'symphony', catalogRecordId: '12345', refresh: true }],
+                sourceId: 'sul:1234'
+              }
+            }
+          )
+        end
+        let(:updated_model_with_delete_and_previous_catkey) do
+          cocina_model.new(
+            {
+              identification: {
+                catalogLinks: [{ catalog: 'previous symphony', catalogRecordId: '55555', refresh: false },
+                               { catalog: 'previous symphony', catalogRecordId: '99999', refresh: false },
+                               { catalog: 'symphony', catalogRecordId: '45678', refresh: true }],
+                sourceId: 'sul:1234'
+              }
+            }
+          )
+        end
+
+        before do
+          cocina_model.identification.catalogLinks << Cocina::Models::CatalogLink.new(catalog: 'previous symphony', refresh: false, catalogRecordId: '55555')
+        end
+
+        it 'updates the single catkey, preserving previous symphony catkey' do
+          patch item_catkey_path(druid), params: catkey_params
+
+          expect(object_client).to have_received(:update)
+            .with(params: updated_model_with_previous_catkey)
+          expect(Argo::Indexer).to have_received(:reindex_druid_remotely).with(druid)
+        end
+
+        it 'deletes a single catkey, adding it to the existing previous symphony catkey list, and then adds a new one' do
+          patch item_catkey_path(druid), params: delete_catkey_params
+
+          expect(object_client).to have_received(:update)
+            .with(params: updated_model_with_delete_and_previous_catkey)
           expect(Argo::Indexer).to have_received(:reindex_druid_remotely).with(druid)
         end
       end
@@ -117,7 +265,7 @@ RSpec.describe 'Set catkey' do
         let(:cocina_model) { build(:collection_with_metadata, id: druid, source_id: 'sul:1234') }
 
         it 'updates the catkey' do
-          patch "/items/#{druid}/catkey", params: catkey_params
+          patch item_catkey_path(druid), params: catkey_params
 
           expect(object_client).to have_received(:update)
             .with(params: updated_model)


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3358 - update catkey editing form so it allows for adding/removing catkeys and setting of refresh/no refresh.  Design in the ticket: https://github.com/sul-dlss/argo/issues/3358#issuecomment-1116329820

As implemented:

![Screen Shot 2022-05-11 at 2 03 14 PM](https://user-images.githubusercontent.com/47137/167947292-ecbe3a99-6981-490f-b3c4-55128b04cd62.png)

Also: validate that there is no more than a single catkey set to refresh and that any entered catkey values are valid..

~~HOLD for PO testing~~

## How was this change tested? 🤨

- Localhost browser
- Updated existing tests for new UI
- Added many more tests for all of the scenarios (deleting, updating, setting refresh)