### PR TITLE
change icon on tag form to trash icon

### DIFF
--- a/app/views/tags/_row.html.erb
+++ b/app/views/tags/_row.html.erb
@@ -1,15 +1,15 @@
 <div class="mb-3 row plain-container">
   <div class="col-sm-2">
-    <%= form.label :email, 'Tag', class: 'col-form-label' %>
+    <%= form.label :name, 'Tag', class: 'col-form-label' %>
   </div>
   <div class="col-sm-10 col-xl-8">
     <%= form.text_field :name, class: "form-control" %>
   </div>
   <div class="col-sm-1">
-    <%= button_tag type: 'button', class: 'btn btn-secondary', aria: { label: 'Remove' },
+    <%= button_tag type: 'button', class: 'btn', aria: { label: 'Remove' },
      data: { action: "click->nested-form#removeAssociation",
              plain: true } do %>
-      <span class='icon-remove-sign text-danger'></span>
+      <span class='bi bi-trash'></span>
     <% end %>
     <%= form.hidden_field :_destroy %>
     <%= form.hidden_field :id %>


### PR DESCRIPTION
## Why was this change made? 🤔

When working on https://github.com/sul-dlss/argo/pull/3681 (catkey editing), I noted that the design for removing catkey rows shows a trash icon, yet the icon for removing tags on a very similar modal form is currently a button.  This makes the tag editing form look like the design for catkeys: https://github.com/sul-dlss/argo/issues/3358#issuecomment-1116329820

**Current:**
![Screen Shot 2022-05-10 at 3 08 19 PM](https://user-images.githubusercontent.com/47137/167729842-b6f226f4-7433-4884-96a0-e2e159df83fd.png)

**Updated:**
![Screen Shot 2022-05-10 at 3 08 07 PM](https://user-images.githubusercontent.com/47137/167729875-eed92140-cca1-428d-bcc5-2c823305f9a8.png)



## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


