### PR TITLE
Add synchronous indexing when necessary

### DIFF
--- a/app/controllers/apo_controller.rb
+++ b/app/controllers/apo_controller.rb
@@ -51,10 +51,18 @@ class ApoController < ApplicationController # rubocop:disable Metrics/ClassLengt
     end
 
     @form.save
+
+    # Index imediately, so that we have a page to send the user to. DSA indexes asynchronously.
+    Argo::Indexer.reindex_druid_remotely(@form.model.externalIdentifier)
+
     notice = "APO #{@form.model.externalIdentifier} created."
 
     # register a collection and make it the default if requested
-    notice += " Collection #{@form.model.administrative.collectionsForRegistration.first} created." if @form.model.administrative.collectionsForRegistration.present?
+    if @form.model.administrative.collectionsForRegistration.present?
+      notice += " Collection #{@form.model.administrative.collectionsForRegistration.first} created."
+      # Index imediately, so that we see the collection name on the page. DSA indexes asynchronously.
+      Argo::Indexer.reindex_druid_remotely(@form.model.administrative.collectionsForRegistration.first)
+    end
 
     redirect_to solr_document_path(@form.model.externalIdentifier), notice:
   end

--- a/app/services/register_agreement.rb
+++ b/app/services/register_agreement.rb
@@ -39,7 +39,10 @@ class RegisterAgreement
                                                     logger: Rails.logger,
                                                     connection:)
 
-    poll_for_job_complete(job_id:)
+    poll_for_job_complete(job_id:).tap do |druid|
+      # Index imediately, so that we have a page to send the user to. DSA indexes asynchronously.
+      Argo::Indexer.reindex_druid_remotely(druid)
+    end
   end
 
   private

--- a/spec/factories/apos.rb
+++ b/spec/factories/apos.rb
@@ -21,7 +21,10 @@ FactoryBot.define do
     end
 
     to_create do |builder|
-      Dor::Services::Client.objects.register(params: builder.cocina_model)
+      Dor::Services::Client.objects.register(params: builder.cocina_model).tap do |apo|
+        # Since we don't run the rabbitMQ service in our cluster, we have to index these manually
+        Argo::Indexer.reindex_druid_remotely(apo.externalIdentifier)
+      end
     end
 
     admin_policy_id { 'druid:hv992ry2431' }

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -18,7 +18,10 @@ FactoryBot.define do
     end
 
     to_create do |builder|
-      Dor::Services::Client.objects.register(params: builder.cocina_model)
+      Dor::Services::Client.objects.register(params: builder.cocina_model).tap do |collection|
+        # Since we don't run the rabbitMQ service in our cluster, we have to index these manually
+        Argo::Indexer.reindex_druid_remotely(collection.externalIdentifier)
+      end
     end
 
     admin_policy_id { 'druid:hv992ry2431' }

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -21,7 +21,10 @@ FactoryBot.define do
     end
 
     to_create do |builder|
-      Dor::Services::Client.objects.register(params: builder.cocina_model)
+      Dor::Services::Client.objects.register(params: builder.cocina_model).tap do |item|
+        # Since we don't run the rabbitMQ service in our cluster, we have to index these manually
+        Argo::Indexer.reindex_druid_remotely(item.externalIdentifier)
+      end
     end
 
     admin_policy_id { 'druid:hv992ry2431' }

--- a/spec/features/item_registration_spec.rb
+++ b/spec/features/item_registration_spec.rb
@@ -141,11 +141,10 @@ RSpec.describe 'Item registration page', js: true do
 
       find('td[aria-describedby=data_status][title=success]')
       object_druid = find('td[aria-describedby=data_druid]').text
-      visit solr_document_path(object_druid)
 
-      # ensure we are up-to-date
-      click_link 'Reindex'
-      expect(page).to have_text('Successfully updated index for')
+      # Since we don't have rabbitMQ in the test suite, we have to fake it by indexing manually.
+      Argo::Indexer.reindex_druid_remotely(object_druid)
+      visit solr_document_path(object_druid)
 
       # now verify that registration succeeded by checking some metadata
       within_table('Overview') do
@@ -170,7 +169,6 @@ RSpec.describe 'Item registration page', js: true do
         expect(page).to have_css 'td a', text: 'Project : X-Files'
         expect(page).to have_css 'td a', text: 'i : believe'
         expect(page).to have_css 'td a', text: "Registered By : #{user.sunetid}"
-        expect(page).to have_css 'td a', text: 'Process : Content Type : Book (ltr)'
       end
     end
   end


### PR DESCRIPTION


## Why was this change made? 🤔

DSA no longer does synchronous indexing, so we need to add one when creating an APO or an agreement.  Also adjusted factories to do the indexing since we have no asynch workers in the tests.  Also stoped expecting a process tag to be created

## How was this change tested? 🤨
Test suite