### PR TITLE
Set catkey to no refresh when updating with serial form.

### DIFF
--- a/app/forms/serials_form.rb
+++ b/app/forms/serials_form.rb
@@ -55,9 +55,12 @@ class SerialsForm < ApplicationChangeSet
   end
 
   def save_model
-    updated_description = model.description.new(title: updated_title, note: updated_note)
-    updated_model = model.new(description: updated_description)
+    updated_model = model.new(description: updated_description, identification: updated_identification)
     Repository.store(updated_model)
+  end
+
+  def updated_description
+    model.description.new(title: updated_title, note: updated_note)
   end
 
   def updated_title
@@ -106,6 +109,16 @@ class SerialsForm < ApplicationChangeSet
       structured_value << { value: part_number, type: PART_NUMBER } if part_number.present?
       structured_value << { value: part_name, type: PART_NAME } if part_name.present?
       structured_value << { value: part_number2, type: PART_NUMBER } if part_number2.present?
+    end
+  end
+
+  def updated_identification
+    model.identification.new(catalogLinks: updated_catalog_links)
+  end
+
+  def updated_catalog_links
+    model.identification.catalogLinks.map do |catalog_link|
+      catalog_link.to_h.merge(refresh: false)
     end
   end
 end

--- a/spec/forms/serials_form_spec.rb
+++ b/spec/forms/serials_form_spec.rb
@@ -321,5 +321,39 @@ RSpec.describe SerialsForm do
         expect(object_client).to have_received(:update).with(params: expected)
       end
     end
+
+    context 'when catalog links present' do
+      let(:cocina_item) { build(:dro_with_metadata, id: druid, catkeys: ['6671606']) }
+
+      let(:expected) do
+        build(:dro_with_metadata, id: druid).new(
+          description: {
+            title: [
+              {
+                structuredValue: [
+                  { value: 'factory DRO title', type: 'main title' }
+                ]
+              }
+            ],
+            purl: 'https://purl.stanford.edu/bc123df4567'
+          },
+          identification: {
+            catalogLinks: [
+              { catalog: 'symphony', refresh: false, catalogRecordId: '6671606' }
+            ],
+            sourceId: 'sul:1234'
+          }
+        )
+      end
+
+      before do
+        instance.validate({ part_number: '', part_name: '', part_number2: '', sort_field: '' })
+        instance.save
+      end
+
+      it 'sets refresh to false' do
+        expect(object_client).to have_received(:update).with(params: expected)
+      end
+    end
   end
 end


### PR DESCRIPTION
closes #3687

## Why was this change made? 🤔
Less work for user.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


