### PR TITLE
Set refresh to true for catkey when registering.

### DIFF
--- a/app/forms/registration_form.rb
+++ b/app/forms/registration_form.rb
@@ -21,7 +21,7 @@ class RegistrationForm
     catalog_links = []
     if params[:other_id] != 'label:'
       catalog, record_id = params[:other_id].split(':')
-      catalog_links = [{ catalog:, catalogRecordId: record_id, refresh: false }]
+      catalog_links = [{ catalog:, catalogRecordId: record_id, refresh: true }]
     end
 
     model_params = {


### PR DESCRIPTION
closes #3694

## Why was this change made? 🤔
Descriptive metadata isn't being refreshed upon registration.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


