### PR TITLE
pin blacklight to a known working branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,8 @@ gem 'zip_tricks', '5.3.1' # 5.3.1 is required as 5.4+ breaks the download all fe
 gem 'openapi_parser', '< 1.0'
 
 # Stanford related gems
-gem 'blacklight', '~> 7.25'
+# temporary pin of blacklight to fix https://github.com/sul-dlss/argo/issues/3697 .... remove when blacklight PR merged, 5/18/2022
+gem 'blacklight', '~> 7.25', git: 'https://github.com/projectblacklight/blacklight', branch: 'backport-unpermitted-params'
 gem 'blacklight-hierarchy', '~> 6.0'
 gem 'dor-services-client', '~> 12.0'
 gem 'dor-workflow-client', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,19 @@
+GIT
+  remote: https://github.com/projectblacklight/blacklight
+  revision: 9644976c01ad7ab4d785ca88b78607a60613cdfa
+  branch: backport-unpermitted-params
+  specs:
+    blacklight (7.25.1)
+      deprecation
+      globalid
+      hashdiff
+      i18n (>= 1.7.0)
+      jbuilder (~> 2.7)
+      kaminari (>= 0.15)
+      ostruct (>= 0.3.2)
+      rails (>= 5.1, < 7.1)
+      view_component (~> 2.43)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -83,15 +99,6 @@ GEM
       parser (>= 2.4)
       smart_properties
     bindex (0.8.1)
-    blacklight (7.25.1)
-      deprecation
-      globalid
-      i18n (>= 1.7.0)
-      jbuilder (~> 2.7)
-      kaminari (>= 0.15)
-      ostruct (>= 0.3.2)
-      rails (>= 5.1, < 7.1)
-      view_component (~> 2.43)
     blacklight-hierarchy (6.0.1)
       blacklight (~> 7.18)
       deprecation
@@ -595,7 +602,7 @@ PLATFORMS
 
 DEPENDENCIES
   barby
-  blacklight (~> 7.25)
+  blacklight (~> 7.25)!
   blacklight-hierarchy (~> 6.0)
   bootsnap (>= 1.4.2)
   byebug


### PR DESCRIPTION
## Why was this change made? 🤔

Temporarily pin blacklight to a known working PR https://github.com/projectblacklight/blacklight/pull/2718 to fix #3697 

Once the blacklight PR https://github.com/projectblacklight/blacklight/pull/2718 is merged, we can unpin.

## How was this change tested? 🤨

Localhost, test suite