### PR TITLE
do not update workflow back to waiting if not in error

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -57,8 +57,13 @@ class ReportController < CatalogController
         druid:,
         workflow:,
         process: step,
+        current_status: 'error',
         status: 'waiting'
       )
+    rescue Dor::WorkflowException => e
+      # NOTE: this may be triggered if the step being set to waiting is no longer in error
+      # which should not normally happen, because the list of druids fetched by `Report` should all be in error
+      Honeybadger.notify(e, context: { druid: })
     end
     message = "#{ids.size} objects were reset back to waiting for #{workflow}:#{step}.  It may take a few seconds to update."
     redirect_back(fallback_location: report_workflow_grid_path, notice: message)

--- a/spec/requests/reset_workflow_steps_spec.rb
+++ b/spec/requests/reset_workflow_steps_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Reset failed workflow steps', type: :request do
       post '/report/reset', params: { reset_workflow: workflow, reset_step: step, q: 'Cephalopods' } # has single match
       expect(response).to redirect_to(report_workflow_grid_path)
       expect(workflow_client).to have_received(:update_status)
-        .with(druid: 'druid:xb482ww9999', workflow:, process: step, status: 'waiting')
+        .with(druid: 'druid:xb482ww9999', workflow:, process: step, status: 'waiting', current_status: 'error')
     end
 
     it 'requires parameters' do
@@ -55,7 +55,7 @@ RSpec.describe 'Reset failed workflow steps', type: :request do
 
       expect(response).to redirect_to(report_workflow_grid_path)
       expect(workflow_client).to have_received(:update_status)
-        .with(druid: 'druid:xb482ww9999', workflow:, process: step, status: 'waiting')
+        .with(druid: 'druid:xb482ww9999', workflow:, process: step, status: 'waiting', current_status: 'error')
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Another attempt to deal with #3697

Guard against setting a workflow step back to waiting that is no longer in an error state.

## How was this change tested? 🤨

Existing tests