### PR TITLE
Add docker compse configuration for indexing workers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,22 @@
 version: '3.6'
 
+x-dor-indexing: &dor-indexing-backend
+  image: suldlss/dor-indexing-app:latest
+  environment:
+    SOLR_URL: http://solr:8983/solr/argo
+    SETTINGS__SOLR__URL: http://solr:8983/solr/argo
+    SETTINGS__DOR_SERVICES__URL: http://dor-services-app:3000/
+    # To generate the token: docker-compose run dor-services-app rake generate_token
+    SETTINGS__DOR_SERVICES__TOKEN: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJGb28ifQ.-BVfLTW9Q1_ZQEsGv4tuzGLs5rESN7LgdtEwUltnKv4
+    SETTINGS__SOLRIZER_URL: http://solr:8983/solr/argo
+    SETTINGS__WORKFLOW_URL: http://workflow:3000
+    SETTINGS__RABBITMQ__HOSTNAME: rabbitmq
+    WORKERS: ReindexJob,ReindexByDruidJob,DeleteByDruidJob
+  depends_on:
+    - solr
+    - workflow
+    - rabbitmq
+
 services:
   web:
     build: .
@@ -33,22 +50,21 @@ services:
     # To allow yarn --watch from Procfile.dev to continue after stdin is closed
     tty: true
 
-  dor-indexing-app:
-    image: suldlss/dor-indexing-app:latest
+  rabbitmq:
+    image: rabbitmq:3
     ports:
-      - 3004:3000
+      - 5672:5672
     environment:
       SOLR_URL: http://solr:8983/solr/argo
-      SETTINGS__SOLR__URL: http://solr:8983/solr/argo
-      SETTINGS__DOR_SERVICES__URL: http://dor-services-app:3000/
-      # To generate the token: docker-compose run dor-services-app rake generate_token
-      SETTINGS__DOR_SERVICES__TOKEN: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJGb28ifQ.-BVfLTW9Q1_ZQEsGv4tuzGLs5rESN7LgdtEwUltnKv4
-      SETTINGS__SOLRIZER_URL: http://solr:8983/solr/argo
-      SETTINGS__WORKFLOW_URL: http://workflow:3000
-    depends_on:
-      - solr
-      - workflow
 
+  dor-indexing-app:
+    <<: *dor-indexing-backend
+    ports:
+      - 3004:3000
+
+  dor-indexing-workers:
+    <<: *dor-indexing-backend
+    command: ['sh', '-c', 'timeout 30 docker/wait-port.sh rabbitmq 5672 ; bin/rake rabbitmq:setup sneakers:run']
   dor-services-app:
     image: suldlss/dor-services-app:latest
     ports:
@@ -68,6 +84,8 @@ services:
       SETTINGS__SURI__URL: http://suri:3000
       SETTINGS__WORKFLOW_URL: http://workflow:3000
       SETTINGS__WORKFLOW__LOGFILE: rails
+      SETTINGS__RABBITMQ__ENABLED: 'true'
+      SETTINGS__RABBITMQ__HOSTNAME: rabbitmq
       SETTINGS__VERSION_SERVICE__SYNC_WITH_PRESERVATION: 'false'
       SETTINGS__ENABLED_FEATURES__UPDATE_DESCRIPTIVE: 'true'
       REDIS_URL: redis://redis:6379/


### PR DESCRIPTION


## Why was this change made? 🤔

Without this, you are unable to access newly registered items without manually triggering the indexing.

## How was this change tested? 🤨
Tested locally.  I can access the newly registered items.




