### PR TITLE
Remove solr bootstrapping

### DIFF
--- a/spec/support/reset_solr.rb
+++ b/spec/support/reset_solr.rb
@@ -5,14 +5,6 @@ module ResetSolr
     blacklight_config = CatalogController.blacklight_config
     solr_conn = blacklight_config.repository_class.new(blacklight_config).connection
     solr_conn.delete_by_query('*:*')
-
-    # Solves an odd bootstrapping problem, where the dor-indexing-app can only index cocina-models,
-    # but cocina-model can't be built unless the AdminPolicy is found in Solr
-    solr_conn.add(id: 'druid:hv992ry2431',
-                  objectType_ssim: ['adminPolicy'],
-                  apo_register_permissions_ssim: ['workgroup:dlss:developers'],
-                  sw_display_title_tesim: ['[Internal System Objects]'],
-                  has_model_ssim: ['info:fedora/afmodel:Dor_AdminPolicyObject'])
     solr_conn.commit
   end
 end


### PR DESCRIPTION


## Why was this change made? 🤔
DSA no longer looks at solr to see if an admin policy exists, so we can remove the bootstrapping


## How was this change tested? 🤨
locally