### PR TITLE
do not allow cocina spreadsheet upload for locked objects

### DIFF
--- a/app/components/show/controls_component.html.erb
+++ b/app/components/show/controls_component.html.erb
@@ -43,9 +43,11 @@
                                      data: { turbo_method: 'post' } %></li>
         <% end %>
         <li><%= link_to 'Download Cocina spreadsheet', item_descriptive_path(doc, format: :csv), class: 'dropdown-item' %></li>
-        <li><%= link_to 'Upload Cocina spreadsheet', edit_item_descriptive_path(doc),
-                                      class: 'dropdown-item',
-                                      data: { controller: 'button', action: 'click->button#open'} %></li>
+        <% if allows_modification? %>
+          <li><%= link_to 'Upload Cocina spreadsheet', edit_item_descriptive_path(doc),
+                                        class: 'dropdown-item',
+                                        data: { controller: 'button', action: 'click->button#open'} %></li>
+        <% end %>
         <% if symphony_record? && item? %>
           <li><%= link_to 'Manage serials', edit_item_serials_path(doc),
                                             class: 'dropdown-item',

--- a/spec/components/show/controls_component_spec.rb
+++ b/spec/components/show/controls_component_spec.rb
@@ -79,13 +79,13 @@ RSpec.describe Show::ControlsComponent, type: :component do
         expect(rendered.css("a.disabled[data-turbo-confirm][data-turbo-method='delete'][href='/items/druid:kv840xx0000/purge']").inner_text).to eq 'Purge'
         expect(page).to have_link 'Manage release', href: '/items/druid:kv840xx0000/manage_release'
         expect(page).to have_link 'Download Cocina spreadsheet', href: '/items/druid:kv840xx0000/descriptive.csv'
-        expect(page).to have_link 'Upload Cocina spreadsheet', href: '/items/druid:kv840xx0000/descriptive/edit'
+        expect(page).not_to have_link 'Upload Cocina spreadsheet', href: '/items/druid:kv840xx0000/descriptive/edit'
 
         # these buttons are disabled since object is locked
         expect(page).to have_css 'a.disabled', text: 'Create embargo'
         expect(page).to have_css 'a.disabled', text: 'Apply APO defaults'
 
-        expect(rendered.css('a').size).to eq 10
+        expect(rendered.css('a').size).to eq 9
         expect(rendered.css('a.disabled').size).to eq 5 # create embargo, apply APO defaults, purge, publish/unpublish are disabled
       end
     end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3706 - do not allow upload of cocina desc metadata spreadsheet for locked objects

## How was this change tested? 🤨

Updated existing test