### PR TITLE
Pass viewing direction to content type job.

### DIFF
--- a/app/controllers/bulk_actions/content_type_jobs_controller.rb
+++ b/app/controllers/bulk_actions/content_type_jobs_controller.rb
@@ -8,7 +8,8 @@ module BulkActions
     def job_params
       super.merge(current_resource_type: params[:current_resource_type],
                   new_content_type: params[:new_content_type],
-                  new_resource_type: params[:new_resource_type])
+                  new_resource_type: params[:new_resource_type],
+                  viewing_direction: params[:viewing_direction])
     end
   end
 end

--- a/spec/features/bulk_content_type_spec.rb
+++ b/spec/features/bulk_content_type_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Bulk set content type', js: true do
+  let(:current_user) { create(:user) }
+  let(:bulk_action) { instance_double(BulkAction, save: true, enqueue_job: nil) }
+
+  before do
+    allow(BulkAction).to receive(:new).and_return(bulk_action)
+    sign_in current_user
+  end
+
+  it 'Creates a new jobs' do
+    visit new_bulk_action_path
+    select 'Set content type'
+    select 'file', from: 'Current resource type'
+    select 'book', from: 'New content type'
+    select 'right-to-left', from: 'Viewing direction'
+    select 'image', from: 'New resource type'
+    fill_in 'Druids to perform bulk action on', with: 'druid:ab123gg7777'
+    click_button 'Submit'
+    expect(page).to have_css 'h1', text: 'Bulk Actions'
+
+    expect(bulk_action).to have_received(:enqueue_job).with(current_resource_type: 'https://cocina.sul.stanford.edu/models/resources/file',
+                                                            druids: ['druid:ab123gg7777'],
+                                                            groups: current_user.groups,
+                                                            new_content_type: 'https://cocina.sul.stanford.edu/models/book',
+                                                            new_resource_type: 'https://cocina.sul.stanford.edu/models/resources/image',
+                                                            viewing_direction: 'right-to-left')
+  end
+end


### PR DESCRIPTION
closes #3726

## Why was this change made? 🤔
It was being ignored.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Andrew on stage.

⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


