### PR TITLE
Remove existing server.pid on startup when using docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ RUN yarn install
 
 COPY . .
 
-CMD ["bin/dev"]
+CMD ["docker/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ -f tmp/pids/server.pid ]; then
+  rm tmp/pids/server.pid
+fi
+
+exec bin/dev


### PR DESCRIPTION
## Why was this change made? 🤔

This is a small docker file change to add an entrypoint script that will remove an existing `tmp/pids/server.pid` on startup because when running with foreman it is not removed on shutdown. When attached (watching the docker output) and ending with `ctrl-c` it remains, as well as when detached and running either `docker compose stop` or `docker compose down`. The result is that subsequent starts of the web application currently require manually removing the `server.pid` file to avoid the web container stopping with the `pid file already exists` error. 

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


