### PR TITLE
Validate barcode on registration page

### DIFF
--- a/app/forms/registration_form.rb
+++ b/app/forms/registration_form.rb
@@ -8,6 +8,9 @@ class RegistrationForm < Reform::Form
     end
   end
 
+  # standard, business, lane, catkey (matches allowed patterns in cocina-models)
+  VALID_BARCODE_REGEX = /\A(36105[0-9]{9}|2050[0-9]{7}|245[0-9]{8}|[0-9]+-[0-9]+)\z/
+
   include HasViewAccessWithCdl
 
   property :current_user, virtual: true
@@ -37,6 +40,7 @@ It's legal to have more than one colon in a hierarchy, but at least one colon is
     property :barcode, virtual: true
     validates :source_id, format: { with: /\A.+:.+\z/, message: 'ID is invalid' }
     validates :catkey, allow_blank: true, format: { with: /\A\d+(:\d+)*\z/, message: 'is invalid' }
+    validates :barcode, allow_blank: true, format: { with: VALID_BARCODE_REGEX, message: 'is invalid' }
   end
 
   def persisted?

--- a/app/javascript/controllers/registration_controller.js
+++ b/app/javascript/controllers/registration_controller.js
@@ -56,7 +56,7 @@ export default class extends Controller {
       if (!field.validity.patternMismatch) { // Only check if the format is valid
         this.clearValidation(field)
 
-        // Check to see if this is unique in SDR        
+        // Check to see if this is unique in SDR
         fetch(`/registration/catkey?catkey=${currentCatkey}`)
           .then(response => {
             if (response.ok) {
@@ -75,5 +75,13 @@ export default class extends Controller {
           })
       }
     }
-    
+
+    validateBarcode(event) {
+      const field = event.target
+      if (field.validity.patternMismatch) {
+        field.classList.toggle("invalid", !field.validity.valid)
+      } else {
+        this.clearValidation(field)
+      }
+    }
 }

--- a/app/views/registrations/_item_row.html.erb
+++ b/app/views/registrations/_item_row.html.erb
@@ -17,7 +17,7 @@
     <%= item_form.text_field :catkey, class: 'form-control',
       pattern: '^[0-9]+(:[0-9]+)*$',
       data: {
-        action: "change->registration#validateCatkey invalid->registration#displayValidation",        
+        action: "change->registration#validateCatkey invalid->registration#displayValidation",
     } %>
   </div>
 </div>
@@ -34,6 +34,10 @@
 <div class="row mb-3">
   <%= item_form.label :barcode, class: 'col-sm-2 col-form-label' %>
   <div class="col-sm-10">
-    <%= item_form.text_field :barcode, class: 'form-control' %>
+    <%= item_form.text_field :barcode, class: 'form-control',
+    pattern: '^(36105[0-9]{9}|2050[0-9]{7}|245[0-9]{8}|[0-9]+-[0-9]+)',
+    data: {
+      action: "change->registration#validateBarcode invalid->registration#displayValidation",
+    } %>
   </div>
 </div>

--- a/spec/features/item_registration_spec.rb
+++ b/spec/features/item_registration_spec.rb
@@ -182,4 +182,28 @@ RSpec.describe 'Item registration page', js: true do
       expect(page).not_to have_content 'Items successfully registered.'
     end
   end
+
+  context 'invalid barcode' do
+    it 'does not register' do
+      visit registration_path
+      select '[Internal System Objects]', from: 'Admin Policy' # "uber APO"
+      select 'registrationWF', from: 'Initial Workflow'
+      select 'book', from: 'Content Type'
+      select 'left-to-right', from: 'Viewing Direction'
+      select 'Stanford', from: 'View access'
+      select 'Stanford', from: 'Download access'
+
+      fill_in 'Project Name', with: 'Y-Files'
+      fill_in 'Tags', with: 'vinsky : believes'
+
+      fill_in 'Barcode', with: 'not_a_barcode'
+      fill_in 'Source ID', with: source_id
+      fill_in 'Label', with: 'object title'
+
+      click_button 'Register'
+
+      expect(page).to have_css('.invalid')
+      expect(page).not_to have_content 'Items successfully registered.'
+    end
+  end
 end


### PR DESCRIPTION
~~[HOLD - for PO review, but also so PR #3751 can go through first]~~

## Why was this change made? 🤔

closes #3748 

Registration page validates barcode against allowed barcodes per cocina.

###  AFTER

![image](https://user-images.githubusercontent.com/96775/175751168-fbe41fbc-d08c-41a2-908f-bc21f4d93fb8.png)

### BEFORE

![image](https://user-images.githubusercontent.com/96775/175612042-b391ee23-8ff4-40f0-877f-d1e997570e41.png)


## How was this change tested? 🤨

po review

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


