### PR TITLE
Fix validation of source ids.

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -41,7 +41,7 @@ class RegistrationsController < ApplicationController
 
   # Allow the front end to check if a source Id already exists
   def source_id
-    raise 'Malformed input' unless /\A[\w:]+\z/.match?(params[:source_id])
+    raise 'Malformed input' unless /\A.+:.+\z/.match?(params[:source_id])
 
     query = "_query_:\"{!raw f=#{SolrDocument::FIELD_SOURCE_ID}}#{params[:source_id]}\""
     solr_conn = blacklight_config.repository_class.new(blacklight_config).connection

--- a/spec/requests/registration_source_id_spec.rb
+++ b/spec/requests/registration_source_id_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Registration source_id check', type: :request do
+  let(:user) { create(:user) }
+  let(:blacklight_config) { CatalogController.blacklight_config }
+  let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
+  let(:source_id) { 'sul:abc-123' }
+
+  before do
+    sign_in user
+    solr_conn.add(:id => 'druid:hv992yv2222', SolrDocument::FIELD_SOURCE_ID => source_id)
+    solr_conn.commit
+  end
+
+  context 'when source_id found' do
+    it 'returns true' do
+      get "/registration/source_id?source_id=#{source_id}"
+
+      expect(response.body).to eq('true')
+    end
+  end
+
+  context 'when source_id not found' do
+    it 'returns false' do
+      get "/registration/source_id?source_id=x#{source_id}"
+
+      expect(response.body).to eq('false')
+    end
+  end
+end


### PR DESCRIPTION
closes #3753

## Why was this change made? 🤔
The check on source ids excluded valid source ids.


## How was this change tested? 🤨

Unit

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


