### PR TITLE
Support refresh in set catkeys CSV bulk action.

### DIFF
--- a/app/jobs/set_catkeys_and_barcodes_csv_job.rb
+++ b/app/jobs/set_catkeys_and_barcodes_csv_job.rb
@@ -15,18 +15,25 @@ class SetCatkeysAndBarcodesCsvJob < SetCatkeysAndBarcodesJob
     update_druids = []
     catkeys = nil
     barcodes = nil
+    refresh = nil
     CSV.parse(params[:csv_file], headers: true).each do |row|
       update_druids << row['Druid']
       if row.header?('Catkey')
         catkeys ||= []
+        refresh ||= []
         catkeys << catkey_cols(row)
+        refresh << refresh?(row)
       end
       if row.header?('Barcode')
         barcodes ||= []
         barcodes << row['Barcode'].presence
       end
     end
-    [update_druids, catkeys, barcodes]
+    [update_druids, catkeys, barcodes, refresh]
+  end
+
+  def refresh?(row)
+    (row['Refresh']&.downcase != 'false')
   end
 
   def catkey_cols(row)

--- a/app/jobs/set_catkeys_and_barcodes_job.rb
+++ b/app/jobs/set_catkeys_and_barcodes_job.rb
@@ -16,7 +16,7 @@ class SetCatkeysAndBarcodesJob < GenericJob
     super
 
     # Catkeys, barcodes are nil if not selected for use.
-    update_druids, catkeys, barcodes = params_from(params)
+    update_druids, catkeys, barcodes, refresh = params_from(params)
 
     with_bulk_action_log do |log|
       update_druid_count(count: update_druids.count)
@@ -24,6 +24,7 @@ class SetCatkeysAndBarcodesJob < GenericJob
         cocina_object = Repository.find(current_druid)
         args = {}
         args[:catkeys] = Array(catkeys[i]) if catkeys
+        args[:refresh] = refresh[i] if refresh
         args[:barcode] = barcodes[i] if barcodes
         change_set = ItemChangeSet.new(cocina_object)
         change_set.validate(args)
@@ -36,8 +37,9 @@ class SetCatkeysAndBarcodesJob < GenericJob
 
   def params_from(params)
     catkeys = catkeys_from_params(params)
+    refresh = catkeys ? Array.new(catkeys.size, true) : nil
     barcodes = barcodes_from_params(params)
-    [druids, catkeys, barcodes]
+    [druids, catkeys, barcodes, refresh]
   end
 
   private

--- a/app/models/item_change_set.rb
+++ b/app/models/item_change_set.rb
@@ -4,6 +4,7 @@
 class ItemChangeSet < ApplicationChangeSet
   property :admin_policy_id, virtual: true
   property :catkeys, virtual: true
+  property :refresh, virtual: true
   property :collection_ids, virtual: true
   property :copyright, virtual: true
   property :license, virtual: true
@@ -31,6 +32,7 @@ class ItemChangeSet < ApplicationChangeSet
   def setup_properties!(_options)
     if model.identification
       self.catkeys = Catkey.symphony_links(model)
+      self.refresh = Catkey.symphony_link_refresh(model)
       self.barcode = model.identification.barcode
       self.source_id = model.identification.sourceId
     end

--- a/app/services/catkey.rb
+++ b/app/services/catkey.rb
@@ -5,8 +5,12 @@ class Catkey
     new(model).symphony_links
   end
 
-  def self.serialize(model, catkeys)
-    new(model).serialize(catkeys)
+  def self.serialize(model, catkeys, refresh: true)
+    new(model).serialize(catkeys, refresh:)
+  end
+
+  def self.symphony_link_refresh(model)
+    new(model).symphony_link_refresh
   end
 
   def initialize(model)
@@ -15,16 +19,21 @@ class Catkey
 
   # If there was already a catkey in the record, store that in the "previous" spot (assuming there is no change)
   # @param [Array<String>] new_catkeys a list of catkeys
+  # @param [boolean] refresh first catkey
   # @return [Array<Hash>] a list of catalog links
-  def serialize(new_catkeys)
+  def serialize(new_catkeys, refresh: true)
     removed_links = symphony_links - new_catkeys
     links = (previous_links + removed_links).map { |record_id| { catalog: Constants::PREVIOUS_CATKEY, catalogRecordId: record_id, refresh: false } }.uniq
 
-    links + new_catkeys.map.with_index { |record_id, index| { catalog: Constants::SYMPHONY, catalogRecordId: record_id, refresh: index.zero? } }
+    links + new_catkeys.map.with_index { |record_id, index| { catalog: Constants::SYMPHONY, catalogRecordId: record_id, refresh: refresh && index.zero? } }
   end
 
   def symphony_links
     find(Constants::SYMPHONY)
+  end
+
+  def symphony_link_refresh
+    find_first(Constants::SYMPHONY)&.refresh || false
   end
 
   def previous_links
@@ -33,6 +42,10 @@ class Catkey
 
   def find(type)
     Array(@model.identification.catalogLinks).filter_map { |link| link.catalogRecordId if link.catalog == type }
+  end
+
+  def find_first(type)
+    Array(@model.identification.catalogLinks).detect { |link| link.catalog == type }
   end
 
   def split(catkey)

--- a/app/services/item_change_set_persister.rb
+++ b/app/services/item_change_set_persister.rb
@@ -39,7 +39,7 @@ class ItemChangeSetPersister
 
   attr_reader :model, :change_set
 
-  delegate :admin_policy_id, :barcode, :catkeys, :source_id, :collection_ids,
+  delegate :admin_policy_id, :barcode, :catkeys, :refresh, :source_id, :collection_ids,
            *ACCESS_FIELDS.keys, :rights_changed?,
            :changed?, to: :change_set
 
@@ -109,7 +109,7 @@ class ItemChangeSetPersister
   end
 
   def identification_changed?
-    changed?(:source_id) || changed?(:catkeys) || changed?(:barcode)
+    changed?(:source_id) || changed?(:catkeys) || changed?(:barcode) || changed?(:refresh)
   end
 
   def updated_object_access(updated)
@@ -131,7 +131,7 @@ class ItemChangeSetPersister
     identification_props = updated.identification.to_h
     identification_props[:sourceId] = source_id if changed?(:source_id)
     identification_props[:barcode] = barcode.presence if changed?(:barcode)
-    identification_props[:catalogLinks] = Catkey.serialize(model, catkeys) if changed?(:catkeys)
+    identification_props[:catalogLinks] = Catkey.serialize(model, catkeys, refresh:) if changed?(:catkeys) || changed?(:refresh)
     updated.new(identification: identification_props.presence)
   end
 end

--- a/app/views/bulk_actions/catkey_and_barcode_csv_jobs/_new.html.erb
+++ b/app/views/bulk_actions/catkey_and_barcode_csv_jobs/_new.html.erb
@@ -10,6 +10,7 @@
     <ul>
       <li>Druid (required)</li>
       <li>Catkey (optional). May be repeated if an item is associated with multiple catkeys.</li>
+      <li>Refresh (optional). Set to "true" to indicate descriptive metadata is refreshable from first catkey; set to "false" to indicate descriptive metadata is not refreshable.</li>
       <li>Barcode (optional)</li>
     </ul>
     </em></small></p>

--- a/spec/jobs/set_catkeys_and_barcodes_csv_job_spec.rb
+++ b/spec/jobs/set_catkeys_and_barcodes_csv_job_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe SetCatkeysAndBarcodesCsvJob do
 
   let(:druids) { %w[druid:bb111cc2222 druid:cc111dd2222 druid:dd111ff2222] }
   let(:catkeys) { ['12345', '', '44444'] }
+  let(:refresh) { ['true', '', 'false'] }
   let(:barcodes) { ['36105014757517', '', '36105014757518'] }
   let(:buffer) { StringIO.new }
 
@@ -29,10 +30,10 @@ RSpec.describe SetCatkeysAndBarcodesCsvJob do
 
   let(:csv_file) do
     [
-      'Druid,Barcode,Catkey,Catkey',
-      [druids[0], barcodes[0], catkeys[0], '55555'].join(','),
-      [druids[1], barcodes[1], catkeys[1], ''].join(','),
-      [druids[2], barcodes[2], catkeys[2], ''].join(',')
+      'Druid,Barcode,Catkey,Catkey,Refresh',
+      [druids[0], barcodes[0], catkeys[0], '55555', refresh[0]].join(','),
+      [druids[1], barcodes[1], catkeys[1], '', refresh[1]].join(','),
+      [druids[2], barcodes[2], catkeys[2], '', refresh[2]].join(',')
     ].join("\n")
   end
 

--- a/spec/services/item_change_set_persister_spec.rb
+++ b/spec/services/item_change_set_persister_spec.rb
@@ -218,6 +218,28 @@ RSpec.describe ItemChangeSetPersister do
       end
     end
 
+    context 'when change set has changed refresh' do
+      let(:new_catkeys) { ['367269'] }
+
+      before do
+        change_set.validate(catkeys: [catkey_before], refresh: false)
+        instance.update
+      end
+
+      it 'invokes object client with item/DRO that has new catkey' do
+        expect(Repository).to have_received(:store).with(
+          cocina_object_with(
+            identification: {
+              barcode: barcode_before,
+              catalogLinks: [
+                { catalog: 'symphony', catalogRecordId: catkey_before, refresh: false }
+              ]
+            }
+          )
+        )
+      end
+    end
+
     context 'when change set has changed catkey' do
       let(:new_catkeys) { ['367269'] }
 


### PR DESCRIPTION
closes #3735

## Why was this change made? 🤔
Need to support setting refresh.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, QA

⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


