### PR TITLE
add webarchive-binary content type to menu

### DIFF
--- a/app/forms/content_type_form.rb
+++ b/app/forms/content_type_form.rb
@@ -15,6 +15,7 @@ class ContentTypeForm < ApplicationChangeSet
     '3d' => Cocina::Models::ObjectType.three_dimensional,
     'document' => Cocina::Models::ObjectType.document,
     'geo' => Cocina::Models::ObjectType.geo,
+    'webarchive-binary' => Cocina::Models::ObjectType.webarchive_binary,
     'webarchive-seed' => Cocina::Models::ObjectType.webarchive_seed
   }.freeze
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3761 - add webarchive-binary content type to menus

Single config file affects both the bulk action and the item detail form (yay).

**Item detail page:**
![Screen Shot 2022-06-29 at 11 46 47 AM](https://user-images.githubusercontent.com/47137/176513177-c3feed7a-ef26-4883-ba51-29947810b959.png)

**Bulk action:**
![Screen Shot 2022-06-29 at 11 46 36 AM](https://user-images.githubusercontent.com/47137/176513172-fd4595d8-2307-4621-bf7c-39ce6c9bc2ea.png)

## How was this change tested? 🤨

Localhost browser, Existing tests



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


