### PR TITLE
add druid column to all exported structural metadata

### DIFF
--- a/app/controllers/structures_controller.rb
+++ b/app/controllers/structures_controller.rb
@@ -12,7 +12,7 @@ class StructuresController < ApplicationController
         cocina = Repository.find(params[:item_id])
         authorize! :update, cocina
         filename = "structure-#{Druid.new(cocina).without_namespace}.csv"
-        send_data StructureSerializer.as_csv(cocina.structural), filename:
+        send_data StructureSerializer.as_csv(cocina.externalIdentifier, cocina.structural), filename:
       end
       format.html do
         # Lazy loading of the structural part of the show page

--- a/app/jobs/export_structural_job.rb
+++ b/app/jobs/export_structural_job.rb
@@ -9,13 +9,9 @@ class ExportStructuralJob < GenericJob
     super
 
     CSV.open(csv_download_path, 'w', headers: true) do |csv|
-      csv << ['druid', *StructureSerializer::HEADERS]
+      csv << StructureSerializer::HEADERS
       with_items(params[:druids], name: 'Export structural metadata') do |cocina_object, success, failure|
-        rows_for_file = item_to_rows(cocina_object, success, failure)
-        druid = Druid.new(cocina_object).without_namespace
-        rows_for_file.each do |row|
-          csv << [druid, *row]
-        end
+        item_to_rows(cocina_object, success, failure).each { |row| csv << row }
       end
     end
   end
@@ -30,7 +26,7 @@ class ExportStructuralJob < GenericJob
       return []
     end
 
-    StructureSerializer.new(item.structural).rows do |row|
+    StructureSerializer.new(item.externalIdentifier, item.structural).rows do |row|
       result << row
     end
     success.call('Exported structural metadata')

--- a/app/services/structure_serializer.rb
+++ b/app/services/structure_serializer.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 class StructureSerializer
-  HEADERS = %w[resource_label resource_type sequence filename file_label publish
+  HEADERS = %w[druid resource_label resource_type sequence filename file_label publish
                shelve preserve rights_view rights_download rights_location mimetype role].freeze
 
-  def self.as_csv(structural)
-    new(structural).as_csv
+  def self.as_csv(druid, structural)
+    new(druid, structural).as_csv
   end
 
-  def initialize(structural)
+  def initialize(druid, structural)
+    @druid = Druid.new(druid).without_namespace
     @structural = structural
   end
 
@@ -24,7 +25,7 @@ class StructureSerializer
   def rows
     Array(structural.contains).each.with_index(1) do |resource, n|
       resource.structural.contains.each do |file|
-        yield [resource.label, type(resource), n, file.filename, file.label,
+        yield [@druid, resource.label, type(resource), n, file.filename, file.label,
                to_yes_no(file.administrative.publish), to_yes_no(file.administrative.shelve),
                to_yes_no(file.administrative.sdrPreserve), file.access.view,
                file.access.download, file.access.location, file.hasMimeType, file.use]

--- a/spec/services/structure_serializer_spec.rb
+++ b/spec/services/structure_serializer_spec.rb
@@ -4,19 +4,22 @@ require 'rails_helper'
 
 RSpec.describe StructureSerializer do
   subject(:csv) do
-    described_class.as_csv(cocina.structural)
+    described_class.as_csv(cocina.externalIdentifier, cocina.structural)
   end
 
   let(:cocina) do
     Cocina::Models.build(JSON.parse(json))
   end
 
+  let(:druid) { 'druid:qr773tm1060' }
+  let(:bare_druid) { 'qr773tm1060' }
+
   context 'with no resources' do
     let(:json) do
       <<~JSON
         {
           "type": "#{Cocina::Models::ObjectType.image}",
-          "externalIdentifier": "druid:qr773tm1060",
+          "externalIdentifier": "#{druid}",
           "label": "dood",
           "version": 1,
           "access": {
@@ -51,7 +54,7 @@ RSpec.describe StructureSerializer do
 
     it 'serializes to CSV' do
       expect(csv).to eq <<~CSV
-        resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
+        druid,resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
       CSV
     end
   end
@@ -61,7 +64,7 @@ RSpec.describe StructureSerializer do
       <<~JSON
         {
           "type": "#{Cocina::Models::ObjectType.image}",
-          "externalIdentifier": "druid:qr773tm1060",
+          "externalIdentifier": "#{druid}",
           "label": "dood",
           "version": 1,
           "access": {
@@ -248,11 +251,11 @@ RSpec.describe StructureSerializer do
 
     it 'serializes to CSV' do
       expect(csv).to eq <<~CSV
-        resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
-        Image 1,image,1,bb045jk9908_0001.tiff,bb045jk9908_0001.tiff,no,no,yes,world,world,,image/tiff,
-        Image 1,image,1,bb045jk9908_0001.jp2,bb045jk9908_0001.jp2,yes,yes,no,world,world,,image/jp2,
-        Image 2,image,2,bb045jk9908_0002.tiff,bb045jk9908_0002.tiff,no,no,yes,world,world,,image/tiff,
-        Image 2,image,2,bb045jk9908_0002.jp2,bb045jk9908_0002.jp2,yes,yes,no,location-based,location-based,music,image/jp2,
+        druid,resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
+        #{bare_druid},Image 1,image,1,bb045jk9908_0001.tiff,bb045jk9908_0001.tiff,no,no,yes,world,world,,image/tiff,
+        #{bare_druid},Image 1,image,1,bb045jk9908_0001.jp2,bb045jk9908_0001.jp2,yes,yes,no,world,world,,image/jp2,
+        #{bare_druid},Image 2,image,2,bb045jk9908_0002.tiff,bb045jk9908_0002.tiff,no,no,yes,world,world,,image/tiff,
+        #{bare_druid},Image 2,image,2,bb045jk9908_0002.jp2,bb045jk9908_0002.jp2,yes,yes,no,location-based,location-based,music,image/jp2,
       CSV
     end
   end

--- a/spec/services/structure_updater_spec.rb
+++ b/spec/services/structure_updater_spec.rb
@@ -7,11 +7,14 @@ RSpec.describe StructureUpdater do
     described_class.from_csv(cocina, csv)
   end
 
+  let(:druid) { 'druid:qr773tm1060' }
+  let(:bare_druid) { 'qr773tm1060' }
+
   let(:json) do
     <<~JSON
       {
         "type": "#{Cocina::Models::ObjectType.image}",
-        "externalIdentifier": "druid:qr773tm1060",
+        "externalIdentifier": "#{druid}",
         "label": "dood",
         "version": 1,
         "access": {
@@ -27,7 +30,7 @@ RSpec.describe StructureUpdater do
               "value": "dood"
             }
           ],
-          "purl": "https://purl.stanford.edu/qr773tm1060",
+          "purl": "https://purl.stanford.edu/#{bare_druid}",
           "access": {
             "digitalRepository": [
               {
@@ -203,11 +206,11 @@ RSpec.describe StructureUpdater do
   context 'with valid csv that has file properties changed' do
     let(:csv) do
       <<~CSV
-        resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
-        Image 1,image,1,bb045jk9908_0001.tiff,bb045jk9908_0001.tiff,yes,yes,yes,stanford,stanford,,image/one,
-        Image 1,image,1,bb045jk9908_0001.jp2,bb045jk9908_0001.jp2,yes,yes,no,world,world,,image/two,transcription
-        Image 2,image,2,bb045jk9908_0002.tiff,bb045jk9908_0002.tiff,yes,yes,yes,stanford,none,,image/three,
-        Image 2,image,2,bb045jk9908_0002.jp2,bb045jk9908_0002.jp2,yes,yes,no,location-based,location-based,music,image/four,
+        druid,resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
+        #{bare_druid},Image 1,image,1,bb045jk9908_0001.tiff,bb045jk9908_0001.tiff,yes,yes,yes,stanford,stanford,,image/one,
+        #{bare_druid},Image 1,image,1,bb045jk9908_0001.jp2,bb045jk9908_0001.jp2,yes,yes,no,world,world,,image/two,transcription
+        #{bare_druid},Image 2,image,2,bb045jk9908_0002.tiff,bb045jk9908_0002.tiff,yes,yes,yes,stanford,none,,image/three,
+        #{bare_druid},Image 2,image,2,bb045jk9908_0002.jp2,bb045jk9908_0002.jp2,yes,yes,no,location-based,location-based,music,image/four,
       CSV
     end
 
@@ -243,11 +246,11 @@ RSpec.describe StructureUpdater do
   context 'with valid csv that has fileset properties changed' do
     let(:csv) do
       <<~CSV
-        resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
-        Picture 1,object,1,bb045jk9908_0001.tiff,bb045jk9908_0001.tiff,yes,yes,yes,stanford,stanford,,image/tiff,
-        Picture 1,object,1,bb045jk9908_0001.jp2,bb045jk9908_0001.jp2,yes,yes,no,world,world,,image/jp2,
-        Picture 2,page,2,bb045jk9908_0002.tiff,bb045jk9908_0002.tiff,yes,yes,yes,stanford,stanford,,image/tiff,
-        Picture 2,page,2,bb045jk9908_0002.jp2,bb045jk9908_0002.jp2,yes,yes,no,world,world,,image/jp2,
+        druid,resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
+        #{bare_druid},Picture 1,object,1,bb045jk9908_0001.tiff,bb045jk9908_0001.tiff,yes,yes,yes,stanford,stanford,,image/tiff,
+        #{bare_druid},Picture 1,object,1,bb045jk9908_0001.jp2,bb045jk9908_0001.jp2,yes,yes,no,world,world,,image/jp2,
+        #{bare_druid},Picture 2,page,2,bb045jk9908_0002.tiff,bb045jk9908_0002.tiff,yes,yes,yes,stanford,stanford,,image/tiff,
+        #{bare_druid},Picture 2,page,2,bb045jk9908_0002.jp2,bb045jk9908_0002.jp2,yes,yes,no,world,world,,image/jp2,
       CSV
     end
 
@@ -272,11 +275,11 @@ RSpec.describe StructureUpdater do
   context 'with valid csv that adds filesets' do
     let(:csv) do
       <<~CSV
-        resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
-        Picture 1,object,1,bb045jk9908_0001.tiff,bb045jk9908_0001.tiff,yes,yes,yes,stanford,stanford,,image/tiff,
-        Picture 2,object,2,bb045jk9908_0001.jp2,bb045jk9908_0001.jp2,yes,yes,no,world,world,,image/jp2,
-        Picture 3,page,3,bb045jk9908_0002.tiff,bb045jk9908_0002.tiff,yes,yes,yes,stanford,stanford,,image/tiff,
-        Picture 4,page,4,bb045jk9908_0002.jp2,bb045jk9908_0002.jp2,yes,yes,no,world,world,,image/jp2,
+        druid,resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
+        #{bare_druid},Picture 1,object,1,bb045jk9908_0001.tiff,bb045jk9908_0001.tiff,yes,yes,yes,stanford,stanford,,image/tiff,
+        #{bare_druid},Picture 2,object,2,bb045jk9908_0001.jp2,bb045jk9908_0001.jp2,yes,yes,no,world,world,,image/jp2,
+        #{bare_druid},Picture 3,page,3,bb045jk9908_0002.tiff,bb045jk9908_0002.tiff,yes,yes,yes,stanford,stanford,,image/tiff,
+        #{bare_druid},Picture 4,page,4,bb045jk9908_0002.jp2,bb045jk9908_0002.jp2,yes,yes,no,world,world,,image/jp2,
       CSV
     end
 
@@ -298,11 +301,11 @@ RSpec.describe StructureUpdater do
   context 'with valid csv that combines filesets' do
     let(:csv) do
       <<~CSV
-        resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
-        Picture 1,object,1,bb045jk9908_0001.tiff,bb045jk9908_0001.tiff,yes,yes,yes,stanford,stanford,,image/tiff,
-        Picture 1,object,1,bb045jk9908_0001.jp2,bb045jk9908_0001.jp2,yes,yes,no,world,world,,image/jp2,
-        Picture 1,page,1,bb045jk9908_0002.tiff,bb045jk9908_0002.tiff,yes,yes,yes,stanford,stanford,,image/tiff,
-        Picture 1,page,1,bb045jk9908_0002.jp2,bb045jk9908_0002.jp2,yes,yes,no,world,world,,image/jp2,
+        druid,resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
+        #{bare_druid},Picture 1,object,1,bb045jk9908_0001.tiff,bb045jk9908_0001.tiff,yes,yes,yes,stanford,stanford,,image/tiff,
+        #{bare_druid},Picture 1,object,1,bb045jk9908_0001.jp2,bb045jk9908_0001.jp2,yes,yes,no,world,world,,image/jp2,
+        #{bare_druid},Picture 1,page,1,bb045jk9908_0002.tiff,bb045jk9908_0002.tiff,yes,yes,yes,stanford,stanford,,image/tiff,
+        #{bare_druid},Picture 1,page,1,bb045jk9908_0002.jp2,bb045jk9908_0002.jp2,yes,yes,no,world,world,,image/jp2,
       CSV
     end
 
@@ -319,11 +322,11 @@ RSpec.describe StructureUpdater do
   context 'with invalid csv' do
     let(:csv) do
       <<~CSV
-        resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
-        Image 1,image,1,bb045jk_0001.tiff,bb045jk9908_0001.tiff,yes,yes,yes,world,world,,image/tiff,
-        Image 1,image,1,bb045jk_0001.jp2,bb045jk9908_0001.jp2,yes,yes,yes,world,world,,image/jp2,
-        Image 2,image,2,bb045jk_0002.tiff,bb045jk9908_0002.tiff,yes,yes,yes,world,world,,image/tiff,
-        Image 2,paper,2,bb045jk_0002.jp2,bb045jk9908_0002.jp2,yes,yes,yes,world,world,,image/jp2,
+        druid,resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
+        #{bare_druid},Image 1,image,1,bb045jk_0001.tiff,bb045jk9908_0001.tiff,yes,yes,yes,world,world,,image/tiff,
+        #{bare_druid},Image 1,image,1,bb045jk_0001.jp2,bb045jk9908_0001.jp2,yes,yes,yes,world,world,,image/jp2,
+        #{bare_druid},Image 2,image,2,bb045jk_0002.tiff,bb045jk9908_0002.tiff,yes,yes,yes,world,world,,image/tiff,
+        #{bare_druid},Image 2,paper,2,bb045jk_0002.jp2,bb045jk9908_0002.jp2,yes,yes,yes,world,world,,image/jp2,
       CSV
     end
 
@@ -341,11 +344,11 @@ RSpec.describe StructureUpdater do
   context 'with switching preservation from no to yes for a file in the csv' do
     let(:csv) do
       <<~CSV
-        resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
-        Picture 1,object,1,bb045jk9908_0001.tiff,bb045jk9908_0001.tiff,yes,yes,yes,stanford,none,,image/tiff,
-        Picture 1,object,1,bb045jk9908_0001.jp2,bb045jk9908_0001.jp2,yes,yes,no,world,world,,image/jp2,
-        Picture 2,page,2,bb045jk9908_0002.tiff,bb045jk9908_0002.tiff,yes,yes,yes,stanford,none,,image/tiff,
-        Picture 2,page,2,bb045jk9908_0002.jp2,bb045jk9908_0002.jp2,yes,yes,yes,world,world,,image/jp2,
+        druid,resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
+        #{bare_druid},Picture 1,object,1,bb045jk9908_0001.tiff,bb045jk9908_0001.tiff,yes,yes,yes,stanford,none,,image/tiff,
+        #{bare_druid},Picture 1,object,1,bb045jk9908_0001.jp2,bb045jk9908_0001.jp2,yes,yes,no,world,world,,image/jp2,
+        #{bare_druid},Picture 2,page,2,bb045jk9908_0002.tiff,bb045jk9908_0002.tiff,yes,yes,yes,stanford,none,,image/tiff,
+        #{bare_druid},Picture 2,page,2,bb045jk9908_0002.jp2,bb045jk9908_0002.jp2,yes,yes,yes,world,world,,image/jp2,
       CSV
     end
 
@@ -359,11 +362,11 @@ RSpec.describe StructureUpdater do
   context 'with specify location-based rights and no location' do
     let(:csv) do
       <<~CSV
-        resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
-        Picture 1,object,1,bb045jk9908_0001.tiff,bb045jk9908_0001.tiff,yes,yes,yes,stanford,none,,image/tiff,
-        Picture 1,object,1,bb045jk9908_0001.jp2,bb045jk9908_0001.jp2,yes,yes,no,world,world,,image/jp2,
-        Picture 2,page,2,bb045jk9908_0002.tiff,bb045jk9908_0002.tiff,yes,yes,yes,stanford,none,,image/tiff,
-        Picture 2,page,2,bb045jk9908_0002.jp2,bb045jk9908_0002.jp2,yes,yes,no,location-based,world,,image/jp2,
+        druid,resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
+        #{bare_druid},Picture 1,object,1,bb045jk9908_0001.tiff,bb045jk9908_0001.tiff,yes,yes,yes,stanford,none,,image/tiff,
+        #{bare_druid},Picture 1,object,1,bb045jk9908_0001.jp2,bb045jk9908_0001.jp2,yes,yes,no,world,world,,image/jp2,
+        #{bare_druid},Picture 2,page,2,bb045jk9908_0002.tiff,bb045jk9908_0002.tiff,yes,yes,yes,stanford,none,,image/tiff,
+        #{bare_druid},Picture 2,page,2,bb045jk9908_0002.jp2,bb045jk9908_0002.jp2,yes,yes,no,location-based,world,,image/jp2,
       CSV
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3758 - include the druid column for all structural metadata exports (even single objects).

This adds the druid column to the core export class, and then removes it from the bulk action job (since it will come automatically from the single object now).

~~HOLD to validate on QA/stage with real data~~ validated on qa, works fine

## How was this change tested? 🤨

Updated/existing tests/localhost.  Verified on qa with actual data.

Note: existing spec for bulk action job is unchanged but passes, showing that it still works as expected (i.e. includes the druid column)