### PR TITLE
Switch to using DSA to check if source id is unique.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ gem 'openapi_parser', '< 1.0'
 # Stanford related gems
 gem 'blacklight', '~> 7.25'
 gem 'blacklight-hierarchy', '~> 6.0'
-gem 'dor-services-client', '~> 12.2'
+gem 'dor-services-client', '~> 12.5'
 gem 'dor-workflow-client', '~> 4.0'
 gem 'druid-tools'
 gem 'mods_display', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,7 +186,7 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.4.0)
-    dor-services-client (12.4.0)
+    dor-services-client (12.5.0)
       activesupport (>= 4.2, < 8)
       cocina-models (~> 0.82.0)
       deprecation
@@ -622,7 +622,7 @@ DEPENDENCIES
   devise
   devise-remote-user (~> 1.0)
   dlss-capistrano
-  dor-services-client (~> 12.2)
+  dor-services-client (~> 12.5)
   dor-workflow-client (~> 4.0)
   druid-tools
   dry-monads

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -43,10 +43,12 @@ class RegistrationsController < ApplicationController
   def source_id
     raise 'Malformed input' unless /\A.+:.+\z/.match?(params[:source_id])
 
-    query = "_query_:\"{!raw f=#{SolrDocument::FIELD_SOURCE_ID}}#{params[:source_id]}\""
-    solr_conn = blacklight_config.repository_class.new(blacklight_config).connection
-    result = solr_conn.get('select', params: { q: query, qt: 'standard', rows: 0 })
-    resp = result.dig('response', 'numFound').to_i.positive?
+    begin
+      Dor::Services::Client.objects.find(source_id: params[:source_id])
+      resp = true
+    rescue Dor::Services::Client::NotFoundResponse
+      resp = false
+    end
 
     render json: resp.to_json, layout: false
   end

--- a/spec/requests/registration_source_id_spec.rb
+++ b/spec/requests/registration_source_id_spec.rb
@@ -4,14 +4,10 @@ require 'rails_helper'
 
 RSpec.describe 'Registration source_id check', type: :request do
   let(:user) { create(:user) }
-  let(:blacklight_config) { CatalogController.blacklight_config }
-  let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
-  let(:source_id) { 'sul:abc-123' }
+  let(:source_id) { FactoryBot.create_for_repository(:persisted_item).identification.sourceId }
 
   before do
     sign_in user
-    solr_conn.add(:id => 'druid:hv992yv2222', SolrDocument::FIELD_SOURCE_ID => source_id)
-    solr_conn.commit
   end
 
   context 'when source_id found' do


### PR DESCRIPTION
## Why was this change made? 🤔
DSA is the canonical source of uniqueness.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


