### PR TITLE
Ensure users with view access to an item are able to download the str…

### DIFF
--- a/app/controllers/bulk_jobs_controller.rb
+++ b/app/controllers/bulk_jobs_controller.rb
@@ -8,7 +8,7 @@ class BulkJobsController < ApplicationController
 
   # Generates the index page for a given DRUID's past bulk metadata upload jobs.
   def index
-    authorize! :view_metadata, @cocina
+    authorize! :read, @cocina
 
     @document = find(params[:apo_id])
     @bulk_jobs = load_bulk_jobs(params[:apo_id])

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -238,7 +238,7 @@ class CatalogController < ApplicationController
     @cocina = Repository.find(params[:id])
     flash[:alert] = 'Warning: this object cannot currently be represented in the Cocina model.' if @cocina.instance_of?(NilModel)
 
-    authorize! :view_metadata, @cocina
+    authorize! :read, @cocina
 
     @workflows = WorkflowService.workflows_for(druid: params[:id])
 
@@ -247,7 +247,7 @@ class CatalogController < ApplicationController
     @milestones_presenter = MilestonesPresenter.new(milestones:,
                                                     versions: object_client.version.inventory)
 
-    # If you have this token, it indicates you have view_metadata access to the object
+    # If you have this token, it indicates you have read access to the object
     @verified_token_with_expiration = Argo.verifier.generate(
       { key: params[:id] },
       expires_in: 1.hour,

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,9 @@
 
 # rubocop:disable Metrics/ClassLength
 class ItemsController < ApplicationController
-  before_action :load_cocina
+  load_and_authorize_resource :cocina, parent: false, class: 'Repository', only: :show
+
+  before_action :load_cocina, except: :show
   before_action :authorize_manage!, only: %i[
     add_collection remove_collection
     purge_object
@@ -76,8 +78,6 @@ class ItemsController < ApplicationController
   end
 
   def show
-    authorize! :view_metadata, @cocina
-
     respond_to do |format|
       format.json { render json: CocinaHashPresenter.new(cocina_object: @cocina).render }
     end

--- a/app/jobs/descmetadata_download_job.rb
+++ b/app/jobs/descmetadata_download_job.rb
@@ -39,7 +39,7 @@ class DescmetadataDownloadJob < GenericJob
       bulk_action.increment(:druid_count_fail).save
       return
     end
-    unless ability.can?(:view_metadata, cocina_object)
+    unless ability.can?(:read, cocina_object)
       log.puts("#{Time.current} Not authorized for #{current_druid}")
       return
     end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -27,12 +27,12 @@ class Ability
     cannot :impersonate, User unless current_user.webauth_admin?
 
     if current_user.manager?
-      can %i[update manage_governing_apo view_content view_metadata],
+      can %i[update manage_governing_apo view_content read],
           [NilModel] + DRO_MODELS + COLLECTION_MODELS
       can :create, ADMIN_POLICY_MODELS
     end
 
-    can %i[view_metadata view_content], DRO_MODELS + COLLECTION_MODELS + ADMIN_POLICY_MODELS if current_user.viewer?
+    can %i[read view_content], DRO_MODELS + COLLECTION_MODELS + ADMIN_POLICY_MODELS if current_user.viewer?
 
     can :update, ADMIN_POLICY_MODELS do |cocina_object|
       can_manage_items? current_user.roles(cocina_object.externalIdentifier)
@@ -51,11 +51,11 @@ class Ability
       can_view? current_user.roles(cocina_item.administrative.hasAdminPolicy)
     end
 
-    can :view_metadata, COLLECTION_MODELS + DRO_MODELS do |cocina_object|
+    can :read, COLLECTION_MODELS + DRO_MODELS do |cocina_object|
       can_view? current_user.roles(cocina_object.administrative.hasAdminPolicy)
     end
 
-    can :view_metadata, ADMIN_POLICY_MODELS do |cocina_admin_policy|
+    can :read, ADMIN_POLICY_MODELS do |cocina_admin_policy|
       can_view?(current_user.roles(cocina_admin_policy.externalIdentifier)) ||
         can_view?(current_user.roles(cocina_admin_policy.administrative.hasAdminPolicy))
     end

--- a/spec/jobs/descmetadata_download_job_spec.rb
+++ b/spec/jobs/descmetadata_download_job_spec.rb
@@ -76,8 +76,8 @@ RSpec.describe DescmetadataDownloadJob, type: :job do
 
     before do
       allow(Ability).to receive(:new).and_return(ability)
-      allow(ability).to receive(:can?).with(:view_metadata, cocina_model1).and_return(true)
-      allow(ability).to receive(:can?).with(:view_metadata, cocina_model2).and_return(true)
+      allow(ability).to receive(:can?).with(:read, cocina_model1).and_return(true)
+      allow(ability).to receive(:can?).with(:read, cocina_model2).and_return(true)
     end
 
     after do
@@ -127,11 +127,11 @@ RSpec.describe DescmetadataDownloadJob, type: :job do
 
     context 'user lacks permission to view metadata on one of the objects' do
       before do
-        allow(ability).to receive(:can?).with(:view_metadata, cocina_model1).and_return(true)
-        allow(ability).to receive(:can?).with(:view_metadata, cocina_model2).and_return(false)
+        allow(ability).to receive(:can?).with(:read, cocina_model1).and_return(true)
+        allow(ability).to receive(:can?).with(:read, cocina_model2).and_return(false)
       end
 
-      it 'creates a valid zip file with only the objects for which the user has view_metadata authorization' do
+      it 'creates a valid zip file with only the objects for which the user has read authorization' do
         expect(download_job).to receive(:bulk_action).and_return(bulk_action).at_least(:once)
 
         download_job.perform(bulk_action.id, dl_job_params)

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -73,14 +73,14 @@ RSpec.describe Ability do
     it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, apo_id) }
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro_with_metadata, apo_id) }
-    it { is_expected.to be_able_to(:view_metadata, dro) }
-    it { is_expected.to be_able_to(:view_metadata, dro_with_metadata) }
+    it { is_expected.to be_able_to(:read, dro) }
+    it { is_expected.to be_able_to(:read, dro_with_metadata) }
     it { is_expected.to be_able_to(:view_content, dro) }
     it { is_expected.to be_able_to(:view_content, dro_with_metadata) }
-    it { is_expected.to be_able_to(:view_metadata, admin_policy) }
-    it { is_expected.to be_able_to(:view_metadata, admin_policy_with_metadata) }
-    it { is_expected.to be_able_to(:view_metadata, collection) }
-    it { is_expected.to be_able_to(:view_metadata, collection_with_metadata) }
+    it { is_expected.to be_able_to(:read, admin_policy) }
+    it { is_expected.to be_able_to(:read, admin_policy_with_metadata) }
+    it { is_expected.to be_able_to(:read, collection) }
+    it { is_expected.to be_able_to(:read, collection_with_metadata) }
     it { is_expected.not_to be_able_to(:update, :workflow) }
   end
 
@@ -103,12 +103,12 @@ RSpec.describe Ability do
     it { is_expected.to be_able_to(:manage_governing_apo, dro_with_metadata, apo_id) }
     it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
 
-    it { is_expected.to be_able_to(:view_metadata, dro) }
-    it { is_expected.to be_able_to(:view_metadata, dro_with_metadata) }
-    it { is_expected.to be_able_to(:view_metadata, collection) }
-    it { is_expected.to be_able_to(:view_metadata, collection_with_metadata) }
-    it { is_expected.to be_able_to(:view_metadata, admin_policy) }
-    it { is_expected.to be_able_to(:view_metadata, admin_policy_with_metadata) }
+    it { is_expected.to be_able_to(:read, dro) }
+    it { is_expected.to be_able_to(:read, dro_with_metadata) }
+    it { is_expected.to be_able_to(:read, collection) }
+    it { is_expected.to be_able_to(:read, collection_with_metadata) }
+    it { is_expected.to be_able_to(:read, admin_policy) }
+    it { is_expected.to be_able_to(:read, admin_policy_with_metadata) }
     it { is_expected.to be_able_to(:view_content, dro) }
     it { is_expected.to be_able_to(:view_content, dro_with_metadata) }
   end
@@ -123,12 +123,12 @@ RSpec.describe Ability do
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro_with_metadata, apo_id) }
     it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
 
-    it { is_expected.not_to be_able_to(:view_metadata, dro) }
-    it { is_expected.not_to be_able_to(:view_metadata, dro_with_metadata) }
-    it { is_expected.not_to be_able_to(:view_metadata, collection) }
-    it { is_expected.not_to be_able_to(:view_metadata, collection_with_metadata) }
-    it { is_expected.to be_able_to(:view_metadata, admin_policy) }
-    it { is_expected.to be_able_to(:view_metadata, admin_policy_with_metadata) }
+    it { is_expected.not_to be_able_to(:read, dro) }
+    it { is_expected.not_to be_able_to(:read, dro_with_metadata) }
+    it { is_expected.not_to be_able_to(:read, collection) }
+    it { is_expected.not_to be_able_to(:read, collection_with_metadata) }
+    it { is_expected.to be_able_to(:read, admin_policy) }
+    it { is_expected.to be_able_to(:read, admin_policy_with_metadata) }
     it { is_expected.not_to be_able_to(:view_content, dro) }
     it { is_expected.not_to be_able_to(:view_content, dro_with_metadata) }
   end

--- a/spec/requests/download_descriptive_csv_spec.rb
+++ b/spec/requests/download_descriptive_csv_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Download the descriptive CSV', type: :request do
 
   before do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
-    sign_in build(:user), groups: ['sdr:administrator-role']
+    sign_in build(:user), groups: ['sdr:manager-role']
   end
 
   it 'returns descriptive csv' do


### PR DESCRIPTION
…uctural CSV

By default the DescriptivesController was looking for `:read` access. So I merged `:view_metadata` into `:read` as it is more idiomatic per the cancancan docs.

## Why was this change made? 🤔

Fixes #3781

## How was this change tested? 🤨

Tested on stage.
