### PR TITLE
Guard against changing the selected content type in CSV registration

### DIFF
--- a/app/services/registration_csv_converter.rb
+++ b/app/services/registration_csv_converter.rb
@@ -4,6 +4,15 @@
 class RegistrationCsvConverter
   include Dry::Monads[:result]
 
+  CONTENT_TYPES = [Cocina::Models::ObjectType.image,
+                   Cocina::Models::ObjectType.three_dimensional,
+                   Cocina::Models::ObjectType.map,
+                   Cocina::Models::ObjectType.media,
+                   Cocina::Models::ObjectType.document,
+                   Cocina::Models::ObjectType.manuscript,
+                   Cocina::Models::ObjectType.book,
+                   Cocina::Models::ObjectType.object].freeze
+
   # @param [String] csv_string CSV string
   # @return [Array<Result>] a list of registration requests suitable for passing off to dor-services-client
   def self.convert(csv_string:, params: {})
@@ -69,7 +78,6 @@ class RegistrationCsvConverter
     model_params[:access] = access(row)
     project_name = params[:project_name] || row['project_name']
     model_params[:administrative][:partOfProject] = project_name if project_name.present?
-
     model_params
   end
 
@@ -87,6 +95,9 @@ class RegistrationCsvConverter
   end
 
   def dro_type(content_type)
+    # for CSV registration, we already have the URI
+    return content_type if CONTENT_TYPES.include?(content_type)
+
     case content_type.downcase
     when 'image'
       Cocina::Models::ObjectType.image


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3802 

The `dro_types` method will always return `Cocina::Models::ObjectType.object` if the `content_type` is already a Cocina::Models type. This guards against changing it.

## How was this change tested? 🤨

Locally, first selecting the content_type (in both cases I selected `media`):
![Screen Shot 2022-07-18 at 3 07 24 PM](https://user-images.githubusercontent.com/2294288/179625961-0f18e9b7-41a9-4376-b975-f718b9df24aa.png)

Before the change, a csv registration shows that it defaults to `Cocina::Models::ObjectType.object` (displayed as `file`):

![Screen Shot 2022-07-18 at 3 07 57 PM](https://user-images.githubusercontent.com/2294288/179626054-14c74c2a-026b-4d14-b24a-7d6e14c34a8f.png)

After this change the proper selection is displayed:
![Screen Shot 2022-07-18 at 3 08 47 PM](https://user-images.githubusercontent.com/2294288/179626096-2aca80ea-8663-4d20-9480-224b585e83e8.png)

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


