### PR TITLE
Add missing types for csv registration

### DIFF
--- a/app/services/registration_csv_converter.rb
+++ b/app/services/registration_csv_converter.rb
@@ -4,14 +4,16 @@
 class RegistrationCsvConverter
   include Dry::Monads[:result]
 
-  CONTENT_TYPES = [Cocina::Models::ObjectType.image,
-                   Cocina::Models::ObjectType.three_dimensional,
+  CONTENT_TYPES = [Cocina::Models::ObjectType.book,
+                   Cocina::Models::ObjectType.document,
+                   Cocina::Models::ObjectType.file,
+                   Cocina::Models::ObjectType.geo,
+                   Cocina::Models::ObjectType.image,
                    Cocina::Models::ObjectType.map,
                    Cocina::Models::ObjectType.media,
-                   Cocina::Models::ObjectType.document,
-                   Cocina::Models::ObjectType.manuscript,
-                   Cocina::Models::ObjectType.book,
-                   Cocina::Models::ObjectType.object].freeze
+                   Cocina::Models::ObjectType.three_dimensional,
+                   Cocina::Models::ObjectType.webarchive_binary,
+                   Cocina::Models::ObjectType.webarchive_seed].freeze
 
   # @param [String] csv_string CSV string
   # @return [Array<Result>] a list of registration requests suitable for passing off to dor-services-client


### PR DESCRIPTION
## Why was this change made? 🤔

This just adds a couple of the missing types for the csv registration so it matches the pulldown menu and alphabetizes the array.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


