### PR TITLE
Add missing types when passed in through csv

### DIFF
--- a/app/services/registration_csv_converter.rb
+++ b/app/services/registration_csv_converter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # Convert CSV to JSON for registration
+# rubocop:disable Metrics/ClassLength
 class RegistrationCsvConverter
   include Dry::Monads[:result]
 
@@ -115,6 +116,12 @@ class RegistrationCsvConverter
       Cocina::Models::ObjectType.manuscript
     when 'book', 'book (ltr)', 'book (rtl)'
       Cocina::Models::ObjectType.book
+    when 'geo'
+      Cocina::Models::ObjectType.geo
+    when 'webarchive-seed'
+      Cocina::Models::ObjectType.webarchive_seed
+    when 'webarchive-binary'
+      Cocina::Models::ObjectType.webarchive_binary
     else
       Cocina::Models::ObjectType.object
     end
@@ -139,3 +146,4 @@ class RegistrationCsvConverter
     end.compact
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/spec/services/registration_csv_converter_spec.rb
+++ b/spec/services/registration_csv_converter_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe RegistrationCsvConverter do
         administrative_policy_object: 'druid:bc123df4567',
         collection: 'druid:bk024qs1808',
         initial_workflow: 'accessionWF',
-        content_type: 'book',
+        content_type: Cocina::Models::ObjectType.book,
         rights_view: 'world',
         rights_download: 'world',
         tags: ['csv : test', 'Project : two']
@@ -84,7 +84,7 @@ RSpec.describe RegistrationCsvConverter do
         administrative_policy_object: 'druid:bc123df4567',
         collection: 'druid:bk024qs1808',
         initial_workflow: 'accessionWF',
-        content_type: 'book',
+        content_type: Cocina::Models::ObjectType.book,
         tags: ['csv : test', 'Project : two']
       }
     end


### PR DESCRIPTION
## Why was this change made? 🤔

Closes #3807 

Since bulk registration still passes the content type in through the CSV, a few of the types were missing that have been added recently (geo and webarchives).

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


