### PR TITLE
add ids to workflow reset buttons to facilitate testing

### DIFF
--- a/app/components/workflow_update_button.html.erb
+++ b/app/components/workflow_update_button.html.erb
@@ -3,6 +3,6 @@
   <%= form_tag item_workflow_path(druid, workflow_name), method: 'put' do %>
     <%= hidden_field_tag('process', name) %>
     <%= hidden_field_tag('status', next_status) %>
-    <%= button_tag(label, type: 'submit', class: 'btn btn-secondary') %>
+    <%= button_tag(label, id: "workflow-status-set-#{name}-#{next_status}", type: 'submit', class: 'btn btn-secondary') %>
   <% end %>
 <% end %>

--- a/spec/components/workflow_update_button_spec.rb
+++ b/spec/components/workflow_update_button_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe WorkflowUpdateButton, type: :component do
 
     it 'renders a form with a button' do
       expect(body.css('input[name="process"]').first['value']).to eq 'technical-metadata'
-      expect(body.css('button').to_html).to eq '<button name="button" type="submit" class="btn btn-secondary">Set to waiting</button>'
+      expect(body.css('button').to_html).to eq \
+        '<button name="button" type="submit" id="workflow-status-set-technical-metadata-waiting" class="btn btn-secondary">Set to waiting</button>'
     end
   end
 
@@ -27,7 +28,8 @@ RSpec.describe WorkflowUpdateButton, type: :component do
     let(:status) { 'waiting' }
 
     it 'renders a button' do
-      expect(body.css('button').to_html).to eq '<button name="button" type="submit" class="btn btn-secondary">Set to completed</button>'
+      expect(body.css('button').to_html).to eq \
+        '<button name="button" type="submit" id="workflow-status-set-technical-metadata-completed" class="btn btn-secondary">Set to completed</button>'
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔

More IDs added to DOM element (workflow step reset button) to facilitate integration testing (follow on from #3814)

## How was this change tested? 🤨

Updated test and localhost