### PR TITLE
registration fix for access citation-only with csv

### DIFF
--- a/app/services/registration_csv_converter.rb
+++ b/app/services/registration_csv_converter.rb
@@ -138,7 +138,7 @@ class RegistrationCsvConverter
   def access(row)
     {}.tap do |access|
       access[:view] = params[:rights_view] || row['rights_view']
-      access[:download] = params[:rights_download] || row['rights_download']
+      access[:download] = params[:rights_download] || row['rights_download'] || ('none' if %w[citation-only dark].include? access[:view])
       access[:location] = (params[:rights_location] || row.fetch('rights_location')) if [access[:view], access[:download]].include?('location-based')
       cdl = params[:rights_controlledDigitalLending] || row['rights_controlledDigitalLending']
       access[:controlledDigitalLending] = ActiveModel::Type::Boolean.new.cast(cdl) if cdl.present?

--- a/spec/services/registration_csv_converter_spec.rb
+++ b/spec/services/registration_csv_converter_spec.rb
@@ -95,4 +95,55 @@ RSpec.describe RegistrationCsvConverter do
       expect(results.first.value![:model]).to eq(expected_cocina.new(access: {}))
     end
   end
+
+  context 'when params have rights_view citation-only but no rights_download' do
+    let(:csv_string) do
+      <<~CSV
+        source_id,label
+        foo:123,My new object
+      CSV
+    end
+
+    let(:params) do
+      {
+        administrative_policy_object: 'druid:bc123df4567',
+        collection: 'druid:bk024qs1808',
+        initial_workflow: 'accessionWF',
+        content_type: Cocina::Models::ObjectType.book,
+        rights_view: 'citation-only',
+        tags: ['csv : test', 'Project : two']
+      }
+    end
+
+    it 'returns result with access citation-only model' do
+      expect(results.size).to be 1
+      expect(results.first.success?).to be true
+      expect(results.first.value![:model]).to eq(expected_cocina.new(access: { 'view' => 'citation-only', 'download' => 'none' }))
+    end
+  end
+
+  context 'when CSV has rights_view citation-only but no rights_download' do
+    let(:csv_string) do
+      <<~CSV
+        source_id,label,rights_view
+        foo:123,My new object,citation-only
+      CSV
+    end
+
+    let(:params) do
+      {
+        administrative_policy_object: 'druid:bc123df4567',
+        collection: 'druid:bk024qs1808',
+        initial_workflow: 'accessionWF',
+        content_type: Cocina::Models::ObjectType.book,
+        tags: ['csv : test', 'Project : two']
+      }
+    end
+
+    it 'returns result with access citation-only model' do
+      expect(results.size).to be 1
+      expect(results.first.success?).to be true
+      expect(results.first.value![:model]).to eq(expected_cocina.new(access: { 'view' => 'citation-only', 'download' => 'none' }))
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Registering items with a csv for access of citation-only was failing.  

Fixes #3818

## How was this change tested? 🤨

I deployed it to stage and checked a csv that was failing before I deployed this fix.  It works now.

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


