### PR TITLE
description_validator: empty header is invalid

### DIFF
--- a/app/services/description_validator.rb
+++ b/app/services/description_validator.rb
@@ -90,12 +90,15 @@ class DescriptionValidator
   def invalid_headers
     # The source_id is only for user reference, and we already validate the druid column is present in bulk jobs
     @headers.excluding('source_id', 'druid').map do |header|
-      split_address = header.scan(/[[:alpha:]]+|[[:digit:]]+/)
-                            .map { |item| /\d+/.match?(item) ? item.to_i - 1 : item.to_sym }
+      if header
+        split_address = header.scan(/[[:alpha:]]+|[[:digit:]]+/)
+                              .map { |item| /\d+/.match?(item) ? item.to_i - 1 : item.to_sym }
+        next if resolve_address(Cocina::Models::Description, split_address)
 
-      next if resolve_address(Cocina::Models::Description, split_address)
-
-      header
+        header
+      else
+        '(empty string)'
+      end
     end.compact
   end
 

--- a/spec/services/description_validator_spec.rb
+++ b/spec/services/description_validator_spec.rb
@@ -89,6 +89,16 @@ RSpec.describe DescriptionValidator do
                                          'Column header invalid: event1.contributor']
         end
       end
+
+      context 'with missing header for column' do
+        let(:csv) { 'druid,title1.value,,title2.value' }
+
+        it 'finds errors' do
+          expect(instance.valid?).to be false
+          # missing header value is not a valid cocina attribute
+          expect(instance.errors).to eq ['Column header invalid: (empty string)']
+        end
+      end
     end
 
     context 'for bulk jobs' do


### PR DESCRIPTION
## Why was this change made? 🤔

To avoid throwing HB errors for empty header cells for DescriptionValidator.  Instead, report it as invalid header:

Fixes #3822

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


