### PR TITLE
use pry, not pry-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,8 +89,8 @@ gem 'devise'
 gem 'devise-remote-user', '~> 1.0'
 
 # useful for debugging, even in prod
+gem 'pry' # make it possible to use pry as the rails console shell instead of IRB
 gem 'pry-byebug' # Adds step-by-step debugging and stack navigation capabilities to pry using byebug
-gem 'pry-rails' # use pry as the rails console shell instead of IRB
 
 group :test, :development do
   gem 'erb_lint', '~> 0.0.31', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -397,8 +397,6 @@ GEM
     pry-byebug (3.10.1)
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
-    pry-rails (0.3.9)
-      pry (>= 0.10.4)
     pry-remote (0.1.8)
       pry (~> 0.9)
       slop (~> 3.0)
@@ -643,8 +641,8 @@ DEPENDENCIES
   prawn-table
   preservation-client (~> 4.0)
   propshaft
+  pry
   pry-byebug
-  pry-rails
   pry-remote
   puma (~> 5.6)
   rack-mini-profiler


### PR DESCRIPTION
## Why was this change made? 🤔

`pry-rails` is no longer maintained;  some of us still prefer `pry`, tho.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


