### PR TITLE
deploy.rb: capistrano first deploy works without sprockets

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -44,3 +44,9 @@ set :honeybadger_env, fetch(:stage)
 
 # update shared_configs before restarting app
 before 'deploy:restart', 'shared_configs:update'
+
+# configure capistrano-rails to work with propshaft instead of sprockets
+# (we don't have public/assets/.sprockets-manifest* or public/assets/manifest*.*)
+set :assets_manifests, lambda {
+  [release_path.join('public', fetch(:assets_prefix), '.manifest.json')]
+}


### PR DESCRIPTION
## Why was this change made? 🤔

This fix made it possible to deploy the argo app to a newly built VM.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


