### PR TITLE
add validation before attempting desc metadata update to get better error messages

### DIFF
--- a/app/jobs/descriptive_metadata_import_job.rb
+++ b/app/jobs/descriptive_metadata_import_job.rb
@@ -17,6 +17,7 @@ class DescriptiveMetadataImportJob < GenericJob
       next failure.call('Not authorized') unless ability.can?(:update, cocina_object)
 
       DescriptionImport.import(csv_row:)
+                       .bind { |description| validate_input(cocina_object, description) }
                        .bind { |description| validate_changed(cocina_object, description) }
                        .bind { |description| open_version(cocina_object, description) }
                        .bind { |description, new_cocina_object| validate_and_save(new_cocina_object, description) }
@@ -29,6 +30,14 @@ class DescriptiveMetadataImportJob < GenericJob
   end
 
   private
+
+  # this validates input data from spreadsheet before any updates are applied to provide error messages to the user
+  def validate_input(cocina_object, description)
+    result = CocinaValidator.validate(cocina_object, description:)
+    return Success(description) if result.success?
+
+    Failure(["validation failed for #{cocina_object.externalIdentifier}: #{result.failure}"])
+  end
 
   def validate_changed(cocina_object, description)
     return Failure(['Description unchanged']) if cocina_object.description == description


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3865 - validate each row of the spreadsheet explicitly first when running a desc metadata import job, before we apply the desc metadata update...this will catch any validation errors and provide the same nice error message as the validate only job does.

## How was this change tested? 🤨

Localhost and QA