### PR TITLE
Unpin sdr-client from 0.96

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,7 @@ gem 'mods_display', '~> 1.0'
 gem 'okcomputer' # monitors application and its dependencies
 gem 'preservation-client', '~> 5.0'
 gem 'rsolr'
-gem 'sdr-client', '~> 0.96.0' # TODO: Unpin and fix the tests with >= 0.97
+gem 'sdr-client', '~> 0.97'
 
 gem 'devise'
 gem 'devise-remote-user', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -510,7 +510,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    sdr-client (0.96.0)
+    sdr-client (0.97.0)
       activesupport
       cocina-models (~> 0.86.0)
       dry-monads
@@ -655,7 +655,7 @@ DEPENDENCIES
   rubocop-rspec (~> 2.1)
   ruby-prof
   rubyzip
-  sdr-client (~> 0.96.0)
+  sdr-client (~> 0.97)
   selenium-webdriver
   sidekiq (~> 6.0)
   simplecov


### PR DESCRIPTION
## Why was this change made? 🤔

To unpin a dependency that should not need to be pinned.

## How was this change tested? 🤨

CI + integration tests
