### PR TITLE
Uncorrupted downloads from pres.

### DIFF
--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -48,7 +48,7 @@ class FilesController < ApplicationController
       druid: @cocina_model.externalIdentifier,
       filepath: filename,
       version: params[:version],
-      on_data: proc { |data, _count| response.stream.write data }
+      on_data: proc { |data, _count| response.stream.write(data) if data.present? }
     )
   rescue Preservation::Client::NotFoundError => e
     # Undo the header setting above for the streaming response. Not relevant here.


### PR DESCRIPTION
closes #3897

## Why was this change made? 🤔
<img width="728" alt="image" src="https://user-images.githubusercontent.com/588335/207088216-823ef2be-3280-4309-a960-103554fcd412.png">
is not helpful.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Tested on stage.

⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


