### PR TITLE
Revert "Uncorrupted downloads from pres."

### DIFF
--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -48,7 +48,7 @@ class FilesController < ApplicationController
       druid: @cocina_model.externalIdentifier,
       filepath: filename,
       version: params[:version],
-      on_data: proc { |data, _count| response.stream.write(data) if data.present? }
+      on_data: proc { |data, _count| response.stream.write data }
     )
   rescue Preservation::Client::NotFoundError => e
     # Undo the header setting above for the streaming response. Not relevant here.


### PR DESCRIPTION
Reverts sul-dlss/argo#3899

We have a hypothesis that this patch was working around a bug present in net-protocol 0.2.0: https://github.com/ruby/net-protocol/pull/14