### PR TITLE
Set the page title in a non-deprecated way

### DIFF
--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -7,7 +7,7 @@
   </div>
 </div>
 
-<% @page_title = t('blacklight.search.show.title', document_title: Deprecation.silence(Blacklight::BlacklightHelperBehavior) { document_show_html_title }, application_name: application_name).html_safe %>
+<% @page_title = t('blacklight.search.show.title', document_title: document_presenter(@document).html_title, application_name: application_name).html_safe %>
 <% content_for(:head) { render_link_rel_alternates } %>
 <%= render (blacklight_config.view_config(:show).document_component || Blacklight::DocumentComponent).new(presenter: document_presenter(@document), component: :div, title_component: :h1, show: true) do |component| %>
   <% component.footer do %>


### PR DESCRIPTION
## Why was this change made? 🤔
Avoiding deprecated methods in Blacklight will make upgrading easier.


## How was this change tested? 🤨
CI
