### PR TITLE
Pass an array to show_fields_for

### DIFF
--- a/app/components/show/project_tag_component.rb
+++ b/app/components/show/project_tag_component.rb
@@ -20,7 +20,7 @@ module Show
     end
 
     def fields
-      @fields ||= blacklight_config.show_fields_for(:show)
+      @fields ||= blacklight_config.show_fields_for([:show])
     end
   end
 end

--- a/app/components/show/tags_component.rb
+++ b/app/components/show/tags_component.rb
@@ -29,7 +29,7 @@ module Show
     end
 
     def fields
-      @fields ||= blacklight_config.show_fields_for(:show)
+      @fields ||= blacklight_config.show_fields_for([:show])
     end
   end
 end

--- a/app/components/show/workflow_error_component.rb
+++ b/app/components/show/workflow_error_component.rb
@@ -11,7 +11,7 @@ module Show
     delegate :blacklight_config, :value_for_wf_error, to: :helpers
 
     def workflow_errors
-      field_config = blacklight_config.show_fields_for(:show).fetch(SolrDocument::FIELD_WORKFLOW_ERRORS)
+      field_config = blacklight_config.show_fields_for([:show]).fetch(SolrDocument::FIELD_WORKFLOW_ERRORS)
       Blacklight::FieldPresenter.new(self, document, field_config).render
     end
 


### PR DESCRIPTION


## Why was this change made? 🤔
Scalars are not permitted in Blacklight 8. This will make upgrading easier


## How was this change tested? 🤨
CI