### PR TITLE
Correctly set collection rights when editing

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -46,7 +46,7 @@ class CollectionsController < ApplicationController
     return unless enforce_versioning
 
     change_set = CollectionChangeSet.new(@cocina)
-    attributes = params.require(:collection).permit(:copyright, :use_statement, :license)
+    attributes = params.require(:collection).permit(:view_access, :copyright, :use_statement, :license)
     change_set.validate(**attributes)
     change_set.save
     Argo::Indexer.reindex_druid_remotely(@cocina.externalIdentifier)

--- a/app/services/collection_change_set_persister.rb
+++ b/app/services/collection_change_set_persister.rb
@@ -29,7 +29,7 @@ class CollectionChangeSetPersister
     copyright: :copyright,
     license: :license,
     use_statement: :useAndReproductionStatement,
-    view_access: :access
+    view_access: :view
   }.freeze
 
   attr_reader :model, :change_set

--- a/app/views/items/_edit_collection_rights.html.erb
+++ b/app/views/items/_edit_collection_rights.html.erb
@@ -5,7 +5,7 @@
       <%= f.select :view_access, [['World', 'world'], ['Dark', 'dark']], {}, class: 'form-select' %>
     </div>
     <div class="float-end">
-      = link_to 'Cancel', show_rights_item_path(params[:id])
+      <%= link_to 'Cancel', show_rights_item_path(params[:id]) %>
       <%= f.submit 'Save', class: 'btn btn-primary' %>
     </div>
   <% end %>


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3901 

There is a small difference between argo and cocina proper where we refer to "view_access" that needs to be sent as "view" for the Cocina::Models::CollectionAccess value

This also fixes a small template error that displayed HTML instead of the cancel button.

Before:
![Screen Shot 2022-12-13 at 3 55 40 PM](https://user-images.githubusercontent.com/2294288/207470825-cac4e342-031d-464b-9228-84ade074cf29.png)

After:

![Screen Shot 2022-12-13 at 3 53 12 PM](https://user-images.githubusercontent.com/2294288/207470920-6e33921a-5255-4fe0-97ac-08ca41776f39.png)


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


