### PR TITLE
Authorize SDR API token endpoint using new workgroup

### DIFF
--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class TokensController < ApplicationController
+  before_action { authorize! :create, :token }
+
   # GET /settings/tokens
   def index
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -26,6 +26,10 @@ class Ability
     can :manage, :all if current_user.admin?
     cannot :impersonate, User unless current_user.webauth_admin?
 
+    # NOTE: Lock down SDR token creation to *explicitly* authorized users
+    cannot :create, :token
+    can :create, :token if current_user.sdr_api_authorized?
+
     if current_user.manager?
       can %i[update manage_governing_apo view_content read],
         [NilModel] + DRO_MODELS + COLLECTION_MODELS

--- a/app/models/null_user.rb
+++ b/app/models/null_user.rb
@@ -13,6 +13,10 @@ class NullUser
     false
   end
 
+  def sdr_api_authorized?
+    false
+  end
+
   def permitted_apos
     []
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
   ADMIN_GROUPS = %w[workgroup:sdr:administrator-role].freeze
   MANAGER_GROUPS = %w[workgroup:sdr:manager-role].freeze
   VIEWER_GROUPS = %w[workgroup:sdr:viewer-role].freeze
+  SDR_API_AUTHORIZED_GROUPS = %w[workgroup:sdr:api-authorized-users].freeze
 
   # @return [Array<String>] list of roles the user can adopt. These must match the roles that Ability looks for.
   # NOTE: 'sdr-administrator' and 'sdr-viewer' may be removed in the future. See https://github.com/sul-dlss/dor-services-app/issues/3856
@@ -119,6 +120,11 @@ class User < ApplicationRecord
   # @return [Boolean] is the user a repository wide viewer
   def viewer?
     !(groups & VIEWER_GROUPS).empty?
+  end
+
+  # @return [Boolean] is the user authorized to use SDR API
+  def sdr_api_authorized?
+    !(groups & SDR_API_AUTHORIZED_GROUPS).empty?
   end
 
   def login

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -78,7 +78,8 @@ class User < ApplicationRecord
     @groups_to_impersonate = if grps.blank?
       nil
     else
-      grps.instance_of?(String) ? [grps] : grps
+      # NOTE: Do not allow impersonation to grant SDR API access!
+      Array(grps) - SDR_API_AUTHORIZED_GROUPS
     end
   end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -20,12 +20,14 @@ RSpec.describe Ability do
       admin?: admin,
       webauth_admin?: webauth_admin,
       manager?: manager,
-      viewer?: viewer)
+      viewer?: viewer,
+      sdr_api_authorized?: sdr_api_authorized)
   end
   let(:admin) { false }
   let(:webauth_admin) { false }
   let(:manager) { false }
   let(:viewer) { false }
+  let(:sdr_api_authorized) { false }
   let(:new_cocina_object_roles) { [] }
   let(:apo_roles) { [] }
   let(:new_cocina_object_id) { "druid:bc123df4567" }
@@ -40,6 +42,7 @@ RSpec.describe Ability do
     let(:admin) { true }
 
     it { is_expected.to be_able_to(:manage, :everything) }
+    it { is_expected.not_to be_able_to(:create, :token) }
     it { is_expected.to be_able_to(:update, dro) }
     it { is_expected.to be_able_to(:manage_governing_apo, dro, apo_id) }
     it { is_expected.to be_able_to(:update, dro_with_metadata) }
@@ -54,6 +57,7 @@ RSpec.describe Ability do
     let(:manager) { true }
 
     it { is_expected.not_to be_able_to(:manage, :everything) }
+    it { is_expected.not_to be_able_to(:create, :token) }
     it { is_expected.to be_able_to(:update, dro) }
     it { is_expected.to be_able_to(:update, dro_with_metadata) }
 
@@ -68,6 +72,7 @@ RSpec.describe Ability do
   context "as a viewer" do
     let(:viewer) { true }
 
+    it { is_expected.not_to be_able_to(:create, :token) }
     it { is_expected.not_to be_able_to(:update, dro) }
     it { is_expected.not_to be_able_to(:update, dro_with_metadata) }
     it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
@@ -84,6 +89,26 @@ RSpec.describe Ability do
     it { is_expected.not_to be_able_to(:update, :workflow) }
   end
 
+  context "as a user authorized for SDR API" do
+    let(:sdr_api_authorized) { true }
+
+    it { is_expected.to be_able_to(:create, :token) }
+    it { is_expected.not_to be_able_to(:update, dro) }
+    it { is_expected.not_to be_able_to(:update, dro_with_metadata) }
+    it { is_expected.not_to be_able_to(:create, Cocina::Models::AdminPolicy) }
+    it { is_expected.not_to be_able_to(:manage_governing_apo, dro, apo_id) }
+    it { is_expected.not_to be_able_to(:manage_governing_apo, dro_with_metadata, apo_id) }
+    it { is_expected.not_to be_able_to(:read, dro) }
+    it { is_expected.not_to be_able_to(:read, dro_with_metadata) }
+    it { is_expected.not_to be_able_to(:view_content, dro) }
+    it { is_expected.not_to be_able_to(:view_content, dro_with_metadata) }
+    it { is_expected.not_to be_able_to(:read, admin_policy) }
+    it { is_expected.not_to be_able_to(:read, admin_policy_with_metadata) }
+    it { is_expected.not_to be_able_to(:read, collection) }
+    it { is_expected.not_to be_able_to(:read, collection_with_metadata) }
+    it { is_expected.not_to be_able_to(:update, :workflow) }
+  end
+
   context "for items without an APO" do
     it { is_expected.not_to be_able_to(:update, dro) }
     it { is_expected.not_to be_able_to(:update, dro_with_metadata) }
@@ -97,6 +122,7 @@ RSpec.describe Ability do
     let(:apo_roles) { ["dor-apo-manager"] }
 
     it { is_expected.not_to be_able_to(:manage, :everything) }
+    it { is_expected.not_to be_able_to(:create, :token) }
     it { is_expected.to be_able_to(:update, dro) }
     it { is_expected.to be_able_to(:update, dro_with_metadata) }
     it { is_expected.to be_able_to(:manage_governing_apo, dro, apo_id) }
@@ -117,6 +143,7 @@ RSpec.describe Ability do
     let(:new_cocina_object_roles) { ["dor-apo-manager"] }
 
     it { is_expected.not_to be_able_to(:manage, :everything) }
+    it { is_expected.not_to be_able_to(:create, :token) }
     it { is_expected.not_to be_able_to(:update, dro) }
     it { is_expected.not_to be_able_to(:update, dro_with_metadata) }
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, apo_id) }
@@ -137,6 +164,7 @@ RSpec.describe Ability do
     let(:apo_roles) { ["dor-apo-metadata"] }
 
     it { is_expected.not_to be_able_to(:manage, :everything) }
+    it { is_expected.not_to be_able_to(:create, :token) }
     it { is_expected.not_to be_able_to(:update, dro) }
     it { is_expected.not_to be_able_to(:update, dro_with_metadata) }
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, apo_id) }
@@ -150,6 +178,7 @@ RSpec.describe Ability do
     let(:apo_roles) { ["dor-viewer"] }
 
     it { is_expected.not_to be_able_to(:manage, :everything) }
+    it { is_expected.not_to be_able_to(:create, :token) }
     it { is_expected.not_to be_able_to(:update, dro) }
     it { is_expected.not_to be_able_to(:update, dro_with_metadata) }
     it { is_expected.not_to be_able_to(:manage_governing_apo, dro, apo_id) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -289,15 +289,26 @@ RSpec.describe User do
     end
 
     context "when impersonating" do
+      let(:groups) { %w[workgroup:dlss:impersonatedgroup1 workgroup:dlss:impersonatedgroup2] }
+
       before do
-        user.set_groups_to_impersonate(%w[workgroup:dlss:impersonatedgroup1 workgroup:dlss:impersonatedgroup2])
+        user.set_groups_to_impersonate(groups)
+      end
+
+      context "and the groups include SDR_API_AUTHORIZED_GROUPS" do
+        let(:groups) { %w[workgroup:dlss:impersonatedgroup1 workgroup:dlss:impersonatedgroup2] + User::SDR_API_AUTHORIZED_GROUPS }
+        let(:webauth_groups) { User::ADMIN_GROUPS }
+
+        it "returns the impersonated groups excluding the SDR_API_AUTHORIZED_GROUPS" do
+          expect(subject).not_to include User::SDR_API_AUTHORIZED_GROUPS.first
+        end
       end
 
       context "and the impersonating user is an admin" do
         let(:webauth_groups) { User::ADMIN_GROUPS }
 
         it "returns only the impersonated groups" do
-          expect(subject).not_to include User::ADMIN_GROUPS
+          expect(subject).not_to include User::ADMIN_GROUPS.first
         end
       end
 
@@ -305,7 +316,7 @@ RSpec.describe User do
         let(:webauth_groups) { User::MANAGER_GROUPS }
 
         it "returns only the impersonated groups" do
-          expect(subject).not_to include User::MANAGER_GROUPS
+          expect(subject).not_to include User::MANAGER_GROUPS.first
         end
       end
 
@@ -313,7 +324,7 @@ RSpec.describe User do
         let(:webauth_groups) { User::VIEWER_GROUPS }
 
         it "returns only the impersonated groups" do
-          expect(subject).not_to include User::VIEWER_GROUPS
+          expect(subject).not_to include User::VIEWER_GROUPS.first
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -68,6 +68,22 @@ RSpec.describe User do
     end
   end
 
+  describe "#sdr_api_authorized?" do
+    subject { user.sdr_api_authorized? }
+
+    let(:user) { described_class.new }
+
+    before do
+      allow(user).to receive(:webauth_groups).and_return(groups)
+    end
+
+    context "with SDR_API_AUTHORIZED_GROUPS" do
+      let(:groups) { User::SDR_API_AUTHORIZED_GROUPS }
+
+      it { is_expected.to be true }
+    end
+  end
+
   describe "#manager?" do
     subject { user.manager? }
 

--- a/spec/views/auth/groups.html.erb_spec.rb
+++ b/spec/views/auth/groups.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "auth/groups" do
   end
 
   context "as admin" do
-    let(:user) { mock_user(admin?: true, groups: %w[dlss dpg]) }
+    let(:user) { mock_user(admin?: true, sdr_api_authorized?: false, groups: %w[dlss dpg]) }
 
     it "shows groups and impersonate form" do
       render
@@ -24,7 +24,7 @@ RSpec.describe "auth/groups" do
   end
 
   context "not admin" do
-    let(:user) { mock_user(admin?: false) }
+    let(:user) { mock_user(admin?: false, sdr_api_authorized?: false) }
 
     it "does not show groups or form" do
       render


### PR DESCRIPTION
## Why was this change made? 🤔

Connects to sul-dlss/sdr-client#250

This commit limits the number of Argo users that are authorized to generate sdr-api tokens. The workgroup that is now used contains the Infra devs, JCoyne, Andrew, and Tony C, and the group is managed by Andrew.


## How was this change tested? 🤨

CI + tested in QA with Andrew
