### PR TITLE
use the same regex to verify source_ids across the app

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -44,7 +44,7 @@ class RegistrationsController < ApplicationController
 
   # Allow the front end to check if a source Id already exists
   def source_id
-    raise "Malformed input" unless /\A.+:.+\z/.match?(params[:source_id])
+    raise "Malformed input" unless Regexp.new(Settings.source_id_regex).match?(params[:source_id])
 
     begin
       Dor::Services::Client.objects.find(source_id: params[:source_id])

--- a/app/forms/agreement_form.rb
+++ b/app/forms/agreement_form.rb
@@ -7,7 +7,7 @@ class AgreementForm < Reform::Form
   property :agreement_file2, virtual: true
 
   validates :title, presence: true
-  validates :source_id, format: {with: /\A\w+:\w+\z/,
+  validates :source_id, format: {with: Regexp.new(Settings.source_id_regex),
                                  message: "must have a single colon in the middle"},
     presence: true
   validates :agreement_file1, presence: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,6 +5,7 @@
 
 # General
 date_format_str: '%Y-%m-%d %H:%M:%S.%L'
+source_id_regex: \A.+:.+\z
 
 # Bulk Metadata
 bulk_metadata:


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3894 - use the same regex to verify source_ids in both the agreement and the item registration forms ... and put it into the settings so we do not get out of sync again.

This was fixed for the item reg form in https://github.com/sul-dlss/argo/pull/3754/files ... this takes that regex and moves it to settings, and then uses it for agreements validation

## How was this change tested? 🤨

Localhost