### PR TITLE
Don't draw a sidebar on a page that doesn't display a sidebar

### DIFF
--- a/app/views/bulk_jobs/index.html.erb
+++ b/app/views/bulk_jobs/index.html.erb
@@ -1,8 +1,5 @@
 <% @page_title = "Bulk Uploads for APO #{@document.id}" %>
 <% content_for(:head) { document_presenter(@document).link_rel_alternates } -%>
-<% content_for(:sidebar) do %>
-  <%= render_document_sidebar_partial @document %>
-<% end %>
 
 <div class="row mt-3">
     <div class="col-md-8"><strong>Spreadsheet bulk upload for APO <%= @document.id %></strong></div>


### PR DESCRIPTION
## Why was this change made? 🤔

Currently it's drawing into a buffer that is never displayed on the page.  This template draws the page like https://argo.stanford.edu/apos/druid:dd051ys2703/bulk_jobs where there is no sidebar. Without this change, we can not upgrade to Blacklight 8, because this unused code will use a different interface.

## How was this change tested? 🤨


