### PR TITLE
Blacklight supports turbo now

### DIFF
--- a/app/javascript/argo.js
+++ b/app/javascript/argo.js
@@ -10,13 +10,6 @@ export default class Argo {
         this.tagsAutocomplete()
         this.projectAutocomplete()
         this.report()
-        this.blacklight()
-    }
-
-    // Because blacklight doesn't yet support turbo, we need to manually initialize
-    // the features we care about.
-    blacklight() {
-      Blacklight.activate()
     }
 
     report() {


### PR DESCRIPTION
## Why was this change made? 🤔
This was fixed in Blacklight 7.21.0 https://github.com/projectblacklight/blacklight/commit/f02bc67fa21014c11869c173386ae6ee3cbfb3b0 so we don't need the workaround


## How was this change tested? 🤨
CI
