### PR TITLE
Update to blacklight-hierarchy 6.1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ gem "openapi_parser", "< 1.0"
 
 # Stanford related gems
 gem "blacklight", "~> 7.25"
-gem "blacklight-hierarchy", "~> 6.0.2"
+gem "blacklight-hierarchy", "~> 6.1"
 gem "dor-services-client", "~> 12.5"
 gem "dor-workflow-client", "~> 4.0"
 gem "druid-tools"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,8 +93,8 @@ GEM
       ostruct (>= 0.3.2)
       rails (>= 5.1, < 7.1)
       view_component (~> 2.66)
-    blacklight-hierarchy (6.0.2)
-      blacklight (~> 7.18)
+    blacklight-hierarchy (6.1.0)
+      blacklight (>= 7.18, < 9)
       deprecation
       rails (>= 5.1, < 7.1)
     bootsnap (1.16.0)
@@ -352,12 +352,12 @@ GEM
     net-ssh (7.0.1)
     newrelic_rpm (8.15.0)
     nio4r (2.5.8)
-    nokogiri (1.14.0)
+    nokogiri (1.14.1)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.14.0-x86_64-darwin)
+    nokogiri (1.14.1-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.14.0-x86_64-linux)
+    nokogiri (1.14.1-x86_64-linux)
       racc (~> 1.4)
     nokogiri-happymapper (0.9.0)
       nokogiri (~> 1.5)
@@ -610,7 +610,7 @@ PLATFORMS
 DEPENDENCIES
   barby
   blacklight (~> 7.25)
-  blacklight-hierarchy (~> 6.0.2)
+  blacklight-hierarchy (~> 6.1)
   bootsnap (>= 1.4.2)
   byebug
   cancancan

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,9 +70,9 @@ blacklight-frontend@>=7.1.0-alpha, blacklight-frontend@^7.20.2:
     typeahead.js "^0.11.1"
 
 blacklight-hierarchy@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/blacklight-hierarchy/-/blacklight-hierarchy-6.0.2.tgz#fa9f6e178ba21266253f810dd4b818421a22f84c"
-  integrity sha512-KRWQJ8Z8khkVxoKMExIp/TqlwlIC/yGHNTCCQAGtb76iWDQWU+rwnimqyvqCnBetvVtc9NMyztDOEY948vxbew==
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/blacklight-hierarchy/-/blacklight-hierarchy-6.1.0.tgz#5126dd5c166b82998be442773fae68427e58d841"
+  integrity sha512-ap/Z/U9lzV5fHw+nLIJb9zM6aP8eH4uM+9g1HcSqlqw57HOW3OmivKwIO7BAphprTzUqWW1eoOr6H9DImcTGXg==
   dependencies:
     blacklight-frontend ">=7.1.0-alpha"
     jquery ">=3.0"


### PR DESCRIPTION
## Why was this change made? 🤔
This makes it possible to upgrade to blacklight 8.x


## How was this change tested? 🤨
CI

