### PR TITLE
bump preservation-client to 6.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ gem "dor-workflow-client", "~> 4.0"
 gem "druid-tools"
 gem "mods_display", "~> 1.0"
 gem "okcomputer" # monitors application and its dependencies
-gem "preservation-client", "~> 5.0"
+gem "preservation-client", "~> 6.0"
 gem "rsolr"
 gem "sdr-client", "~> 1.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,7 +382,7 @@ GEM
       ttfunk (~> 1.4.0)
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
-    preservation-client (5.2.0)
+    preservation-client (6.1.0)
       activesupport (>= 4.2, < 8)
       faraday (~> 2.0)
       moab-versioning (>= 5.0.0, < 7)
@@ -648,7 +648,7 @@ DEPENDENCIES
   openapi_parser (< 1.0)
   prawn (~> 1)
   prawn-table
-  preservation-client (~> 5.0)
+  preservation-client (~> 6.0)
   propshaft
   pry
   pry-byebug


### PR DESCRIPTION
## Why was this change made? 🤔

none of the pres client changes are to methods used by argo, based on a grep for pres client invocations

(this is just meant to allow automated dependency updates to keep pres client updated)

## How was this change tested? 🤨

unit tests

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


