### PR TITLE
remove solr bootstrapping

### DIFF
--- a/spec/support/reset_solr.rb
+++ b/spec/support/reset_solr.rb
@@ -5,14 +5,6 @@ module ResetSolr
     blacklight_config = CatalogController.blacklight_config
     solr_conn = blacklight_config.repository_class.new(blacklight_config).connection
     solr_conn.delete_by_query("*:*")
-
-    # Solves an odd bootstrapping problem, where the dor-indexing-app can only index cocina-models,
-    # but cocina-model can't be built unless the AdminPolicy is found in Solr
-    solr_conn.add(id: "druid:hv992ry2431",
-      objectType_ssim: ["adminPolicy"],
-      apo_register_permissions_ssim: ["workgroup:dlss:developers"],
-      sw_display_title_tesim: ["[Internal System Objects]"])
-    solr_conn.commit
   end
 end
 


### PR DESCRIPTION
## Why was this change made? 🤔

based on PR #3715;  removes Solr bootstrapping, as it is no longer used in DSA

## How was this change tested? 🤨

unit tests (this only affects specs)

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


