### PR TITLE
remove unnec SolrDocument.catkey_id method

### DIFF
--- a/app/components/show/controls_component.rb
+++ b/app/components/show/controls_component.rb
@@ -38,7 +38,7 @@ module Show
 
     # a catkey indicates there's a symphony record
     def symphony_record?
-      doc.catkey_id.present?
+      doc.catkey.present?
     end
 
     delegate :admin_policy?, :agreement?, :item?, :collection?, :embargoed?, to: :doc

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -144,13 +144,6 @@ class SolrDocument
   end
 
   ##
-  # Access a SolrDocument's catkey identifier
-  # @return [String, nil]
-  def catkey_id
-    catkey&.delete_prefix("catkey:")
-  end
-
-  ##
   # Access a SolrDocument's druid parsed from the id format of 'druid:abc123'
   # @return [String]
   def druid

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -220,26 +220,6 @@ RSpec.describe SolrDocument do
     end
   end
 
-  describe "#catkey" do
-    context "when catkey is not present" do
-      let(:document_attributes) { {} }
-
-      it "returns nil" do
-        expect(document.catkey).to be_nil
-        expect(document.catkey_id).to be_nil
-      end
-    end
-
-    context "when a catkey is present" do
-      let(:document_attributes) { {SolrDocument::FIELD_CATKEY_ID => ["catkey:8675309"]} }
-
-      it "returns catkey value" do
-        expect(document.catkey).to eq "catkey:8675309"
-        expect(document.catkey_id).to eq "8675309"
-      end
-    end
-  end
-
   describe "#registered_date" do
     let(:document_attributes) do
       {SolrDocument::FIELD_REGISTERED_DATE => single_date}


### PR DESCRIPTION
## Why was this change made? 🤔

`catkey_id_ssim` method never has catkey prefix.  https://github.com/sul-dlss/dor_indexing_app/blob/main/app/indexers/identity_metadata_indexer.rb - note how it is added to `prefixed_identifiers` which is used for other fields, `identifier_ssim` and `identifier_tesim`

## How was this change tested? 🤨

- unit tests, on stage (I looked at show page, at search results, at republished public_xml ...)
- many integration tests
- had Andrew check Argo
- checked Solr field contents with Solr admin tools to ensure no "catkey:" present in the `catkey_id_ssim` values for prod Argo index.

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


