### PR TITLE
Blacklight's SolrDocument gets folio hrid

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -10,6 +10,7 @@ class SolrDocument
   FIELD_EMBARGO_STATUS = :embargo_status_ssim
   FIELD_EMBARGO_RELEASE_DATE = :embargo_release_dtsim
   FIELD_CATKEY_ID = :catkey_id_ssim
+  FIELD_FOLIO_ID = :folio_instance_hrid_ssim
   FIELD_CREATED_DATE = :created_at_dttsi
   FIELD_REGISTERED_DATE = :registered_dttsim
   FIELD_LAST_ACCESSIONED_DATE = :accessioned_latest_dttsi
@@ -47,6 +48,7 @@ class SolrDocument
   attribute :object_type, Blacklight::Types::String, FIELD_OBJECT_TYPE
   attribute :content_type, Blacklight::Types::String, FIELD_CONTENT_TYPE
   attribute :catkey, Blacklight::Types::String, FIELD_CATKEY_ID
+  attribute :catkey, Blacklight::Types::String, FIELD_FOLIO_ID
   attribute :current_version, Blacklight::Types::String, FIELD_CURRENT_VERSION
   attribute :embargo_status, Blacklight::Types::String, FIELD_EMBARGO_STATUS
   attribute :embargo_release_date, Blacklight::Types::Date, FIELD_EMBARGO_RELEASE_DATE

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -10,7 +10,7 @@ class SolrDocument
   FIELD_EMBARGO_STATUS = :embargo_status_ssim
   FIELD_EMBARGO_RELEASE_DATE = :embargo_release_dtsim
   FIELD_CATKEY_ID = :catkey_id_ssim
-  FIELD_FOLIO_ID = :folio_instance_hrid_ssim
+  FIELD_FOLIO_INSTANCE_HRID = :folio_instance_hrid_ssim
   FIELD_CREATED_DATE = :created_at_dttsi
   FIELD_REGISTERED_DATE = :registered_dttsim
   FIELD_LAST_ACCESSIONED_DATE = :accessioned_latest_dttsi
@@ -48,7 +48,7 @@ class SolrDocument
   attribute :object_type, Blacklight::Types::String, FIELD_OBJECT_TYPE
   attribute :content_type, Blacklight::Types::String, FIELD_CONTENT_TYPE
   attribute :catkey, Blacklight::Types::String, FIELD_CATKEY_ID
-  attribute :catkey, Blacklight::Types::String, FIELD_FOLIO_ID
+  attribute :folio_instance_hrid, Blacklight::Types::String, FIELD_FOLIO_INSTANCE_HRID
   attribute :current_version, Blacklight::Types::String, FIELD_CURRENT_VERSION
   attribute :embargo_status, Blacklight::Types::String, FIELD_EMBARGO_STATUS
   attribute :embargo_release_date, Blacklight::Types::Date, FIELD_EMBARGO_RELEASE_DATE


### PR DESCRIPTION
## Why was this change made? 🤔

This is a prerequisite to changing any of the Argo display to include Folio identifiers:  in order to start using `folio_instance_hrid` in Argo, we need to do the blacklight configuration.  It has NO changes to Argo displays.

## How was this change tested? 🤨

- unit tests
- ran a number of integration tests
- deployed to qa and eyeballed various views of a record with folio_instance_hrid_ssim populated in index

![image](https://user-images.githubusercontent.com/96775/221051512-ccc1d95a-8609-49a1-8e0f-c52816e48c95.png)

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


