### PR TITLE
profile view of search results no longer includes Catkey stats

### DIFF
--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 ##
-# Used for the profile view but just inherits from CatalogController
+# Used for the profile view of search results but just inherits from CatalogController
 class ProfileController < CatalogController
 end

--- a/app/presenters/profile_presenter.rb
+++ b/app/presenters/profile_presenter.rb
@@ -90,10 +90,6 @@ class ProfilePresenter
     facet_query_field['-rights_primary_ssi:"dark" AND published_dttsim:*']
   end
 
-  def catkey
-    stats_field["catkey_id_ssim"]
-  end
-
   private
 
   def stats_field

--- a/app/search_builders/argo/profile_queries.rb
+++ b/app/search_builders/argo/profile_queries.rb
@@ -23,7 +23,6 @@ module Argo
       solr_parameters["stats.field"] << "content_file_count_itsi"
       solr_parameters["stats.field"] << "shelved_content_file_count_itsi"
       solr_parameters["stats.field"] << "preserved_size_dbtsi"
-      solr_parameters["stats.field"] << "catkey_id_ssim"
       # Use this paradigm to add pivot facets
       solr_parameters["facet.pivot"] ||= []
       solr_parameters["facet.pivot"] << "#{SolrDocument::FIELD_OBJECT_TYPE},processing_status_text_ssi"

--- a/app/views/profile/_document_list.html.erb
+++ b/app/views/profile/_document_list.html.erb
@@ -23,17 +23,6 @@
       <td>Published to PURL</td>
       <td><%= @presenter.published_to_purl %></td>
     </tr>
-    <tr>
-      <td><h5>Catkeys</h5></td><td></td>
-    </tr>
-    <tr>
-      <td>has value</td>
-      <td><%= @presenter.catkey['count'] %></td>
-    </tr>
-    <tr>
-      <td>value missing</td>
-      <td><%= @presenter.catkey['missing'] %></td>
-    </tr>
   </table>
 </div>
 

--- a/spec/features/profile_spec.rb
+++ b/spec/features/profile_spec.rb
@@ -45,8 +45,6 @@ RSpec.describe "Profile" do
     within "#discovery" do
       expect(page).to have_css "h4", text: "Discovery"
       expect(page).to have_css "td:nth-child(1)", text: "Published to PURL"
-      expect(page).to have_css "h5", text: "Catkeys"
-      expect(page).to have_css "td:nth-child(1)", text: "has value"
     end
 
     within "#rights" do

--- a/spec/search_builders/argo/profile_queries_spec.rb
+++ b/spec/search_builders/argo/profile_queries_spec.rb
@@ -60,7 +60,6 @@ RSpec.describe Argo::ProfileQueries do
         content_file_count_itsi
         shelved_content_file_count_itsi
         preserved_size_dbtsi
-        catkey_id_ssim
       ]
       expect(solr_parameters["stats"]).to be true
       expect(stats_fields).to include(*required_fields)


### PR DESCRIPTION
## Why was this change made? 🤔

Closes #3964 

# After

![image](https://user-images.githubusercontent.com/96775/221637300-1da650b3-e38c-487d-b615-f7da8a14dfe3.png)


# Before

![image](https://user-images.githubusercontent.com/96775/221637888-192f1da9-02a6-447e-9fac-5801d5e3647e.png)


## How was this change tested? 🤨

unit tests, deployed to QA

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


