### PR TITLE
Add `metadata_source_ssim` facet field behind feature flag

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
 
   before_action :authenticate_user!
   before_action :set_folio_flag_per_param
+  before_action :set_multivalued_metadata_source_flag_per_param
 
   rescue_from CanCan::AccessDenied, with: -> { render status: :forbidden, plain: "forbidden" }
 
@@ -37,6 +38,10 @@ class ApplicationController < ActionController::Base
 
   def set_folio_flag_per_param
     Settings.enabled_features.folio = true if params[:folio] == "true"
+  end
+
+  def set_multivalued_metadata_source_flag_per_param
+    Settings.enabled_features.multivalued_metadata_sources = true if params[:multivalued] == "true"
   end
 
   protected

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -133,6 +133,11 @@ class CatalogController < ApplicationController
     config.add_facet_field "metadata_source_ssi", label: "Metadata Source", home: false,
       component: true
 
+    if Settings.enabled_features.multivalued_metadata_sources
+      config.add_facet_field "metadata_source_ssim", label: "Metadata Source (Multi)", home: false,
+        component: true
+    end
+
     # common method since search results and reports all do the same configuration
     add_common_date_facet_fields_to_config! config
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -105,3 +105,4 @@ redis_url: 'redis://localhost:6379/'
 
 enabled_features:
   folio: false
+  multivalued_metadata_sources: false

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -7,3 +7,4 @@ solrizer_url: 'http://localhost:8983/solr/argo'
 
 enabled_features:
   folio: true
+  multivalued_metadata_sources: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -7,3 +7,4 @@ dor_indexing_url: http://localhost:3004/dor
 
 enabled_features:
   folio: true
+  multivalued_metadata_sources: true


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3977

This commit adds a new facet field to the Blacklight catalog if and only if the multi-valued metadata sources feature flag is on. It also flips this flag on in dev & test, and allows the user to flip it on for a given request by adding `?multivalued=true` as a query param in the URL.

It's not clear that there are any specs that could be extended to cover the two small changes to `app/controllers/` and I'm not sure it's worth the effort to write new specs for this when we'll be extensively testing this via the browser given we're dealing with Blacklight internals.


## How was this change tested? 🤨

- [x] CI
- [x] QA (flag flipped on)
