### PR TITLE
Remove facet for single-valued metadata source field

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,6 @@ class ApplicationController < ActionController::Base
 
   before_action :authenticate_user!
   before_action :set_folio_flag_per_param
-  before_action :set_multivalued_metadata_source_flag_per_param
 
   rescue_from CanCan::AccessDenied, with: -> { render status: :forbidden, plain: "forbidden" }
 
@@ -38,10 +37,6 @@ class ApplicationController < ActionController::Base
 
   def set_folio_flag_per_param
     Settings.enabled_features.folio = true if params[:folio] == "true"
-  end
-
-  def set_multivalued_metadata_source_flag_per_param
-    Settings.enabled_features.multivalued_metadata_sources = true if params[:multivalued] == "true"
   end
 
   protected

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -130,13 +130,8 @@ class CatalogController < ApplicationController
       limit: 9999,
       home: false
 
-    config.add_facet_field "metadata_source_ssi", label: "Metadata Source", home: false,
+    config.add_facet_field "metadata_source_ssim", label: "Metadata Source", home: false,
       component: true
-
-    if Settings.enabled_features.multivalued_metadata_sources
-      config.add_facet_field "metadata_source_ssim", label: "Metadata Source (Multi)", home: false,
-        component: true
-    end
 
     # common method since search results and reports all do the same configuration
     add_common_date_facet_fields_to_config! config

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -105,4 +105,3 @@ redis_url: 'redis://localhost:6379/'
 
 enabled_features:
   folio: false
-  multivalued_metadata_sources: false

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -7,4 +7,3 @@ solrizer_url: 'http://localhost:8983/solr/argo'
 
 enabled_features:
   folio: true
-  multivalued_metadata_sources: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -7,4 +7,3 @@ dor_indexing_url: http://localhost:3004/dor
 
 enabled_features:
   folio: true
-  multivalued_metadata_sources: true


### PR DESCRIPTION
~~This is **ON HOLD** until reindexing has been done in all environments.~~

## Why was this change made? 🤔

Fixes #3980

This commit removes a metadata source facet field that is no longer needed after the Folio migration is complete. It also removes the feature flag that would now be dead code.


## How was this change tested? 🤨

CI
