### PR TITLE
Handle malformed CSV for descriptive upload.

### DIFF
--- a/app/controllers/descriptives_controller.rb
+++ b/app/controllers/descriptives_controller.rb
@@ -33,6 +33,9 @@ class DescriptivesController < ApplicationController
       @errors = validator.errors
       render :edit, status: :unprocessable_entity
     end
+  rescue CSV::MalformedCSVError
+    @errors = ["The file you uploaded is not a valid CSV file."]
+    render :edit, status: :unprocessable_entity
   end
 
   private


### PR DESCRIPTION
closes #4014

## Why was this change made? 🤔
So that users are not befuddled by malformed descriptive CSV.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

<img width="1145" alt="image" src="https://user-images.githubusercontent.com/588335/234129388-b1f4d9d6-0042-46ae-8f52-2facd1da6173.png">


⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


