### PR TITLE
Remove gisDiscoveryWF from APO options

### DIFF
--- a/app/helpers/apo_helper.rb
+++ b/app/helpers/apo_helper.rb
@@ -8,7 +8,6 @@ module ApoHelper
       accessionWF
       gisAssemblyWF
       gisDeliveryWF
-      gisDiscoveryWF
       goobiWF
       registrationWF
       wasCrawlDisseminationWF

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -95,6 +95,7 @@ inactive_workflows:
   - swIndexWF
   - googleScannedBookWF
   - eemsAccessionWF
+  - gisDiscoveryWF
 
 tech_md_service:
   url: 'http://localhost:3005'


### PR DESCRIPTION
It has been deprecated and has not been in use for 3+ years.

## Why was this change made? 🤔



## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


