### PR TITLE
Create administrative tags before workflow

### DIFF
--- a/app/services/registration_service.rb
+++ b/app/services/registration_service.rb
@@ -11,9 +11,10 @@ class RegistrationService
     response = Dor::Services::Client.objects.register(params: model)
     druid = response.externalIdentifier
 
+    Dor::Services::Client.object(druid).administrative_tags.create(tags:) unless tags.empty?
+
     WorkflowClientFactory.build.create_workflow_by_name(druid, workflow, version: "1")
 
-    Dor::Services::Client.object(druid).administrative_tags.create(tags:) unless tags.empty?
     Success(response)
   rescue Dor::Services::Client::UnexpectedResponse => e
     Failure(e)

--- a/app/services/registration_service.rb
+++ b/app/services/registration_service.rb
@@ -11,6 +11,8 @@ class RegistrationService
     response = Dor::Services::Client.objects.register(params: model)
     druid = response.externalIdentifier
 
+    # NOTE: Create administrative tags before the workflow is created, else workflows
+    #       that rely on admin tags (e.g., `goobiWF`) could sporadically fail.
     Dor::Services::Client.object(druid).administrative_tags.create(tags:) unless tags.empty?
 
     WorkflowClientFactory.build.create_workflow_by_name(druid, workflow, version: "1")


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #1043

This commit makes a small tweak to the Argo registration service, creating administrative tags for an object before creating its workflow. This should *ensure* the problematic behavior of getting too far in a workflow (the `goobiWF` in particular) before administrative tags are created since the tag creation in DSA is synchronous.


## How was this change tested? 🤨

- [x] CI
