### PR TITLE
Stop pinning reform-rails to pick up patch in 0.2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,10 +60,7 @@ gem "nokogiri", "~> 1.14"
 gem "prawn", "~> 1"
 gem "prawn-table"
 gem "rake"
-# TODO: Deal with this
-# pinned because 0.2.4 broke the build: https://app.circleci.com/pipelines/github/sul-dlss/argo/6018/workflows/fd256885-f9aa-4cf6-bb60-8bd2be232f49/jobs/13023/tests#failed-test-1
-# Specifically because of the `TagsForm` thinking a new tag was a tag to update
-gem "reform-rails", "< 0.2.4"
+gem "reform-rails"
 gem "retries"
 gem "ruby-prof"
 gem "rubyzip"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -449,7 +449,7 @@ GEM
       disposable (>= 0.5.0, < 1.0.0)
       representable (>= 3.1.1, < 4)
       uber (< 0.2.0)
-    reform-rails (0.2.3)
+    reform-rails (0.2.5)
       activemodel (>= 5.0)
       reform (>= 2.3.1, < 3.0.0)
     regexp_parser (2.8.0)
@@ -672,7 +672,7 @@ DEPENDENCIES
   rack-mini-profiler
   rails (~> 7.0.2)
   rake
-  reform-rails (< 0.2.4)
+  reform-rails
   retries
   roo (~> 2.9.0)
   roo-xls

--- a/app/forms/tags_form.rb
+++ b/app/forms/tags_form.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class TagsForm < Reform::Form
-  collection :tags, populator: lambda { |collection:, index:, **|
-                                 if (item = collection[index])
+  collection :tags, populator: lambda { |collection:, index:, fragment:, **|
+                                 if (item = collection.find { |tag| tag.id == fragment[:id] })
                                    item
                                  else
                                    collection.insert(index, TagsController::Tag.new)


### PR DESCRIPTION
## Why was this change made? 🤔

Keep pace with reform-rails now that the bug we found was patched.

## How was this change tested? 🤨

CI
