### PR TITLE
Remove controller code to flip Folio flag on based on a param

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,6 @@ class ApplicationController < ActionController::Base
   include Blacklight::Controller
 
   before_action :authenticate_user!
-  before_action :set_folio_flag_per_param
 
   rescue_from CanCan::AccessDenied, with: -> { render status: :forbidden, plain: "forbidden" }
 
@@ -33,10 +32,6 @@ class ApplicationController < ActionController::Base
 
   def default_html_head
     stylesheet_links << ["argo"]
-  end
-
-  def set_folio_flag_per_param
-    Settings.enabled_features.folio = true if params[:folio] == "true"
   end
 
   protected


### PR DESCRIPTION
## Why was this change made? 🤔

This turns out not to work as we expected. Mutating a `Settings` value changes **global** state, so when the `folio=true` query param is added to a request, the setting is tweaked not only for that request but flips the setting across the entire site.🤦🏻‍ Andrew does not use this feature anyway. Once I hear from Arcadia, that will unblock this PR.


## How was this change tested? 🤨

CI + QA
