### PR TITLE
Add validation for catalog record IDs/barcodes before saving in bulk action

### DIFF
--- a/app/jobs/set_catalog_record_ids_and_barcodes_job.rb
+++ b/app/jobs/set_catalog_record_ids_and_barcodes_job.rb
@@ -27,8 +27,12 @@ class SetCatalogRecordIdsAndBarcodesJob < GenericJob
         args[:refresh] = refresh[i] if refresh
         args[:barcode] = barcodes[i] if barcodes && cocina_object.dro?
         change_set = change_set_for(cocina_object)
-        change_set.validate(args)
-        update_catalog_record_id_and_barcode(change_set, args, log) if change_set.changed?
+        if change_set.validate(args)
+          update_catalog_record_id_and_barcode(change_set, args, log) if change_set.changed?
+        else
+          log.puts("#{Time.current} Invalid #{CatalogRecordId.label}/barcode for #{cocina_object.externalIdentifier}")
+          bulk_action.increment(:druid_count_fail).save
+        end
       end
     end
   end

--- a/app/models/item_change_set.rb
+++ b/app/models/item_change_set.rb
@@ -22,6 +22,7 @@ class ItemChangeSet < ApplicationChangeSet
     with: /\A(2050[0-9]{7}|245[0-9]{8}|36105[0-9]{9}|[0-9]+-[0-9]+)\z/,
     allow_blank: true
   }
+  validate :format_of_catalog_record_ids
 
   def self.model_name
     ::ActiveModel::Name.new(nil, nil, "Item")
@@ -45,6 +46,12 @@ class ItemChangeSet < ApplicationChangeSet
     self.use_statement = model.access.useAndReproductionStatement
     self.license = model.access.license
     setup_view_access_with_cdl_properties(model.access)
+  end
+
+  def format_of_catalog_record_ids
+    return if catalog_record_ids.blank? || CatalogRecordId.valid?(catalog_record_ids)
+
+    errors.add(:catalog_record_ids, "are not a valid format")
   end
 
   def sync


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #4034 - validate that catalog record IDs (either catkey or folio_instance_hrid) and/or barcodes are valid before attempting to version/save an object.  This stops opening the object and adding a message, only to have the save fail because it was invalid.

Note: even though the ticket describes the problem as updates from a CSV file, the same thing would happen for the bulk job that allows you paste in druids, barcodes and catalog record IDs.  This will fix both jobs (as they both use the same underlying update code, just different code for getting the input data loaded).

~~[HOLD] to test on QA or stage first~~

## How was this change tested? 🤨

Added specs.  Tested on QA with both CSV file and pasted values (i.e. both related jobs)