### PR TITLE
Update standard gems and require standard-custom

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,9 @@ inherit_mode:
 
 require:
   - standard
+  - standard-custom
+  - standard-performance
+  - standard-rails
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec

--- a/Gemfile
+++ b/Gemfile
@@ -97,14 +97,9 @@ group :test, :development do
   gem "http_logger", require: false # Change this to `true` to see all http requests logged
   gem "pry-remote" # allows you to attach remote session to pry
   gem "rspec-rails", "~> 5.0"
-  # NOTE: the `standard` way does not support using the rubocop CLI with
-  # extensions like standard-rails, so until that changes or we decide to switch
-  # to the standardrb CLI (which would need CI and editor support), we have to
-  # carry both this dependency and standard-rails.
-  gem "rubocop-rails"
   gem "rubocop-rspec"
   gem "sqlite3", "~> 1.4.2"
-  gem "standard", "< 1.30", require: false # TODO: 1.30.x breaks build as of 2023-07-10, unpin once a later release fixes this, or if suggested workaround is acceptable and fixes the issue, see https://github.com/standardrb/standard/issues/569
+  gem "standard", require: false
   gem "standard-rails"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -561,14 +561,15 @@ GEM
     sshkit (1.21.5)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    standard (1.29.0)
+    standard (1.30.1)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
       rubocop (~> 1.52.0)
       standard-custom (~> 1.0.0)
       standard-performance (~> 1.1.0)
-    standard-custom (1.0.1)
+    standard-custom (1.0.2)
       lint_roller (~> 1.0)
+      rubocop (~> 1.50)
     standard-performance (1.1.1)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.18.0)
@@ -686,7 +687,6 @@ DEPENDENCIES
   rsolr
   rspec-rails (~> 5.0)
   rspec_junit_formatter
-  rubocop-rails
   rubocop-rspec
   ruby-prof
   rubyzip
@@ -695,7 +695,7 @@ DEPENDENCIES
   sidekiq (~> 7.0)
   simplecov
   sqlite3 (~> 1.4.2)
-  standard (< 1.30)
+  standard
   standard-rails
   turbo-rails (~> 1.0)
   view_component (~> 2.74.1)


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #4067

This commit updates the standard gems and uses the new pattern for requiring standardrb plugins in the `require` section of the rubocop configuration.

# How was this change tested? 🤨

CI

# Does your change introduce accessibility violations? 🩺

No
