### PR TITLE
csv upload: do not import contributor roles without names or form source or type without a form value

### DIFF
--- a/spec/services/description_import_spec.rb
+++ b/spec/services/description_import_spec.rb
@@ -8,160 +8,160 @@ RSpec.describe DescriptionImport do
   let(:expected_json) do
     <<~JSON
       {
-      	"title": [{
-      		"value": "Concerto for piano, strings, brass and percussion!",
-      		"status": "primary"
-      	}, {
-      		"value": "Concertos, piano, orchestra",
-      		"type": "uniform",
-      		"note": [{
-      			"structuredValue": [{
-      				"value": "Harvey, Robert Gibson",
-      				"type": "name"
-      			}, {
-      				"value": "1951-",
-      				"type": "life dates"
-      			}],
-      			"type": "associated name"
-      		}]
-      	}],
-      	"contributor": [{
-      		"name": [{
-      			"structuredValue": [{#{"\t\t\t\t\t\t"}
-      				"value": "Harvey, Robert Gibson",
-      				"type": "name"
-      			}, {
-      				"value": "1951-",
-      				"type": "life dates"
-      			}]
-      		}],
-      		"type": "person",
-      		"status": "primary"
-      	}],
-      	"event": [{#{"\t\t\t\t"}
-      		"location": [{#{"\t\t\t\t\t"}
-      			"code": "xx",
-      			"source": {
-      				"code": "marccountry"
-      			}
-      		}],#{"\t\t\t\t"}
-      		"note": [{
-      			"value": "monographic",
-      			"type": "issuance",
-      			"source": {
-      				"value": "MODS issuance terms"
-      			}
-      		}]
-      	}, {
-      		"date": [{
-      			"value": "1978",
-      			"type": "publication"
-      		}]
-      	}],
-      	"form": [{
-      		"value": "notated music",
-      		"type": "resource type",
-      		"source": {
-      			"value": "MODS resource types"
-      		}
-      	}, {
-      		"value": "print",
-      		"type": "form",
-      		"source": {
-      			"code": "marcform"
-      		}
-      	}, {
-      		"value": "score (77 leaves) : music ; 28 cm.",
-      		"type": "extent"
-      	}],
-      	"language": [{
-      		"code": "und",
-      		"source": {
-      			"code": "iso639-2b"
-      		}
-      	}],
-      	"note": [{
-      		"value": "by Robert Harvey.",
-      		"type": "statement of responsibility"
-      	}, {
-      		"value": "D.M.A. project - Department of Music, Stanford University.",
-      		"type": "thesis"
-      	}],
-      	"subject": [{
-      		"structuredValue": [{
-      			"value": "Concertos (Piano)",
-      			"type": "topic"
-      		}, {
-      			"value": "Scores",
-      			"type": "genre"
-      		}],
-      		"source": {
-      			"code": "lcsh"
-      		}
-      	}],
-      	"relatedResource": [{
-      		"title": [{
-      			"structuredValue": [{
-      				"value": "Projects",
-      				"type": "main title"
-      			}, {
-      				"value": "D.M.A. Final",
-      				"type": "part name"
-      			}]
-      		}],
-      		"contributor": [{
-      			"name": [{
-      				"structuredValue": [{
-      					"value": "Stanford University",
-      					"type": "name"
-      				}, {
-      					"value": "Department of Music",
-      					"type": "name"
-      				}]
-      			}],
-      			"type": "organization"
-      		}]#{"\t\t\t\t"}
-      	}],
-      	"adminMetadata": {
-      		"contributor": [{
-      			"name": [{
-      				"code": "CSt",
-      				"source": {
-      					"code": "marcorg"
-      				}
-      			}],
-      			"type": "organization",
-      			"role": [{
-      				"value": "original cataloging agency"
-      			}]
-      		}],
-      		"event": [{
-      			"type": "creation",
-      			"date": [{
-      				"value": "790730",
-      				"encoding": {
-      					"code": "marc"
-      				}
-      			}]
-      		}, {
-      			"type": "modification",
-      			"date": [{
-      				"value": "19900820141050.0",
-      				"encoding": {
-      					"code": "iso8601"
-      				}
-      			}]
-      		}],
-      		"note": [{
-      			"value": "Converted from MARCXML to MODS version 3.7 using MARC21slim2MODS3-7_SDR_v2-5.xsl (SUL 3.7 version 2.5 20210421; LC Revision 1.140 20200717)",
-      			"type": "record origin"
-      		}],
-      		"identifier": [{
-      			"value": "a111",
-      			"type": "SIRSI"
-      		}]
-      	},
-      	"purl": "https://sul-purl-stage.stanford.edu/bb041bm1345"
+        "title": [{
+          "value": "Concerto for piano, strings, brass and percussion!",
+          "status": "primary"
+        }, {
+          "value": "Concertos, piano, orchestra",
+          "type": "uniform",
+          "note": [{
+            "structuredValue": [{
+              "value": "Harvey, Robert Gibson",
+              "type": "name"
+            }, {
+              "value": "1951-",
+              "type": "life dates"
+            }],
+            "type": "associated name"
+          }]
+        }],
+        "contributor": [{
+          "name": [{
+            "structuredValue": [{#{"\t\t\t\t\t\t"}
+              "value": "Harvey, Robert Gibson",
+              "type": "name"
+            }, {
+              "value": "1951-",
+              "type": "life dates"
+            }]
+          }],
+          "type": "person",
+          "status": "primary"
+        }],
+        "event": [{#{"\t\t\t\t"}
+          "location": [{#{"\t\t\t\t\t"}
+            "code": "xx",
+            "source": {
+              "code": "marccountry"
+            }
+          }],#{"\t\t\t\t"}
+          "note": [{
+            "value": "monographic",
+            "type": "issuance",
+            "source": {
+              "value": "MODS issuance terms"
+            }
+          }]
+        }, {
+          "date": [{
+            "value": "1978",
+            "type": "publication"
+          }]
+        }],
+        "form": [{
+          "value": "notated music",
+          "type": "resource type",
+          "source": {
+            "value": "MODS resource types"
+          }
+        }, {
+          "value": "print",
+          "type": "form",
+          "source": {
+            "code": "marcform"
+          }
+        }, {
+          "value": "score (77 leaves) : music ; 28 cm.",
+          "type": "extent"
+        }],
+        "language": [{
+          "code": "und",
+          "source": {
+            "code": "iso639-2b"
+          }
+        }],
+        "note": [{
+          "value": "by Robert Harvey.",
+          "type": "statement of responsibility"
+        }, {
+          "value": "D.M.A. project - Department of Music, Stanford University.",
+          "type": "thesis"
+        }],
+        "subject": [{
+          "structuredValue": [{
+            "value": "Concertos (Piano)",
+            "type": "topic"
+          }, {
+            "value": "Scores",
+            "type": "genre"
+          }],
+          "source": {
+            "code": "lcsh"
+          }
+        }],
+        "relatedResource": [{
+          "title": [{
+            "structuredValue": [{
+              "value": "Projects",
+              "type": "main title"
+            }, {
+              "value": "D.M.A. Final",
+              "type": "part name"
+            }]
+          }],
+          "contributor": [{
+            "name": [{
+              "structuredValue": [{
+                "value": "Stanford University",
+                "type": "name"
+              }, {
+                "value": "Department of Music",
+                "type": "name"
+              }]
+            }],
+            "type": "organization"
+          }]#{"\t\t\t\t"}
+        }],
+        "adminMetadata": {
+          "contributor": [{
+            "name": [{
+              "code": "CSt",
+              "source": {
+                "code": "marcorg"
+              }
+            }],
+            "type": "organization",
+            "role": [{
+              "value": "original cataloging agency"
+            }]
+          }],
+          "event": [{
+            "type": "creation",
+            "date": [{
+              "value": "790730",
+              "encoding": {
+                "code": "marc"
+              }
+            }]
+          }, {
+            "type": "modification",
+            "date": [{
+              "value": "19900820141050.0",
+              "encoding": {
+                "code": "iso8601"
+              }
+            }]
+          }],
+          "note": [{
+            "value": "Converted from MARCXML to MODS version 3.7 using MARC21slim2MODS3-7_SDR_v2-5.xsl (SUL 3.7 version 2.5 20210421; LC Revision 1.140 20200717)",
+            "type": "record origin"
+          }],
+          "identifier": [{
+            "value": "a111",
+            "type": "SIRSI"
+          }]
+        },
+        "purl": "https://sul-purl-stage.stanford.edu/bb041bm1345"
       }
     JSON
   end
@@ -254,6 +254,435 @@ RSpec.describe DescriptionImport do
 
     it "ignores the empty field" do
       expect(updated.value!).to eq expected
+    end
+  end
+
+  context "when top level contributor" do
+    let(:csv) do
+      CSV.parse(csv_data, headers: true)
+    end
+    let(:expected_hash) do
+      {
+        title: [{value: "my great contributor"}],
+        purl: "https://purl/jr825qh8124"
+      }.tap do |h|
+        h[:contributor] = [expected_contributor] if expected_contributor
+      end
+    end
+    let(:expected) { Cocina::Models::Description.new(expected_hash) }
+
+    [nil, "Someone"].each do |name|
+      context "when role as code (not value), name: '#{name}'" do
+        let(:csv_data) do
+          <<~CSV
+            druid,source_id,purl,title1.value,contributor1.name1.value,contributor1.role1.code,contributor1.role1.value
+            jr825qh8124,event:contrib-roles,https://purl/jr825qh8124,my great contributor,#{name},pbl,
+          CSV
+        end
+        let(:expected_contributor) do
+          if name
+            {
+              name: [{value: name}],
+              role: [{code: "pbl"}]
+            }
+          end
+        end
+
+        it "has the expected value" do
+          expect(updated.value!.to_h).to eq expected.to_h
+        end
+      end
+
+      context "when role as value (not code), name: '#{name}'" do
+        let(:csv_data) do
+          <<~CSV
+            druid,source_id,purl,title1.value,contributor1.name1.value,contributor1.role1.code,contributor1.role1.value
+            jr825qh8124,event:contrib-roles,https://purl/jr825qh8124,my great contributor,#{name},,Publisher
+          CSV
+        end
+        let(:expected_contributor) do
+          if name
+            {
+              name: [{value: name}],
+              role: [{value: "Publisher"}]
+            }
+          end
+        end
+
+        it "has the expected value" do
+          expect(updated.value!.to_h).to eq expected.to_h
+        end
+      end
+
+      context "when role as both code and value, name: '#{name}'" do
+        let(:csv_data) do
+          <<~CSV
+            druid,source_id,purl,title1.value,contributor1.name1.value,contributor1.role1.code,contributor1.role1.value
+            jr825qh8124,event:contrib-roles,https://purl/jr825qh8124,my great contributor,#{name},pbl,Publisher
+          CSV
+        end
+        let(:expected_contributor) do
+          if name
+            {
+              name: [{value: name}],
+              role: [
+                {
+                  code: "pbl",
+                  value: "Publisher"
+                }
+              ]
+            }
+          end
+        end
+
+        it "has the expected value" do
+          expect(updated.value!.to_h).to eq expected.to_h
+        end
+      end
+
+      context "when role code and value both empty, name: '#{name}'" do
+        let(:csv_data) do
+          <<~CSV
+            druid,source_id,purl,title1.value,contributor1.name1.value,contributor1.role1.code,contributor1.role1.value
+            jr825qh8124,event:contrib-roles,https://purl/jr825qh8124,my great contributor,#{name},,
+          CSV
+        end
+        let(:expected_contributor) do
+          if name
+            {
+              name: [{value: name}]
+            }
+          end
+        end
+
+        it "has the expected value" do
+          expect(updated.value!.to_h).to eq expected.to_h
+        end
+      end
+    end
+  end
+
+  context "when nested contributor role" do
+    let(:csv) do
+      CSV.parse(csv_data, headers: true)
+    end
+    let(:expected_hash) do
+      {
+        title: [{value: "my great event"}],
+        purl: "https://purl/jr825qh8124"
+      }.tap do |h|
+        contributor_value =
+          if expected_contributor
+            [expected_contributor]
+          else
+            []
+          end
+        h[:event] = [
+          contributor: contributor_value,
+          note: [
+            {
+              structuredValue: [],
+              parallelValue: [],
+              groupedValue: [],
+              value: "noted",
+              identifier: [],
+              note: [],
+              appliesTo: []
+            }
+          ],
+          structuredValue: [],
+          date: [],
+          location: [],
+          identifier: [],
+          parallelEvent: []
+        ]
+      end
+    end
+    let(:expected) { Cocina::Models::Description.new(expected_hash) }
+
+    [nil, "Someone"].each do |name|
+      context "when role as code (not value), name: '#{name}'" do
+        let(:csv_data) do
+          <<~CSV
+            druid,source_id,purl,title1.value,event1.contributor1.name1.value,event1.contributor1.role1.code,event1.contributor1.role1.value,event1.note1.value
+            jr825qh8124,event:contrib-roles,https://purl/jr825qh8124,my great event,#{name},pbl,,noted
+          CSV
+        end
+        let(:expected_contributor) do
+          if name
+            {
+              name: [{value: name}],
+              role: [{code: "pbl"}]
+            }
+          end
+        end
+
+        it "has the expected value" do
+          expect(updated.value!.to_h).to eq expected.to_h
+        end
+      end
+
+      context "when role as value (not code), name: '#{name}'" do
+        let(:csv_data) do
+          <<~CSV
+            druid,source_id,purl,title1.value,event1.contributor1.name1.value,event1.contributor1.role1.code,event1.contributor1.role1.value,event1.note1.value
+            jr825qh8124,event:contrib-roles,https://purl/jr825qh8124,my great event,#{name},,Publisher,noted
+          CSV
+        end
+        let(:expected_contributor) do
+          if name
+            {
+              name: [{value: name}],
+              role: [{value: "Publisher"}]
+            }
+          end
+        end
+
+        it "has the expected value" do
+          expect(updated.value!.to_h).to eq expected.to_h
+        end
+      end
+
+      context "when role as both code and value, name: '#{name}'" do
+        let(:csv_data) do
+          <<~CSV
+            druid,source_id,purl,title1.value,event1.contributor1.name1.value,event1.contributor1.role1.code,event1.contributor1.role1.value,event1.note1.value
+            jr825qh8124,event:contrib-roles,https://purl/jr825qh8124,my great event,#{name},pbl,Publisher,noted
+          CSV
+        end
+        let(:expected_contributor) do
+          if name
+            {
+              name: [{value: name}],
+              role: [
+                {
+                  code: "pbl",
+                  value: "Publisher"
+                }
+              ]
+            }
+          end
+        end
+
+        it "has the expected value" do
+          expect(updated.value!.to_h).to eq expected.to_h
+        end
+      end
+
+      context "when role code and value both empty, name: '#{name}'" do
+        let(:csv_data) do
+          <<~CSV
+            druid,source_id,purl,title1.value,event1.contributor1.name1.value,event1.contributor1.role1.code,event1.contributor1.role1.value,event1.note1.value
+            jr825qh8124,event:contrib-roles,https://purl/jr825qh8124,my great event,#{name},,,noted
+          CSV
+        end
+        let(:expected_contributor) do
+          if name
+            {
+              name: [{value: name}]
+            }
+          end
+        end
+
+        it "has the expected value" do
+          expect(updated.value!.to_h).to eq expected.to_h
+        end
+      end
+    end
+  end
+
+  context "with form property" do
+    let(:title) { "my great form" }
+    let(:csv) do
+      CSV.parse(csv_data, headers: true)
+    end
+    let(:expected) { Cocina::Models::Description.new(expected_hash) }
+
+    context "when at top level" do
+      let(:expected_hash) do
+        {
+          title: [{value: title}],
+          purl: "https://purl/jr825qh8124"
+        }.tap do |h|
+          h[:form] = [expected_form] if expected_form
+        end
+      end
+
+      [nil, "prints"].each do |form_value|
+        context "when type, no source, value: '#{form_value}'" do
+          let(:csv_data) do
+            <<~CSV
+              druid,source_id,purl,title1.value,form1.value,form1.type,form1.source.code,form1.source.value,form1.source.uri
+              jr825qh8124,form:values,https://purl/jr825qh8124,#{title},#{form_value},genre,,,
+            CSV
+          end
+          let(:expected_form) do
+            if form_value
+              {
+                value: form_value,
+                type: "genre"
+              }
+            end
+          end
+
+          it "has the expected value" do
+            expect(updated.value!.to_h).to eq expected.to_h
+          end
+        end
+
+        context "when form source as code (not value or URI), no form type, form value: '#{form_value}'" do
+          let(:csv_data) do
+            <<~CSV
+              druid,source_id,purl,title1.value,form1.value,form1.type,form1.source.code,form1.source.value,form1.source.uri
+              jr825qh8124,form:values,https://purl/jr825qh8124,#{title},#{form_value},,lcgft,,
+            CSV
+          end
+          let(:expected_form) do
+            if form_value
+              {
+                value: form_value,
+                source: {code: "lcgft"}
+              }
+            end
+          end
+
+          it "has the expected value" do
+            expect(updated.value!.to_h).to eq expected.to_h
+          end
+        end
+
+        context "when form source as value (not code or URI), no form type, form value: '#{form_value}'" do
+          let(:csv_data) do
+            <<~CSV
+              druid,source_id,purl,title1.value,form1.value,form1.type,form1.source.code,form1.source.value,form1.source.uri
+              jr825qh8124,form:values,https://purl/jr825qh8124,#{title},#{form_value},,,source-value,
+            CSV
+          end
+          let(:expected_form) do
+            if form_value
+              {
+                value: form_value,
+                source: {value: "source-value"}
+              }
+            end
+          end
+
+          it "has the expected value" do
+            expect(updated.value!.to_h).to eq expected.to_h
+          end
+        end
+
+        context "when form source as URI (not code or value), no form type, form value: '#{form_value}'" do
+          let(:csv_data) do
+            <<~CSV
+              druid,source_id,purl,title1.value,form1.value,form1.type,form1.source.code,form1.source.value,form1.source.uri
+              jr825qh8124,form:values,https://purl/jr825qh8124,#{title},#{form_value},,,,http://id.loc.gov/authorities/genreForms/
+            CSV
+          end
+          let(:expected_form) do
+            if form_value
+              {
+                value: form_value,
+                source: {uri: "http://id.loc.gov/authorities/genreForms/"}
+              }
+            end
+          end
+
+          it "has the expected value" do
+            expect(updated.value!.to_h).to eq expected.to_h
+          end
+        end
+
+        context "when form source as code and URI (no value), no form type, form value: '#{form_value}'" do
+          let(:csv_data) do
+            <<~CSV
+              druid,source_id,purl,title1.value,form1.value,form1.type,form1.source.code,form1.source.value,form1.source.uri
+              jr825qh8124,form:values,https://purl/jr825qh8124,#{title},#{form_value},,lcgft,,http://id.loc.gov/authorities/genreForms/
+            CSV
+          end
+          let(:expected_form) do
+            if form_value
+              {
+                value: form_value,
+                source: {
+                  code: "lcgft",
+                  uri: "http://id.loc.gov/authorities/genreForms/"
+                }
+              }
+            end
+          end
+
+          it "has the expected value" do
+            expect(updated.value!.to_h).to eq expected.to_h
+          end
+        end
+
+        context "when form source and type empty, form value: '#{form_value}'" do
+          let(:csv_data) do
+            <<~CSV
+              druid,source_id,purl,title1.value,form1.value,form1.type,form1.source.code,form1.source.value,form1.source.uri
+              jr825qh8124,form:values,https://purl/jr825qh8124,#{title},#{form_value},,,,
+            CSV
+          end
+          let(:expected_form) do
+            {value: form_value} if form_value
+          end
+
+          it "has the expected value" do
+            expect(updated.value!.to_h).to eq expected.to_h
+          end
+        end
+      end
+    end
+
+    context "when at nested level" do
+      let(:expected_hash) do
+        {
+          title: [{value: title}],
+          purl: "https://purl/jr825qh8124"
+        }.tap do |h|
+          form_value =
+            if expected_form
+              [expected_form]
+            else
+              []
+            end
+          h[:relatedResource] = [
+            form: form_value,
+            title: [],
+            contributor: [],
+            event: [],
+            language: [],
+            note: [],
+            identifier: [],
+            subject: []
+          ]
+        end
+      end
+      let(:expected) { Cocina::Models::Description.new(expected_hash) }
+
+      [nil, "prints"].each do |form_value|
+        context "when form has type, no source, value: '#{form_value}'" do
+          let(:csv_data) do
+            <<~CSV
+              druid,source_id,purl,title1.value,relatedResource1.form1.value,relatedResource1.form1.type,relatedResource1.form1.source.code,relatedResource1.form1.source.value,relatedResource1.form1.source.uri
+              jr825qh8124,form:values,https://purl/jr825qh8124,#{title},#{form_value},genre,,,
+            CSV
+          end
+          let(:expected_form) do
+            if form_value
+              {
+                value: form_value,
+                type: "genre"
+              }
+            end
+          end
+
+          it "has the expected value" do
+            expect(updated.value!.to_h).to eq expected.to_h
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
~~HOLD for PO approval (Andrew)~~

# Why was this change made? 🤔

Fixes #4071
Fixes #4072

Contributors with roles but not name are basically invalid and require complex remediation (error when publishing).  
Form data without a value (e.g. it just has source or type, but no value) also require complex remediation (prevents indexing)

I've created sul-dlss/cocina-models/issues/610 for cocina validation of contributors

# How was this change tested? 🤨

Andrew reviewed it in stage;  also specs.

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


# Does your change introduce accessibility violations? 🩺

Nope!

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



