### PR TITLE
Make the PR template less spammy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,12 @@
-# Why was this change made? 🤔
+# Why was this change made?
+
+<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->
 
 
+# How was this change tested?
 
-# How was this change tested? 🤨
+<!-- Run infrastructure integration test(s) if change has cross-service impact.-->
 
-⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡
-
-⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡
-
-
-# Does your change introduce accessibility violations? 🩺
-
-⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡
-
+<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->
 
 


### PR DESCRIPTION
# Why was this change made?

<!-- Feel free to use whatever GitHub copy/pastes into the PR description above, or even just `Fixes https://github.com/sul-dlss/argo/issues/1234` if the PR is closely tied to an issue. -->

We discussed making the PR template more useful and less noisy for code authors and reviewers today, and this PR amends the template so the team can review how close these changes are to what they had in mind.

# How was this change tested?

<!-- If this change has cross-service impact (including writing to shared file systems or interacting with other SDR APIs), or includes changes to the Argo UI, **please run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)** and/or test in [stage|qa] environment. -->

N/A