### PR TITLE
Disable refresh mods bulk action during cutover.

### DIFF
--- a/app/components/bulk_actions_form_component.rb
+++ b/app/components/bulk_actions_form_component.rb
@@ -30,7 +30,7 @@ class BulkActionsFormComponent < ApplicationComponent
         ["Set object rights", new_rights_job_path(search_of_druids)],
         ["Edit license and rights statements", new_license_and_rights_statement_job_path(search_of_druids)],
         ["Edit #{CatalogRecordId.label}s and barcodes", new_catalog_record_id_and_barcode_job_path(search_of_druids)],
-        ["Refresh MODS from #{CatalogRecordId.label}", new_refresh_mods_job_path(search_of_druids)],
+        Settings.ils_cutover_in_progress ? ["DISABLED: Refresh MODS from #{CatalogRecordId.label}", nil] : ["Refresh MODS from #{CatalogRecordId.label}", new_refresh_mods_job_path(search_of_druids)],
         ["Set content type", new_content_type_job_path(search_of_druids)],
         ["Set collection", new_collection_job_path(search_of_druids)]
       ]],

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -100,3 +100,5 @@ redis_url: 'redis://localhost:6379/'
 
 enabled_features:
   folio: false
+
+ils_cutover_in_progress: false


### PR DESCRIPTION
closes #4032 

# Why was this change made? 🤔

Avoid problems during cutover.

# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Local

<img width="1329" alt="image" src="https://github.com/sul-dlss/argo/assets/588335/fe481818-39e3-4721-8e58-8f8e14d37dce">


⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



