### PR TITLE
Disable create collection from folio during cutover

### DIFF
--- a/app/views/collections/new.html.erb
+++ b/app/views/collections/new.html.erb
@@ -14,14 +14,16 @@
                   data: { action: 'change->collection-editor#revealCreateCollection' } %>
           </div>
 
-          <div class="form-check">
-            <label class="form-check-label" for="from-catalog">
-              Create a Collection from <%= CatalogRecordId.type.capitalize %>
-            </label>
-            <%= radio_button_tag 'collection_radio', 'create', false, id: 'from-catalog',
-                  class: 'form-check-input',
-                  data: { action: 'change->collection-editor#revealCreateCollectionCatalogRecordId' } %>
-          </div>
+          <% unless Settings.ils_cutover_in_progress %>
+            <div class="form-check">
+              <label class="form-check-label" for="from-catalog">
+                Create a Collection from <%= CatalogRecordId.type.capitalize %>
+              </label>
+              <%= radio_button_tag 'collection_radio', 'create', false, id: 'from-catalog',
+                    class: 'form-check-input',
+                    data: { action: 'change->collection-editor#revealCreateCollectionCatalogRecordId' } %>
+            </div>
+          <% end %>
         </div>
 
         <div data-collection-editor-target="createCollectionFields">

--- a/spec/features/create_collection_spec.rb
+++ b/spec/features/create_collection_spec.rb
@@ -16,6 +16,17 @@ RSpec.describe "Add collection" do
   let(:cocina_model) { instance_double(Cocina::Models::AdminPolicyWithMetadata, label: "hey", externalIdentifier: apo_id) }
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
 
+  describe "during folio cutover when collection catalog_record_id is provided", js: true do
+    before do
+      allow(Settings).to receive(:ils_cutover_in_progress).and_return(true)
+    end
+
+    it "doesn't allow the collection to be created" do
+      visit new_apo_collection_path apo_id
+      expect(page).not_to have_text("Create a Collection from Folio")
+    end
+  end
+
   describe "when collection catalog_record_id is provided", js: true do
     it "warns if catalog_record_id exists" do
       visit new_apo_collection_path apo_id


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #4079  By removing the option to create a collection from a Folio hrid when the in cutover flag is set.

Before:

![Screenshot 2023-08-11 at 1 55 38 PM](https://github.com/sul-dlss/argo/assets/2294288/45f2eefb-9a0e-46a2-988d-217adbbf441a)

After:


![Screenshot 2023-08-11 at 1 57 01 PM](https://github.com/sul-dlss/argo/assets/2294288/a6e8c9b4-046d-404d-b406-cb144f8b3049)

# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



