### PR TITLE
Disable metadata refresh on show page during ILS cutover

### DIFF
--- a/app/components/show/controls_component.html.erb
+++ b/app/components/show/controls_component.html.erb
@@ -38,8 +38,8 @@
       </button>
       <ul class="dropdown-menu" aria-labelledby="dropdown-descriptive">
         <% if catalog_record? %>
-          <li><%= link_to 'Refresh', refresh_metadata_item_path(id: druid),
-                                     class: "dropdown-item #{'disabled' if button_disabled?}",
+          <li><%= link_to refresh_button_label, refresh_metadata_item_path(id: druid),
+                                     class: "dropdown-item #{'disabled' if button_disabled? || Settings.ils_cutover_in_progress}",
                                      data: { turbo_method: 'post' } %></li>
         <% end %>
         <li><%= link_to 'Download Cocina spreadsheet', item_descriptive_path(doc, format: :csv), class: 'dropdown-item' %></li>

--- a/app/components/show/controls_component.rb
+++ b/app/components/show/controls_component.rb
@@ -48,6 +48,12 @@ module Show
       !allows_modification?
     end
 
+    def refresh_button_label
+      return "Refresh (disabled during ILS cutover)" if Settings.ils_cutover_in_progress
+
+      "Refresh"
+    end
+
     private
 
     def manage_release

--- a/spec/components/show/controls_component_spec.rb
+++ b/spec/components/show/controls_component_spec.rb
@@ -65,6 +65,20 @@ RSpec.describe Show::ControlsComponent, type: :component do
 
           expect(rendered.css("a").size).to eq 12
         end
+
+        context "when ILS cutover flag is enabled" do # rubocop:disable RSpec/NestedGroups
+          around do |spec|
+            original_value = Settings.ils_cutover_in_progress
+            Settings.ils_cutover_in_progress = true
+            spec.run
+            Settings.ils_cutover_in_progress = original_value
+          end
+
+          it "includes the disabled descriptive metadata refresh button" do
+            # Refresh button is disabled during ILS cutover
+            expect(page).to have_css "a.disabled", text: "Refresh (disabled during ILS cutover)"
+          end
+        end
       end
     end
 


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #4031

This commit disables the metadata refresh button on the show page when the ILS cutover flag is flipped on. Not specified in the issue, I also included a small change to the "Refresh" label to make it clear to users *why* metadata refresh is not enabled. I pondered whether we should also include similar prevention code in the ItemsController, but since this operation is a POST, I figured it was very unlikely one of our users was going to bypass the UI controls and try to hack in a metadata refresh. Check me on this.

# How was this change tested? 🤨

CI

# Does your change introduce accessibility violations? 🩺

No
