### PR TITLE
Enable new cops and update specs

### DIFF
--- a/.rubocop/custom.yml
+++ b/.rubocop/custom.yml
@@ -95,3 +95,7 @@ FactoryBot/FactoryAssociationWithStrategy: # new in 2.23
   Enabled: true
 FactoryBot/RedundantFactoryOption: # new in 2.23
   Enabled: true
+RSpec/ReceiveMessages: # new in 2.23
+  Enabled: true
+RSpec/Rails/NegationBeValid: # new in 2.23
+  Enabled: true

--- a/spec/components/document_title_component_spec.rb
+++ b/spec/components/document_title_component_spec.rb
@@ -19,8 +19,7 @@ RSpec.describe DocumentTitleComponent, type: :component do
   let(:rendered) { render_inline(component) }
 
   before do
-    allow(component).to receive(:helpers).and_return(ability_mock)
-    allow(component).to receive(:title).and_return("Dummy Title")
+    allow(component).to receive_messages(helpers: ability_mock, title: "Dummy Title")
   end
 
   context "with an APO" do

--- a/spec/components/workflow_table_process_component_spec.rb
+++ b/spec/components/workflow_table_process_component_spec.rb
@@ -27,8 +27,7 @@ RSpec.describe WorkflowTableProcessComponent, type: :component do
     let(:search_state) { Blacklight::SearchState.new(query_params, blacklight_config) }
 
     before do
-      allow(component).to receive(:search_state).and_return search_state
-      allow(component).to receive(:report_reset_path).and_return("/foo")
+      allow(component).to receive_messages(search_state: search_state, report_reset_path: "/foo")
     end
 
     describe "wf_hash structure" do

--- a/spec/features/enable_buttons_spec.rb
+++ b/spec/features/enable_buttons_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe "Enable buttons" do
     solr_conn.add(id: item_id, objectType_ssim: "item")
     solr_conn.commit
     allow(StateService).to receive(:new).and_return(state_service)
-    allow(state_service).to receive(:published?).and_return(true)
-    allow(state_service).to receive(:object_state).and_return(:unlock)
+    allow(state_service).to receive_messages(published?: true, object_state: :unlock)
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
   end
 

--- a/spec/helpers/value_helper_spec.rb
+++ b/spec/helpers/value_helper_spec.rb
@@ -14,9 +14,7 @@ RSpec.describe ValueHelper do
   let(:honeybadger) { double(Honeybadger) }
 
   before do
-    allow(helper).to receive(:blacklight_config).and_return blacklight_config
-    allow(helper).to receive(:search_state).and_return search_state
-    allow(helper).to receive(:search_action_path).and_return search_action_path
+    allow(helper).to receive_messages(blacklight_config: blacklight_config, search_state: search_state, search_action_path: search_action_path)
   end
 
   describe "#link_to_admin_policy" do

--- a/spec/models/bulk_action_spec.rb
+++ b/spec/models/bulk_action_spec.rb
@@ -34,8 +34,7 @@ RSpec.describe BulkAction do
 
     context "when status completed but file has zero length" do
       before do
-        allow(File).to receive(:exist?).and_return(true)
-        allow(File).to receive(:zero?).and_return(true)
+        allow(File).to receive_messages(exist?: true, zero?: true)
       end
 
       let(:status) { "Completed" }


### PR DESCRIPTION
# Why was this change made? 🤔

Enables new cops and implements the new `receive_messages` rspec operation over `receive().and_return()`

# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



