### PR TITLE
Disable SearchWorks release bulk action in the immediate pre-cutover period

### DIFF
--- a/app/components/bulk_actions_form_component.rb
+++ b/app/components/bulk_actions_form_component.rb
@@ -16,7 +16,7 @@ class BulkActionsFormComponent < ApplicationComponent
   def action_types
     grouped_options_for_select [
       ["Perform actions", [
-        Settings.ils_cutover_in_progress ? ["DISABLED: Manage release", nil] : ["Manage release", new_manage_release_job_path(search_of_druids)],
+        Settings.disable_release_prior_to_ils_cutover ? ["DISABLED: Manage release", nil] : ["Manage release", new_manage_release_job_path(search_of_druids)],
         ["Reindex", new_reindex_job_path(search_of_druids)],
         ["Republish objects", new_republish_job_path(search_of_druids)],
         ["Purge", new_purge_job_path(search_of_druids)],

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -102,3 +102,4 @@ enabled_features:
   folio: false
 
 ils_cutover_in_progress: false
+disable_release_prior_to_ils_cutover: false


### PR DESCRIPTION
# Why was this change made?

Fixes #4097

This commit changes what was done in #4086 to disable releases to SearchWorks not *during* the cutover, but immediately *prior* to the cutover.

# How was this change tested?

CI

# Does your change introduce accessibility violations?

No.
