### PR TITLE
Update settings.yml for FOLIO cutover

### DIFF
--- a/app/components/show/controls_component.rb
+++ b/app/components/show/controls_component.rb
@@ -57,7 +57,7 @@ module Show
     private
 
     def manage_release
-      render ActionButton.new(url: item_manage_release_path(druid), label: "Manage release", open_modal: true)
+      render ActionButton.new(url: item_manage_release_path(druid), label: "Manage release", open_modal: true) unless Settings.disable_release_prior_to_ils_cutover
     end
 
     def apply_apo_defaults

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -102,4 +102,4 @@ enabled_features:
   folio: false
 
 ils_cutover_in_progress: false
-disable_release_prior_to_ils_cutover: false
+disable_release_prior_to_ils_cutover: true

--- a/spec/components/show/controls_component_spec.rb
+++ b/spec/components/show/controls_component_spec.rb
@@ -38,13 +38,13 @@ RSpec.describe Show::ControlsComponent, type: :component do
         expect(page).to have_link "Publish", href: "/items/druid:kv840xx0000/publish"
         expect(page).to have_link "Unpublish", href: "/items/druid:kv840xx0000/publish"
         expect(rendered.css("a.disabled[data-turbo-confirm][data-turbo-method='delete'][href='/items/druid:kv840xx0000/purge']").inner_text).to eq "Purge"
-        expect(page).to have_link "Manage release", href: "/items/druid:kv840xx0000/manage_release"
+        # TODO: Renable after FOLIO cutover - expect(page).to have_link "Manage release", href: "/items/druid:kv840xx0000/manage_release"
         expect(page).to have_link "Create embargo", href: "/items/druid:kv840xx0000/embargo/new"
         expect(rendered.css("a[data-turbo-method='post'][href='/items/druid:kv840xx0000/apply_apo_defaults']").inner_text).to eq "Apply APO defaults"
         expect(page).to have_link "Download Cocina spreadsheet", href: "/items/druid:kv840xx0000/descriptive.csv"
         expect(page).to have_link "Upload Cocina spreadsheet", href: "/items/druid:kv840xx0000/descriptive/edit"
 
-        expect(rendered.css("a").size).to eq 10
+        expect(rendered.css("a").size).to eq 9
         expect(rendered.css("a.disabled").size).to eq 3 # purge, publish/unpublish are disabled
       end
 
@@ -63,7 +63,7 @@ RSpec.describe Show::ControlsComponent, type: :component do
           expect(page).to have_link "Refresh", href: "/items/druid:kv840xx0000/refresh_metadata"
           expect(page).to have_link "Manage serials", href: "/items/druid:kv840xx0000/serials/edit"
 
-          expect(rendered.css("a").size).to eq 12
+          expect(rendered.css("a").size).to eq 11
         end
 
         context "when ILS cutover flag is enabled" do # rubocop:disable RSpec/NestedGroups
@@ -91,7 +91,7 @@ RSpec.describe Show::ControlsComponent, type: :component do
         expect(page).to have_link "Publish", href: "/items/druid:kv840xx0000/publish"
         expect(page).to have_link "Unpublish", href: "/items/druid:kv840xx0000/publish"
         expect(rendered.css("a.disabled[data-turbo-confirm][data-turbo-method='delete'][href='/items/druid:kv840xx0000/purge']").inner_text).to eq "Purge"
-        expect(page).to have_link "Manage release", href: "/items/druid:kv840xx0000/manage_release"
+        # TODO: Renable after FOLIO cutover - expect(page).to have_link "Manage release", href: "/items/druid:kv840xx0000/manage_release"
         expect(page).to have_link "Download Cocina spreadsheet", href: "/items/druid:kv840xx0000/descriptive.csv"
         expect(page).not_to have_link "Upload Cocina spreadsheet", href: "/items/druid:kv840xx0000/descriptive/edit"
 
@@ -99,7 +99,7 @@ RSpec.describe Show::ControlsComponent, type: :component do
         expect(page).to have_css "a.disabled", text: "Create embargo"
         expect(page).to have_css "a.disabled", text: "Apply APO defaults"
 
-        expect(rendered.css("a").size).to eq 9
+        expect(rendered.css("a").size).to eq 8
         expect(rendered.css("a.disabled").size).to eq 5 # create embargo, apply APO defaults, purge, publish/unpublish are disabled
       end
     end
@@ -147,7 +147,7 @@ RSpec.describe Show::ControlsComponent, type: :component do
 
     it "renders the appropriate buttons" do
       expect(page).to have_link "Reindex", href: "/dor/reindex/druid:kv840xx0000"
-      expect(page).to have_link "Manage release", href: "/items/druid:kv840xx0000/manage_release"
+      # TODO: Renable after FOLIO cutover - expect(page).to have_link "Manage release", href: "/items/druid:kv840xx0000/manage_release"
       expect(page).to have_link "Add workflow", href: "/items/druid:kv840xx0000/workflows/new"
       expect(page).to have_link "Publish"
       expect(page).to have_link "Unpublish"
@@ -156,7 +156,7 @@ RSpec.describe Show::ControlsComponent, type: :component do
       expect(page).to have_link "Download Cocina spreadsheet", href: "/items/druid:kv840xx0000/descriptive.csv"
       expect(page).to have_link "Upload Cocina spreadsheet", href: "/items/druid:kv840xx0000/descriptive/edit"
 
-      expect(rendered.css("a").size).to eq 9
+      expect(rendered.css("a").size).to eq 8
     end
 
     context "when the collection has a catalog record ID" do
@@ -166,7 +166,7 @@ RSpec.describe Show::ControlsComponent, type: :component do
         expect(page).to have_link "Refresh", href: "/items/druid:kv840xx0000/refresh_metadata"
         expect(page).not_to have_link "Manage serials", href: "/items/druid:kv840xx0000/serials/edit"
 
-        expect(rendered.css("a").size).to eq 10
+        expect(rendered.css("a").size).to eq 9
       end
     end
   end

--- a/spec/features/bulk_desc_metadata_download_spec.rb
+++ b/spec/features/bulk_desc_metadata_download_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe "Bulk Descriptive Metadata Download", js: true do
     sign_in current_user
   end
 
-  it "New page has a populate druids button and div with last search" do
+  # TODO: This test is disabled temporarily during the FOLIO Cutover
+  it "New page has a populate druids button and div with last search", pending: "FOLIO Cutover" do
     visit search_catalog_path q: "stanford"
     within ".search-widgets" do
       click_link "Bulk Actions"

--- a/spec/features/bulk_release_object_spec.rb
+++ b/spec/features/bulk_release_object_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe "Bulk Object Release", js: true do
     sign_in current_user
   end
 
-  it "Creates a new jobs" do
+  # TODO: This test is disabled temporarily during the FOLIO Cutover
+  it "Creates a new jobs", pending: "FOLIO Cutover" do
     visit new_bulk_action_path
     select "Manage release"
     fill_in "Druids to perform bulk action on", with: "druid:ab123gg7777"

--- a/spec/features/collection_manage_release_spec.rb
+++ b/spec/features/collection_manage_release_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Collection manage release" do
   let(:uber_apo_id) { "druid:hv992ry2431" }
   let(:collection_id) { "druid:gg232vv1111" }
 
-  it "Has a manage release button" do
+  it "Has a manage release button", pending: "FOLIO Cutover" do
     visit solr_document_path(collection_id)
     expect(page).to have_css "a", text: "Manage release"
   end

--- a/spec/features/item_manage_release_spec.rb
+++ b/spec/features/item_manage_release_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Item manage release" do
     FactoryBot.create_for_repository(:persisted_item)
   end
 
-  it "has a manage release button" do
+  it "has a manage release button", pending: "FOLIO Cutover" do
     visit solr_document_path(item.externalIdentifier)
     expect(page).to have_css "a", text: "Manage release"
   end


### PR DESCRIPTION
set `disable_release_prior_to_ils_cutover` to true

# Why was this change made? 🤔



# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡


# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



