### PR TITLE
override styles for error and note text

### DIFF
--- a/app/assets/stylesheets/document.scss
+++ b/app/assets/stylesheets/document.scss
@@ -35,11 +35,13 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .errortext {
-  color: red;
+ color: red;
+ --bs-table-color: red; // override bootstrap table text color
 }
 
 .notetext {
   color: green;
+  --bs-table-color: green;  // override bootstrap table text color
 }
 
 .clear {


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #4066 - ensure error message and note colors do not have their colors overridden


![Screen Shot 2023-08-23 at 11 50 56 AM](https://github.com/sul-dlss/argo/assets/47137/a03eaa38-439c-4fc3-be6d-c35784c83b90)

# How was this change tested? 🤨

Localhost