### PR TITLE
Add header to registration report

### DIFF
--- a/app/views/registrations/create_status.html.erb
+++ b/app/views/registrations/create_status.html.erb
@@ -4,6 +4,16 @@
 <div class="row">
   <div class="col-sm-4">
     <table class="table">
+      <thead>
+        <tr>
+          <th>DRUID</th>
+          <th>Barcode</th>
+          <th><%= CatalogRecordId.label %></th>
+          <th>Source ID</th>
+          <th>Label</th>
+        </tr>
+      </thead>
+      <tbody>
       <% @registration_form.created.each do |dro| %>
         <tr>
           <td><%= link_to Druid.new(dro).without_namespace, solr_document_path(dro.externalIdentifier) %></td>
@@ -13,6 +23,7 @@
           <td><%= dro.label %></td>
         </tr>
       <% end %>
+      </tbody>
     </table>
   </div>
 </div>


### PR DESCRIPTION
# Why was this change made? 🤔

Related to #4104 (though not a fix for it) -- just adds a header to the registration output to make it clear that barcode and folio instance HRID may be blank.  As you can see elsewhere in the code, the barcode and catkey/instance HRID are already in the output (just blank sometimes). 

Copying and pasting the data into Excel or google sheets preserves the blank columns.

~~HOLD pending review by Andrew~~

<img width="638" alt="Screen Shot 2023-08-28 at 10 25 58 AM" src="https://github.com/sul-dlss/argo/assets/47137/5434f987-7d3b-4cd9-be27-1b38a0e56b98">

# How was this change tested? 🤨

Localhost