### PR TITLE
add columns to registration job report output

### DIFF
--- a/spec/jobs/register_druids_job_spec.rb
+++ b/spec/jobs/register_druids_job_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe RegisterDruidsJob do
   let(:response) { Success(model) }
   let(:fake_log) { double("logger", puts: nil) }
   let(:catalog_link) do
-    instance_double(Cocina::Models::FolioCatalogLink, catalog: "folio", catalogRecordId: "in12345", refresh: true)
+    Cocina::Models::FolioCatalogLink.new(catalog: "folio", catalogRecordId: "in12345", refresh: true)
   end
   let(:identification) do
-    instance_double(Cocina::Models::Identification, barcode: "12345", catalogLinks: [catalog_link], sourceId: "foo:bar1")
+    Cocina::Models::Identification.new(barcode: "36105010101010", catalogLinks: [catalog_link], sourceId: "foo:bar1")
   end
 
   let(:model) do
@@ -86,7 +86,7 @@ RSpec.describe RegisterDruidsJob do
           workflow: "accessionWF")
         expect(fake_log).to have_received(:puts).with(/Successfully registered druid:123/).twice
         expect(bulk_action.druid_count_success).to eq 2
-        expect(File.read(csv_filepath)).to eq("Druid,Barcode,Folio Instance HRID,Source Id,Label\n123,12345,in12345,foo:bar1,My object\n123,12345,in12345,foo:bar1,My object\n")
+        expect(File.read(csv_filepath)).to eq("Druid,Barcode,Folio Instance HRID,Source Id,Label\n123,36105010101010,in12345,foo:bar1,My object\n123,36105010101010,in12345,foo:bar1,My object\n")
       end
     end
 

--- a/spec/jobs/register_druids_job_spec.rb
+++ b/spec/jobs/register_druids_job_spec.rb
@@ -10,8 +10,11 @@ RSpec.describe RegisterDruidsJob do
   let(:bulk_action) { create(:bulk_action) }
   let(:response) { Success(model) }
   let(:fake_log) { double("logger", puts: nil) }
+  let(:catalog_link) do
+    instance_double(Cocina::Models::FolioCatalogLink, catalog: "folio", catalogRecordId: "in12345", refresh: true)
+  end
   let(:identification) do
-    instance_double(Cocina::Models::Identification, sourceId: "foo:bar1")
+    instance_double(Cocina::Models::Identification, barcode: "12345", catalogLinks: [catalog_link], sourceId: "foo:bar1")
   end
 
   let(:model) do
@@ -83,7 +86,7 @@ RSpec.describe RegisterDruidsJob do
           workflow: "accessionWF")
         expect(fake_log).to have_received(:puts).with(/Successfully registered druid:123/).twice
         expect(bulk_action.druid_count_success).to eq 2
-        expect(File.read(csv_filepath)).to eq("Druid,Source Id,Label\n123,foo:bar1,My object\n123,foo:bar1,My object\n")
+        expect(File.read(csv_filepath)).to eq("Druid,Barcode,Folio Instance HRID,Source Id,Label\n123,12345,in12345,foo:bar1,My object\n123,12345,in12345,foo:bar1,My object\n")
       end
     end
 


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #4104 - the output of the registration bulk job should include the same columns that are shown on the webpage you get when registering objects

Todo: 
- [x] fix tests

# How was this change tested? 🤨

Localhost and CI