### PR TITLE
update csv registration template to match form

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -81,7 +81,7 @@ class RegistrationsController < ApplicationController
     respond_to do |format|
       format.csv do
         csv_template = CSV.generate do |csv|
-          csv << ["source_id", CatalogRecordId.label.downcase.tr(" ", "_"), "barcode", "label"]
+          csv << ["barcode", CatalogRecordId.label.downcase.tr(" ", "_"), "source_id", "label"]
         end
         send_data csv_template, filename: "registration.csv"
       end


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #4103 - make CSV registration template have the same columns in the same order as the registration form (even though the order of the columns doesn't really matter when registering, we want to be consistent)

Todo: 
- [x] verify that order of CSV columns doesn't matter

# How was this change tested? 🤨

Localhost