### PR TITLE
Add orcid and doi facets (and to detail page)

### DIFF
--- a/app/components/show/item/details_component.html.erb
+++ b/app/components/show/item/details_component.html.erb
@@ -68,12 +68,12 @@
         <tr>
           <th class="col-3" scope="row">DOI</th>
           <td>
-            <%= doi.join(', ') %>
+            <%= doi %>
           </td>
         </tr>
       <% end %>
 
-      <% if orcids %>
+      <% unless orcids.blank? %>
         <tr>
           <th class="col-3" scope="row">Contributor ORCIDs</th>
           <td>

--- a/app/components/show/item/details_component.html.erb
+++ b/app/components/show/item/details_component.html.erb
@@ -64,6 +64,24 @@
         </td>
       </tr>
 
+      <% if doi %>
+        <tr>
+          <th class="col-3" scope="row">DOI</th>
+          <td>
+            <%= doi.join(', ') %>
+          </td>
+        </tr>
+      <% end %>
+
+      <% if orcids %>
+        <tr>
+          <th class="col-3" scope="row">Contributor ORCIDs</th>
+          <td>
+            <%= orcids.join(', ') %>
+          </td>
+        </tr>
+      <% end %>
+
       <tr>
         <th class="col-3" scope="row">Tags</th>
         <td>

--- a/app/components/show/item/details_component.rb
+++ b/app/components/show/item/details_component.rb
@@ -13,7 +13,7 @@ module Show
         !@presenter.cocina.is_a? NilModel
       end
 
-      delegate :object_type, :created_date, :preservation_size, to: :@solr_document
+      delegate :object_type, :created_date, :preservation_size, :doi, :orcids, to: :@solr_document
       delegate :state_service, to: :@presenter
 
       def catalog_record_id_label

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -145,6 +145,15 @@ class CatalogController < ApplicationController
     # This will help us find records that need to be fixed before we can move to cocina.
     config.add_facet_field "data_quality_ssim", label: "Data Quality", home: false, component: true
 
+    config.add_facet_field "identifiers", label: "Identifiers",
+      component: true,
+      query: {
+        has_orcids: {label: "Has contributor ORCIDs", fq: "+contributor_orcids_ssim:*"},
+        has_doi: {label: "Has DOI", fq: "+doi_ssim:*"},
+        has_barcode: {label: "Has barcode", fq: "+barcode_id_ssim:*"},
+        has_folio_hrid: {label: "Has Folio instance HRIDs", fq: "+folio_instance_hrid_ssim:*"}
+      }
+
     config.add_facet_field "empties", label: "Empty Fields", home: false,
       component: true,
       query: {

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -150,8 +150,7 @@ class CatalogController < ApplicationController
       query: {
         has_orcids: {label: "Has contributor ORCIDs", fq: "+contributor_orcids_ssim:*"},
         has_doi: {label: "Has DOI", fq: "+doi_ssim:*"},
-        has_barcode: {label: "Has barcode", fq: "+barcode_id_ssim:*"},
-        has_folio_hrid: {label: "Has Folio instance HRIDs", fq: "+folio_instance_hrid_ssim:*"}
+        has_barcode: {label: "Has barcode", fq: "+barcode_id_ssim:*"}
       }
 
     config.add_facet_field "empties", label: "Empty Fields", home: false,

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -52,7 +52,7 @@ class SolrDocument
   attribute :catkey, Blacklight::Types::String, FIELD_CATKEY_ID
   attribute :folio_instance_hrid, Blacklight::Types::String, FIELD_FOLIO_INSTANCE_HRID
   attribute :doi, Blacklight::Types::String, FIELD_DOI
-  attribute :orcids, Blacklight::Types::String, FIELD_ORCIDS
+  attribute :orcids, Blacklight::Types::Array, FIELD_ORCIDS
   attribute :current_version, Blacklight::Types::String, FIELD_CURRENT_VERSION
   attribute :embargo_status, Blacklight::Types::String, FIELD_EMBARGO_STATUS
   attribute :embargo_release_date, Blacklight::Types::Date, FIELD_EMBARGO_RELEASE_DATE

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -11,6 +11,8 @@ class SolrDocument
   FIELD_EMBARGO_RELEASE_DATE = :embargo_release_dtsim
   FIELD_CATKEY_ID = :catkey_id_ssim
   FIELD_FOLIO_INSTANCE_HRID = :folio_instance_hrid_ssim
+  FIELD_DOI = :doi_ssim
+  FIELD_ORCIDS = :contributor_orcids_ssim
   FIELD_CREATED_DATE = :created_at_dttsi
   FIELD_REGISTERED_DATE = :registered_dttsim
   FIELD_LAST_ACCESSIONED_DATE = :accessioned_latest_dttsi
@@ -49,6 +51,8 @@ class SolrDocument
   attribute :content_type, Blacklight::Types::String, FIELD_CONTENT_TYPE
   attribute :catkey, Blacklight::Types::String, FIELD_CATKEY_ID
   attribute :folio_instance_hrid, Blacklight::Types::String, FIELD_FOLIO_INSTANCE_HRID
+  attribute :doi, Blacklight::Types::String, FIELD_DOI
+  attribute :orcids, Blacklight::Types::String, FIELD_ORCIDS
   attribute :current_version, Blacklight::Types::String, FIELD_CURRENT_VERSION
   attribute :embargo_status, Blacklight::Types::String, FIELD_EMBARGO_STATUS
   attribute :embargo_release_date, Blacklight::Types::Date, FIELD_EMBARGO_RELEASE_DATE

--- a/spec/components/show/item/details_component_spec.rb
+++ b/spec/components/show/item/details_component_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Show::Item::DetailsComponent, type: :component do
     SolrDocument.new("id" => "druid:kv840xx0000",
       SolrDocument::FIELD_REGISTERED_DATE => ["2012-04-05T01:00:04.148Z"],
       SolrDocument::FIELD_OBJECT_TYPE => object_type,
-      SolrDocument::FIELD_DOI => ["doi-12345"],
-      SolrDocument::FIELD_ORCIDS => ["orcid/123-1234-123-1234"])
+      SolrDocument::FIELD_DOI => ["10.25740/yr775yn6440"],
+      SolrDocument::FIELD_ORCIDS => ["0000-0002-7262-6251"])
   end
   let(:object_type) { "item" }
 

--- a/spec/components/show/item/details_component_spec.rb
+++ b/spec/components/show/item/details_component_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Show::Item::DetailsComponent, type: :component do
     SolrDocument.new("id" => "druid:kv840xx0000",
       SolrDocument::FIELD_REGISTERED_DATE => ["2012-04-05T01:00:04.148Z"],
       SolrDocument::FIELD_OBJECT_TYPE => object_type,
-      SolrDocument::FIELD_DOI => ["10.25740/yr775yn6440"],
-      SolrDocument::FIELD_ORCIDS => ["0000-0002-7262-6251"])
+      SolrDocument::FIELD_DOI => "10.25740/yr775yn6440",
+      SolrDocument::FIELD_ORCIDS => ["0000-0002-7262-6251", "0000-0002-7262-999X"])
   end
   let(:object_type) { "item" }
 
@@ -40,8 +40,8 @@ RSpec.describe Show::Item::DetailsComponent, type: :component do
     end
 
     it "includes doi and orcid when available" do
-      expect(rendered.to_html).to include "doi-12345"
-      expect(rendered.to_html).to include "orcid/123-1234-123-1234"
+      expect(rendered.to_html).to include "10.25740/yr775yn6440"
+      expect(rendered.to_html).to include "0000-0002-7262-6251, 0000-0002-7262-999X"
     end
   end
 

--- a/spec/components/show/item/details_component_spec.rb
+++ b/spec/components/show/item/details_component_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe Show::Item::DetailsComponent, type: :component do
   let(:doc) do
     SolrDocument.new("id" => "druid:kv840xx0000",
       SolrDocument::FIELD_REGISTERED_DATE => ["2012-04-05T01:00:04.148Z"],
-      SolrDocument::FIELD_OBJECT_TYPE => object_type)
+      SolrDocument::FIELD_OBJECT_TYPE => object_type,
+      SolrDocument::FIELD_DOI => ["doi-12345"],
+      SolrDocument::FIELD_ORCIDS => ["orcid/123-1234-123-1234"])
   end
   let(:object_type) { "item" }
 
@@ -35,6 +37,11 @@ RSpec.describe Show::Item::DetailsComponent, type: :component do
       expect(rendered.to_html).to include "Preservation size"
       expect(rendered.to_html).to include "Content type"
       expect(rendered.css("a[aria-label='Edit tags']")).to be_present
+    end
+
+    it "includes doi and orcid when available" do
+      expect(rendered.to_html).to include "doi-12345"
+      expect(rendered.to_html).to include "orcid/123-1234-123-1234"
     end
   end
 


### PR DESCRIPTION
# Why was this change made? 🤔

Fix for #4096 (but also need https://github.com/sul-dlss/dor_indexing_app/pull/986 first to ensure these fields gets indexed).

- Adds a new "Indentifiers" facet that will show you any objects with a DOI or with contributors have ORCIDs.  Also added items with a barcode or folio_instance_hrid to this facet since they are already in solr anyway.  I know there is a separate "metadata source" facet that sort of duplicates this, but perhaps this is useful here too?
- Adds the DOI and ORCIDs to the show page (if they exist in the object).  Not in the ticket, but potentially useful and already in solr with the indexing work.

**New facet:**
![Screen Shot 2023-08-30 at 11 13 27 AM](https://github.com/sul-dlss/argo/assets/47137/0b9abd2b-43ca-4b7f-8262-18b4ca77a694)

**Additions to detail page** (note, the fields only show when in the record, else the table is as current):
![Screen Shot 2023-08-30 at 11 13 37 AM](https://github.com/sul-dlss/argo/assets/47137/3f40f84e-3dd0-4b4a-8926-5a37f32ad0d3)



Todo:
- [x] test with indexer changes on stage or QA
- [x] validate with Andrew

# How was this change tested? 🤨

Localhost and stage