### PR TITLE
Change checksum report job to make multiple calls to pres cat.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem "dor-services-client", "~> 12.5"
 gem "dor-workflow-client", "~> 6.0"
 gem "druid-tools"
 gem "mods_display", "~> 1.0"
-gem "preservation-client", "~> 6.0"
+gem "preservation-client", "~> 6.2"
 gem "rsolr"
 gem "sdr-client", "~> 2.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -390,7 +390,7 @@ GEM
       ttfunk (~> 1.4.0)
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
-    preservation-client (6.1.0)
+    preservation-client (6.2.0)
       activesupport (>= 4.2, < 8)
       faraday (~> 2.0)
       moab-versioning (>= 5.0.0, < 7)
@@ -674,7 +674,7 @@ DEPENDENCIES
   openapi_parser (< 1.0)
   prawn (~> 1)
   prawn-table
-  preservation-client (~> 6.0)
+  preservation-client (~> 6.2)
   propshaft
   pry
   pry-byebug


### PR DESCRIPTION
closes #1997

# Why was this change made? 🤔
To allow checksum report job to handle large numbers of druids.


# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other SDR APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

⚡ ⚠ If this change updates the Argo UI, run all integration tests that use Argo and create a PR on the integration test repo to fix anything this change breaks. ⚡

Unit, QA, Andrew

# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



