### PR TITLE
No more browsertools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ version: 2.1
 orbs:
   ruby: circleci/ruby@2.1.0
   node: circleci/node@5.1.0
-  browser-tools: circleci/browser-tools@1.4.4
 
 references:
   default_ruby_version: &default_ruby_version 3.2.2-browsers
@@ -211,7 +210,6 @@ jobs:
     executor: ruby_with_all_deps
     steps:
       - checkout
-      - browser-tools/install-chrome
       - ruby/install-deps:
           key: gems-v2
       - node/install-packages:


### PR DESCRIPTION
# Why was this change made? 🤔

As of Selenium v4 it ships with a browser: https://www.selenium.dev/documentation/selenium_manager/

# How was this change tested? 🤨

CI

# Does your change introduce accessibility violations? 🩺

No



