### PR TITLE
[HOLD] use the previously accessioned version when downloading all files

### DIFF
--- a/app/components/contents_component.html.erb
+++ b/app/components/contents_component.html.erb
@@ -7,7 +7,7 @@
   <div id="document-contents-section" class="accordion-collapse collapse show" aria-labelledby="document-contents-heading">
     <div class="accordion-body" data-controller="structural">
       <div class="mb-3">
-        <%= render DownloadAllButtonComponent.new(document: @document) %>
+        <%= render DownloadAllButtonComponent.new(cocina: @cocina, document: @document) %>
         <% if allows_modification? %>
           <%= button_tag class: 'btn btn-link float-end', data: { action: 'click->structural#open' } do %>
             <span class="bi-upload"></span> Upload CSV

--- a/app/components/download_all_button_component.rb
+++ b/app/components/download_all_button_component.rb
@@ -2,8 +2,9 @@
 
 class DownloadAllButtonComponent < ViewComponent::Base
   # @param [SolrDocument] document
-  def initialize(document:)
+  def initialize(cocina:, document:)
     @document = document
+    @cocina = cocina
   end
 
   def link_options
@@ -12,6 +13,10 @@ class DownloadAllButtonComponent < ViewComponent::Base
     return options if !document.preservation_size || document.preservation_size < 1_000_000_000
 
     options.merge(data: {turbo_confirm: "This will be a large download. Are you sure?"})
+  end
+
+  def render?
+    StateService.new(@cocina).accessioned?
   end
 
   attr_reader :document

--- a/app/services/state_service.rb
+++ b/app/services/state_service.rb
@@ -39,6 +39,13 @@ class StateService
     STATES[:unlock_inactive]
   end
 
+  ##
+  # Ported over logic from app/helpers/dor_object_helper.rb#LN133
+  # @return [Boolean]
+  def accessioned?
+    @accessioned ||= lifecycle("accessioned") ? true : false
+  end
+
   private
 
   attr_reader :druid, :version
@@ -57,13 +64,6 @@ class StateService
 
   def submitted?
     @submitted ||= active_lifecycle("submitted")
-  end
-
-  ##
-  # Ported over logic from app/helpers/dor_object_helper.rb#LN133
-  # @return [Boolean]
-  def accessioned?
-    @accessioned ||= lifecycle("accessioned") ? true : false
   end
 
   def active_assembly_wf?

--- a/spec/components/download_all_button_component_spec.rb
+++ b/spec/components/download_all_button_component_spec.rb
@@ -6,19 +6,37 @@ RSpec.describe DownloadAllButtonComponent, type: :component do
   include Rails.application.routes.url_helpers
   subject { page }
 
+  let(:cocina) { build(:dro) }
   let(:document) { instance_double(SolrDocument, preservation_size: 0) }
-  let(:component) { described_class.new(document:) }
+  let(:component) { described_class.new(document:, cocina:) }
+  let(:state_service) { instance_double(StateService) }
 
   before do
-    render_inline(component)
+    allow(StateService).to receive(:new).and_return(state_service)
   end
 
-  it { is_expected.to have_link "Download all files", href: download_item_files_path(document) }
-  it { is_expected.to have_selector 'a[onclick="event.stopPropagation()"]' }
+  context "when accessioned" do
+    before do
+      allow(state_service).to receive(:accessioned?).and_return(true)
+      render_inline(component)
+    end
 
-  context "with a large file" do
-    let(:document) { instance_double(SolrDocument, preservation_size: 1_000_000_000) }
+    it { is_expected.to have_link "Download all files", href: download_item_files_path(document) }
+    it { is_expected.to have_selector 'a[onclick="event.stopPropagation()"]' }
 
-    it { is_expected.to have_selector 'a[data-turbo-confirm="This will be a large download. Are you sure?"]' }
+    context "with a large file" do
+      let(:document) { instance_double(SolrDocument, preservation_size: 1_000_000_000) }
+
+      it { is_expected.to have_selector 'a[data-turbo-confirm="This will be a large download. Are you sure?"]' }
+    end
+  end
+
+  context "when not accessioned" do
+    before do
+      allow(state_service).to receive(:accessioned?).and_return(false)
+      render_inline(component)
+    end
+
+    it { is_expected.not_to have_link "Download all files", href: download_item_files_path(document) }
   end
 end

--- a/spec/features/enable_buttons_spec.rb
+++ b/spec/features/enable_buttons_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Enable buttons" do
     solr_conn.add(id: item_id, objectType_ssim: "item")
     solr_conn.commit
     allow(StateService).to receive(:new).and_return(state_service)
-    allow(state_service).to receive_messages(published?: true, object_state: :unlock)
+    allow(state_service).to receive_messages(published?: true, object_state: :unlock, accessioned?: true)
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
   end
 

--- a/spec/features/item_catalog_record_id_change_spec.rb
+++ b/spec/features/item_catalog_record_id_change_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Item catalog_record_id change" do
   describe "when modification is not allowed" do
     let(:item) { FactoryBot.create_for_repository(:persisted_item) }
     let(:druid) { item.externalIdentifier }
-    let(:state_service) { instance_double(StateService, allows_modification?: false) }
+    let(:state_service) { instance_double(StateService, allows_modification?: false, accessioned?: false) }
 
     it "cannot change the catalog_record_id" do
       visit edit_item_catalog_record_id_path druid
@@ -29,7 +29,7 @@ RSpec.describe "Item catalog_record_id change" do
     let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
     let(:druid) { "druid:kv840xx0000" }
     let(:cocina_model) { build(:dro_with_metadata, id: druid) }
-    let(:state_service) { instance_double(StateService, allows_modification?: true) }
+    let(:state_service) { instance_double(StateService, allows_modification?: true, accessioned?: true) }
     let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
     let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
     let(:object_client) do

--- a/spec/features/item_manage_release_spec.rb
+++ b/spec/features/item_manage_release_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Item manage release" do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
   end
 
-  let(:state_service) { instance_double(StateService, allows_modification?: true) }
+  let(:state_service) { instance_double(StateService, allows_modification?: true, accessioned?: true) }
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
   let(:object_client) do

--- a/spec/features/item_source_id_change_spec.rb
+++ b/spec/features/item_source_id_change_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Item source id change" do
   describe "when modification is not allowed" do
     let(:item) { FactoryBot.create_for_repository(:persisted_item) }
     let(:druid) { item.externalIdentifier }
-    let(:state_service) { instance_double(StateService, allows_modification?: false) }
+    let(:state_service) { instance_double(StateService, allows_modification?: false, accessioned?: false) }
 
     it "cannot change the source id" do
       visit source_id_ui_item_path druid
@@ -29,7 +29,7 @@ RSpec.describe "Item source id change" do
     let(:cocina_model) do
       build(:dro_with_metadata, id: druid)
     end
-    let(:state_service) { instance_double(StateService, allows_modification?: true) }
+    let(:state_service) { instance_double(StateService, allows_modification?: true, accessioned?: true) }
     let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
     let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
     let(:object_client) do

--- a/spec/features/set_governing_apo_spec.rb
+++ b/spec/features/set_governing_apo_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Set governing APO" do
   end
 
   let(:identity_md) { instance_double(Nokogiri::XML::Document, xpath: []) }
-  let(:state_service) { instance_double(StateService, allows_modification?: true) }
+  let(:state_service) { instance_double(StateService, allows_modification?: true, accessioned?: true) }
 
   let(:item) do
     FactoryBot.create_for_repository(:persisted_item, label: "Foo", title: "Test")

--- a/spec/requests/files_spec.rb
+++ b/spec/requests/files_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe "Files" do
   let(:druid) { "druid:bc123df4567" }
   let(:user) { create(:user) }
   let(:cocina_model) do
-    instance_double(Cocina::Models::DROWithMetadata, externalIdentifier: druid, structural:)
+    instance_double(Cocina::Models::DROWithMetadata, externalIdentifier: druid, structural:, version: mock_version)
   end
+  let(:mock_version) { 4 }
   let(:file_set) do
     instance_double(Cocina::Models::FileSet, structural: fs_structural)
   end

--- a/spec/requests/item_files_download_spec.rb
+++ b/spec/requests/item_files_download_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe "Download item files" do
     model = Cocina::Models.build(cocina_params.stringify_keys)
     Cocina::Models.with_metadata(model, "abc123")
   end
+  let(:state_service) { instance_double(StateService) }
+
   let(:cocina_params) do
     {
       type: Cocina::Models::ObjectType.image,
@@ -119,6 +121,7 @@ RSpec.describe "Download item files" do
 
   before do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+    allow(Preservation::Client.objects).to receive(:current_version).and_return(4)
     sign_in user
   end
 

--- a/spec/services/state_service_spec.rb
+++ b/spec/services/state_service_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe StateService do
   let(:service) { described_class.new(cocina) }
 
   describe "#allows_modification?" do
-    subject(:allows_modification?) { service.allows_modification? }
-
     before do
       allow(service).to receive(:object_state).and_return(:unlock)
     end
@@ -27,7 +25,7 @@ RSpec.describe StateService do
       end
 
       it "returns true" do
-        expect(subject).to be true
+        expect(service).to be_allows_modification
       end
     end
 
@@ -37,7 +35,7 @@ RSpec.describe StateService do
       end
 
       it "returns true" do
-        expect(subject).to be true
+        expect(service).to be_allows_modification
       end
     end
 
@@ -47,7 +45,7 @@ RSpec.describe StateService do
       end
 
       it "returns false" do
-        expect(subject).to be false
+        expect(service).not_to be_allows_modification
       end
     end
 
@@ -57,14 +55,12 @@ RSpec.describe StateService do
       end
 
       it "returns false" do
-        expect(subject).to be false
+        expect(service).not_to be_allows_modification
       end
     end
   end
 
   describe "#object_state" do
-    subject(:object_state) { service.object_state }
-
     context "if the object is not opened and hasn't been submitted" do
       before do
         allow(workflow_client).to receive(:active_lifecycle).with(druid:, milestone_name: "submitted", version: 3).and_return(false)
@@ -72,7 +68,7 @@ RSpec.describe StateService do
       end
 
       it "returns unlock_inactive" do
-        expect(subject).to eq :unlock_inactive
+        expect(service.object_state).to eq :unlock_inactive
       end
     end
 
@@ -83,7 +79,7 @@ RSpec.describe StateService do
       end
 
       it "returns unlock" do
-        expect(subject).to be :unlock
+        expect(service.object_state).to eq :unlock
       end
     end
 
@@ -94,7 +90,7 @@ RSpec.describe StateService do
       end
 
       it "returns lock_inactive" do
-        expect(subject).to be :lock_inactive
+        expect(service.object_state).to eq :lock_inactive
       end
     end
 
@@ -106,14 +102,12 @@ RSpec.describe StateService do
       end
 
       it "returns lock" do
-        expect(subject).to be :lock
+        expect(service.object_state).to eq :lock
       end
     end
   end
 
   describe "#published?" do
-    subject(:published?) { service.published? }
-
     before do
       allow(workflow_client).to receive(:workflow_status).with(druid:, process: "accessioning-initiate", workflow: "assemblyWF").and_return("completed")
       allow(workflow_client).to receive(:lifecycle).with(druid:, milestone_name: "accessioned").and_return(false)
@@ -125,7 +119,7 @@ RSpec.describe StateService do
       end
 
       it "returns true" do
-        expect(subject).to be true
+        expect(service).to be_published
       end
     end
 
@@ -135,21 +129,19 @@ RSpec.describe StateService do
       end
 
       it "returns false" do
-        expect(subject).to be false
+        expect(service).not_to be_published
       end
     end
   end
 
   describe "#accessioned?" do
-    subject(:accessioned?) { service.accessioned? }
-
     context "if the accessioned lifecycle exists" do
       before do
         allow(workflow_client).to receive(:lifecycle).with(druid:, milestone_name: "accessioned").and_return("2022-04-20 21:55:25 +0000")
       end
 
       it "returns true" do
-        expect(subject).to be true
+        expect(service).to be_accessioned
       end
     end
 
@@ -159,7 +151,7 @@ RSpec.describe StateService do
       end
 
       it "returns false" do
-        expect(subject).to be false
+        expect(service).not_to be_accessioned
       end
     end
   end

--- a/spec/services/state_service_spec.rb
+++ b/spec/services/state_service_spec.rb
@@ -139,4 +139,28 @@ RSpec.describe StateService do
       end
     end
   end
+
+  describe "#accessioned?" do
+    subject(:accessioned?) { service.accessioned? }
+
+    context "if the accessioned lifecycle exists" do
+      before do
+        allow(workflow_client).to receive(:lifecycle).with(druid:, milestone_name: "accessioned").and_return("2022-04-20 21:55:25 +0000")
+      end
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+
+    context "if the accessioned lifecycle does not exist" do
+      before do
+        allow(workflow_client).to receive(:lifecycle).with(druid:, milestone_name: "accessioned").and_return(nil)
+      end
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Why was this change made?

Fixes #4141 - download all files fails when an object is opened for versioning (it looks in preservation for the newly bumped version which doesn't exist yet, instead of the last version in preservation).  This fixes it by using the last preserved version.  

This also removes the "Download all files" link unless there is an accessioned version.  This is because you can only download files once they are in preservation (this is current behavior too).  Currently, the link shows for an v1 object that has never been accessioned, but gives you a blank ZIP file.  This change removes the link (because we now have to ask for the previous version and we may as well just not show the link in this case).

HOLD to verify with Andrew

# How was this change tested?

- [x] Updated specs and localhost.
- [x] Test on stage
- [ ] Validate with Andrew