### PR TITLE
Update base.html.erb

### DIFF
--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -19,7 +19,7 @@
   </head>
   <body class="<%= render_body_class %>">
     <nav id="skip-link" role="navigation" aria-label="<%= t('blacklight.skip_links.label') %>">
-      <%= link_to t('blacklight.skip_links.search_field'), '#search_field', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
+      <%= link_to t('blacklight.skip_links.search_field'), '#q', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
       <%= link_to t('blacklight.skip_links.main_content'), '#main-container', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
       <%= content_for(:skip_links) %>
     </nav>


### PR DESCRIPTION
Fragment links can't be activated if they point to elements on the page that are hidden. This updates the skip to search link to point to the (non-hidden) query input.

# Why was this change made?

Fixes #4159

# How was this change tested?

I edited the href using browser devtools and then tested tab-navigation in browser and was able to activate the link and go to the search field correctly

