### PR TITLE
Update dependencies for cocina-models update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
     capybara-screenshot (1.0.26)
       capybara (>= 1.0, < 4)
       launchy
-    cocina-models (0.91.0)
+    cocina-models (0.91.1)
       activesupport
       deprecation
       dry-struct (~> 1.0)


### PR DESCRIPTION
# Why was this change made?

To allow dor_indexing_app to use stanford-mods, a small, backwards compatible change was made to cocina-models in PR https://github.com/sul-dlss/cocina-models/pull/623, resulting in release 0.91.1

# How was this change tested?

CI and integration tests will be run



