### PR TITLE
argo empty fields facet changed to only show two values

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -156,24 +156,8 @@ class CatalogController < ApplicationController
     config.add_facet_field "empties", label: "Empty Fields", home: false,
       component: true,
       query: {
-        no_source_id: {label: "No Source ID", fq: "-source_id_ssim:*"},
-        no_rights_characteristics: {label: "No Rights Characteristics", fq: "-rights_characteristics_ssim:*"},
-        no_object_title: {label: "No Object Title", fq: "-#{SolrDocument::FIELD_TITLE}:*"},
-        no_collection_title: {label: "No Collection Title", fq: "-#{SolrDocument::FIELD_COLLECTION_TITLE}:*"},
-        no_copyright: {label: "No Copyright", fq: "-#{SolrDocument::FIELD_COPYRIGHT}:*"},
-        no_license: {label: "No License", fq: "-use_license_machine_ssi:*"},
-        no_sw_author_ssim: {label: "No SW Author", fq: "-sw_author_ssim:*"},
-        # TODO: mods extent (?)
-        # TODO: mods form (?)
-        no_sw_genre: {label: "No SW Genre", fq: "-sw_genre_ssim:*"}, # spec said "mods genre"
-        no_sw_language_ssim: {label: "No SW Language", fq: "-sw_language_ssim:*"},
         no_mods_typeOfResource_ssim: {label: "No MODS typeOfResource", fq: "-mods_typeOfResource_ssim:*"},
-        no_sw_pub_date_sort: {label: "No SW Date", fq: "-sw_pub_date_sort_ssi:*"},
-        no_sw_topic_ssim: {label: "No SW Topic", fq: "-sw_topic_ssim:*"},
-        no_sw_subject_temporal: {label: "No SW Era", fq: "-sw_subject_temporal_ssim:*"},
-        no_sw_subject_geographic: {label: "No SW Region", fq: "-sw_subject_geographic_ssim:*"},
-        no_sw_format: {label: "No SW Resource Type", fq: "-sw_format_ssim:*"},
-        no_use_statement: {label: "No Use & Reproduction Statement", fq: "-#{SolrDocument::FIELD_USE_STATEMENT}:*"}
+        no_sw_format: {label: "No SW Resource Type", fq: "-sw_format_ssim:*"}
       }
 
     config.add_facet_field "sw_format_ssim", label: "SW Resource Type", component: true, limit: 10, home: false


### PR DESCRIPTION
keep "No MODS typeOfResource" and "No SW Resource Type", drop all the rest.

# Why was this change made?

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->
closes https://github.com/sul-dlss/dor_indexing_app/issues/998


# How was this change tested?

CI, display of seed data on laptop dev env:
<img width="1541" alt="Screen Shot 2023-09-21 at 9 52 53 AM" src="https://github.com/sul-dlss/argo/assets/7741604/c49a24ad-615d-487d-b7e4-100ffc2495c4">


<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


