### PR TITLE
Adjust padding in description import to allow > 999 contributors.

### DIFF
--- a/app/services/description_import.rb
+++ b/app/services/description_import.rb
@@ -45,7 +45,7 @@ class DescriptionImport
     split_address(address).map do |part|
       next part unless part.is_a?(Integer)
 
-      part.to_s.rjust(3, "0")
+      part.to_s.rjust(4, "0")
     end.join(".")
   end
 


### PR DESCRIPTION
# Why was this change made?

Per Andrew, to account for user data that has large number of contributors.

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?

Unit, Andrew

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


