### PR TITLE
Improve accessibility of landing page

### DIFF
--- a/app/assets/stylesheets/argo.scss
+++ b/app/assets/stylesheets/argo.scss
@@ -1,8 +1,3 @@
-// Here we override blacklight to wrap the $logo-image in a url()
-.navbar-logo {  // The main logo image for the Blacklight instance
-  background: transparent url("logo.png") no-repeat top left;
-}
-
 .topbar.bg-dark {
   @extend .bg-primary; // make the topbar red
 }

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,12 +1,10 @@
-<div id="getting-started">
-  <h1 class="h3">Welcome to Argo!</h1>
-  <% if @presenter.view_something? %>
-    <p>
-      Enter one or more search terms or select a facet on the left to begin.
-    </p>
-  <% else %>
-    <p>
-      You do not appear to have permission to view any items in Argo. Please contact an administrator.
-    </p>
-  <% end %>
-</div>
+<h1 class="h3">Welcome to Argo!</h1>
+<% if @presenter.view_something? %>
+  <p>
+    Enter one or more search terms or select a facet on the left to begin.
+  </p>
+<% else %>
+  <p>
+    You do not appear to have permission to view any items in Argo. Please contact an administrator.
+  </p>
+<% end %>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,0 +1,27 @@
+<nav class="navbar navbar-expand-md navbar-dark bg-dark topbar" role="navigation">
+  <div class="<%= container_classes %>">
+    <%# We override this Blacklight partial in order to replace the navbar-logo rendering,
+        which uses a textual link to home, with an image-based link to home (with appropriate alt text) %>
+    <%= link_to root_path, class: "mb-0 navbar-brand" do %>
+      <%= image_tag("logo.png", alt: "Link to Argo homepage") %>
+    <% end %>
+    <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-bs-toggle="collapse" data-target="#user-util-collapse" data-bs-target="#user-util-collapse" aria-controls="user-util-collapse" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <div class="collapse navbar-collapse justify-content-md-end" id="user-util-collapse">
+      <%= render "shared/user_util_links" %>
+    </div>
+  </div>
+</nav>
+
+<%= content_tag :div, class: "navbar-search navbar navbar-light bg-light", role: "navigation", aria: {label: t("blacklight.search.header")} do %>
+  <div class="<%= container_classes %>">
+    <%= render((blacklight_config&.view_config(document_index_view_type)&.search_bar_component || Blacklight::SearchBarComponent).new(
+          url: search_action_url,
+          advanced_search_url: search_action_url(action: "advanced_search"),
+          params: search_state.params_for_search.except(:qt),
+          autocomplete_path: search_action_path(action: :suggest)
+        )) %>
+  </div>
+<% end %>


### PR DESCRIPTION
# Why was this change made?

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->
Fixes #4160

This commit includes a small number of accessibility-related changes to the homepage / landing page, including:
* Override `_header_navbar`, and remove custom `.navbar-logo` override, to replace how the Argo logo is handled. We do this to continue using the Argo logo in the upper-lefthand corner of the page, but there are two improvements:
  * There is no longer an occluded string in the UI, "Argo", that scanners like Siteimprove complain about not being visible
  * The Argo logo now has alt text
* Bump `Welcome to Argo` header (an `<h1>`) up a level so it is closer to the `<main>` element. The intervening `.getting-started` div was not referenced or used anywhere in Argo or Blacklight, so there is no impact on the look & feel.

It is unclear to me how to further make progress on #4160 without a new set of landing page designs.


# How was this change tested?

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->
- [x] CI
- [x] Accessibility checks improved
