### PR TITLE
add project tag facet with hierarchy

### DIFF
--- a/app/components/lazy_nonproject_tag_facet_component.html.erb
+++ b/app/components/lazy_nonproject_tag_facet_component.html.erb
@@ -1,0 +1,9 @@
+<turbo-frame id="nonproject-tag-facet" src="<%= lazy_nonproject_tag_facet_catalog_path(helpers.search_state.params_for_search) %>" target="_top">
+  <div class="card facet-limit blacklight-exploded_nonproject_tag_ssim">
+    <h3 class="card-header p-0 facet-field-heading" id="facet-exploded_nonproject_tag_ssim-header">
+      <button type="button" disabled style="pointer-events: auto; cursor: wait" class="btn w-100 d-block btn-block p-2 text-start collapse-toggle collapsed" aria-expanded="false">
+        Tag
+      </button>
+    </h3>
+  </div>
+</turbo-frame>

--- a/app/components/lazy_nonproject_tag_facet_component.rb
+++ b/app/components/lazy_nonproject_tag_facet_component.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class LazyTagFacetComponent < ViewComponent::Base
+class LazyNonprojectTagFacetComponent < ViewComponent::Base
   def initialize(**); end
 end

--- a/app/components/lazy_project_tag_facet_component.html.erb
+++ b/app/components/lazy_project_tag_facet_component.html.erb
@@ -1,0 +1,9 @@
+<turbo-frame id="project-tag-facet" src="<%= lazy_project_tag_facet_catalog_path(helpers.search_state.params_for_search) %>" target="_top">
+  <div class="card facet-limit blacklight-exploded_project_tag_ssim">
+    <h3 class="card-header p-0 facet-field-heading" id="facet-exploded_project_tag_ssim-header">
+      <button type="button" disabled style="pointer-events: auto; cursor: wait" class="btn w-100 d-block btn-block p-2 text-start collapse-toggle collapsed" aria-expanded="false">
+        Project Tag
+      </button>
+    </h3>
+  </div>
+</turbo-frame>

--- a/app/components/lazy_project_tag_facet_component.rb
+++ b/app/components/lazy_project_tag_facet_component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class LazyProjectTagFacetComponent < ViewComponent::Base
+  def initialize(**); end
+end

--- a/app/components/lazy_tag_facet_component.html.erb
+++ b/app/components/lazy_tag_facet_component.html.erb
@@ -1,9 +1,0 @@
-<turbo-frame id="tag-facet" src="<%= lazy_tag_facet_catalog_path(helpers.search_state.params_for_search) %>" target="_top">
-  <div class="card facet-limit blacklight-exploded_tag_ssim">
-    <h3 class="card-header p-0 facet-field-heading" id="facet-exploded_tag_ssim-header">
-      <button type="button" disabled style="pointer-events: auto; cursor: wait" class="btn w-100 d-block btn-block p-2 text-start collapse-toggle collapsed" aria-expanded="false">
-        Tag
-      </button>
-    </h3>
-  </div>
-</turbo-frame>

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -54,19 +54,16 @@ class CatalogController < ApplicationController
     config.add_show_field 'tag_ssim', label: 'Tags', link_to_facet: true
     config.add_show_field SolrDocument::FIELD_WORKFLOW_ERRORS, label: 'Error', helper_method: :value_for_wf_error
 
-    # exploded_project_tag_ssim indexes all project tag prefixes whereas project tag_ssim only indexes whole tags.
-    # we want to facet on exploded_project_tag_ssim to get the hierarchy.
-    config.add_facet_field 'exploded_project_tag_ssim', label: 'Project Tag', limit: 9999,
+    # exploded_project_tag_ssim indexes all project tag prefixes for hierarchical facet display, whereas
+    #   project tag_ssim only indexes whole tags
+    config.add_facet_field 'exploded_project_tag_ssim', label: 'Project', limit: 9999,
                                                         component: LazyProjectTagFacetComponent,
                                                         unless: ->(controller, _config, _response) { controller.params[:no_tags] }
-    # exploded_tag_ssim indexes all tag prefixes (see IdentityMetadataDS#to_solr for a more exact
-    # description), whereas tag_ssim only indexes whole tags.  we want to facet on exploded_tag_ssim
-    # to get the hierarchy.
-    config.add_facet_field 'exploded_tag_ssim', label: 'Tag', limit: 9999,
-                                                component: LazyTagFacetComponent,
-                                                unless: lambda { |controller, _config, _response|
-                                                          controller.params[:no_tags]
-                                                        }
+    # exploded_nonproject_tag_ssim indexes all tag prefixes, except project tags, for hierarchical facet display,
+    #   whereas tag_ssim only indexes whole tags.
+    config.add_facet_field 'exploded_nonproject_tag_ssim', label: 'Tag', limit: 9999,
+                                                           component: LazyNonprojectTagFacetComponent,
+                                                           unless: ->(controller, _config, _response) { controller.params[:no_tags] }
     config.add_facet_field 'objectType_ssim', label: 'Object Type', component: true, limit: 10
     config.add_facet_field SolrDocument::FIELD_CONTENT_TYPE, label: 'Content Type', component: true, limit: 10
     config.add_facet_field 'content_file_mimetypes_ssim', label: 'MIME Types', component: true, limit: 10, home: false
@@ -204,7 +201,7 @@ class CatalogController < ApplicationController
         'wf_wps' => [['ssim'], ':'],
         'wf_wsp' => [['ssim'], ':'],
         'wf_swp' => [['ssim'], ':'],
-        'exploded_tag' => [['ssim'], ':'],
+        'exploded_nonproject_tag' => [['ssim'], ':'],
         'exploded_project_tag' => [['ssim'], ':']
       }
     }
@@ -281,12 +278,12 @@ class CatalogController < ApplicationController
     super
   end
 
-  def lazy_tag_facet
+  def lazy_nonproject_tag_facet
     (response,) = search_service.search_results
-    facet_config = facet_configuration_for_field('exploded_tag_ssim')
+    facet_config = facet_configuration_for_field('exploded_nonproject_tag_ssim')
     display_facet = response.aggregations[facet_config.field]
     @facet_field_presenter = facet_config.presenter.new(facet_config, display_facet, view_context)
-    render partial: 'lazy_tag_facet'
+    render partial: 'lazy_nonproject_tag_facet'
   end
 
   def lazy_project_tag_facet

--- a/app/helpers/blacklight_config_helper.rb
+++ b/app/helpers/blacklight_config_helper.rb
@@ -39,14 +39,14 @@ module BlacklightConfigHelper
         contributor_orcids_ssim
       ),
       facet: true,
-      "facet.mincount": 1,
-      "f.wf_wps_ssim.facet.limit": -1,
-      "f.wf_wsp_ssim.facet.limit": -1,
-      "f.wf_swp_ssim.facet.limit": -1,
-      "f.exploded_project_tag_ssim.facet.limit": -1,
-      "f.exploded_project_tag_ssim.facet.sort": 'index',
-      "f.exploed_nonproject_tag_ssim.facet.limit": -1,
-      "f.exploded_nonproject_tag_ssim.facet.sort": 'index'
+      'facet.mincount': 1,
+      'f.wf_wps_ssim.facet.limit': -1,
+      'f.wf_wsp_ssim.facet.limit': -1,
+      'f.wf_swp_ssim.facet.limit': -1,
+      'f.exploded_project_tag_ssim.facet.limit': -1,
+      'f.exploded_project_tag_ssim.facet.sort': 'index',
+      'f.exploed_nonproject_tag_ssim.facet.limit': -1,
+      'f.exploded_nonproject_tag_ssim.facet.sort': 'index'
     }
   end
 end

--- a/app/helpers/blacklight_config_helper.rb
+++ b/app/helpers/blacklight_config_helper.rb
@@ -39,12 +39,14 @@ module BlacklightConfigHelper
         contributor_orcids_ssim
       ),
       facet: true,
-      'facet.mincount': 1,
-      'f.wf_wps_ssim.facet.limit': -1,
-      'f.wf_wsp_ssim.facet.limit': -1,
-      'f.wf_swp_ssim.facet.limit': -1,
-      'f.tag_ssim.facet.limit': -1,
-      'f.tag_ssim.facet.sort': 'index'
+      "facet.mincount": 1,
+      "f.wf_wps_ssim.facet.limit": -1,
+      "f.wf_wsp_ssim.facet.limit": -1,
+      "f.wf_swp_ssim.facet.limit": -1,
+      "f.exploded_project_tag_ssim.facet.limit": -1,
+      "f.exploded_project_tag_ssim.facet.sort": 'index',
+      "f.exploed_nonproject_tag_ssim.facet.limit": -1,
+      "f.exploded_nonproject_tag_ssim.facet.sort": 'index'
     }
   end
 end

--- a/app/views/catalog/_lazy_nonproject_tag_facet.html.erb
+++ b/app/views/catalog/_lazy_nonproject_tag_facet.html.erb
@@ -1,4 +1,4 @@
-<turbo-frame id="tag-facet" target="_top">
+<turbo-frame id="nonproject-tag-facet" target="_top">
   <%= render Blacklight::Hierarchy::FacetFieldListComponent.new(
         facet_field: @facet_field_presenter,
         layout: Blacklight::FacetFieldComponent

--- a/app/views/catalog/_lazy_project_tag_facet.html.erb
+++ b/app/views/catalog/_lazy_project_tag_facet.html.erb
@@ -1,0 +1,6 @@
+<turbo-frame id="project-tag-facet" target="_top">
+  <%= render Blacklight::Hierarchy::FacetFieldListComponent.new(
+        facet_field: @facet_field_presenter,
+        layout: Blacklight::FacetFieldComponent
+      ) %>
+</turbo-frame>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
+Rails.application.routes.draw do
   require 'sidekiq/web'
   mount Sidekiq::Web => '/queues'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,7 +63,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   resource :catalog, only: [:index], controller: 'catalog', path: '/catalog' do
     concerns :searchable
     member do
-      get 'lazy_tag_facet'
+      get 'lazy_nonproject_tag_facet'
       get 'lazy_project_tag_facet'
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Rails.application.routes.draw do
+Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   require 'sidekiq/web'
   mount Sidekiq::Web => '/queues'
 
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
     concerns :searchable
     member do
       get 'lazy_tag_facet'
+      get 'lazy_project_tag_facet'
     end
   end
 

--- a/spec/components/workflow_table_process_component_spec.rb
+++ b/spec/components/workflow_table_process_component_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe WorkflowTableProcessComponent, type: :component do
             'wf_wps' => [['ssim'], ':'],
             'wf_wsp' => [['ssim'], ':'],
             'wf_swp' => [['ssim'], ':'],
-            'exploded_tag' => [['ssim'], ':']
+            'exploded_nonproject_tag' => [['ssim'], ':'],
+            'exploded_project_tag' => [['ssim'], ':']
           }
         }
       end


### PR DESCRIPTION
~~Hold until Friday Nov 3~~

HOLD until:
- [x] Andrew signs off
- [x] Solr facet field for project tags (_exploded_project_tag_ssim_) is fully populated. The indexing change for _exploded_project_tag_ssim_ went into prod dor_indexing_app on Tues 10/3 and it will take approx 2 weeks to finish populating.   You can go to http://sul-solr-prod-a.stanford.edu/solr/#/argo3_prod/schema?field=exploded_project_tag_ssim and see how many docs have been loaded for the field:    
    <img width="764" alt="image" src="https://github.com/sul-dlss/argo/assets/96775/b829bdb4-3716-4652-b450-b3e5731c54ed">
- [x] Solr facet field for non-project tags (_exploded_nonproject_tag_ssim_)  is fully populated.   This indexing change went into prod dor_indexing_app on Wed 10/4.
    <img width="731" alt="image" src="https://github.com/sul-dlss/argo/assets/96775/d0fa792a-9bac-40f0-aba0-2fba8c91b422">
- [x] this PR is updated to ALSO switch the field used for the "Tag" facet in Argo (in addition to adding the "Project Tag" facet above it)
- [x] PO (Andrew) signs off (again, for tags facet without project tags included)

# Why was this change made?

- Part of #4187 - add a project tag facet at the top, showing hierarchy...modeled after the similar tag facet
- Also switches field used for tag facet to no longer include project tags.

![Screen Shot 2023-10-02 at 3 54 24 PM](https://github.com/sul-dlss/argo/assets/47137/88503572-8f5a-458a-9b24-b4b3892d86ec)

# How was this change tested?

Localhost and stage/qa
HOLD for PO review - ✅ as of 10/5, ✅ as of 11/1 
