### PR TITLE
do not offer download link if file not available for download

### DIFF
--- a/app/views/files/index.html.erb
+++ b/app/views/files/index.html.erb
@@ -2,11 +2,16 @@
   <% component.header { "File Availability" } %>
   <% component.body do %>
     <% if @file.administrative.shelve %>
-      <p>
-        Stacks: <%= link_to params[:file], stacks_url_full_size(params[:item_id], params[:id]) %>
-      </p>
+      <% if @file.access.download == 'none' %>
+        <p>
+          Stacks: <%= stacks_url_full_size(params[:item_id], params[:id]) %> <em>(not available for download)</em>
+        </p>
+      <% else %>
+        <p>
+          Stacks: <%= link_to params[:file], stacks_url_full_size(params[:item_id], params[:id]) %>
+        </p>
+      <% end %>
     <% end %>
-
     <% if @file.administrative.sdrPreserve && @has_been_accessioned %>
       <p>
         Preservation:

--- a/spec/views/files/index.html.erb_spec.rb
+++ b/spec/views/files/index.html.erb_spec.rb
@@ -4,9 +4,10 @@ require "rails_helper"
 
 RSpec.describe "files/index" do
   let(:admin) { instance_double(Cocina::Models::FileAdministrative, shelve: true, sdrPreserve: true) }
+  let(:file_url) { "https://stacks-test.stanford.edu/file/druid:rn653dy9317/M1090_S15_B01_F07_0106.jp2" }
 
   before do
-    @file = instance_double(Cocina::Models::File, administrative: admin)
+    @file = instance_double(Cocina::Models::File, administrative: admin, access: access)
     @has_been_accessioned = true
     @last_accessioned_version = "7"
     params[:id] = "M1090_S15_B01_F07_0106.jp2"
@@ -14,8 +15,25 @@ RSpec.describe "files/index" do
     render
   end
 
-  it "renders the partial content" do
-    expect(rendered).to have_content "Stacks"
-    expect(rendered).to have_content "Preservation"
+  context "when download access is world" do
+    let(:access) { instance_double(Cocina::Models::FileAccess, download: "world") }
+
+    it "renders the partial content with links" do
+      expect(rendered).to have_content "Stacks"
+      expect(rendered).to have_content "Preservation"
+      expect(rendered).to have_link file_url, href: file_url
+      expect(rendered).not_to have_content "(not available for download)"
+    end
+  end
+
+  context "when download access is none" do
+    let(:access) { instance_double(Cocina::Models::FileAccess, download: "none") }
+
+    it "renders the partial content without links" do
+      expect(rendered).to have_content "Stacks"
+      expect(rendered).to have_content "Preservation"
+      expect(rendered).not_to have_link file_url, href: file_url
+      expect(rendered).to have_content "(not available for download)"
+    end
   end
 end


### PR DESCRIPTION
# Why was this change made?

Fixes #4208 - do not offer download link when file is not available for download

# How was this change tested?

Stage
Updated spec