### PR TITLE
Move the sidebar above the content in the dom

### DIFF
--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,7 +1,7 @@
 <h1 class="h3">Welcome to Argo!</h1>
 <% if @presenter.view_something? %>
   <p>
-    Enter one or more search terms or select a facet on the left to begin.
+    To begin, enter one or more search terms, or select a facet under the 'Limit your search' panel.
   </p>
 <% else %>
   <p>

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -1,0 +1,17 @@
+<% content_for(:content) do %>
+  <% if content_for? :sidebar %>
+    <section id="sidebar" class="<%= sidebar_classes %> order-first" aria-label="<%= t("blacklight.search.documents.aria.limit_search") %>">
+      <%= content_for(:sidebar) %>
+    </section>
+
+    <section id="content" class="<%= main_content_classes %> order-last" aria-label="<%= t("blacklight.search.documents.aria.search_results") %>">
+      <%= yield %>
+    </section>
+  <% else %>
+    <section class="col-md-12">
+      <%= yield %>
+    </section>
+  <% end %>
+<% end %>
+
+<%= render template: "layouts/blacklight/base" %>

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -1,3 +1,4 @@
+<%# We are overriding this Blacklight layout to address WCAG21 1.3.2 (Level A) %>
 <% content_for(:content) do %>
   <% if content_for? :sidebar %>
     <section id="sidebar" class="<%= sidebar_classes %> order-first" aria-label="<%= t("blacklight.search.documents.aria.limit_search") %>">

--- a/spec/views/catalog/_home_text.html.erb_spec.rb
+++ b/spec/views/catalog/_home_text.html.erb_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe "catalog/_home_text" do
     let(:presenter) { instance_double(HomeTextPresenter, view_something?: true) }
 
     it "shows the home page text" do
-      expect(rendered).to have_css "p", text: "Enter one or more search terms " \
-                                              "or select a facet on the left to begin."
+      expect(rendered).to have_css "p", text: "To begin, enter one or more search terms, " \
+                                              "or select a facet under the 'Limit your search' panel."
     end
   end
 


### PR DESCRIPTION
# Why was this change made?

Fixes #4161 

This overrides the default blacklight layout to move the sidebar higher in the dom than content to improve the screenreader experience.

Note: I will put up a separate blacklight PR to address this upstream, at which time we can remove this override.

# How was this change tested?

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


