### PR TITLE
Fix setting download to none in csv registration form.

### DIFF
--- a/app/forms/csv_registration_form.rb
+++ b/app/forms/csv_registration_form.rb
@@ -63,7 +63,7 @@ It's legal to have more than one colon in a hierarchy, but at least one colon is
     }.merge(access_params).compact
   end
 
-  # TODO: Similar code is in the ItemChangeSet
+  # Note that similar code is in the ItemChangeSet
   def access_params
     {
       rights_view: view_access,
@@ -71,7 +71,7 @@ It's legal to have more than one colon in a hierarchy, but at least one colon is
       rights_location: access_location,
       rights_controlledDigitalLending: ::ActiveModel::Type::Boolean.new.cast(controlled_digital_lending)
     }.tap do |access_params|
-      access_params[:download] = 'none' if %w[dark citation-only].include?(access_params[:view])
+      access_params[:rights_download] = 'none' if %w[dark citation-only].include?(access_params[:rights_view])
     end.compact_blank
   end
 

--- a/spec/features/item_registration_csv_spec.rb
+++ b/spec/features/item_registration_csv_spec.rb
@@ -59,6 +59,54 @@ RSpec.describe 'Item registration page', :js do
     end
   end
 
+  context 'successful registration with dark' do
+    let(:bulk_action) { instance_double(BulkAction, save: true, enqueue_job: true) }
+
+    before do
+      allow(BulkAction).to receive(:new).and_return(bulk_action)
+    end
+
+    it 'starts bulk action and changes download to none' do
+      visit registration_path
+      select '[Internal System Objects]', from: 'Admin Policy' # "uber APO"
+      select 'registrationWF', from: 'Initial Workflow'
+      select 'book', from: 'Content Type'
+      select 'left-to-right', from: 'Viewing Direction'
+      select 'Dark', from: 'View access'
+
+      fill_in 'Project Name', with: 'X-Files'
+
+      click_button 'Upload CSV'
+
+      attach_file 'Upload a CSV file', file_fixture('item_registration.csv')
+
+      click_button 'Register'
+
+      expect(page).to have_content 'Register druids job was successfully created.'
+      expect(page).to have_content 'Bulk Actions'
+
+      expect(BulkAction).to have_received(:new).with(user:, action_type: 'RegisterDruidsJob')
+      expect(bulk_action).to have_received(:save)
+      expect(bulk_action).to have_received(:enqueue_job).with(
+        {
+          administrative_policy_object: 'druid:hv992ry2431',
+          content_type: 'https://cocina.sul.stanford.edu/models/book',
+          csv_file: "source_id,catkey,barcode,label\nfoo:123,,,My new object\n",
+          groups:
+           ["sunetid:#{user.login}",
+            'workgroup:sdr:administrator-role',
+            'workgroup:dlss:developers'],
+          initial_workflow: 'registrationWF',
+          project_name: 'X-Files',
+          reading_order: 'left-to-right',
+          rights_download: 'none',
+          rights_view: 'dark',
+          tags: ["Registered By : #{user.login}"]
+        }
+      )
+    end
+  end
+
   context 'registration fails validation' do
     it 'reports error' do
       visit registration_path


### PR DESCRIPTION
# Why was this change made?

I noticed the code was wrong.

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


