### PR TITLE
add copy/paste icon to facet modal

### DIFF
--- a/app/javascript/controllers/copy_controller.js
+++ b/app/javascript/controllers/copy_controller.js
@@ -1,0 +1,27 @@
+import bootstrap from 'bootstrap/dist/js/bootstrap'
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  copy (event) {
+    let formattedOutput = ''
+
+    // iterate over all facet values and construct a tab delimited string with two columns
+    const facetList = document.querySelectorAll('.modal-body .facet-values li')
+    facetList.forEach(function (facetItem) {
+      const facetValue = facetItem.querySelector('.facet-label a').innerHTML
+      const facetCount = facetItem.querySelector('.facet-count').innerHTML
+      formattedOutput += facetValue + '\t' + facetCount + '\n'
+    })
+
+    navigator.clipboard.writeText(formattedOutput)
+    event.preventDefault()
+
+    const popover = new bootstrap.Popover(event.target, {
+      content: 'Copied.',
+      placement: 'top',
+      trigger: 'manual'
+    })
+    popover.show()
+    setTimeout(function () { popover.dispose() }, 1500)
+  }
+}

--- a/app/javascript/controllers/copy_controller.js
+++ b/app/javascript/controllers/copy_controller.js
@@ -19,7 +19,8 @@ export default class extends Controller {
     const popover = new bootstrap.Popover(event.target, {
       content: 'Copied.',
       placement: 'top',
-      trigger: 'manual'
+      trigger: 'manual',
+      title: 'List'
     })
     popover.show()
     setTimeout(function () { popover.dispose() }, 1500)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -23,6 +23,7 @@ import RegistrationItems from './registration_items_controller'
 import RegistrationItemRow from './registration_item_row_controller'
 import RegistrationTabs from './registration_tabs_controller'
 import ObjectReporter from './object_reporter'
+import CopyController from './copy_controller'
 
 const application = Application.start()
 application.register('bulk-actions', BulkActions)
@@ -49,3 +50,4 @@ application.register('registration-items', RegistrationItems)
 application.register('registration-item-row', RegistrationItemRow)
 application.register('registration-tabs', RegistrationTabs)
 application.register('object-reporter', ObjectReporter)
+application.register('copy', CopyController)

--- a/app/views/catalog/facet.html.erb
+++ b/app/views/catalog/facet.html.erb
@@ -6,7 +6,7 @@
   <%= render BlacklightModalComponent.new do |component| %>
     <% component.header do %>
       <%= facet_field_label(@facet.key) %>
-      <a class="copy-button" data-controller="copy" data-action="copy#copy" aria-label="Copy facet values" href=""><i class="bi bi-clipboard"></i></a>
+      <a class="copy-button" data-controller="copy" data-action="copy#copy" aria-label="Copy this list" href="#"><i class="bi bi-clipboard" title="Copy this list"></i></a>
      <% end %>
     <% component.body do %>
 

--- a/app/views/catalog/facet.html.erb
+++ b/app/views/catalog/facet.html.erb
@@ -6,7 +6,7 @@
   <%= render BlacklightModalComponent.new do |component| %>
     <% component.header do %>
       <%= facet_field_label(@facet.key) %>
-      <a class="copy-button" data-controller="copy" data-action="copy#copy" aria-label="Copy this list" href="#"><i class="bi bi-clipboard" title="Copy this list"></i></a>
+      <a class="copy-button" data-controller="copy" data-action="copy#copy" aria-label="Copy this list" title="Copy this list" href="#"><span class="bi bi-clipboard"></span></a>
      <% end %>
     <% component.body do %>
 

--- a/app/views/catalog/facet.html.erb
+++ b/app/views/catalog/facet.html.erb
@@ -4,8 +4,12 @@
 
 <div data-controller="facet-filter">
   <%= render BlacklightModalComponent.new do |component| %>
-    <% component.header { facet_field_label(@facet.key) } %>
+    <% component.header do %>
+      <%= facet_field_label(@facet.key) %>
+      <a class="copy-button" data-controller="copy" data-action="copy#copy" aria-label="Copy facet values" href=""><i class="bi bi-clipboard"></i></a>
+     <% end %>
     <% component.body do %>
+
       <%= render 'facet_index_navigation' if @facet.index_range && @display_facet.index? %>
       <div data-facet-filter-target="list">
         <%= render_facet_limit(@display_facet, layout: false) %>


### PR DESCRIPTION
# Why was this change made?

Fixes #4234 - add a copy/paste icon to the facet model to allow users to grab the facet list values onto their clipboard.  Note: copy/paste icon only shows on the modal window (for when you click "more >>").  We can adapt later if we need to shows this for all facets on the main argo page.

~~HOLD for testing on stage~~

<img width="334" alt="Screen Shot 2023-10-17 at 9 26 18 AM" src="https://github.com/sul-dlss/argo/assets/47137/3268f0fc-fade-47c0-8257-5cfc1845a502">

# How was this change tested?

Localhost and stage