### PR TITLE
when argo url has qt=qttest, use more realistic "where we are going" qf parameter.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -221,48 +221,55 @@ class CatalogController < ApplicationController
     # For comparison of search results with different Solr params:
     # if qt param is passed to Argo, we can also change the params we send to Solr.
     # This allows us to compare, e.g. search results with different Solr qf params.
-    # Request handlers can be wholly configured in Solr, in which case you can remove
-    # default_solr_params to use what is in the Solr configuration.
+    # Request handlers can be configured:
+    #  1. in Solr, in which case you can remove default_solr_params to use only
+    #     what is in the Solr configuration.
+    #  2. in Argo/Blacklight BUT the request handler (qt param) must match an existing request handler in Solr.
+    #  3. configured with url params, e.g. qt=wingnut BUT - if default_solr_params are in play,
+    #     you cannot override those params with url params, and the qt param value has to match an
+    #     existing request handler in Solr.
+    #  4. a combination of the above - some params can be configured in Solr, some in Argo/Blacklight, and some
+    #     in the url.
     if params.key?(:qt)
       blacklight_config.default_solr_params = {
         qt: params[:qt],
         defType: 'dismax',
-        'q.alt': '*:*'
-        # qf: %(
-        # sw_display_title_tesim^5
-        # sw_author_tesim^3
-        # topic_tesim^2
+        'q.alt': '*:*',
+        qf: %(
+          sw_display_title_tesim^5
+          contributor_text_nostem_im^3
+          topic_tesim^2
 
-        # exploded_project_tag_ssim^2
-        # exploded_nonproject_tag_ssim
-        # exploded_tag_ssim
-        # tag_ssim
+          exploded_project_tag_ssim^2
+          exploded_nonproject_tag_ssim
+          exploded_tag_ssim
+          tag_ssim
 
-        # content_type_ssim
-        # sw_format_ssim
-        # object_type_ssim
+          content_type_ssim
+          sw_format_ssim
+          object_type_ssim
 
-        # descriptive_tiv
-        # descriptive_text_nostem_i
-        # descriptive_teiv
+          descriptive_text_nostem_i
+          descriptive_tiv
+          descriptive_teiv
 
-        # collection_title_tesim
+          collection_title_tesim
 
-        # id
-        # objectId_tesim
-        # identifier_ssim
-        # identifier_tesim
-        # barcode_id_ssim
-        # folio_instance_hrid_ssim
-        # source_id_ssim^3
-        # source_id_ssi
-        # source_id_text_nostem_i^3
-        # previous_ils_ids_ssim
-        # doi_ssim
-        # contributor_orcids_ssim
-        # )
+          id
+          objectId_tesim
+          identifier_ssim
+          identifier_tesim
+          barcode_id_ssim
+          folio_instance_hrid_ssim
+          source_id_ssi
+          source_id_text_nostem_i^3
+          previous_ils_ids_ssim
+          doi_ssim
+          contributor_orcids_ssim
+        )
       }
-      blacklight_config.default_solr_params.delete(:qf) # use what is in solrconfig.xml for the request handler
+      # NOTE: if you want to use the qf in solrconfig.xml, you can delete the qf param here:
+      # blacklight_config.default_solr_params.delete(:qf) # use what is in solrconfig.xml for the request handler
     end
     super
   end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -227,22 +227,42 @@ class CatalogController < ApplicationController
       blacklight_config.default_solr_params = {
         qt: params[:qt],
         defType: 'dismax',
-        'q.alt': '*:*',
-        qf: %(
-          id
-          collection_title_tesim
-          dor_id_tesim
-          identifier_tesim
-          obj_label_tesim
-          objectId_tesim
-          originInfo_place_placeTerm_tesim
-          originInfo_publisher_tesim
-          sw_display_title_tesim
-          source_id_ssim
-          tag_ssim
-          topic_tesim
-        )
+        'q.alt': '*:*'
+        # qf: %(
+        # sw_display_title_tesim^5
+        # sw_author_tesim^3
+        # topic_tesim^2
+
+        # exploded_project_tag_ssim^2
+        # exploded_nonproject_tag_ssim
+        # exploded_tag_ssim
+        # tag_ssim
+
+        # content_type_ssim
+        # sw_format_ssim
+        # object_type_ssim
+
+        # descriptive_tiv
+        # descriptive_text_nostem_i
+        # descriptive_teiv
+
+        # collection_title_tesim
+
+        # id
+        # objectId_tesim
+        # identifier_ssim
+        # identifier_tesim
+        # barcode_id_ssim
+        # folio_instance_hrid_ssim
+        # source_id_ssim^3
+        # source_id_ssi
+        # source_id_text_nostem_i^3
+        # previous_ils_ids_ssim
+        # doi_ssim
+        # contributor_orcids_ssim
+        # )
       }
+      blacklight_config.default_solr_params.delete(:qf) # use what is in solrconfig.xml for the request handler
     end
     super
   end


### PR DESCRIPTION
# Why was this change made?

This is the result of some experimentation after issue #4224 - how to use a param in the argo url to test new solr fields/other discovery improvements.

This PR updates the "query fields" for the qttest Solr requestHandler to reflect where we are going at this moment - wiriing in new author and catch all fields.

Originally, I was hoping that we would add "qt=qttest" AND "qf=field1 field2" into the argo url.  But that turned out to be less great than expected, because I think the lazy loading facet queries revert to the qf params in blacklight_config_helper.   (There is definitely a second query to Solr which reverts to the params in blacklight_config_helper .)

However, the qt=qttest param in the Argo url still allows us to see how certain differences in the request handler arguments can affect search results.   E.g. after you create a new way to index, say, author data, then you can experiment with qt=qttest to ensure the new indexing, combined with request handler tweaks, will improve search results.

It is easier for us to experiment with Solr request handler configurations (such as qf and weightings and such) in an argo branch, deployed to qa or stage or one of the prod boxes, than to expect folks to do the qf configuration in solrconfig.xml.


I also note that it's unfortunate that blacklight ended up with a design that involves passing so many parameters to Solr for every query!  E.g. parsing this 4590 character string in the Solr logs isn't fun!

```
params={f.content_file_roles_ssim.facet.limit=11&f.tag_ssim.facet.sort=index&f.sw_subject_temporal_ssim.facet.limit=11&f.wf_swp_ssim.facet.limit=10000&f.collection_title_ssim.facet.limit=11&f.hydrus_apo_title_ssim.facet.sort=index&f.collection_title_ssim.facet.sort=index&f.rights_descriptions_ssim.facet.limit=1001&facet.query=released_to_earthworks_dttsi:[NOW-7DAY/DAY+TO+NOW]&facet.query=released_to_earthworks_dttsi:[NOW-1MONTH/DAY+TO+NOW]&facet.query=released_to_earthworks_dttsi:[NOW-1YEAR/DAY+TO+NOW]&facet.query=released_to_earthworks_dttsi:[*+TO+*]&facet.query=-released_to_earthworks_dttsi:[*+TO+*]&facet.query=released_to_searchworks_dttsi:[NOW-7DAY/DAY+TO+NOW]&facet.query=released_to_searchworks_dttsi:[NOW-1MONTH/DAY+TO+NOW]&facet.query=released_to_searchworks_dttsi:[NOW-1YEAR/DAY+TO+NOW]&facet.query=released_to_searchworks_dttsi:[*+TO+*]&facet.query=-released_to_searchworks_dttsi:[*+TO+*]&facet.query=registered_dttsim:*&facet.query=registered_dttsim:[NOW/DAY-7DAYS+TO+*]&facet.query=registered_dttsim:[NOW/DAY-30DAYS+TO+*]&facet.query=accessioned_latest_dttsi:*&facet.query=accessioned_latest_dttsi:[NOW/DAY-7DAYS+TO+*]&facet.query=accessioned_latest_dttsi:[NOW/DAY-30DAYS+TO+*]&facet.query=accessioned_earliest_dttsi:*&facet.query=accessioned_earliest_dttsi:[NOW/DAY-1DAYS+TO+*]&facet.query=accessioned_earliest_dttsi:[NOW/DAY-7DAYS+TO+*]&facet.query=accessioned_earliest_dttsi:[NOW/DAY-30DAYS+TO+*]&facet.query=accessioned_earliest_dttsi:[NOW/DAY-365DAYS+TO+*]&facet.query=published_latest_dttsi:[NOW/DAY-7DAYS+TO+*]&facet.query=published_latest_dttsi:[NOW/DAY-30DAYS+TO+*]&facet.query=modified_latest_dttsi:[NOW/DAY-7DAYS+TO+*]&facet.query=modified_latest_dttsi:[NOW/DAY-30DAYS+TO+*]&facet.query=opened_latest_dttsi:*&facet.query=opened_latest_dttsi:[*+TO+NOW/DAY-7DAYS]&facet.query=opened_latest_dttsi:[*+TO+NOW/DAY-30DAYS]&facet.query=embargo_release_dtsim:[NOW+TO+NOW/DAY%2B7DAYS]&facet.query=embargo_release_dtsim:[NOW+TO+NOW/DAY%2B30DAYS]&facet.query=embargo_release_dtsim:*&facet.query=has_constituents_ssim:*&facet.query=%2Bcontributor_orcids_ssim:*&facet.query=%2Bdoi_ssim:*&facet.query=%2Bbarcode_id_ssim:*&facet.query=-mods_typeOfResource_ssim:*&facet.query=-sw_format_ssim:*&defType=dismax&f.sw_subject_geographic_ssim.facet.limit=11&f.objectType_ssim.facet.limit=11&qf=%0a++++++++id%0a++++++++collection_title_tesim%0a++++++++dor_id_tesim%0a++++++++identifier_tesim%0a++++++++obj_label_tesim%0a++++++++objectId_tesim%0a++++++++originInfo_place_placeTerm_tesim%0a++++++++originInfo_publisher_tesim%0a++++++++sw_display_title_tesim%0a++++++++source_id_ssim%0a++++++++tag_ssim%0a++++++++topic_tesim%0a++++++&f.exploded_tag_ssim.facet.limit=10000&f.wf_wps_ssim.facet.limit=10000&f.sw_pub_date_facet_ssi.facet.limit=11&f.hydrus_apo_title_ssim.facet.limit=11&f.sw_genre_ssim.facet.limit=11&wt=json&f.current_version_isi.facet.limit=11&f.sw_language_ssim.facet.limit=11&f.use_license_machine_ssi.facet.limit=11&q.alt=*:*&facet.field=exploded_tag_ssim&facet.field=objectType_ssim&facet.field=content_type_ssim&facet.field=content_file_mimetypes_ssim&facet.field=content_file_roles_ssim&facet.field=rights_descriptions_ssim&facet.field=use_license_machine_ssi&facet.field=collection_title_ssim&facet.field=nonhydrus_apo_title_ssim&facet.field=hydrus_apo_title_ssim&facet.field=current_version_isi&facet.field=processing_status_text_ssi&facet.field=wf_wps_ssim&facet.field=wf_wsp_ssim&facet.field=wf_swp_ssim&facet.field=metadata_source_ssim&facet.field=registered_dttsim&facet.field=accessioned_latest_dttsi&facet.field=accessioned_earliest_dttsi&facet.field=published_latest_dttsi&facet.field=modified_latest_dttsi&facet.field=opened_latest_dttsi&facet.field=embargo_release_dtsim&facet.field=data_quality_ssim&facet.field=sw_format_ssim&facet.field=sw_pub_date_facet_ssi&facet.field=topic_ssim&facet.field=sw_subject_geographic_ssim&facet.field=sw_subject_temporal_ssim&facet.field=sw_genre_ssim&facet.field=sw_language_ssim&facet.field=mods_typeOfResource_ssim&facet.field=is_governed_by_ssim&facet.field=is_member_of_collection_ssim&facet.field=tag_ssim&facet.field=project_tag_ssim&qt=qttest&f.nonhydrus_apo_title_ssim.facet.sort=index&f.topic_ssim.facet.limit=11&f.content_type_ssim.facet.limit=11&sort=id+asc&rows=10&f.mods_typeOfResource_ssim.facet.limit=11&f.processing_status_text_ssi.facet.limit=11&q=ruth&f.nonhydrus_apo_title_ssim.facet.limit=11&f.wf_wsp_ssim.facet.limit=10000&f.rights_descriptions_ssim.facet.sort=index&f.tag_ssim.facet.limit=-1&facet.mincount=1&f.sw_format_ssim.facet.limit=11&facet=true&f.content_file_mimetypes_ssim.facet.limit=11
```

# How was this change tested?

This has no changes for CI or regular production use -- it's only in play if the argo url gets "qt=qttest" ... and this was vetted locally as well as on argo-qa.  


