### PR TITLE
upgrade to solr 8.11 as in prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,19 +37,16 @@ commands:
         type: string
     steps:
       - run:
-          command: 'dockerize -wait tcp://<< parameters.solr_host >>:<< parameters.solr_port >> -timeout 1m'
-          name: Wait for Solr
-      - run:
           command: >
             cd << parameters.solr_config_path >>
 
             zip -1 -r solr_config.zip ./*
 
             curl -H "Content-type:application/octet-stream" --data-binary
-            @solr_config.zip "http://<< parameters.solr_host >>:<< parameters.solr_port
+            @solr_config.zip "http://solr:SolrRocks@<< parameters.solr_host >>:<< parameters.solr_port
             >>/solr/admin/configs?action=UPLOAD&name=solrconfig"
 
-            curl -H 'Content-type: application/json' http://<< parameters.solr_host >>:<<
+            curl -H 'Content-type: application/json' http://solr:SolrRocks@<< parameters.solr_host >>:<<
             parameters.solr_port >>/api/collections/ -d '{create: {name: <<
             parameters.core_name >>, config: solrconfig, numShards: 1}}'
           name: Load config into solr
@@ -79,20 +76,30 @@ executors:
         <<: *ruby_envs
       - image: cimg/postgres:<< parameters.postgres_tag >>
         <<: *postgres_envs
-      - image: solr:7
-        command: bin/solr -cloud -noprompt -f
+      - image: zookeeper:3.9.1
+        name: zookeeper
+      - image: solr:8.11.2
         name: solr
+        # In order to have access to Solr contrib/analysis-extras/lib etc. for the ICU tokenizers and filters,
+        # Solr 8 Cloud requires permissions to add a collection to Zookeeper. This is kludgy but it works.
+        # It would be a lot easier if Circle's docker executor allowed us to use a mounted volumes for the permissions,
+        # like we do for our local docker compose setup.
+        command: [
+          'sh',
+          '-c',
+          'wget -O /tmp/security.json "https://gist.githubusercontent.com/eliotjordan/a27be341dc2e7a532bad99203e0f55b7/raw/5866efab9242f953764c1b03d17763309e22948f/security.json" && server/scripts/cloud-scripts/zkcli.sh -zkhost zookeeper:2181 -cmd putfile /security.json /tmp/security.json && bin/solr -cloud -noprompt -f -z zookeeper:2181',
+        ]
       - image: rabbitmq:3
         name: rabbitmq
       - image: suldlss/dor-indexing-app:latest
         name: dor-indexing-app
         environment:
-          SOLR_URL: http://solr:8983/solr/argo
-          SETTINGS__SOLR__URL: http://solr:8983/solr/argo
+          SOLR_URL: http://solr:SolrRocks@solr:8983/solr/argo
+          SETTINGS__SOLR__URL: http://solr:SolrRocks@solr:8983/solr/argo
           SETTINGS__DOR_SERVICES__URL: http://dor-services-app:3000/
           # To generate the token: docker-compose run dor-services-app rake generate_token
           SETTINGS__DOR_SERVICES__TOKEN: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJGb28ifQ.-BVfLTW9Q1_ZQEsGv4tuzGLs5rESN7LgdtEwUltnKv4
-          SETTINGS__SOLRIZER_URL: http://solr:8983/solr/argo
+          SETTINGS__SOLRIZER_URL: http://solr:SolrRocks@solr:8983/solr/argo
           SETTINGS__WORKFLOW_URL: http://workflow:3000
       - image: suldlss/dor-indexing-app:latest
         name: dor-indexing-workers
@@ -103,12 +110,12 @@ executors:
             'timeout 30 docker/wait-port.sh rabbitmq 5672 ; bin/rake rabbitmq:setup sneakers:run',
           ]
         environment:
-          SOLR_URL: http://solr:8983/solr/argo
-          SETTINGS__SOLR__URL: http://solr:8983/solr/argo
+          SOLR_URL: http://solr:SolrRocks@solr:8983/solr/argo
+          SETTINGS__SOLR__URL: http://solr:SolrRocks@solr:8983/solr/argo
           SETTINGS__DOR_SERVICES__URL: http://dor-services-app:3000/
           # To generate the token: docker-compose run dor-services-app rake generate_token
           SETTINGS__DOR_SERVICES__TOKEN: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJGb28ifQ.-BVfLTW9Q1_ZQEsGv4tuzGLs5rESN7LgdtEwUltnKv4
-          SETTINGS__SOLRIZER_URL: http://solr:8983/solr/argo
+          SETTINGS__SOLRIZER_URL: http://solr:SolrRocks@solr:8983/solr/argo
           SETTINGS__WORKFLOW_URL: http://workflow:3000
           SETTINGS__RABBITMQ__HOSTNAME: rabbitmq
       - image: suldlss/dor-services-app:latest
@@ -120,9 +127,9 @@ executors:
           DATABASE_HOSTNAME: db
           DATABASE_PORT: 5432
           SECRET_KEY_BASE: 769171f88c527d564fb65b4b7ef712d5ae9761a21e26a41cd7c88eb0af89c74f857b9be4089119f71cf806dfc8bf9d9d2f0df91c00b119c96f462b46ebf43b0f
-          SOLR_URL: http://solr:8983/solr/argo
+          SOLR_URL: http://solr:SolrRocks@solr:8983/solr/argo
           SETTINGS__DOR_INDEXING__URL: http://dor-indexing-app:3000/dor
-          SETTINGS__SOLR__URL: http://solr:8983/solr/argo
+          SETTINGS__SOLR__URL: http://solr:SolrRocks@solr:8983/solr/argo
           SETTINGS__SURI__URL: http://suri:3000
           SETTINGS__WORKFLOW_URL: http://workflow:3000
           SETTINGS__ENABLED_FEATURES__CREATE_UR_ADMIN_POLICY: 'true'
@@ -223,7 +230,7 @@ jobs:
       SETTINGS__DOR_SERVICES__URL: http://dor-services-app:3000
       SETTINGS__REDIS_URL: redis://redis:6379/
       SETTINGS__SDR_API__URL: http://sdr-api:3000
-      SETTINGS__SOLRIZER_URL: http://solr:8983/solr/argo
+      SETTINGS__SOLRIZER_URL: http://solr:SolrRocks@solr:8983/solr/argo
       SETTINGS__TECH_MD_SERVICE__URL: http://techmd:3000
       SETTINGS__WORKFLOW_URL: http://workflow:3000
       TT: 1 # track templates

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,7 @@ services:
       - dor-services-app
 
   solr:
-    image: solr:7
+    image: solr:8.11.2
     volumes:
       - ./solr_conf/conf/:/myconfig
     command: solr-create -c argo -d /myconfig


### PR DESCRIPTION
# Why was this change made?

Solr 9 is out.  Our prod Solr cloud is at Solr 8.11.2.    This is an upgrade from Solr 7.

# How was this change tested?

local tests
circleci

