### PR TITLE
circleci: add docker layer caching for faster builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,6 +237,8 @@ jobs:
     executor: ruby_with_all_deps
     steps:
       - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
       - ruby/install-deps:
           key: gems-v2
       - node/install-packages:


### PR DESCRIPTION
# Why was this change made?

one of the longest parts of the circleci build is downloading and expanding all the docker images.  This should make it faster.

# How was this change tested?

ran the build in CircleCI a few times.

