### PR TITLE
use new source_id fields for search and elsewhere

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -262,8 +262,8 @@ class CatalogController < ApplicationController
           identifier_tesim
           barcode_id_ssim
           folio_instance_hrid_ssim
-          source_id_ssi
           source_id_text_nostem_i^3
+          source_id_ssi
           previous_ils_ids_ssim
           doi_ssim
           contributor_orcids_ssim

--- a/app/helpers/blacklight_config_helper.rb
+++ b/app/helpers/blacklight_config_helper.rb
@@ -32,9 +32,8 @@ module BlacklightConfigHelper
         identifier_tesim
         barcode_id_ssim
         folio_instance_hrid_ssim
-        source_id_ssim
-        source_id_ssi
         source_id_text_nostem_i^3
+        source_id_ssi
         previous_ils_ids_ssim
         doi_ssim
         contributor_orcids_ssim

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -58,7 +58,7 @@ class Report
       sort: false, default: false, width: 100
     },
     {
-      field: :source_id_ssim, label: 'Source ID',
+      field: :source_id_ssi, label: 'Source ID',
       sort: false, default: true, width: 100
     },
     {
@@ -250,7 +250,7 @@ class Report
     until @response.documents.empty?
       report_data.each do |rec|
         if opts[:source_id].present?
-          druids << ("#{rec[:druid]}\t#{rec[:source_id_ssim]}")
+          druids << ("#{rec[:druid]}\t#{rec[:source_id_ssi]}")
         elsif opts[:tags].present?
           tags = ''
           rec[:tag_ssim]&.split(';')&.each do |tag|

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -39,7 +39,7 @@ class SolrDocument
   FIELD_LICENSE = 'use_license_machine_ssi'
   FIELD_PROJECT_TAG = 'project_tag_ssim'
   FIELD_TAGS = 'tag_ssim'
-  FIELD_SOURCE_ID = 'source_id_ssim'
+  FIELD_SOURCE_ID = 'source_id_ssi'
   FIELD_BARCODE_ID = 'barcode_id_ssim'
   FIELD_WORKFLOW_ERRORS = 'wf_error_ssim'
   FIELD_CONSTITUENTS = 'has_constituents_ssim'

--- a/app/models/track_sheet.rb
+++ b/app/models/track_sheet.rb
@@ -108,7 +108,7 @@ class TrackSheet
       table_data.push(["#{CatalogRecordId.label}:",
                        Array(doc[CatalogRecordId.index_field]).join(', ')])
     end
-    table_data.push(['Source ID:', Array(doc['source_id_ssim']).first]) if doc['source_id_ssim'].present?
+    table_data.push(['Source ID:', doc['source_id_ssi']]) if doc['source_id_ssi'].present?
     table_data.push(['Barcode:', Array(doc['barcode_id_ssim']).first]) if doc['barcode_id_ssim'].present?
     table_data.push(['Date Printed:', Time.zone.now.strftime('%c')])
     table_data

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -61,9 +61,8 @@
         identifier_tesim
         barcode_id_ssim
         folio_instance_hrid_ssim
-        source_id_ssim^3
-        source_id_ssi
         source_id_text_nostem_i^3
+        source_id_ssi
         previous_ils_ids_ssim
         doi_ssim
         contributor_orcids_ssim
@@ -171,9 +170,8 @@
         identifier_tesim
         barcode_id_ssim
         folio_instance_hrid_ssim
-        source_id_ssim^3
-        source_id_ssi
         source_id_text_nostem_i^3
+        source_id_ssi
         previous_ils_ids_ssim
         doi_ssim
         contributor_orcids_ssim

--- a/spec/features/item_view_spec.rb
+++ b/spec/features/item_view_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe 'Item view', :js do
               SolrDocument::FIELD_APO_ID => 'info:fedora/druid:ww057qx5555',
               SolrDocument::FIELD_APO_TITLE => 'Stanford University Libraries - Special Collections',
               :project_tag_ssim => 'Fuller Slides',
-              :source_id_ssim => 'fuller:M1090_S15_B02_F01_0126',
+              :source_id_ssi => 'fuller:M1090_S15_B02_F01_0126',
               :identifier_tesim => ['fuller:M1090_S15_B02_F01_0126', 'uuid:ad2d8894-7eba-11e1-b714-0016034322e7'],
               :tag_ssim => ['Project : Fuller Slides', 'Registered By : renzo']
             }

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Search results' do
                     SolrDocument::FIELD_APO_ID => 'info:fedora/druid:ww057qx5555',
                     SolrDocument::FIELD_APO_TITLE => 'Stanford University Libraries - Special Collections',
                     :project_tag_ssim => 'Fuller Slides',
-                    :source_id_ssim => 'fuller:M1090_S15_B02_F01_0126',
+                    :source_id_ssi => 'fuller:M1090_S15_B02_F01_0126',
                     :identifier_tesim => ['fuller:M1090_S15_B02_F01_0126',
                                           'uuid:ad2d8894-7eba-11e1-b714-0016034322e7'],
                     :tag_ssim => ['Project : Fuller Slides', 'Registered By : renzo'])

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Report do
         :druid,
         :purl,
         :citation,
-        :source_id_ssim,
+        :source_id_ssi,
         SolrDocument::FIELD_APO_TITLE,
         :processing_status_text_ssi,
         :published_earliest_dttsi,
@@ -146,7 +146,7 @@ RSpec.describe Report do
     end
 
     it 'returns druids and source ids' do
-      doc = { id: 'druid:qq613vj0238', source_id_ssim: 'sul:36105011952764' }
+      doc = { id: 'druid:qq613vj0238', source_id_ssi: 'sul:36105011952764' }
       service = instance_double(Blacklight::SearchService)
       allow(Blacklight::SearchService).to receive(:new).and_return(service)
       allow(service).to receive(:search_results).and_return(

--- a/spec/models/track_sheet_spec.rb
+++ b/spec/models/track_sheet_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe TrackSheet do
     context 'with a source_id' do
       let(:solr_doc) do
         base_solr_doc.merge({
-                              'source_id_ssim' => ['source:123']
+                              'source_id_ssi' => 'source:123'
                             })
       end
 

--- a/spec/requests/report_spec.rb
+++ b/spec/requests/report_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Reports from a search' do
     let(:csv) { "Druid,Purl,Source Id,Tags\nab123gg7777\nqh056qq6868" }
 
     it 'downloads valid CSV data for specific fields' do
-      get '/report/download?fields=druid,purl,source_id_ssim,tag_ssim'
+      get '/report/download?fields=druid,purl,source_id_ssi,tag_ssim'
 
       expect(response).to have_http_status(:ok)
       data = CSV.parse(response.body)


### PR DESCRIPTION
~~Hold until Friday Nov 3~~

# Why was this change made?

Closes #4194

To allow source id fragments to be searchable. 

# How was this change tested?

- [x] continuous integration tests
- [x] deployed a branch to stage and tried it there.
- [x] Andrew approved

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->


