### PR TITLE
discovery improvement work; sync solr configs with sul-solr-config

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -240,10 +240,10 @@ class CatalogController < ApplicationController
           contributor_text_nostem_im^3
           topic_tesim^2
 
-          exploded_project_tag_ssim^2
-          exploded_nonproject_tag_ssim
-          exploded_tag_ssim
           tag_ssim
+
+          originInfo_place_placeTerm_tesim
+          originInfo_publisher_tesim
 
           content_type_ssim
           sw_format_ssim
@@ -257,6 +257,7 @@ class CatalogController < ApplicationController
 
           id
           objectId_tesim
+          obj_label_tesim
           identifier_ssim
           identifier_tesim
           barcode_id_ssim

--- a/app/helpers/blacklight_config_helper.rb
+++ b/app/helpers/blacklight_config_helper.rb
@@ -6,18 +6,38 @@ module BlacklightConfigHelper
       'q.alt': '*:*',
       defType: 'dismax',
       qf: %(
-        id
-        collection_title_tesim
-        dor_id_tesim
-        identifier_tesim
-        obj_label_tesim
-        objectId_tesim
+        sw_display_title_tesim^5
+        contributor_text_nostem_im^3
+        topic_tesim^2
+
+        tag_ssim
+
         originInfo_place_placeTerm_tesim
         originInfo_publisher_tesim
-        sw_display_title_tesim
+
+        content_type_ssim
+        sw_format_ssim
+        object_type_ssim
+
+        descriptive_text_nostem_i
+        descriptive_tiv
+        descriptive_teiv
+
+        collection_title_tesim
+
+        id
+        objectId_tesim
+        obj_label_tesim
+        identifier_ssim
+        identifier_tesim
+        barcode_id_ssim
+        folio_instance_hrid_ssim
         source_id_ssim
-        tag_ssim
-        topic_tesim
+        source_id_ssi
+        source_id_text_nostem_i^3
+        previous_ils_ids_ssim
+        doi_ssim
+        contributor_orcids_ssim
       ),
       facet: true,
       'facet.mincount': 1,

--- a/solr_conf/conf/schema.xml
+++ b/solr_conf/conf/schema.xml
@@ -8,36 +8,40 @@
 
   <fields>
     <field name="id" type="string" stored="true" indexed="true" multiValued="false" required="true"/>
+    <!-- DEPRECATED: "long" is a Trie based field type; use solr.LongPointField class instead ... -->
     <field name="_version_" type="long" indexed="true" stored="true" multiValued="false"/>
+    <!-- DEPRECATED: "date" is a Trie based field type; use solr.DatePointField class instead ... -->
     <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
 
     <!-- NOTE:  not all possible Solr field types are represented in the dynamic fields -->
 
     <!-- string (_s...) -->
-    <dynamicField name="*_si"    type="string"    stored="false" indexed="true"  multiValued="false"/>
-    <dynamicField name="*_sim"   type="string"    stored="false" indexed="true"  multiValued="true"/>
-    <dynamicField name="*_ss"    type="string"    stored="true" indexed="false" multiValued="false"/>
-    <dynamicField name="*_ssm"   type="string"    stored="true" indexed="false" multiValued="true"/>
-    <dynamicField name="*_ssi"   type="string"    stored="true" indexed="true"  multiValued="false"/>
-    <dynamicField name="*_ssim"  type="string"    stored="true" indexed="true"  multiValued="true"/>
-    <dynamicField name="*_ssort" type="alphaSort" stored="false" indexed="true"  multiValued="false"/>
+    <!-- docValues true makes for faster facets, but more storage -->
+    <dynamicField name="*_si"     type="string"    stored="false" indexed="true"  multiValued="false"/>
+    <dynamicField name="*_sim"    type="string"    stored="false" indexed="true"  multiValued="true"/>
+    <dynamicField name="*_ss"     type="string"    stored="true"  indexed="false" multiValued="false"/>
+    <dynamicField name="*_ssm"    type="string"    stored="true"  indexed="false" multiValued="true"/>
+    <dynamicField name="*_ssi"    type="string"    stored="true"  indexed="true"  multiValued="false"/>
+    <dynamicField name="*_ssidv"  type="string"    stored="true"  indexed="true"  multiValued="false" docValues="true"/>
+    <dynamicField name="*_ssim"   type="string"    stored="true"  indexed="true"  multiValued="true"/>
+    <dynamicField name="*_ssimdv" type="string"    stored="true"  indexed="true"  multiValued="true"  docValues="true"/>
 
-    <!-- integer (_i...) -->
+    <!-- IntPointField integer (_ip...) (very efficient searches for specific values, or ranges of values) -->
+    <!-- docValues true makes for faster facets, but more storage -->
+    <dynamicField name="*_ipi"    type="intPoint" stored="false" indexed="true"  multiValued="false" docValues="true"/>
+    <dynamicField name="*_ipim"   type="intPoint" stored="false" indexed="true"  multiValued="true"/>
+    <dynamicField name="*_ips"    type="intPoint" stored="true"  indexed="false" multiValued="false" docValues="true"/>
+    <dynamicField name="*_ipsm"   type="intPoint" stored="true"  indexed="false" multiValued="true"/>
+    <dynamicField name="*_ipsi"   type="intPoint" stored="true"  indexed="true"  multiValued="false"/>
+    <dynamicField name="*_ipsidv" type="intPoint" stored="true"  indexed="true"  multiValued="false" docValues="true"/>
+    <dynamicField name="*_ipsim"  type="intPoint" stored="true"  indexed="true"  multiValued="true"/>
+    <!-- DEPRECATED: use IntPointField (_ip...) instead as type int is TrieInteger integer (_i...) -->
     <dynamicField name="*_ii"   type="int" stored="false" indexed="true"  multiValued="false"/>
     <dynamicField name="*_iim"  type="int" stored="false" indexed="true"  multiValued="true"/>
     <dynamicField name="*_is"   type="int" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_ism"  type="int" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_isi"  type="int" stored="true" indexed="true"  multiValued="false"/>
     <dynamicField name="*_isim" type="int" stored="true" indexed="true"  multiValued="true"/>
-
-    <!-- IntPointField integer (_ip...) (very efficient searches for specific values, or ranges of values) -->
-    <dynamicField name="*_ipi"   class="solr.IntPointField" stored="false" indexed="true"  multiValued="false" docValues="true"/>
-    <dynamicField name="*_ipim"  class="solr.IntPointField" stored="false" indexed="true"  multiValued="true"/>
-    <dynamicField name="*_ips"   class="solr.IntPointField" stored="true"  indexed="false" multiValued="false" docValues="true"/>
-    <dynamicField name="*_ipsm"  class="solr.IntPointField" stored="true"  indexed="false" multiValued="true"/>
-    <dynamicField name="*_ipsi"  class="solr.IntPointField" stored="true"  indexed="true"  multiValued="false" docValues="true"/>
-    <dynamicField name="*_ipsim" class="solr.IntPointField" stored="true"  indexed="true"  multiValued="true"/>
-
     <!-- DEPRECATED: trie integer (_it...) (for faster range queries) -->
     <dynamicField name="*_iti"   type="tint" stored="false" indexed="true"  multiValued="false"/>
     <dynamicField name="*_itim"  type="tint" stored="false" indexed="true"  multiValued="true"/>
@@ -46,7 +50,19 @@
     <dynamicField name="*_itsi"  type="tint" stored="true"  indexed="true"  multiValued="false"/>
     <dynamicField name="*_itsim" type="tint" stored="true"  indexed="true"  multiValued="true"/>
 
-    <!-- date (_dt...) -->
+    <!-- DatePointField (_dtp...) (very efficient searches for specific values, or ranges of values) -->
+    <!-- The format for this date field is of the form 1995-12-31T23:59:59Z
+         Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z -->
+    <!-- docValues true makes for faster facets, but more storage -->
+    <dynamicField name="*_dtpi"     type="datePoint" stored="false" indexed="true"  multiValued="false" docValues="true"/>
+    <dynamicField name="*_dtpim"    type="datePoint" stored="false" indexed="true"  multiValued="true"/>
+    <dynamicField name="*_dtps"     type="datePoint" stored="true"  indexed="false" multiValued="false" docValues="true"/>
+    <dynamicField name="*_dtpsm"    type="datePoint" stored="true"  indexed="false" multiValued="true"/>
+    <dynamicField name="*_dtpsi"    type="datePoint" stored="true"  indexed="true"  multiValued="false" docValues="true"/>
+    <dynamicField name="*_dtpsidv"  type="datePoint" stored="true"  indexed="true"  multiValued="false" docValues="true"/>
+    <dynamicField name="*_dtpsim"   type="datePoint" stored="true"  indexed="true"  multiValued="true"/>
+    <dynamicField name="*_dtpsimdv" type="datePoint" stored="true"  indexed="true"  multiValued="true"  docValues="true"/>
+    <!-- DEPRECATED: (_dt...) type date is a TrieDate -->
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z
          Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z -->
     <dynamicField name="*_dti"   type="date" stored="false" indexed="true"  multiValued="false"/>
@@ -55,15 +71,6 @@
     <dynamicField name="*_dtsm"  type="date" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_dtsi"  type="date" stored="true" indexed="true"  multiValued="false"/>
     <dynamicField name="*_dtsim" type="date" stored="true" indexed="true"  multiValued="true"/>
-
-    <!-- DatePointField (_dtp...) (very efficient searches for specific values, or ranges of values) -->
-    <dynamicField name="*_dtpi"   class="solr.DatePointField" stored="false" indexed="true"  multiValued="false" docValues="true"/>
-    <dynamicField name="*_dtpim"  class="solr.DatePointField" stored="false" indexed="true"  multiValued="true"/>
-    <dynamicField name="*_dtps"   class="solr.DatePointField" stored="true" indexed="false" multiValued="false" docValues="true"/>
-    <dynamicField name="*_dtpsm"  class="solr.DatePointField" stored="true" indexed="false" multiValued="true"/>
-    <dynamicField name="*_dtpsi"  class="solr.DatePointField" stored="true" indexed="true"  multiValued="false" docValues="true"/>
-    <dynamicField name="*_dtpsim" class="solr.DatePointField" stored="true" indexed="true"  multiValued="true"/>
-
     <!-- DEPRECATED: trie date (_dtt...) (for faster range queries) -->
     <dynamicField name="*_dtti"   type="tdate" stored="false" indexed="true"  multiValued="false"/>
     <dynamicField name="*_dttim"  type="tdate" stored="false" indexed="true"  multiValued="true"/>
@@ -72,22 +79,20 @@
     <dynamicField name="*_dttsi"  type="tdate" stored="true" indexed="true"  multiValued="false"/>
     <dynamicField name="*_dttsim" type="tdate" stored="true" indexed="true"  multiValued="true"/>
 
-    <!-- double (_db...) -->
+    <!-- DoublePointField (_dbp...) (very efficient searches for specific values, or ranges of values) -->
+    <dynamicField name="*_dbpi"   type="doublePoint" stored="false" indexed="true"  multiValued="false" docValues="true"/>
+    <dynamicField name="*_dbpim"  type="doublePoint" stored="false" indexed="true"  multiValued="true"/>
+    <dynamicField name="*_dbps"   type="doublePoint" stored="true"  indexed="false" multiValued="false" docValues="true"/>
+    <dynamicField name="*_dbpsm"  type="doublePoint" stored="true"  indexed="false" multiValued="true"/>
+    <dynamicField name="*_dbpsi"  type="doublePoint" stored="true"  indexed="true"  multiValued="false" docValues="true"/>
+    <dynamicField name="*_dbpsim" type="doublePoint" stored="true"  indexed="true"  multiValued="true"/>
+    <!-- DEPRECATED: double is a TrieDouble (_db...) -->
     <dynamicField name="*_dbi"   type="double" stored="false" indexed="true"  multiValued="false"/>
     <dynamicField name="*_dbim"  type="double" stored="false" indexed="true"  multiValued="true"/>
     <dynamicField name="*_dbs"   type="double" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_dbsm"  type="double" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_dbsi"  type="double" stored="true" indexed="true"  multiValued="false"/>
     <dynamicField name="*_dbsim" type="double" stored="true" indexed="true"  multiValued="true"/>
-
-    <!-- DoublePointField (_dbp...) (very efficient searches for specific values, or ranges of values) -->
-    <dynamicField name="*_dbpi"   class="solr.DoublePointField" stored="false" indexed="true"  multiValued="false" docValues="true"/>
-    <dynamicField name="*_dbpim"  class="solr.DoublePointField" stored="false" indexed="true"  multiValued="true"/>
-    <dynamicField name="*_dbps"   class="solr.DoublePointField" stored="true" indexed="false" multiValued="false" docValues="true"/>
-    <dynamicField name="*_dbpsm"  class="solr.DoublePointField" stored="true" indexed="false" multiValued="true"/>
-    <dynamicField name="*_dbpsi"  class="solr.DoublePointField" stored="true" indexed="true"  multiValued="false" docValues="true"/>
-    <dynamicField name="*_dbpsim" class="solr.DoublePointField" stored="true" indexed="true"  multiValued="true"/>
-
     <!-- DEPRECATED: trie double (_dbt...) (for faster range queries) -->
     <dynamicField name="*_dbti"   type="tdouble" stored="false" indexed="true"  multiValued="false"/>
     <dynamicField name="*_dbtim"  type="tdouble" stored="false" indexed="true"  multiValued="true"/>
@@ -101,7 +106,18 @@
     <dynamicField name="*_bs"  type="boolean" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_bsi" type="boolean" stored="true" indexed="true"  multiValued="false"/>
 
-    <!-- text (_t...) -->
+    <!-- English text (_ten...) -->
+    <dynamicField name="*_teni"    type="textEnglish" stored="false" indexed="true"  multiValued="false"/>
+    <dynamicField name="*_tenim"   type="textEnglish" stored="false" indexed="true"  multiValued="true"/>
+    <dynamicField name="*_tens"    type="textEnglish" stored="true"  indexed="false" multiValued="false"/>
+    <dynamicField name="*_tensm"   type="textEnglish" stored="true"  indexed="false" multiValued="true"/>
+    <dynamicField name="*_tensi"   type="textEnglish" stored="true"  indexed="true"  multiValued="false"/>
+    <dynamicField name="*_tensim"  type="textEnglish" stored="true"  indexed="true"  multiValued="true"/>
+    <dynamicField name="*_teniv"   type="textEnglish" stored="false" indexed="true"  multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
+    <dynamicField name="*_tenimv"  type="textEnglish" stored="false" indexed="true"  multiValued="true"  termVectors="true" termPositions="true" termOffsets="true"/>
+    <dynamicField name="*_tensiv"  type="textEnglish" stored="true"  indexed="true"  multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
+    <dynamicField name="*_tensimv" type="textEnglish" stored="true"  indexed="true"  multiValued="true"  termVectors="true" termPositions="true" termOffsets="true"/>
+    <!-- DEPRECATED: use textEnglish (_ten...) or textUnstemmed (..text_unstemmed...) instead -->
     <dynamicField name="*_ti"    type="text" stored="false" indexed="true"  multiValued="false"/>
     <dynamicField name="*_tim"   type="text" stored="false" indexed="true"  multiValued="true"/>
     <dynamicField name="*_ts"    type="text" stored="true" indexed="false" multiValued="false"/>
@@ -112,8 +128,7 @@
     <dynamicField name="*_timv"  type="text" stored="false" indexed="true"  multiValued="true"  termVectors="true" termPositions="true" termOffsets="true"/>
     <dynamicField name="*_tsiv"  type="text" stored="true" indexed="true"  multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
     <dynamicField name="*_tsimv" type="text" stored="true" indexed="true"  multiValued="true"  termVectors="true" termPositions="true" termOffsets="true"/>
-
-    <!-- English text (_te...) -->
+    <!-- DEPRECATED: text_en is a deprecated type -->
     <dynamicField name="*_tei"    type="text_en" stored="false" indexed="true"  multiValued="false"/>
     <dynamicField name="*_teim"   type="text_en" stored="false" indexed="true"  multiValued="true"/>
     <dynamicField name="*_tes"    type="text_en" stored="true" indexed="false" multiValued="false"/>
@@ -125,21 +140,28 @@
     <dynamicField name="*_tesiv"  type="text_en" stored="true" indexed="true"  multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
     <dynamicField name="*_tesimv" type="text_en" stored="true" indexed="true"  multiValued="true"  termVectors="true" termPositions="true" termOffsets="true"/>
 
+    <!-- Text tokenized without stemming -->
+    <dynamicField name="*_text_unstemmed_i"  type="textUnstemmed" indexed="true"  stored="false" multiValued="false"/>
+    <dynamicField name="*_text_unstemmed_im" type="textUnstemmed" indexed="true"  stored="false" multiValued="true"/>
+    <!-- DEPRECATED:  textNoStem is a deprecated type -->
     <dynamicField name="*_text_nostem_i"  type="textNoStem" indexed="true"  stored="false" multiValued="false"/>
-    <dynamicField name="*_text_nostem_im"  type="textNoStem" indexed="true"  stored="false" multiValued="true"/>
+    <dynamicField name="*_text_nostem_im" type="textNoStem" indexed="true"  stored="false" multiValued="true"/>
 
-    <dynamicField name="random*" type="rand" />
-
-    <dynamicField name="*_sort"    type="alphaSort" indexed="true"  stored="false" multiValued="false" />
-    <dynamicField name="*_dt_sort" type="tdate"     indexed="true"  stored="false" multiValued="false" />
+    <!-- Text tokenized without stemming but left and right anchored, for "exactish" matches -->
+    <dynamicField name="*_text_anchored_i"  type="textAnchored" indexed="true"  stored="false" multiValued="false"/>
+    <dynamicField name="*_text_anchored_im" type="textAnchored" indexed="true"  stored="false" multiValued="true"/>
   </fields>
 
   <types>
     <fieldType name="string"  class="solr.StrField" sortMissingLast="true" />
     <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>
-    <fieldType name="rand"    class="solr.RandomSortField" omitNorms="true"/>
 
-    <!-- All Trie* numeric and date field types have been deprecated in favor of *Point field types. -->
+    <fieldType name="intPoint" class="solr.IntPointField" />
+    <fieldType name="datePoint" class="solr.DatePointField" />
+    <fieldType name="doublePoint" class="solr.DoublePointField" />
+
+    <!-- DEPRECATED: All Trie* numeric and date field types have been deprecated in favor of *Point field types. -->
+
     <!-- Default numeric field types.  -->
     <fieldType name="int"     class="solr.TrieIntField"    precisionStep="0" positionIncrementGap="0"/>
     <fieldType name="float"   class="solr.TrieFloatField"  precisionStep="0" positionIncrementGap="0"/>
@@ -158,6 +180,86 @@
     <!-- A Trie based date field for faster date range queries and date faceting. -->
     <fieldType name="tdate" class="solr.TrieDateField" precisionStep="6" positionIncrementGap="0"/>
 
+   <!-- Text stemmed for English -->
+    <fieldtype name="textEnglish" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
+      <analyzer type="index">
+        <!-- remove stand-alone punctuation, which gets dropped by the WDGFF but an empty hole is left in the position and screws up phrase searches -->
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s+(\p{Punct}+)\s+" replacement=" " />
+        <tokenizer class="solr.WhitespaceTokenizerFactory" />
+        <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC_Casefold, diacritics removed -->
+        <filter class="solr.WordDelimiterGraphFilterFactory"
+          splitOnCaseChange="1" generateWordParts="1" catenateWords="1"
+          splitOnNumerics="0" generateNumberParts="1" catenateNumbers="1"
+          catenateAll="0" preserveOriginal="0" stemEnglishPossessive="1" />
+        <filter class="solr.FlattenGraphFilterFactory"/>
+        <filter class="solr.RemoveDuplicatesTokenFilterFactory" />
+        <filter class="solr.SnowballPorterFilterFactory" language="English"/>
+      </analyzer>
+      <analyzer type="query">
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s+(\p{Punct}+)\s+" replacement=" " />
+        <tokenizer class="solr.WhitespaceTokenizerFactory" />
+        <filter class="solr.ICUFoldingFilterFactory"/>
+        <filter class="solr.WordDelimiterGraphFilterFactory"
+          splitOnCaseChange="1" generateWordParts="1" catenateWords="1"
+          splitOnNumerics="0" generateNumberParts="1" catenateNumbers="1"
+          catenateAll="0" preserveOriginal="0" stemEnglishPossessive="1" />
+        <filter class="solr.RemoveDuplicatesTokenFilterFactory" />
+        <filter class="solr.SnowballPorterFilterFactory" language="English"/>
+      </analyzer>
+    </fieldtype>
+
+    <!-- Text tokenized and case folded but not stemmed -->
+    <fieldtype name="textUnstemmed" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
+      <analyzer type="index">
+        <!-- for whitespace separated chars that will be processed as their own token stream at query time, e.g. in 'felines : warm and fuzzy' -->
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s+(\p{Punct}+)\s+" replacement=" " />
+        <tokenizer class="solr.WhitespaceTokenizerFactory" />
+        <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC_Casefold, diacritics removed -->
+        <filter class="solr.WordDelimiterGraphFilterFactory"
+          splitOnCaseChange="1" generateWordParts="1" catenateWords="1"
+          splitOnNumerics="0" generateNumberParts="1" catenateNumbers="1"
+          catenateAll="0" preserveOriginal="0" stemEnglishPossessive="0" />
+        <filter class="solr.FlattenGraphFilterFactory"/>
+      </analyzer>
+      <analyzer type="query">
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s+(\p{Punct}+)\s+" replacement=" " />
+        <tokenizer class="solr.WhitespaceTokenizerFactory" />
+        <filter class="solr.ICUFoldingFilterFactory"/>
+        <filter class="solr.WordDelimiterGraphFilterFactory"
+          splitOnCaseChange="1" generateWordParts="1" catenateWords="1"
+          splitOnNumerics="0" generateNumberParts="1" catenateNumbers="1"
+          catenateAll="0" preserveOriginal="0" stemEnglishPossessive="0" />
+      </analyzer>
+    </fieldtype>
+
+    <!-- Left and right anchored tokenized text, without stemming, for "exactish" matches -->
+    <fieldtype name="textAnchored" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
+      <analyzer type="index">
+        <!-- for whitespace separated chars that will be processed as their own token stream at query time, e.g. in 'felines : warm and fuzzy' -->
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s+(\p{Punct}+)\s+" replacement=" " />
+        <!-- anchor beginning and ending of field value, removing trailing chars -->
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^\s*(.*[\S&amp;&amp;[^\.\,:;/=&lt;&gt;\(\)\[\]\&amp;\|]])[\s\.\,:;/=&lt;&gt;\(\)\[\]\&amp;\|]*$" replacement="aaaaaa$1zzzzzz"/>
+        <tokenizer class="solr.WhitespaceTokenizerFactory" />
+        <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC_Casefold, diacritics removed -->
+        <filter class="solr.WordDelimiterGraphFilterFactory"
+          splitOnCaseChange="1" generateWordParts="1" catenateWords="1"
+          splitOnNumerics="0" generateNumberParts="1" catenateNumbers="1"
+          catenateAll="0" preserveOriginal="0" stemEnglishPossessive="1" />
+        <filter class="solr.FlattenGraphFilterFactory"/>
+      </analyzer>
+      <analyzer type="query">
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s+(\p{Punct}+)\s+" replacement=" " />
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^\s*(.*[\S&amp;&amp;[^\.\,:;/=&lt;&gt;\(\)\[\]\&amp;\|]])[\s\.\,:;/=&lt;&gt;\(\)\[\]\&amp;\|]*$" replacement="aaaaaa$1zzzzzz"/>
+        <tokenizer class="solr.WhitespaceTokenizerFactory" />
+        <filter class="solr.ICUFoldingFilterFactory"/>
+        <filter class="solr.WordDelimiterGraphFilterFactory"
+          splitOnCaseChange="1" generateWordParts="1" catenateWords="1"
+          splitOnNumerics="0" generateNumberParts="1" catenateNumbers="1"
+          catenateAll="0" preserveOriginal="0" stemEnglishPossessive="1" />
+      </analyzer>
+    </fieldtype>
+
+    <!-- DEPRECATED:  use textUnstemmed or textEnglish. tokenized, case folded -->
     <fieldType name="text" class="solr.TextField" omitNorms="false">
       <analyzer>
         <tokenizer class="solr.ICUTokenizerFactory"/>
@@ -166,15 +268,7 @@
       </analyzer>
     </fieldType>
 
-    <!-- A text field that only splits on whitespace for exact matching of words -->
-    <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.TrimFilterFactory"/>
-      </analyzer>
-    </fieldType>
-
-    <!-- Analyzed Text, no Stemming or Synonyms -->
+   <!-- DEPRECATED:  use textUnstemmed, as WordDelimiterFilterFactory is deprecated.  Analyzed Text, no Stemming or Synonyms -->
     <fieldtype name="textNoStem" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
       <analyzer>
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
@@ -185,7 +279,7 @@
       </analyzer>
     </fieldtype>
 
-    <!-- A text field with defaults appropriate for English -->
+    <!-- DEPRECATED:  use textEnglish, as more aggressive stemming desired.  A text field with defaults appropriate for English -->
     <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
         <tokenizer class="solr.ICUTokenizerFactory"/>
@@ -196,14 +290,5 @@
         <filter class="solr.TrimFilterFactory"/>
       </analyzer>
     </fieldType>
-
-    <!-- single token analyzed text, for sorting.  Punctuation is significant. -->
-    <fieldtype name="alphaSort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
-      <analyzer>
-        <tokenizer class="solr.KeywordTokenizerFactory" />
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.TrimFilterFactory" />
-      </analyzer>
-    </fieldtype>
   </types>
 </schema>

--- a/solr_conf/conf/schema.xml
+++ b/solr_conf/conf/schema.xml
@@ -30,13 +30,21 @@
     <dynamicField name="*_isi"  type="int" stored="true" indexed="true"  multiValued="false"/>
     <dynamicField name="*_isim" type="int" stored="true" indexed="true"  multiValued="true"/>
 
-    <!-- trie integer (_it...) (for faster range queries) -->
+    <!-- IntPointField integer (_ip...) (very efficient searches for specific values, or ranges of values) -->
+    <dynamicField name="*_ipi"   class="solr.IntPointField" stored="false" indexed="true"  multiValued="false" docValues="true"/>
+    <dynamicField name="*_ipim"  class="solr.IntPointField" stored="false" indexed="true"  multiValued="true"/>
+    <dynamicField name="*_ips"   class="solr.IntPointField" stored="true"  indexed="false" multiValued="false" docValues="true"/>
+    <dynamicField name="*_ipsm"  class="solr.IntPointField" stored="true"  indexed="false" multiValued="true"/>
+    <dynamicField name="*_ipsi"  class="solr.IntPointField" stored="true"  indexed="true"  multiValued="false" docValues="true"/>
+    <dynamicField name="*_ipsim" class="solr.IntPointField" stored="true"  indexed="true"  multiValued="true"/>
+
+    <!-- DEPRECATED: trie integer (_it...) (for faster range queries) -->
     <dynamicField name="*_iti"   type="tint" stored="false" indexed="true"  multiValued="false"/>
     <dynamicField name="*_itim"  type="tint" stored="false" indexed="true"  multiValued="true"/>
-    <dynamicField name="*_its"   type="tint" stored="true" indexed="false" multiValued="false"/>
-    <dynamicField name="*_itsm"  type="tint" stored="true" indexed="false" multiValued="true"/>
-    <dynamicField name="*_itsi"  type="tint" stored="true" indexed="true"  multiValued="false"/>
-    <dynamicField name="*_itsim" type="tint" stored="true" indexed="true"  multiValued="true"/>
+    <dynamicField name="*_its"   type="tint" stored="true"  indexed="false" multiValued="false"/>
+    <dynamicField name="*_itsm"  type="tint" stored="true"  indexed="false" multiValued="true"/>
+    <dynamicField name="*_itsi"  type="tint" stored="true"  indexed="true"  multiValued="false"/>
+    <dynamicField name="*_itsim" type="tint" stored="true"  indexed="true"  multiValued="true"/>
 
     <!-- date (_dt...) -->
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z
@@ -48,29 +56,21 @@
     <dynamicField name="*_dtsi"  type="date" stored="true" indexed="true"  multiValued="false"/>
     <dynamicField name="*_dtsim" type="date" stored="true" indexed="true"  multiValued="true"/>
 
-    <!-- trie date (_dtt...) (for faster range queries) -->
+    <!-- DatePointField (_dtp...) (very efficient searches for specific values, or ranges of values) -->
+    <dynamicField name="*_dtpi"   class="solr.DatePointField" stored="false" indexed="true"  multiValued="false" docValues="true"/>
+    <dynamicField name="*_dtpim"  class="solr.DatePointField" stored="false" indexed="true"  multiValued="true"/>
+    <dynamicField name="*_dtps"   class="solr.DatePointField" stored="true" indexed="false" multiValued="false" docValues="true"/>
+    <dynamicField name="*_dtpsm"  class="solr.DatePointField" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_dtpsi"  class="solr.DatePointField" stored="true" indexed="true"  multiValued="false" docValues="true"/>
+    <dynamicField name="*_dtpsim" class="solr.DatePointField" stored="true" indexed="true"  multiValued="true"/>
+
+    <!-- DEPRECATED: trie date (_dtt...) (for faster range queries) -->
     <dynamicField name="*_dtti"   type="tdate" stored="false" indexed="true"  multiValued="false"/>
     <dynamicField name="*_dttim"  type="tdate" stored="false" indexed="true"  multiValued="true"/>
     <dynamicField name="*_dtts"   type="tdate" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_dttsm"  type="tdate" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_dttsi"  type="tdate" stored="true" indexed="true"  multiValued="false"/>
     <dynamicField name="*_dttsim" type="tdate" stored="true" indexed="true"  multiValued="true"/>
-
-    <!-- long (_l...) -->
-    <dynamicField name="*_li"   type="long" stored="false" indexed="true"  multiValued="false"/>
-    <dynamicField name="*_lim"  type="long" stored="false" indexed="true"  multiValued="true"/>
-    <dynamicField name="*_ls"   type="long" stored="true" indexed="false" multiValued="false"/>
-    <dynamicField name="*_lsm"  type="long" stored="true" indexed="false" multiValued="true"/>
-    <dynamicField name="*_lsi"  type="long" stored="true" indexed="true"  multiValued="false"/>
-    <dynamicField name="*_lsim" type="long" stored="true" indexed="true"  multiValued="true"/>
-
-    <!-- trie long (_lt...) (for faster range queries) -->
-    <dynamicField name="*_lti"   type="tlong" stored="false" indexed="true"  multiValued="false"/>
-    <dynamicField name="*_ltim"  type="tlong" stored="false" indexed="true"  multiValued="true"/>
-    <dynamicField name="*_lts"   type="tlong" stored="true" indexed="false" multiValued="false"/>
-    <dynamicField name="*_ltsm"  type="tlong" stored="true" indexed="false" multiValued="true"/>
-    <dynamicField name="*_ltsi"  type="tlong" stored="true" indexed="true"  multiValued="false"/>
-    <dynamicField name="*_ltsim" type="tlong" stored="true" indexed="true"  multiValued="true"/>
 
     <!-- double (_db...) -->
     <dynamicField name="*_dbi"   type="double" stored="false" indexed="true"  multiValued="false"/>
@@ -80,7 +80,15 @@
     <dynamicField name="*_dbsi"  type="double" stored="true" indexed="true"  multiValued="false"/>
     <dynamicField name="*_dbsim" type="double" stored="true" indexed="true"  multiValued="true"/>
 
-    <!-- trie double (_dbt...) (for faster range queries) -->
+    <!-- DoublePointField (_dbp...) (very efficient searches for specific values, or ranges of values) -->
+    <dynamicField name="*_dbpi"   class="solr.DoublePointField" stored="false" indexed="true"  multiValued="false" docValues="true"/>
+    <dynamicField name="*_dbpim"  class="solr.DoublePointField" stored="false" indexed="true"  multiValued="true"/>
+    <dynamicField name="*_dbps"   class="solr.DoublePointField" stored="true" indexed="false" multiValued="false" docValues="true"/>
+    <dynamicField name="*_dbpsm"  class="solr.DoublePointField" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_dbpsi"  class="solr.DoublePointField" stored="true" indexed="true"  multiValued="false" docValues="true"/>
+    <dynamicField name="*_dbpsim" class="solr.DoublePointField" stored="true" indexed="true"  multiValued="true"/>
+
+    <!-- DEPRECATED: trie double (_dbt...) (for faster range queries) -->
     <dynamicField name="*_dbti"   type="tdouble" stored="false" indexed="true"  multiValued="false"/>
     <dynamicField name="*_dbtim"  type="tdouble" stored="false" indexed="true"  multiValued="true"/>
     <dynamicField name="*_dbts"   type="tdouble" stored="true" indexed="false" multiValued="false"/>
@@ -131,6 +139,7 @@
     <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>
     <fieldType name="rand"    class="solr.RandomSortField" omitNorms="true"/>
 
+    <!-- All Trie* numeric and date field types have been deprecated in favor of *Point field types. -->
     <!-- Default numeric field types.  -->
     <fieldType name="int"     class="solr.TrieIntField"    precisionStep="0" positionIncrementGap="0"/>
     <fieldType name="float"   class="solr.TrieFloatField"  precisionStep="0" positionIncrementGap="0"/>
@@ -140,7 +149,6 @@
     <!-- trie numeric field types for faster range queries -->
     <fieldType name="tint"    class="solr.TrieIntField"    precisionStep="8" positionIncrementGap="0"/>
     <fieldType name="tfloat"  class="solr.TrieFloatField"  precisionStep="8" positionIncrementGap="0"/>
-    <fieldType name="tlong"   class="solr.TrieLongField"   precisionStep="8" positionIncrementGap="0"/>
     <fieldType name="tdouble" class="solr.TrieDoubleField" precisionStep="8" positionIncrementGap="0"/>
 
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -35,16 +35,86 @@
       <str name="fl"> *, score</str>
 
       <str name="qf">
-        id
-        descriptive_tiv
-        descriptive_text_nostem_i
-        descriptive_teiv
+        sw_display_title_tesim^5
+        contributor_text_nostem_im^3
+        topic_tesim^2
+
+        tag_ssim
+
+        originInfo_place_placeTerm_tesim
+        originInfo_publisher_tesim
+
+        content_type_ssim
+        sw_format_ssim
         object_type_ssim
+
+        descriptive_text_nostem_i
+        descriptive_tiv
+        descriptive_teiv
+
+        collection_title_tesim
+
+        id
+        objectId_tesim
+        obj_label_tesim
+        identifier_ssim
+        identifier_tesim
+        barcode_id_ssim
+        folio_instance_hrid_ssim
+        source_id_ssim^3
+        source_id_ssi
+        source_id_text_nostem_i^3
+        previous_ils_ids_ssim
+        doi_ssim
+        contributor_orcids_ssim
       </str>
-      <str name="pf">
-        descriptive_tiv^10
+      <str name="pf">  <!-- (defType dismax, edismax: phrase boost within result set) -->
+        sw_display_title_tesim^25
+        contributor_text_nostem_im^15
+        topic_tesim^10
+
         descriptive_text_nostem_i^5
-        descriptive_teiv^3
+        descriptive_tiv^3
+        descriptive_teiv^2
+
+        collection_title_tesim^5
+
+        objectId_tesim^5
+        obj_label_tesim^5
+        identifier_tesim^5
+        source_id_text_nostem_i^5
+      </str>
+      <str name="pf3">  <!-- (defType edismax: token trigrams boost within result set) -->
+        sw_display_title_tesim^15
+        contributor_text_nostem_im^9
+        topic_tesim^6
+
+        descriptive_text_nostem_i^15
+        descriptive_tiv^9
+        descriptive_teiv^6
+
+        collection_title_tesim^3
+
+        objectId_tesim^3
+        obj_label_tesim^3
+        identifier_tesim^3
+        source_id_text_nostem_i^3
+      </str>
+      <str name="pf2"> <!--(defType edismax: token bigrams boost within result set) -->
+        sw_display_title_tesim^10
+        contributor_text_nostem_im^6
+        topic_tesim^4
+
+        descriptive_text_nostem_i^10
+        descriptive_tiv^6
+        descriptive_teiv^4
+
+        collection_title_tesim^2
+
+        objectId_tesim^2
+        obj_label_tesim^2
+        identifier_tesim^2
+        source_id_text_nostem_i^2
       </str>
 
       <str name="facet">true</str>
@@ -76,26 +146,27 @@
 
       <str name="qf">
         sw_display_title_tesim^5
-        sw_author_tesim^3
+        contributor_text_nostem_im^3
         topic_tesim^2
 
-        exploded_project_tag_ssim^2
-        exploded_nonproject_tag_ssim
-        exploded_tag_ssim
         tag_ssim
+
+        originInfo_place_placeTerm_tesim
+        originInfo_publisher_tesim
 
         content_type_ssim
         sw_format_ssim
         object_type_ssim
 
-        descriptive_tiv
         descriptive_text_nostem_i
+        descriptive_tiv
         descriptive_teiv
 
         collection_title_tesim
 
         id
         objectId_tesim
+        obj_label_tesim
         identifier_ssim
         identifier_tesim
         barcode_id_ssim
@@ -107,48 +178,51 @@
         doi_ssim
         contributor_orcids_ssim
       </str>
-      <str name="pf">  <!-- (phrase boost within result set) -->
+      <str name="pf">  <!-- (defType dismax, edismax: phrase boost within result set) -->
         sw_display_title_tesim^25
-        sw_author_tesim^15
+        contributor_text_nostem_im^15
         topic_tesim^10
 
-        descriptive_tiv^5
-        descriptive_text_nostem_i^3
+        descriptive_text_nostem_i^5
+        descriptive_tiv^3
         descriptive_teiv^2
 
         collection_title_tesim^5
 
         objectId_tesim^5
+        obj_label_tesim^5
         identifier_tesim^5
         source_id_text_nostem_i^5
       </str>
-      <str name="pf3">  <!-- (token trigrams boost within result set) -->
+      <str name="pf3">  <!-- (defType edismax: token trigrams boost within result set) -->
         sw_display_title_tesim^15
-        sw_author_tesim^9
+        contributor_text_nostem_im^9
         topic_tesim^6
 
-        descriptive_tiv^15
-        descriptive_text_nostem_i^9
+        descriptive_text_nostem_i^15
+        descriptive_tiv^9
         descriptive_teiv^6
 
         collection_title_tesim^3
 
         objectId_tesim^3
+        obj_label_tesim^3
         identifier_tesim^3
         source_id_text_nostem_i^3
       </str>
-      <str name="pf2"> <!--(token bigrams boost within result set) -->
+      <str name="pf2"> <!--(defType edismax: token bigrams boost within result set) -->
         sw_display_title_tesim^10
-        sw_author_tesim^6
+        contributor_text_nostem_im^6
         topic_tesim^4
 
-        descriptive_tiv^10
-        descriptive_text_nostem_i^6
+        descriptive_text_nostem_i^10
+        descriptive_tiv^6
         descriptive_teiv^4
 
         collection_title_tesim^2
 
         objectId_tesim^2
+        obj_label_tesim^2
         identifier_tesim^2
         source_id_text_nostem_i^2
       </str>


### PR DESCRIPTION
~~HOLD for integration tests to pass on stage.~~

# Why was this change made?

Part of sul-dlss/dor_indexing_app#1032

As part of the Argo Discovery Improvements, various needs have arisen:
- improve search results for queries on authors, source ids, and in general (catch all field) with qf changes in blacklight_config_helper
- sync Solr config files with updates in  sul-dlss/sul-solr-configs/pull/280

Andrew vetted the blacklight_config_helper changes when I set him up with the same configuration for `qt=qttest` in the url;  he vetted the improvements for author searching and for source id searching.

I diffed solrconfig.xml against the ones in sul-solr-configs/pull/281 and they are the same in all the right ways

# How was this change tested?
- ci tests
- see sul-dlss/sul-solr-configs/pull/280 for how the Solr config changes were tested

TODO:
- [x] deploy branch to -stage and run integration tests
- [x] get this PR merged
- [ ] deploy to all environments (intent is for this to happen with dependency updates on Monday)


