### PR TITLE
no more Hydrus Admin Policy facet - Solr field is no longer used

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -75,8 +75,6 @@ class CatalogController < ApplicationController
                                                                  more_limit: 9999, sort: 'index'
     config.add_facet_field 'nonhydrus_apo_title_ssim', label: 'Admin Policy', component: true, limit: 10,
                                                        more_limit: 9999, sort: 'index'
-    config.add_facet_field 'hydrus_apo_title_ssim', label: 'Hydrus Admin Policy', component: true, limit: 10,
-                                                    more_limit: 9999, sort: 'index', home: false
     config.add_facet_field SolrDocument::FIELD_CURRENT_VERSION, label: 'Version', component: true, limit: 10,
                                                                 home: false
     config.add_facet_field 'processing_status_text_ssi', label: 'Processing Status', component: true, limit: 10,


### PR DESCRIPTION
# Why was this change made?

Tying up loose ends for sul-dlss/dor_indexing_app/issues/841

hydrus_apo_title_ssim is NOT populated in Argo prod index, so we can remove a little cruft.


# How was this change tested?

Triple checked this facet isn't showing in Argo prod ... and it's not because it is empty.  Whee!

