### PR TITLE
blacklight_config_helper.rb - fix typo for non project tags

### DIFF
--- a/app/helpers/blacklight_config_helper.rb
+++ b/app/helpers/blacklight_config_helper.rb
@@ -45,7 +45,7 @@ module BlacklightConfigHelper
       'f.wf_swp_ssim.facet.limit': -1,
       'f.exploded_project_tag_ssim.facet.limit': -1,
       'f.exploded_project_tag_ssim.facet.sort': 'index',
-      'f.exploed_nonproject_tag_ssim.facet.limit': -1,
+      'f.exploded_nonproject_tag_ssim.facet.limit': -1,
       'f.exploded_nonproject_tag_ssim.facet.sort': 'index'
     }
   end


### PR DESCRIPTION
# Why was this change made?

May address problem reported in #4273.

# How was this change tested?




