### PR TITLE
APO form prefers title over label for default collections

### DIFF
--- a/app/forms/apo_form.rb
+++ b/app/forms/apo_form.rb
@@ -73,7 +73,7 @@ class ApoForm < ApplicationChangeSet
       .fetch(default_collections, rows: default_collections.size)
       .last
       .sort_by do |solr_doc|
-        solr_doc.label.downcase
+        solr_doc.title.downcase || solr_doc.label.downcase
       end
   end
 

--- a/app/views/apo/_form.html.erb
+++ b/app/views/apo/_form.html.erb
@@ -18,7 +18,8 @@
       <legend>Default Collections</legend>
       <% @form.default_collection_objects.each_with_index do |solr_doc, index| %>
         <%= hidden_field_tag "apo[collections_for_registration][#{index}][id]", solr_doc.id %>
-        <%= link_to solr_doc.label, solr_doc %> <%= link_to('(remove)', delete_collection_apo_path(collection: solr_doc.id, id: @form), data: { turbo_confirm: 'You are about to leave the page, are you sure?' }) %><br>
+        <% title_shown = solr_doc.title.presence || solr_doc.label %>
+        <%= link_to title_shown, solr_doc %> <%= link_to('(remove)', delete_collection_apo_path(collection: solr_doc.id, id: @form), data: { turbo_confirm: 'You are about to leave the page, are you sure?' }) %><br>
       <% end %>
     </fieldset>
   <% end %>

--- a/spec/features/apo_spec.rb
+++ b/spec/features/apo_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe 'Create an apo', :js do
   let(:agreement) { FactoryBot.create_for_repository(:agreement) }
   let!(:preexisting_collection) do
     FactoryBot.create_for_repository(:persisted_collection,
-                                     label: 'Another type of collection',
-                                     title: 'Another type of collection',
+                                     label: 'Another type of collection label',
+                                     title: 'Another type of collection title',
                                      admin_policy_id: agreement.administrative.hasAdminPolicy)
   end
 
@@ -111,10 +111,10 @@ RSpec.describe 'Create an apo', :js do
     click_on 'Edit APO'
     expect(page).to have_text 'Add group' # wait for form to render
 
-    # Add testing for adding another default collection to this apo.
+    # Add another default collection to this apo.
     within_fieldset 'Default Collections' do
       expect(page).to have_text 'New Testing Collection'
-      expect(page).to have_text 'Another type of collection'
+      expect(page).to have_text 'Another type of collection title'
     end
   end
 end

--- a/spec/forms/apo_form_spec.rb
+++ b/spec/forms/apo_form_spec.rb
@@ -303,8 +303,8 @@ RSpec.describe ApoForm do
     let(:default_collection_druids) { administrative[:collectionsForRegistration] }
     let(:default_collection_objects) do
       default_collection_druids.map do |druid|
-        label = druid[-1].to_i.even? ? druid : druid.upcase # introduce arbitrary mixed case to test sorting
-        instance_double(SolrDocument, label:)
+        title = druid[-1].to_i.even? ? druid : druid.upcase # introduce arbitrary mixed case to test sorting
+        instance_double(SolrDocument, title:)
       end
     end
     let(:search_service_result) { [nil, default_collection_objects] }
@@ -315,6 +315,6 @@ RSpec.describe ApoForm do
                                               .and_return(search_service_result)
     end
 
-    it { is_expected.to eq(default_collection_objects.sort_by { |solr_doc| solr_doc.label.downcase }) }
+    it { is_expected.to eq(default_collection_objects.sort_by { |solr_doc| solr_doc.title.downcase }) }
   end
 end


### PR DESCRIPTION
# Why was this change made?

Fixes #4275 

# How was this change tested?

CI
me on stage
Andrew on stage

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


