### PR TITLE
searches use searchable tag field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -255,7 +255,7 @@ class CatalogController < ApplicationController
           contributor_text_nostem_im^3
           topic_tesim^2
 
-          tag_ssim
+          tag_text_unstemmed_im
 
           originInfo_place_placeTerm_tesim
           originInfo_publisher_tesim

--- a/app/helpers/blacklight_config_helper.rb
+++ b/app/helpers/blacklight_config_helper.rb
@@ -10,7 +10,7 @@ module BlacklightConfigHelper
         contributor_text_nostem_im^3
         topic_tesim^2
 
-        tag_ssim
+        tag_text_unstemmed_im
 
         originInfo_place_placeTerm_tesim
         originInfo_publisher_tesim

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -39,7 +39,7 @@
         contributor_text_nostem_im^3
         topic_tesim^2
 
-        tag_ssim
+        tag_text_unstemmed_im
 
         originInfo_place_placeTerm_tesim
         originInfo_publisher_tesim
@@ -148,7 +148,7 @@
         contributor_text_nostem_im^3
         topic_tesim^2
 
-        tag_ssim
+        tag_text_unstemmed_im
 
         originInfo_place_placeTerm_tesim
         originInfo_publisher_tesim


### PR DESCRIPTION
HOLD for prod index to have new field fully populated.

# Why was this change made?

part of #4265 

# How was this change tested?

on stage and qa,  with all the objects reindexed


