### PR TITLE
use object label less

### DIFF
--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Home page' do
   before do
     solr_conn.add(id: 'druid:xb482bw3983',
                   objectType_ssim: 'item',
-                  obj_label_tesim: 'Report about stuff',
+                  main_title_tenim: 'Report about stuff',
                   collection_title_ssim: '123',
                   current_version_isi: '1')
     solr_conn.commit

--- a/spec/jobs/tracking_sheet_report_job_spec.rb
+++ b/spec/jobs/tracking_sheet_report_job_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe TrackingSheetReportJob do
   describe '#perform_now' do
     context 'with authorization' do
       let(:response) { { 'response' => { 'docs' => docs } } }
-      let(:solr_doc) { { obj_label_tesim: 'Some label' } }
+      let(:solr_doc) { { main_title_tenim: 'Some label' } }
       let(:docs) { [solr_doc] }
 
       before do

--- a/spec/models/track_sheet_spec.rb
+++ b/spec/models/track_sheet_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe TrackSheet do
 
     let(:base_solr_doc) do
       {
-        'obj_label_tesim' => ['bogus label'] # the fedora label
+        'main_title_tenim' => ['main_title']
       }
     end
 

--- a/spec/search_builders/argo/date_field_queries_spec.rb
+++ b/spec/search_builders/argo/date_field_queries_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe Argo::DateFieldQueries do
       end
 
       it 'does not affect non-date queries' do
-        blacklight_params = { 'f' => { obj_label_tesim: ['hello'] } }
-        solr_params = { fq: ['{!term f=obj_label_tesim}hello'] }
+        blacklight_params = { 'f' => { main_title_tenim: ['hello'] } }
+        solr_params = { fq: ['{!term f=main_title_tenim}hello'] }
         expect(subject).to receive(:blacklight_params)
           .twice.and_return(blacklight_params)
         subject.add_date_field_queries(solr_params)
-        expect(solr_params).to eq fq: ['{!term f=obj_label_tesim}hello']
+        expect(solr_params).to eq fq: ['{!term f=main_title_tenim}hello']
       end
     end
   end


### PR DESCRIPTION
# Why was this change made?

Andrew would like us to get away from using object label for anything as it's vestigial from Fedora days.   This PR does some of that.

Part of #4262


# How was this change tested?

CI.  There is one code change, which will increase recall when searching for an existing collection.



