### PR TITLE
Dor::Workflow::Document is no more

### DIFF
--- a/spec/requests/workflows_spec.rb
+++ b/spec/requests/workflows_spec.rb
@@ -65,7 +65,6 @@ RSpec.describe 'WorkflowsController' do
   end
 
   describe '#show' do
-    let(:workflow) { instance_double(Dor::Workflow::Document) }
     let(:workflow_status) { instance_double(WorkflowStatus) }
     let(:template_response) { { 'processes' => workflow_steps } }
     let(:workflow_steps) do


### PR DESCRIPTION
an offshoot of sul-dlss/dor_indexing/pull/25 - this is the only other instance of Dor::Workflow::Document and it is an unused line in a spec.

https://github.com/search?q=org%3Asul-dlss%20Dor%3A%3AWorkflow%3A%3ADocument&type=code

