### PR TITLE
use author_display_ss for FIELD_AUTHOR in SolrDocument

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -25,7 +25,7 @@ class SolrDocument
   FIELD_RELEASED_TO = :released_to_ssim
 
   FIELD_TITLE = 'sw_display_title_tesim'
-  FIELD_AUTHOR = 'sw_author_tesim'
+  FIELD_AUTHOR = 'author_display_ss'
   FIELD_LABEL = 'obj_label_tesim'
   FIELD_PLACE = 'originInfo_place_placeTerm_tesim'
   FIELD_PUBLISHER = 'originInfo_publisher_tesim'


### PR DESCRIPTION
Note:  Andrew has signed off;  this is ready to go.

# Why was this change made?

Because `sw_author_tesim` is a much worse name and field type than `author_display_ss` for a Solr field only used for display purposes.

And because the new field, author_display_ss, is now fully populated.


# How was this change tested?

I carefully checked and rechecked, and only argo git repo references this Solr field (besides dor_indexer gem).  

I carefully checked and rechecked, and argo only uses this field for search result display and for citation presentation (I searched on the Solr field name, which came up with FIELD_AUTHOR in the SolrDocument, which is only used for search results and citation presentation;  I even searched on "author" as a word, which is the attribute name in SolrDocument, and didn't find any other matches.

I also deployed this branch to qa and compared item record search results before and after deployment and the author names were the same in both. 



