### PR TITLE
replace solr search field objectId_tesim with druid_prefixed_ssi and druid_bare_ssi

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -271,7 +271,8 @@ class CatalogController < ApplicationController
           collection_title_tesim
 
           id
-          objectId_tesim
+          druid_bare_ssi
+          druid_prefixed_ssi
           obj_label_tesim
           identifier_ssim
           identifier_tesim

--- a/app/helpers/blacklight_config_helper.rb
+++ b/app/helpers/blacklight_config_helper.rb
@@ -26,7 +26,8 @@ module BlacklightConfigHelper
         collection_title_tesim
 
         id
-        objectId_tesim
+        druid_bare_ssi
+        druid_prefixed_ssi
         obj_label_tesim
         identifier_ssim
         identifier_tesim

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -62,7 +62,8 @@
         collection_title_tesim
 
         id
-        objectId_tesim
+        druid_bare_ssi
+        druid_prefixed_ssi
         obj_label_tesim
         identifier_ssim
         identifier_tesim
@@ -85,7 +86,6 @@
 
         collection_title_tesim^5
 
-        objectId_tesim^5
         obj_label_tesim^5
         identifier_tesim^5
         source_id_text_nostem_i^5
@@ -101,7 +101,6 @@
 
         collection_title_tesim^3
 
-        objectId_tesim^3
         obj_label_tesim^3
         identifier_tesim^3
         source_id_text_nostem_i^3
@@ -117,7 +116,6 @@
 
         collection_title_tesim^2
 
-        objectId_tesim^2
         obj_label_tesim^2
         identifier_tesim^2
         source_id_text_nostem_i^2
@@ -171,7 +169,8 @@
         collection_title_tesim
 
         id
-        objectId_tesim
+        druid_bare_ssi
+        druid_prefixed_ssi
         obj_label_tesim
         identifier_ssim
         identifier_tesim
@@ -194,7 +193,6 @@
 
         collection_title_tesim^5
 
-        objectId_tesim^5
         obj_label_tesim^5
         identifier_tesim^5
         source_id_text_nostem_i^5
@@ -210,7 +208,6 @@
 
         collection_title_tesim^3
 
-        objectId_tesim^3
         obj_label_tesim^3
         identifier_tesim^3
         source_id_text_nostem_i^3
@@ -226,7 +223,6 @@
 
         collection_title_tesim^2
 
-        objectId_tesim^2
         obj_label_tesim^2
         identifier_tesim^2
         source_id_text_nostem_i^2


### PR DESCRIPTION
# Why was this change made?

Part of sul-dlss/dor_indexing_app/issues/1031

Search the newly populated fields `druid_prefixed_ssi` and `druid_bare_ssi` instead of the old `objectId_tesim` which had both a poor name and a poor field type.

# How was this change tested?

I deployed to qa and searches for druids still worked, with and without prefixes.


