### PR TITLE
boost matches on primary author over other contributors in search results

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -259,7 +259,9 @@ class CatalogController < ApplicationController
           additional_titles_unstemmed_im^5
           additional_titles_tenim^3
 
-          contributor_text_nostem_im^3
+          author_text_nostem_im^3
+          contributor_text_nostem_im
+
           topic_tesim^2
 
           tag_text_unstemmed_im

--- a/app/helpers/blacklight_config_helper.rb
+++ b/app/helpers/blacklight_config_helper.rb
@@ -18,7 +18,9 @@ module BlacklightConfigHelper
         additional_titles_unstemmed_im^5
         additional_titles_tenim^3
 
-        contributor_text_nostem_im^3
+        author_text_nostem_im^3
+        contributor_text_nostem_im
+
         topic_tesim^2
 
         tag_text_unstemmed_im

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -50,7 +50,9 @@
         additional_titles_unstemmed_im^5
         additional_titles_tenim^3
 
-        contributor_text_nostem_im^3
+        author_text_nostem_im^3
+        contributor_text_nostem_im
+
         topic_tesim^2
 
         tag_text_unstemmed_im
@@ -91,7 +93,9 @@
         additional_titles_unstemmed_im^25
         additional_titles_tenim^15
 
-        contributor_text_nostem_im^15
+        author_text_nostem_im^15
+        contributor_text_nostem_im^5
+
         topic_tesim^10
 
         descriptive_text_nostem_i^5
@@ -113,7 +117,9 @@
         additional_titles_unstemmed_im^15
         additional_titles_tenim^9
 
-        contributor_text_nostem_im^9
+        author_text_nostem_im^9
+        contributor_text_nostem_im^3
+
         topic_tesim^6
 
         descriptive_text_nostem_i^15
@@ -135,7 +141,9 @@
         additional_titles_unstemmed_im^10
         additional_titles_tenim^6
 
-        contributor_text_nostem_im^6
+        author_text_nostem_im^6
+        contributor_text_nostem_im^2
+
         topic_tesim^4
 
         descriptive_text_nostem_i^10
@@ -185,7 +193,9 @@
         additional_titles_unstemmed_im^5
         additional_titles_tenim^3
 
-        contributor_text_nostem_im^3
+        author_text_nostem_im^3
+        contributor_text_nostem_im
+
         topic_tesim^2
 
         tag_text_unstemmed_im
@@ -226,7 +236,9 @@
         additional_titles_unstemmed_im^25
         additional_titles_tenim^15
 
-        contributor_text_nostem_im^15
+        author_text_nostem_im^15
+        contributor_text_nostem_im^5
+
         topic_tesim^10
 
         descriptive_text_nostem_i^5
@@ -248,7 +260,9 @@
         additional_titles_unstemmed_im^15
         additional_titles_tenim^9
 
-        contributor_text_nostem_im^9
+        author_text_nostem_im^9
+        contributor_text_nostem_im^3
+
         topic_tesim^6
 
         descriptive_text_nostem_i^15
@@ -270,7 +284,9 @@
         additional_titles_unstemmed_im^10
         additional_titles_tenim^6
 
-        contributor_text_nostem_im^6
+        author_text_nostem_im^6
+        contributor_text_nostem_im^2
+
         topic_tesim^4
 
         descriptive_text_nostem_i^10


### PR DESCRIPTION
hold for testing - i think boost values may need to be higher, but easier to tell with sort by relevancy as default.

# Why was this change made?

Part of #4329

This is desired for better search results ... but they do need to be ordered by relevancy, not druid!

# How was this change tested?

I ran some searches in qa.  It certainly made nothing worse.

