### PR TITLE
structure_updater_spec.rb: file and fileset update test completely blank labels

### DIFF
--- a/app/services/structure_updater.rb
+++ b/app/services/structure_updater.rb
@@ -72,7 +72,7 @@ class StructureUpdater
 
   def update_file(existing_file, row)
     attributes = {
-      label: row['file_label'],
+      label: row['file_label'] || '',
       hasMimeType: row['mimetype'],
       use: row['role'],
       languageTag: row['file_language'],
@@ -103,7 +103,7 @@ class StructureUpdater
     # Which files go in which filesets
     files_by_fileset = csv.each_with_object({}) do |row, hash|
       hash[row['sequence']] ||= []
-      fileset_attributes[row['sequence']] = { label: row['resource_label'], type: type(row['resource_type']) }
+      fileset_attributes[row['sequence']] = { label: row['resource_label'] || '', type: type(row['resource_type']) }
       hash[row['sequence']] << update_file(existing_files_by_filename[row['filename']], row)
     end
 

--- a/spec/services/structure_updater_spec.rb
+++ b/spec/services/structure_updater_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe StructureUpdater do
         #{bare_druid},Image 1,image,1,bb045jk9908_0001.tiff,bb045jk9908_0001.tiff,yes,yes,yes,stanford,stanford,,image/one,,en-US
         #{bare_druid},Image 1,image,1,bb045jk9908_0001.jp2,bb045jk9908_0001.jp2,yes,yes,no,world,world,,image/two,transcription,
         #{bare_druid},Image 2,image,2,bb045jk9908_0002.tiff,bb045jk9908_0002.tiff,yes,yes,yes,stanford,none,,image/three,,
-        #{bare_druid},Image 2,image,2,CCTV新闻联播文本数据-20060615-20220630-Stanford University.xlsx,CCTV新闻联播文本数据-20060615-20220630-Stanford University.xlsx,yes,yes,no,location-based,location-based,music,image/four,,
+        #{bare_druid},Image 2,image,2,CCTV新闻联播文本数据-20060615-20220630-Stanford University.xlsx,,yes,yes,no,location-based,location-based,music,image/four,,
       CSV
     end
 
@@ -241,6 +241,9 @@ RSpec.describe StructureUpdater do
 
       expect(new_files.map(&:use)).to eq [nil, 'transcription', nil, nil]
       expect(new_files.map(&:languageTag)).to eq ['en-US', nil, nil, nil]
+      expect(new_files.map(&:filename)).to eq(['bb045jk9908_0001.tiff', 'bb045jk9908_0001.jp2',
+                                               'bb045jk9908_0002.tiff', 'CCTV新闻联播文本数据-20060615-20220630-Stanford University.xlsx'])
+      expect(new_files.map(&:label)).to eq(['bb045jk9908_0001.tiff', 'bb045jk9908_0001.jp2', 'bb045jk9908_0002.tiff', ''])
     end
 
     it 'produces valid cocina' do
@@ -254,8 +257,8 @@ RSpec.describe StructureUpdater do
         druid,resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role
         #{bare_druid},Picture 1,object,1,bb045jk9908_0001.tiff,bb045jk9908_0001.tiff,yes,yes,yes,stanford,stanford,,image/tiff,
         #{bare_druid},Picture 1,object,1,bb045jk9908_0001.jp2,bb045jk9908_0001.jp2,yes,yes,no,world,world,,image/jp2,
-        #{bare_druid},Picture 2,page,2,bb045jk9908_0002.tiff,bb045jk9908_0002.tiff,yes,yes,yes,stanford,stanford,,image/tiff,
-        #{bare_druid},Picture 2,page,2,CCTV新闻联播文本数据-20060615-20220630-Stanford University.xlsx,CCTV新闻联播文本数据-20060615-20220630-Stanford University.xlsx,yes,yes,no,world,world,,image/jp2,
+        #{bare_druid},,page,2,bb045jk9908_0002.tiff,bb045jk9908_0002.tiff,yes,yes,yes,stanford,stanford,,image/tiff,
+        #{bare_druid},,page,2,CCTV新闻联播文本数据-20060615-20220630-Stanford University.xlsx,CCTV新闻联播文本数据-20060615-20220630-Stanford University.xlsx,yes,yes,no,world,world,,image/jp2,
       CSV
     end
 
@@ -268,7 +271,7 @@ RSpec.describe StructureUpdater do
 
       expect(new_filesets.map(&:label)).to eq [
         'Picture 1',
-        'Picture 2'
+        ''
       ]
     end
 


### PR DESCRIPTION
# Why was this change made?

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->

fixes #4334

# How was this change tested?

deployed to stage and followed updated steps to reproduce from [comment on](https://github.com/sul-dlss/argo/issues/4334#issuecomment-1974228931) #4334.

_**note**_: Code Climate must've gotten tripped up when, on a flappy spec, I re-ran only the one failed test, leading to the modified app code lines (and most of the rest of the codebase) not being reported as covered on that first successful CI run (the flappy spec was unrelated to the change in this PR).  Code Climate must've only counted the coverage from the one re-run test after the full suite run?  Then when I re-ran the whole test suite, Code Climate never updated its coverage report.  Likely because the test suite had the same outcome on the same commit hash?  But the failing test in the first commit and the passing tests in the second commit show that the code modified in the second commit did make a difference, and thus had to have been exercised.

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


