### PR TITLE
.gitignore: ignore compiled js that won't be committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ db/*.sqlite3*
 examples.txt
 
 /public/assets
+/public/packs
+/public/packs-test
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml


### PR DESCRIPTION
# Why was this change made?

get rid of this in the `git status` output:

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	public/packs-test/
	public/packs/
```

# How was this change tested?

i ran `git status` again, and those `Untracked files` results were gone, without causing any other issues.

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


