### PR TITLE
CollectionTitleService is new name of CollectionNameService

### DIFF
--- a/app/controllers/apo_controller.rb
+++ b/app/controllers/apo_controller.rb
@@ -34,18 +34,18 @@ class ApoController < ApplicationController
     }.compact)
     @access_template = AccessTemplate.new(access_template:, apo_defaults_template: administrative.accessTemplate)
 
-    @collections = Array(administrative.collectionsForRegistration).filter_map do |col_id|
-      name = CollectionNameService.find(col_id)
-      unless name
-        Honeybadger.notify("The APO #{params[:id]} asserts that #{col_id} is a collection for registration, but we don't find that collection in solr")
+    @collections = Array(administrative.collectionsForRegistration).filter_map do |coll_id|
+      coll_title = CollectionTitleService.find(coll_id)
+      unless coll_title
+        Honeybadger.notify("The APO #{params[:id]} asserts that #{coll_id} is a collection for registration, but we don't find that collection in Solr")
         next
       end
 
-      ["#{name.truncate(60, separator: /\s/)} (#{col_id.delete_prefix('druid:')})", col_id]
+      ["#{coll_title.truncate(60, separator: /\s/)} (#{coll_id.delete_prefix('druid:')})", coll_id]
     end
 
-    # before returning the list, sort by collection name (case insensitive, dropping brackets)
-    @collections.sort_by! { |collection_name| collection_name.first.downcase.delete('[]') }
+    # before returning the list, sort by collection title (case insensitive, dropping brackets)
+    @collections.sort_by! { |collection_title| collection_title.first.downcase.delete('[]') }
   end
 
   def create

--- a/app/services/collection_title_service.rb
+++ b/app/services/collection_title_service.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-# Looks up collection name (title) from Solr
-class CollectionNameService
-  # @return [NilClass,String] the name (title) of the collection if found in solr
+# Looks up collection title from Solr
+class CollectionTitleService
+  # @return [NilClass,String] the title of the collection if found in solr
   def self.find(collection_id)
     solr_doc = SearchService.query("id:\"#{collection_id}\"",
                                    rows: 1,


### PR DESCRIPTION
# Why was this change made?

It's really the title for the collection;  we use "name" in speech but it's a bit weird to have the "CollectionNameService" get the data in the title field.

Or maybe I'm too close to the descriptive metadata at the moment.   It's fine if you close this PR and delete the branch if you think CollectionName makes more sense.


# How was this change tested?

CI

