### PR TITLE
Unpin sqlite3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ group :test, :development do
   gem 'rubocop-performance'
   gem 'rubocop-rails'
   gem 'rubocop-rspec'
-  gem 'sqlite3', '~> 1.4.2'
+  gem 'sqlite3', '~> 1.4'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -573,7 +573,10 @@ GEM
     spreadsheet (1.3.1)
       bigdecimal
       ruby-ole
-    sqlite3 (1.4.4)
+    sqlite3 (1.7.3)
+      mini_portile2 (~> 2.8.0)
+    sqlite3 (1.7.3-x86_64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
     sshkit (1.22.0)
       mutex_m
       net-scp (>= 1.1.2)
@@ -699,7 +702,7 @@ DEPENDENCIES
   selenium-webdriver
   sidekiq (~> 7.1)
   simplecov
-  sqlite3 (~> 1.4.2)
+  sqlite3 (~> 1.4)
   turbo-rails (~> 1.0)
   view_component
   web-console


### PR DESCRIPTION


# Why was this change made?
We pinned it in #1372 for Rails 5.2.2 compatability. We can get up to date now that we're on rails 7.

# How was this change tested?
Test suite
