### PR TITLE
Remove obsolete version rake task

### DIFF
--- a/lib/tasks/argo.rake
+++ b/lib/tasks/argo.rake
@@ -56,28 +56,6 @@ namespace :argo do
     end
   end
 
-  desc "Bump Argo's version number before release"
-  task :bump_version, [:level] => :environment do |_t, args|
-    levels = %w[major minor patch rc]
-    version_file = File.expand_path('../../VERSION', __dir__)
-    version = File.read(version_file)
-    version = version.split('.')
-    index = levels.index(args[:level] || (version.length == 4 ? 'rc' : 'patch'))
-    version.pop if version.length == 4 && index < 3
-    if index == 3
-      rc = version.length == 4 ? version.pop : 'rc0'
-      rc.sub!(/^rc(\d+)$/) { |_m| "rc#{Regexp.last_match(1).to_i + 1}" }
-      version << rc
-      puts version.inspect
-    else
-      version[index] = version[index].to_i + 1
-      (index + 1).upto(2) { |i| version[i] = '0' }
-    end
-    version = version.join('.')
-    File.write(version_file, version)
-    warn "Version bumped to #{version}"
-  end
-
   desc "List APO workgroups from Solr (#{apo_field_default})"
   task workgroups: :environment do
     facet = workgroups_facet


### PR DESCRIPTION


# Why was this change made?

This isn't used. We no longer have the VERSION file this operates on.


# How was this change tested?

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


