### PR TITLE
Update test to work without accessionWF:descriptive-metadata

### DIFF
--- a/spec/requests/workflow_grid_spec.rb
+++ b/spec/requests/workflow_grid_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Display the workflow grid' do
     {
       'response' => { 'docs' => [] },
       'facet_counts' => {
-        'facet_fields' => { 'wf_wps_ssim' => ['accessionWF:descriptive-metadata:waiting', 500], 'wf_wsp_ssim' => [],
+        'facet_fields' => { 'wf_wps_ssim' => ['accessionWF:publish:waiting', 500], 'wf_wsp_ssim' => [],
                             'wf_swp_ssim' => [] }
       }
     }


### PR DESCRIPTION


# Why was this change made?

This was removed from the accessionWF in the workflow-service


# How was this change tested?

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


