### PR TITLE
Do not show Described lifecycle event

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,7 +201,7 @@ GEM
       faraday (~> 2.0)
       faraday-retry
       zeitwerk (~> 2.1)
-    dor-workflow-client (7.0.2)
+    dor-workflow-client (7.2.0)
       activesupport (>= 3.2.1, < 8)
       deprecation (>= 0.99.0)
       faraday (~> 2.0)

--- a/app/services/milestone_service.rb
+++ b/app/services/milestone_service.rb
@@ -10,7 +10,6 @@ class MilestoneService
         'registered' => {}, # each of these *could* have :display and :time elements
         'opened' => {},
         'submitted' => {},
-        'described' => {},
         'published' => {},
         'deposited' => {},
         'accessioned' => {}

--- a/spec/presenters/milestones_presenter_spec.rb
+++ b/spec/presenters/milestones_presenter_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe MilestonesPresenter do
     {
       'opened' => { time: '2020-05-04 18:24:14 +0000' },
       'submitted' => { time: '2020-05-04 18:24:15 +0000' },
-      'described' => { time: '2020-05-04 18:24:15 +0000' },
       'published' => { time: '2020-05-04 18:24:15 +0000' },
       'deposited' => { time: '2020-05-04 18:24:15 +0000' },
       'accessioned' => { time: '2020-05-04 18:24:15 +0000' }
@@ -22,7 +21,6 @@ RSpec.describe MilestonesPresenter do
     { '1' => {
       'registered' => { time: '2020-03-02 13:12:43 +0000' },
       'submitted' => { time: '2020-05-01 19:26:37 +0000' },
-      'described' => { time: '2020-05-01 19:26:37 +0000' },
       'published' => { time: '2020-05-01 19:26:37 +0000' },
       'deposited' => { time: '2020-05-01 19:26:37 +0000' },
       'accessioned' => { time: '2020-05-01 19:26:37 +0000' }
@@ -31,8 +29,8 @@ RSpec.describe MilestonesPresenter do
 
   let(:versions) do
     [
-      Dor::Services::Client::ObjectVersion::Version.new(versionId: 1, tag: '1.0.0', message: 'Initial version'),
-      Dor::Services::Client::ObjectVersion::Version.new(versionId: 2, tag: '1.1.0', message: 'Minor change')
+      Dor::Services::Client::ObjectVersion::Version.new(versionId: 1, message: 'Initial version'),
+      Dor::Services::Client::ObjectVersion::Version.new(versionId: 2, message: 'Minor change')
     ]
   end
 


### PR DESCRIPTION
# Why was this change made?
Fixes #4387. 

# How was this change tested?
Unit, integration testing on stage. Lifecycle events now do not show "Described".

![Screenshot 2024-04-03 at 9 47 26 AM](https://github.com/sul-dlss/argo/assets/1619369/31bec91e-74a2-47f0-8f5f-6728076e5261)

