### PR TITLE
Refactor bulk action jobs to use version service.

### DIFF
--- a/app/jobs/descriptive_metadata_import_job.rb
+++ b/app/jobs/descriptive_metadata_import_job.rb
@@ -63,9 +63,7 @@ class DescriptiveMetadataImportJob < GenericJob
   end
 
   def close_version(cocina_object)
-    unless StateService.new(cocina_object).object_state == :unlock_inactive
-      VersionService.close(druid: cocina_object.externalIdentifier)
-    end
+    VersionService.close(druid: cocina_object.externalIdentifier)
     Success()
   rescue RuntimeError => e
     Failure([e.message])

--- a/app/jobs/generic_job.rb
+++ b/app/jobs/generic_job.rb
@@ -165,13 +165,12 @@ class GenericJob < ApplicationJob
     false
   end
 
-  # Opens a new minor version of the provided cocina object.
+  # Opens a new version of the provided cocina object.
   # @param [Cocina::Models::DROWithMetadata|CollectionWithMetadata|AdminPolicyWithMetadata]
   # @param [String] description for new version
   # @returns [Cocina::Models::DROWithMetadata|CollectionWithMetadata|AdminPolicyWithMetadata] cocina object with the new version
   def open_new_version(cocina_object, description)
-    wf_status = DorObjectWorkflowStatus.new(cocina_object.externalIdentifier, version: cocina_object.version)
-    raise 'Unable to open new version' unless wf_status.can_open_version?
+    raise 'Unable to open new version' unless VersionService.openable?(druid: cocina_object.externalIdentifier)
 
     VersionService.open(druid: cocina_object.externalIdentifier,
                         description:,
@@ -183,8 +182,7 @@ class GenericJob < ApplicationJob
   # @param [String] description for new version
   # @returns [Cocina::Models::DROWithMetadata|CollectionWithMetadata|AdminPolicyWithMetadata] cocina object with the new/existing version
   def open_new_version_if_needed(cocina_object, description)
-    state_service = StateService.new(cocina_object)
-    return cocina_object if state_service.open?
+    return cocina_object if VersionService.open?(druid: cocina_object.externalIdentifier)
 
     open_new_version(cocina_object, description)
   end

--- a/spec/jobs/apply_apo_defaults_job_spec.rb
+++ b/spec/jobs/apply_apo_defaults_job_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe ApplyApoDefaultsJob do
 
   context 'with manage ability' do
     let(:ability) { instance_double(Ability, can?: true) }
-    let(:state_service) { instance_double(StateService, open?: true) }
 
     let(:perform) do
       described_class.perform_now(bulk_action.id,
@@ -43,7 +42,7 @@ RSpec.describe ApplyApoDefaultsJob do
     end
 
     before do
-      allow(StateService).to receive(:new).and_return(state_service)
+      allow(VersionService).to receive(:open?).and_return(true)
     end
 
     context 'when the version is open' do
@@ -63,8 +62,8 @@ RSpec.describe ApplyApoDefaultsJob do
       let(:state_service) { instance_double(StateService, open?: false) }
 
       before do
-        allow_any_instance_of(described_class).to receive(:open_new_version) # rubocop:disable RSpec/AnyInstance
-          .and_return(cocina1.new(version: 2), cocina2.new(version: 2))
+        allow(VersionService).to receive_messages(open?: false, openable?: true)
+        allow(VersionService).to receive(:open).and_return(cocina1.new(version: 2), cocina2.new(version: 2))
         perform
       end
 

--- a/spec/jobs/descriptive_metadata_import_job_spec.rb
+++ b/spec/jobs/descriptive_metadata_import_job_spec.rb
@@ -7,9 +7,8 @@ RSpec.describe DescriptiveMetadataImportJob do
   let(:druids) { %w[druid:bb111cc2222 druid:cc111dd2222] }
   let(:item1) { build(:dro_with_metadata, id: druids[0]) }
   let(:item2) { build(:dro_with_metadata, id: druids[1]) }
-  let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, open: true, close: true) }
-  let(:object_client1) { instance_double(Dor::Services::Client::Object, find: item1, version: version_client) }
-  let(:object_client2) { instance_double(Dor::Services::Client::Object, find: item2, version: version_client) }
+  let(:object_client1) { instance_double(Dor::Services::Client::Object, find: item1) }
+  let(:object_client2) { instance_double(Dor::Services::Client::Object, find: item2) }
   let(:filename) { 'test.csv' }
   let(:log_buffer) { StringIO.new }
 
@@ -21,21 +20,21 @@ RSpec.describe DescriptiveMetadataImportJob do
     ].join("\n")
   end
 
-  let(:state_service) { instance_double(StateService, open?: true, object_state: :unlock) }
-
   before do
     allow(BulkJobLog).to receive(:open).and_yield(log_buffer)
     allow(subject).to receive(:bulk_action).and_return(bulk_action)
     allow(Repository).to receive(:find).with(druids[0]).and_return(item1)
     allow(Repository).to receive(:find).with(druids[1]).and_return(item2)
-    allow(StateService).to receive(:new).and_return(state_service)
     allow(Dor::Services::Client).to receive(:object).with(druids[0]).and_return(object_client1)
     allow(Dor::Services::Client).to receive(:object).with(druids[1]).and_return(object_client2)
+    allow(VersionService).to receive(:open?).and_return(true)
   end
 
   describe '#perform' do
     before do
       allow(Repository).to receive(:store)
+      allow(VersionService).to receive(:open)
+      allow(VersionService).to receive(:close)
     end
 
     context 'when authorized' do
@@ -58,9 +57,8 @@ RSpec.describe DescriptiveMetadataImportJob do
         expect(bulk_action.druid_count_total).to eq druids.length
         expect(Repository).to have_received(:store).with(expected1)
         expect(Repository).to have_received(:store).with(expected2)
-        expect(state_service).to have_received(:open?).twice
-        expect(state_service).to have_received(:object_state).twice
-        expect(version_client).to have_received(:close).twice
+        expect(VersionService).to have_received(:open?).twice
+        expect(VersionService).to have_received(:close).twice
       end
     end
 
@@ -72,7 +70,7 @@ RSpec.describe DescriptiveMetadataImportJob do
       it 'does not update or close items' do
         expect(bulk_action.druid_count_total).to eq druids.length
         expect(Repository).not_to have_received(:store)
-        expect(version_client).not_to have_received(:close)
+        expect(VersionService).not_to have_received(:close)
       end
     end
 
@@ -95,10 +93,10 @@ RSpec.describe DescriptiveMetadataImportJob do
         expect(bulk_action.druid_count_total).to eq 1
         expect(bulk_action.druid_count_fail).to eq 1
         expect(bulk_action.druid_count_success).to eq 0
-        expect(version_client).not_to have_received(:open)
+        expect(VersionService).not_to have_received(:open)
         expect(Repository).not_to have_received(:store)
         expect(Honeybadger).not_to have_received(:notify)
-        expect(version_client).not_to have_received(:close)
+        expect(VersionService).not_to have_received(:close)
       end
     end
 
@@ -148,15 +146,14 @@ RSpec.describe DescriptiveMetadataImportJob do
         expect(bulk_action.druid_count_fail).to eq 1
         expect(bulk_action.druid_count_success).to eq 0
         expect(Repository).not_to have_received(:store)
-        expect(version_client).not_to have_received(:close)
+        expect(VersionService).not_to have_received(:close)
       end
     end
 
-    context 'when not open for modification' do
+    context 'when not open' do
       before do
         allow(Ability).to receive(:new).and_return(ability)
-        allow(DorObjectWorkflowStatus).to receive(:new).and_return(wf_status)
-        allow(VersionService).to receive(:open).and_return(item1.new(version: 2))
+        allow(VersionService).to receive_messages(open?: false, openable?: true, open: item1.new(version: 2))
         subject.perform(bulk_action.id, { csv_file:, csv_filename: filename })
       end
 
@@ -169,40 +166,18 @@ RSpec.describe DescriptiveMetadataImportJob do
 
       let(:ability) { instance_double(Ability, can?: true) }
 
-      let(:wf_status) { instance_double(DorObjectWorkflowStatus, can_open_version?: true) }
-
-      context 'when already accessioned and locked' do
-        let(:state_service) { instance_double(StateService, open?: false, object_state: :lock) }
-        let(:expected1) do
-          item1.new(version: 2, description: item1.description.new(title: [{ value: 'new title 1' }], purl: "https://purl.stanford.edu/#{item1.externalIdentifier.delete_prefix('druid:')}"))
-        end
-
-        it 'opens the item, updates the descriptive metadata and then closes the item' do
-          expect(bulk_action.druid_count_total).to eq 1
-          expect(Repository).to have_received(:store).with(expected1)
-          expect(state_service).to have_received(:open?)
-          expect(VersionService).to have_received(:open).with(druid: item1.externalIdentifier, opening_user_name: bulk_action.user.to_s,
-                                                              description: 'Descriptive metadata upload')
-          expect(version_client).to have_received(:close).once
-          expect(log_buffer.string).to include "CSV filename: #{filename}"
-        end
+      let(:expected1) do
+        item1.new(version: 2, description: item1.description.new(title: [{ value: 'new title 1' }], purl: "https://purl.stanford.edu/#{item1.externalIdentifier.delete_prefix('druid:')}"))
       end
 
-      context 'when registered v1 but no accessioningWF in progress' do
-        let(:state_service) do
-          instance_double(StateService, open?: true, object_state: :unlock_inactive)
-        end
-        let(:expected1) do
-          item1.new(version: 1, description: item1.description.new(title: [{ value: 'new title 1' }], purl: "https://purl.stanford.edu/#{item1.externalIdentifier.delete_prefix('druid:')}"))
-        end
-
-        it 'updates the descriptive metadata but does not open or close the item' do
-          expect(bulk_action.druid_count_total).to eq 1
-          expect(Repository).to have_received(:store).with(expected1)
-          expect(state_service).to have_received(:open?)
-          expect(VersionService).not_to have_received(:open)
-          expect(version_client).not_to have_received(:close)
-        end
+      it 'opens the item, updates the descriptive metadata and then closes the item' do
+        expect(bulk_action.druid_count_total).to eq 1
+        expect(Repository).to have_received(:store).with(expected1)
+        expect(VersionService).to have_received(:open?)
+        expect(VersionService).to have_received(:open).with(druid: item1.externalIdentifier, opening_user_name: bulk_action.user.to_s,
+                                                            description: 'Descriptive metadata upload')
+        expect(VersionService).to have_received(:close).once
+        expect(log_buffer.string).to include "CSV filename: #{filename}"
       end
     end
   end

--- a/spec/jobs/refresh_mods_job_spec.rb
+++ b/spec/jobs/refresh_mods_job_spec.rb
@@ -55,10 +55,8 @@ RSpec.describe RefreshModsJob do
     end
 
     context 'with catalog_record_id' do
-      let(:state_service) { instance_double(StateService, open?: true) }
-
       before do
-        allow(StateService).to receive(:new).and_return(state_service)
+        allow(VersionService).to receive(:open?).and_return(true)
       end
 
       context 'when the version is open' do
@@ -75,9 +73,8 @@ RSpec.describe RefreshModsJob do
       end
 
       context 'when the version is not open' do
-        let(:state_service) { instance_double(StateService, open?: false) }
-
         before do
+          allow(VersionService).to receive(:open?).and_return(false)
           allow_any_instance_of(described_class).to receive(:open_new_version) # rubocop:disable RSpec/AnyInstance
             .and_return(cocina1.new(version: 2), cocina2.new(version: 2))
           perform

--- a/spec/jobs/set_collection_job_spec.rb
+++ b/spec/jobs/set_collection_job_spec.rb
@@ -44,13 +44,15 @@ RSpec.describe SetCollectionJob do
     end
     let(:object_client1) { instance_double(Dor::Services::Client::Object, find: cocina1, update: true) }
     let(:object_client2) { instance_double(Dor::Services::Client::Object, find: cocina2, update: true) }
-    let(:state_service) { instance_double(StateService, open?: true) }
+
+    before do
+      allow(VersionService).to receive(:open?).and_return(true)
+    end
 
     context 'with authorization' do
       before do
         allow(Dor::Services::Client).to receive(:object).with(druids[0]).and_return(object_client1)
         allow(Dor::Services::Client).to receive(:object).with(druids[1]).and_return(object_client2)
-        allow(StateService).to receive(:new).and_return(state_service)
         allow(subject.ability).to receive(:can?).and_return true
       end
 
@@ -76,9 +78,8 @@ RSpec.describe SetCollectionJob do
         end
 
         context 'when the version is closed' do
-          let(:state_service) { instance_double(StateService, open?: false) }
-
           before do
+            allow(VersionService).to receive(:open?).and_return(false)
             allow(job).to receive(:open_new_version).and_return(cocina1.new(version: 2))
           end
 

--- a/spec/jobs/set_governing_apo_job_spec.rb
+++ b/spec/jobs/set_governing_apo_job_spec.rb
@@ -28,11 +28,10 @@ RSpec.describe SetGoverningApoJob do
     end
 
     let(:buffer) { StringIO.new }
-    let(:state_service) { instance_double(StateService, open?: true) }
 
     before do
       allow(BulkJobLog).to receive(:open).and_yield(buffer)
-      allow(StateService).to receive(:new).and_return(state_service)
+      allow(VersionService).to receive(:open?).and_return(true)
     end
 
     context 'when the user can modify all items' do
@@ -67,7 +66,7 @@ RSpec.describe SetGoverningApoJob do
       # test of #perform, to prove that common failure cases for individual objects wouldn't fail the whole run.
       it 'increments the failure and success counts and logs status of each update' do
         subject.perform(bulk_action.id, params)
-        expect(state_service).to have_received(:open?)
+        expect(VersionService).to have_received(:open?)
         expect(object_client1).to have_received(:update).with(params: Cocina::Models::DROWithMetadata)
 
         expect(bulk_action.druid_count_success).to eq 1

--- a/spec/jobs/set_source_ids_csv_job_spec.rb
+++ b/spec/jobs/set_source_ids_csv_job_spec.rb
@@ -38,13 +38,12 @@ RSpec.describe SetSourceIdsCsvJob do
   let(:object_client1) { instance_double(Dor::Services::Client::Object, find: item1, update: true) }
   let(:object_client2) { instance_double(Dor::Services::Client::Object, find: item2, update: true) }
   let(:object_client3) { instance_double(Dor::Services::Client::Object, find: item3, update: true) }
-  let(:state_service) { instance_double(StateService, open?: true) }
 
   before do
     allow(subject).to receive(:bulk_action).and_return(bulk_action)
     allow(BulkJobLog).to receive(:open).and_yield(log_buffer)
     allow(Ability).to receive(:new).and_return(ability)
-    allow(StateService).to receive(:new).and_return(state_service)
+    allow(VersionService).to receive(:open?).and_return(true)
     allow(Dor::Services::Client).to receive(:object).with(druids[0]).and_return(object_client1)
     allow(Dor::Services::Client).to receive(:object).with(druids[1]).and_return(object_client2)
     allow(Dor::Services::Client).to receive(:object).with(druids[2]).and_return(object_client3)
@@ -77,9 +76,8 @@ RSpec.describe SetSourceIdsCsvJob do
       end
 
       context 'when the version is closed' do
-        let(:state_service) { instance_double(StateService, open?: false) }
-
         before do
+          allow(VersionService).to receive(:open?).and_return(false)
           allow(job).to receive(:open_new_version).and_return(item1.new(version: 2), item2.new(version: 2),
                                                               item3.new(version: 2))
           job.perform(bulk_action.id,


### PR DESCRIPTION
closes #4391

# Why was this change made?

To get rid of local versioning logic.

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?

Unit

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


