### PR TITLE
Changes admin policy persister to close version.

### DIFF
--- a/app/services/admin_policy_persister.rb
+++ b/app/services/admin_policy_persister.rb
@@ -53,8 +53,8 @@ class AdminPolicyPersister
 
     response = update
 
-    # Kick off the accessionWF after all updates are complete.
-    WorkflowClientFactory.build.create_workflow_by_name(response.externalIdentifier, 'accessionWF', version: '1')
+    # Close the version after all updates are complete.
+    VersionService.close(druid: response.externalIdentifier)
 
     response
   end


### PR DESCRIPTION
closes #4386

# Why was this change made?
Normalizing versioning.

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


