### PR TITLE
Rename allows_modification to open

### DIFF
--- a/app/components/contents_component.html.erb
+++ b/app/components/contents_component.html.erb
@@ -8,7 +8,7 @@
     <div class="accordion-body" data-controller="structural">
       <div class="mb-3">
         <%= render DownloadAllButtonComponent.new(cocina: @cocina, document: @document) %>
-        <% if allows_modification? %>
+        <% if open? %>
           <%= button_tag class: 'btn btn-link float-end', data: { action: 'click->structural#open' } do %>
             <span class="bi-upload"></span> Upload CSV
           <% end %>

--- a/app/components/contents_component.rb
+++ b/app/components/contents_component.rb
@@ -12,5 +12,5 @@ class ContentsComponent < ApplicationComponent
     @cocina.respond_to?(:structural)
   end
 
-  delegate :allows_modification?, to: :@state_service
+  delegate :open?, to: :@state_service
 end

--- a/app/components/show/barcode_component.html.erb
+++ b/app/components/show/barcode_component.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="barcode">
   <%= barcode %>
-  <% if allows_modification? %>
+  <% if open? %>
     <%= link_to edit_barcode_item_path(id:), aria: { label: 'Edit barcode' } do %>
       <span class="bi-pencil"></span>
     <% end %>

--- a/app/components/show/barcode_component.rb
+++ b/app/components/show/barcode_component.rb
@@ -11,7 +11,7 @@ module Show
       @change_set.barcode || 'Not recorded'
     end
 
-    delegate :allows_modification?, to: :@state_service
+    delegate :open?, to: :@state_service
     delegate :id, to: :@change_set
   end
 end

--- a/app/components/show/catalog_record_id_component.html.erb
+++ b/app/components/show/catalog_record_id_component.html.erb
@@ -1,6 +1,6 @@
 <%= catalog_record_id %>
 
-<% if allows_modification? %>
+<% if open? %>
   <%= link_to edit_item_catalog_record_id_path(item_id: id),
               aria: { label: manage_label },
               data: { controller: 'button', action: 'click->button#open' } do %>

--- a/app/components/show/catalog_record_id_component.rb
+++ b/app/components/show/catalog_record_id_component.rb
@@ -11,7 +11,7 @@ module Show
       @change_set.catalog_record_ids.presence&.join(', ') || 'None assigned'
     end
 
-    delegate :allows_modification?, to: :@state_service
+    delegate :open?, to: :@state_service
     delegate :id, to: :@change_set
     delegate :manage_label, to: CatalogRecordId
   end

--- a/app/components/show/collection/access_rights_component.html.erb
+++ b/app/components/show/collection/access_rights_component.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="access-rights">
   <%= access_rights %>
-  <% if allows_modification? %>
+  <% if open? %>
     <%= link_to edit_rights_item_path(id:), aria: { label: 'Edit rights' } do %>
       <span class="bi-pencil"></span>
     <% end %>

--- a/app/components/show/collection/access_rights_component.rb
+++ b/app/components/show/collection/access_rights_component.rb
@@ -12,7 +12,7 @@ module Show
         view_access.capitalize
       end
 
-      delegate :allows_modification?, to: :@state_service
+      delegate :open?, to: :@state_service
       delegate :id, :view_access, to: :@change_set
     end
   end

--- a/app/components/show/content_type_component.html.erb
+++ b/app/components/show/content_type_component.html.erb
@@ -1,6 +1,6 @@
 <%= content_type %>
 
-<% if allows_modification? %>
+<% if open? %>
   <%= link_to edit_item_content_type_path(item_id: id),
               aria: { label: 'Set content type' },
               data: { controller: 'button', action: 'click->button#open' } do %>

--- a/app/components/show/content_type_component.rb
+++ b/app/components/show/content_type_component.rb
@@ -7,7 +7,7 @@ module Show
       @state_service = state_service
     end
 
-    delegate :allows_modification?, to: :@state_service
+    delegate :open?, to: :@state_service
     delegate :id, :content_type, to: :@document
   end
 end

--- a/app/components/show/controls_component.html.erb
+++ b/app/components/show/controls_component.html.erb
@@ -43,7 +43,7 @@
                           data: { turbo_method: 'post' } %></li>
         <% end %>
         <li><%= link_to 'Download Cocina spreadsheet', item_descriptive_path(doc, format: :csv), class: 'dropdown-item' %></li>
-        <% if allows_modification? %>
+        <% if open? %>
           <li><%= link_to 'Upload Cocina spreadsheet', edit_item_descriptive_path(doc),
                           class: 'dropdown-item',
                           data: { controller: 'button', action: 'click->button#open' } %></li>

--- a/app/components/show/controls_component.rb
+++ b/app/components/show/controls_component.rb
@@ -42,10 +42,10 @@ module Show
     end
 
     delegate :admin_policy?, :agreement?, :item?, :collection?, :embargoed?, to: :doc
-    delegate :allows_modification?, to: :presenter
+    delegate :open?, to: :presenter
 
     def button_disabled?
-      !allows_modification?
+      !open?
     end
 
     def refresh_button_label

--- a/app/components/show/copyright_component.html.erb
+++ b/app/components/show/copyright_component.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="copyright">
   <%= copyright %>
-  <% if allows_modification? %>
+  <% if open? %>
     <%= link_to edit_copyright_item_path(id:), aria: { label: 'Edit copyright' } do %>
       <span class="bi-pencil"></span>
     <% end %>

--- a/app/components/show/copyright_component.rb
+++ b/app/components/show/copyright_component.rb
@@ -11,7 +11,7 @@ module Show
       @change_set.copyright || 'Not entered'
     end
 
-    delegate :allows_modification?, to: :@state_service
+    delegate :open?, to: :@state_service
     delegate :id, to: :@change_set
   end
 end

--- a/app/components/show/governed_by_component.html.erb
+++ b/app/components/show/governed_by_component.html.erb
@@ -1,6 +1,6 @@
 <%= admin_policy %>
 
-<% if allows_modification? %>
+<% if open? %>
   <%= link_to set_governing_apo_ui_item_path(id:),
               aria: { label: 'Set governing APO' },
               data: { controller: 'button', action: 'click->button#open' } do %>

--- a/app/components/show/governed_by_component.rb
+++ b/app/components/show/governed_by_component.rb
@@ -13,7 +13,7 @@ module Show
       helpers.link_to_admin_policy_with_objs(document: @document, value: @document.apo_id)
     end
 
-    delegate :allows_modification?, to: :@state_service
+    delegate :open?, to: :@state_service
     delegate :id, to: :@document
   end
 end

--- a/app/components/show/is_member_of_component.html.erb
+++ b/app/components/show/is_member_of_component.html.erb
@@ -1,6 +1,6 @@
 <%= collection %>
 
-<% if allows_modification? %>
+<% if open? %>
   <%= link_to collection_ui_item_path(id:),
               aria: { label: 'Edit collections' },
               data: { controller: 'button', action: 'click->button#open' } do %>

--- a/app/components/show/is_member_of_component.rb
+++ b/app/components/show/is_member_of_component.rb
@@ -13,7 +13,7 @@ module Show
       helpers.links_to_collections_with_objs(document: @document, value: Array(@document.collection_ids))
     end
 
-    delegate :allows_modification?, to: :@state_service
+    delegate :open?, to: :@state_service
     delegate :id, to: :@document
   end
 end

--- a/app/components/show/item/access_rights_component.html.erb
+++ b/app/components/show/item/access_rights_component.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="access-rights">
   <%= access_rights %>
-  <% if allows_modification? %>
+  <% if open? %>
     <%= link_to edit_rights_item_path(id:), aria: { label: 'Edit rights' } do %>
       <span class="bi-pencil"></span>
     <% end %>

--- a/app/components/show/item/access_rights_component.rb
+++ b/app/components/show/item/access_rights_component.rb
@@ -18,7 +18,7 @@ module Show
         val
       end
 
-      delegate :allows_modification?, to: :@state_service
+      delegate :open?, to: :@state_service
       delegate :id, :view_access, :download_access, :access_location, :controlled_digital_lending, to: :@change_set
 
       def humanize_value(val)

--- a/app/components/show/license_component.html.erb
+++ b/app/components/show/license_component.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="license">
   <%= license %>
-  <% if allows_modification? %>
+  <% if open? %>
     <%= link_to edit_license_item_path(id:), aria: { label: 'Edit license' } do %>
       <span class="bi-pencil"></span>
     <% end %>

--- a/app/components/show/license_component.rb
+++ b/app/components/show/license_component.rb
@@ -15,7 +15,7 @@ module Show
       value.fetch(:label)
     end
 
-    delegate :allows_modification?, to: :@state_service
+    delegate :open?, to: :@state_service
     delegate :id, to: :@change_set
   end
 end

--- a/app/components/show/source_id_component.html.erb
+++ b/app/components/show/source_id_component.html.erb
@@ -1,6 +1,6 @@
 <%= source_id %>
 
-<% if allows_modification? && item? %>
+<% if open? && item? %>
   <%= link_to source_id_ui_item_path(id:),
               aria: { label: 'Change source id' },
               data: { controller: 'button', action: 'click->button#open' } do %>

--- a/app/components/show/source_id_component.rb
+++ b/app/components/show/source_id_component.rb
@@ -7,7 +7,7 @@ module Show
       @state_service = state_service
     end
 
-    delegate :allows_modification?, to: :@state_service
+    delegate :open?, to: :@state_service
     delegate :id, :source_id, :item?, to: :@document
   end
 end

--- a/app/components/show/use_statement_component.html.erb
+++ b/app/components/show/use_statement_component.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="use_statement">
   <%= use_statement %>
-  <% if allows_modification? %>
+  <% if open? %>
     <%= link_to edit_use_statement_item_path(id:), aria: { label: 'Edit use and reproduction' } do %>
       <span class="bi-pencil"></span>
     <% end %>

--- a/app/components/show/use_statement_component.rb
+++ b/app/components/show/use_statement_component.rb
@@ -11,7 +11,7 @@ module Show
       @change_set.use_statement || 'Not entered'
     end
 
-    delegate :allows_modification?, to: :@state_service
+    delegate :open?, to: :@state_service
     delegate :id, to: :@change_set
   end
 end

--- a/app/components/show_embargo_component.rb
+++ b/app/components/show_embargo_component.rb
@@ -7,14 +7,14 @@ class ShowEmbargoComponent < ApplicationComponent
   end
 
   delegate :id, :embargoed?, :embargo_release_date, to: :@solr_document
-  delegate :allows_modification?, to: :@state_service
+  delegate :open?, to: :@state_service
 
   def render?
     embargoed? && embargo_release_date.present?
   end
 
   def edit_embargo
-    return unless allows_modification?
+    return unless open?
 
     link_to edit_item_embargo_path(id),
             class: 'text-white',

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,9 +10,9 @@ class ApplicationController < ActionController::Base
 
   layout :determine_layout
 
-  def allows_modification?(cocina_object)
+  def open?(cocina_object)
     state_service = StateService.new(cocina_object)
-    state_service.allows_modification?
+    state_service.open?
   end
 
   def current_user
@@ -44,7 +44,7 @@ class ApplicationController < ActionController::Base
     end
 
     # if this object has been submitted and doesn't have an open version, they cannot change it.
-    return true if allows_modification?(@cocina)
+    return true if open?(@cocina)
 
     redirect_to solr_document_path(@cocina.externalIdentifier),
                 flash: { error: 'Object cannot be modified in its current state.' }

--- a/app/jobs/generic_job.rb
+++ b/app/jobs/generic_job.rb
@@ -184,7 +184,7 @@ class GenericJob < ApplicationJob
   # @returns [Cocina::Models::DROWithMetadata|CollectionWithMetadata|AdminPolicyWithMetadata] cocina object with the new/existing version
   def open_new_version_if_needed(cocina_object, description)
     state_service = StateService.new(cocina_object)
-    return cocina_object if state_service.allows_modification?
+    return cocina_object if state_service.open?
 
     open_new_version(cocina_object, description)
   end

--- a/app/jobs/import_structural_job.rb
+++ b/app/jobs/import_structural_job.rb
@@ -11,7 +11,7 @@ class ImportStructuralJob < GenericJob
       next failure.call('Not authorized') unless ability.can?(:update, cocina_item)
 
       state_service = StateService.new(cocina_item)
-      next failure.call('Object cannot be modified in its current state.') unless state_service.allows_modification?
+      next failure.call('Object cannot be modified in its current state.') unless state_service.open?
 
       druid = cocina_item.externalIdentifier
       result = StructureUpdater.from_csv(cocina_item, item_csv(csv.headers, grouped.fetch(druid)))

--- a/app/jobs/set_content_type_job.rb
+++ b/app/jobs/set_content_type_job.rb
@@ -36,7 +36,7 @@ class SetContentTypeJob < GenericJob
     return failure.call('Not authorized') unless ability.can?(:update, cocina_object)
 
     state_service = StateService.new(cocina_object)
-    return failure.call('Object cannot be modified in its current state.') unless state_service.allows_modification?
+    return failure.call('Object cannot be modified in its current state.') unless state_service.open?
 
     # use dor services client to pass a hash for structural metadata and update the cocina object
     new_model = cocina_object.new(cocina_update_attributes(cocina_object))

--- a/app/jobs/set_rights_job.rb
+++ b/app/jobs/set_rights_job.rb
@@ -17,7 +17,7 @@ class SetRightsJob < GenericJob
       next failure.call('Not authorized') unless ability.can?(:update, cocina_object)
 
       state_service = StateService.new(cocina_object)
-      next failure.call('Object cannot be modified in its current state.') unless state_service.allows_modification?
+      next failure.call('Object cannot be modified in its current state.') unless state_service.open?
 
       change_set = if cocina_object.collection?
                      # Collection only allows setting view access to dark or world

--- a/app/presenters/argo_show_presenter.rb
+++ b/app/presenters/argo_show_presenter.rb
@@ -17,7 +17,7 @@ class ArgoShowPresenter < Blacklight::ShowPresenter
     cocina.externalIdentifier
   end
 
-  delegate :allows_modification?, to: :state_service
+  delegate :open?, to: :state_service
 
   attr_accessor :cocina, :view_token, :state_service
 end

--- a/app/services/state_service.rb
+++ b/app/services/state_service.rb
@@ -14,7 +14,7 @@ class StateService
     @version = cocina.version
   end
 
-  def allows_modification?
+  def open?
     UNLOCKED_STATES.include? object_state
   end
 

--- a/spec/components/contents_component_spec.rb
+++ b/spec/components/contents_component_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ContentsComponent, type: :component do
                     state_service:)
   end
   let(:component) { described_class.new(presenter:) }
-  let(:state_service) { instance_double(StateService, allows_modification?: allows_modification) }
+  let(:state_service) { instance_double(StateService, open?: open) }
 
   let(:rendered) { render_inline(component) }
 
@@ -25,7 +25,7 @@ RSpec.describe ContentsComponent, type: :component do
     end
 
     context 'with unlocked object' do
-      let(:allows_modification) { true }
+      let(:open) { true }
 
       it 'renders a turbo frame' do
         expect(rendered.css('turbo-frame').first['src']).to eq '/items/skret-t0k3n/structure'
@@ -37,7 +37,7 @@ RSpec.describe ContentsComponent, type: :component do
     end
 
     context 'with locked object' do
-      let(:allows_modification) { false }
+      let(:open) { false }
 
       it 'hides Upload CSV button' do
         expect(rendered.css('.bi-upload')).not_to be_present

--- a/spec/components/show/apo/details_component_spec.rb
+++ b/spec/components/show/apo/details_component_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Show::Apo::DetailsComponent, type: :component do
   let(:presenter) { instance_double(ArgoShowPresenter, document: doc, cocina:, state_service:) }
   let(:cocina) { build(:admin_policy) }
   let(:rendered) { render_inline(component) }
-  let(:allows_modification) { true }
-  let(:state_service) { instance_double(StateService, allows_modification?: allows_modification) }
+  let(:open) { true }
+  let(:state_service) { instance_double(StateService, open?: open) }
   let(:doc) do
     SolrDocument.new('id' => 'druid:kv840xx0000',
                      SolrDocument::FIELD_REGISTERED_DATE => ['2012-04-05T01:00:04.148Z'],
@@ -16,7 +16,7 @@ RSpec.describe Show::Apo::DetailsComponent, type: :component do
   end
   let(:object_type) { 'adminPolicy' }
 
-  context 'when allows_modification is true' do
+  context 'when open is true' do
     it 'renders the appropriate buttons' do
       expect(rendered.css("a[aria-label='Edit tags']")).to be_present
     end

--- a/spec/components/show/apo/overview_component_spec.rb
+++ b/spec/components/show/apo/overview_component_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Show::Apo::OverviewComponent, type: :component do
     build(:admin_policy, registration_workflow: %w[registrationWF goobiWF])
   end
   let(:rendered) { render_inline(component) }
-  let(:allows_modification) { true }
-  let(:state_service) { instance_double(StateService, allows_modification?: allows_modification) }
+  let(:open) { true }
+  let(:state_service) { instance_double(StateService, open?: open) }
 
   let(:doc) do
     SolrDocument.new('id' => 'druid:kv840xx0000',

--- a/spec/components/show/collection/details_component_spec.rb
+++ b/spec/components/show/collection/details_component_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Show::Collection::DetailsComponent, type: :component do
 
   let(:change_set) { instance_double(ItemChangeSet, barcode: nil, id: doc.id, catalog_record_ids: []) }
   let(:rendered) { render_inline(component) }
-  let(:allows_modification) { true }
-  let(:state_service) { instance_double(StateService, allows_modification?: allows_modification) }
+  let(:open) { true }
+  let(:state_service) { instance_double(StateService, open?: open) }
   let(:doc) do
     SolrDocument.new('id' => 'druid:kv840xx0000',
                      SolrDocument::FIELD_REGISTERED_DATE => ['2012-04-05T01:00:04.148Z'],
@@ -19,7 +19,7 @@ RSpec.describe Show::Collection::DetailsComponent, type: :component do
   let(:catalog_record_id_button) { rendered.css("a[aria-label='#{CatalogRecordId.manage_label}']") }
   let(:object_type) { 'collection' }
 
-  context 'when allows_modification is true' do
+  context 'when open is true' do
     it 'creates a edit buttons' do
       expect(rendered.css("a[aria-label='Edit tags']")).to be_present
       expect(catalog_record_id_button).to be_present

--- a/spec/components/show/collection/overview_component_spec.rb
+++ b/spec/components/show/collection/overview_component_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe Show::Collection::OverviewComponent, type: :component do
                                    })
   end
   let(:rendered) { render_inline(component) }
-  let(:allows_modification) { true }
-  let(:state_service) { instance_double(StateService, allows_modification?: allows_modification) }
+  let(:open) { true }
+  let(:state_service) { instance_double(StateService, open?: open) }
 
   let(:edit_copyright_button) { rendered.css("a[aria-label='Edit copyright']") }
   let(:edit_license_button) { rendered.css("a[aria-label='Edit license']") }

--- a/spec/components/show/controls_component_spec.rb
+++ b/spec/components/show/controls_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Show::ControlsComponent, type: :component do
   let(:governing_apo_id) { 'druid:hv992yv2222' }
   let(:manager) { true }
   let(:rendered) { render_inline(component) }
-  let(:presenter) { instance_double(ArgoShowPresenter, document: doc, allows_modification?: allows_modification) }
+  let(:presenter) { instance_double(ArgoShowPresenter, document: doc, open?: open) }
 
   before do
     rendered
@@ -30,7 +30,7 @@ RSpec.describe Show::ControlsComponent, type: :component do
     let(:catalog_record_id) { nil }
 
     context 'when the object is unlocked' do
-      let(:allows_modification) { true }
+      let(:open) { true }
 
       it 'draws the buttons' do
         expect(page).to have_link 'Reindex', href: '/dor/reindex/druid:kv840xx0000'
@@ -69,7 +69,7 @@ RSpec.describe Show::ControlsComponent, type: :component do
     end
 
     context 'when the object is locked' do
-      let(:allows_modification) { false }
+      let(:open) { false }
 
       it 'the embargo and apply APO buttons are disabled' do
         expect(page).to have_link 'Reindex', href: '/dor/reindex/druid:kv840xx0000'
@@ -93,7 +93,7 @@ RSpec.describe Show::ControlsComponent, type: :component do
 
   context 'when the object is an AdminPolicy the user can manage' do
     let(:view_apo_id) { 'druid:zt570qh4444' }
-    let(:allows_modification) { true }
+    let(:open) { true }
 
     let(:doc) do
       SolrDocument.new('id' => view_apo_id,
@@ -120,7 +120,7 @@ RSpec.describe Show::ControlsComponent, type: :component do
 
   context 'when the object is a Collection the user can manage' do
     let(:view_collection_id) { 'druid:kv840xx0000' }
-    let(:allows_modification) { true }
+    let(:open) { true }
 
     let(:doc) do
       SolrDocument.new('id' => view_collection_id,
@@ -160,7 +160,7 @@ RSpec.describe Show::ControlsComponent, type: :component do
   describe '#registered_only?' do
     subject { component.send(:registered_only?) }
 
-    let(:allows_modification) { true }
+    let(:open) { true }
     let(:item_id) { 'druid:kv840xx0000' }
 
     context 'when registered' do

--- a/spec/components/show/item/access_rights_component_spec.rb
+++ b/spec/components/show/item/access_rights_component_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Show::Item::AccessRightsComponent, type: :component do
                             structural: {})
   end
   let(:rendered) { render_inline(component) }
-  let(:allows_modification) { true }
-  let(:state_service) { instance_double(StateService, allows_modification?: allows_modification) }
+  let(:open) { true }
+  let(:state_service) { instance_double(StateService, open?: open) }
 
   context 'with view location' do
     let(:access) do

--- a/spec/components/show/item/details_component_spec.rb
+++ b/spec/components/show/item/details_component_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Show::Item::DetailsComponent, type: :component do
 
   let(:change_set) { instance_double(ItemChangeSet, barcode: nil, id: doc.id, catalog_record_ids: []) }
   let(:rendered) { render_inline(component) }
-  let(:allows_modification) { true }
-  let(:state_service) { instance_double(StateService, allows_modification?: allows_modification) }
+  let(:open) { true }
+  let(:state_service) { instance_double(StateService, open?: open) }
   let(:doc) do
     SolrDocument.new('id' => 'druid:kv840xx0000',
                      SolrDocument::FIELD_REGISTERED_DATE => ['2012-04-05T01:00:04.148Z'],
@@ -25,7 +25,7 @@ RSpec.describe Show::Item::DetailsComponent, type: :component do
   let(:catalog_record_id_button) { rendered.css("a[aria-label='#{CatalogRecordId.manage_label}']") }
   let(:barcode_button) { rendered.css("a[aria-label='Edit barcode']") }
 
-  context 'when allows_modification is true' do
+  context 'when open is true' do
     it 'creates a edit buttons' do
       expect(source_id_button).to be_present
       expect(rendered.to_html).to include 'Not released'
@@ -45,8 +45,8 @@ RSpec.describe Show::Item::DetailsComponent, type: :component do
     end
   end
 
-  context 'when allows_modification is false' do
-    let(:allows_modification) { false }
+  context 'when open is false' do
+    let(:open) { false }
 
     it 'creates only the tag edit buttons' do
       expect(source_id_button).not_to be_present

--- a/spec/components/show/item/overview_component_spec.rb
+++ b/spec/components/show/item/overview_component_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Show::Item::OverviewComponent, type: :component do
     build(:dro)
   end
   let(:rendered) { render_inline(component) }
-  let(:allows_modification) { true }
-  let(:state_service) { instance_double(StateService, allows_modification?: allows_modification) }
+  let(:open) { true }
+  let(:state_service) { instance_double(StateService, open?: open) }
   let(:edit_collection_button) { rendered.css("a[aria-label='Edit collections']") }
   let(:edit_copyright_button) { rendered.css("a[aria-label='Edit copyright']") }
   let(:edit_license_button) { rendered.css("a[aria-label='Edit license']") }
@@ -61,7 +61,7 @@ RSpec.describe Show::Item::OverviewComponent, type: :component do
     end
   end
 
-  context 'when allows_modification is true' do
+  context 'when open is true' do
     it 'creates a edit buttons' do
       expect(edit_governing_apo_button).to be_present
       expect(edit_rights_button).to be_present
@@ -72,8 +72,8 @@ RSpec.describe Show::Item::OverviewComponent, type: :component do
     end
   end
 
-  context 'when allows_modification is false' do
-    let(:allows_modification) { false }
+  context 'when open is false' do
+    let(:open) { false }
 
     it 'creates no edit buttons' do
       expect(edit_governing_apo_button).not_to be_present

--- a/spec/components/show_embargo_component_spec.rb
+++ b/spec/components/show_embargo_component_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ShowEmbargoComponent, type: :component do
   let(:component) { described_class.new(presenter:) }
   let(:rendered) { render_inline(component) }
   let(:presenter) { instance_double(ArgoShowPresenter, document:, state_service:) }
-  let(:state_service) { instance_double(StateService, allows_modification?: allows_modification) }
+  let(:state_service) { instance_double(StateService, open?: open) }
 
   describe 'embargo with release date' do
     let(:document) do
@@ -18,7 +18,7 @@ RSpec.describe ShowEmbargoComponent, type: :component do
     end
 
     context 'with unlocked object' do
-      let(:allows_modification) { true }
+      let(:open) { true }
 
       it 'displays release date and edit icon' do
         expect(rendered.to_html).to include 'Embargoed until February 24, 2259'
@@ -28,7 +28,7 @@ RSpec.describe ShowEmbargoComponent, type: :component do
     end
 
     context 'with locked object' do
-      let(:allows_modification) { false }
+      let(:open) { false }
 
       it 'displays release date but not edit link' do
         expect(rendered.to_html).to include 'Embargoed until February 24, 2259'
@@ -39,7 +39,7 @@ RSpec.describe ShowEmbargoComponent, type: :component do
   end
 
   context 'for embargo without release date' do
-    let(:allows_modification) { true }
+    let(:open) { true }
     let(:document) do
       SolrDocument.new(
         :id => 1,
@@ -53,7 +53,7 @@ RSpec.describe ShowEmbargoComponent, type: :component do
   end
 
   context 'for bad embargo status with release date' do
-    let(:allows_modification) { true }
+    let(:open) { true }
     let(:document) do
       SolrDocument.new(
         :id => 1,

--- a/spec/features/collection_manage_release_spec.rb
+++ b/spec/features/collection_manage_release_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Collection manage release' do
   let(:current_user) { create(:user, sunetid: 'esnowden') }
   let(:blacklight_config) { CatalogController.blacklight_config }
   let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
-  let(:state_service) { instance_double(StateService, allows_modification?: true) }
+  let(:state_service) { instance_double(StateService, open?: true) }
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
   let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: []) }

--- a/spec/features/enable_buttons_spec.rb
+++ b/spec/features/enable_buttons_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Enable buttons' do
   let(:blacklight_config) { CatalogController.blacklight_config }
   let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
   let(:item_id) { 'druid:hj185xx2222' }
-  let(:state_service) { instance_double(StateService, allows_modification?: true) }
+  let(:state_service) { instance_double(StateService, open?: true) }
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: [], current: 1) }
   let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: []) }

--- a/spec/features/item_catalog_record_id_change_spec.rb
+++ b/spec/features/item_catalog_record_id_change_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Item catalog_record_id change' do
   describe 'when modification is not allowed' do
     let(:item) { FactoryBot.create_for_repository(:persisted_item) }
     let(:druid) { item.externalIdentifier }
-    let(:state_service) { instance_double(StateService, allows_modification?: false) }
+    let(:state_service) { instance_double(StateService, open?: false) }
 
     it 'cannot change the catalog_record_id' do
       visit edit_item_catalog_record_id_path druid
@@ -30,7 +30,7 @@ RSpec.describe 'Item catalog_record_id change' do
     let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
     let(:druid) { 'druid:kv840xx0000' }
     let(:cocina_model) { build(:dro_with_metadata, id: druid) }
-    let(:state_service) { instance_double(StateService, allows_modification?: true) }
+    let(:state_service) { instance_double(StateService, open?: true) }
     let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
     let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
     let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: []) }

--- a/spec/features/item_manage_release_spec.rb
+++ b/spec/features/item_manage_release_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Item manage release' do
   let(:current_user) { create(:user, sunetid: 'esnowden') }
-  let(:state_service) { instance_double(StateService, allows_modification?: true) }
+  let(:state_service) { instance_double(StateService, open?: true) }
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
   let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: []) }

--- a/spec/features/item_source_id_change_spec.rb
+++ b/spec/features/item_source_id_change_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Item source id change' do
   describe 'when modification is not allowed' do
     let(:item) { FactoryBot.create_for_repository(:persisted_item) }
     let(:druid) { item.externalIdentifier }
-    let(:state_service) { instance_double(StateService, allows_modification?: false) }
+    let(:state_service) { instance_double(StateService, open?: false) }
 
     before do
       allow(WorkflowService).to receive(:accessioned?).and_return(false)
@@ -33,7 +33,7 @@ RSpec.describe 'Item source id change' do
     let(:cocina_model) do
       build(:dro_with_metadata, id: druid)
     end
-    let(:state_service) { instance_double(StateService, allows_modification?: true) }
+    let(:state_service) { instance_double(StateService, open?: true) }
     let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
     let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
     let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: []) }

--- a/spec/features/set_governing_apo_spec.rb
+++ b/spec/features/set_governing_apo_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Set governing APO' do
   end
 
   let(:identity_md) { instance_double(Nokogiri::XML::Document, xpath: []) }
-  let(:state_service) { instance_double(StateService, allows_modification?: true) }
+  let(:state_service) { instance_double(StateService, open?: true) }
 
   let(:item) do
     FactoryBot.create_for_repository(:persisted_item, label: 'Foo', title: 'Test')

--- a/spec/jobs/apply_apo_defaults_job_spec.rb
+++ b/spec/jobs/apply_apo_defaults_job_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ApplyApoDefaultsJob do
 
   context 'with manage ability' do
     let(:ability) { instance_double(Ability, can?: true) }
-    let(:state_service) { instance_double(StateService, allows_modification?: true) }
+    let(:state_service) { instance_double(StateService, open?: true) }
 
     let(:perform) do
       described_class.perform_now(bulk_action.id,
@@ -60,7 +60,7 @@ RSpec.describe ApplyApoDefaultsJob do
     end
 
     context 'when the version is not open' do
-      let(:state_service) { instance_double(StateService, allows_modification?: false) }
+      let(:state_service) { instance_double(StateService, open?: false) }
 
       before do
         allow_any_instance_of(described_class).to receive(:open_new_version) # rubocop:disable RSpec/AnyInstance

--- a/spec/jobs/manage_embargoes_job_spec.rb
+++ b/spec/jobs/manage_embargoes_job_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe ManageEmbargoesJob do
     ].join("\n")
   end
 
-  let(:state_service) { instance_double(StateService, allows_modification?: true) }
+  let(:state_service) { instance_double(StateService, open?: true) }
   let(:params) { { csv_file: } }
 
   before do
@@ -68,7 +68,7 @@ RSpec.describe ManageEmbargoesJob do
     end
 
     context 'when modification is not allowed' do
-      let(:state_service) { instance_double(StateService, allows_modification?: false) }
+      let(:state_service) { instance_double(StateService, open?: false) }
 
       it 'opens new version and updates the embargo' do
         subject.perform(bulk_action.id, params)
@@ -81,7 +81,7 @@ RSpec.describe ManageEmbargoesJob do
 
     context 'when error' do
       before do
-        allow(state_service).to receive(:allows_modification?).and_raise('oops')
+        allow(state_service).to receive(:open?).and_raise('oops')
       end
 
       it 'logs' do

--- a/spec/jobs/refresh_mods_job_spec.rb
+++ b/spec/jobs/refresh_mods_job_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe RefreshModsJob do
     end
 
     context 'with catalog_record_id' do
-      let(:state_service) { instance_double(StateService, allows_modification?: true) }
+      let(:state_service) { instance_double(StateService, open?: true) }
 
       before do
         allow(StateService).to receive(:new).and_return(state_service)
@@ -75,7 +75,7 @@ RSpec.describe RefreshModsJob do
       end
 
       context 'when the version is not open' do
-        let(:state_service) { instance_double(StateService, allows_modification?: false) }
+        let(:state_service) { instance_double(StateService, open?: false) }
 
         before do
           allow_any_instance_of(described_class).to receive(:open_new_version) # rubocop:disable RSpec/AnyInstance

--- a/spec/jobs/set_catalog_record_ids_and_barcodes_job_spec.rb
+++ b/spec/jobs/set_catalog_record_ids_and_barcodes_job_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe SetCatalogRecordIdsAndBarcodesJob do
       end
 
       context 'when not authorized' do
-        let(:state_service) { instance_double(StateService, allows_modification?: false) }
+        let(:state_service) { instance_double(StateService, open?: false) }
 
         before do
           allow(subject.ability).to receive(:can?).and_return(false)
@@ -204,7 +204,7 @@ RSpec.describe SetCatalogRecordIdsAndBarcodesJob do
         let(:state_service) { instance_double(StateService) }
 
         before do
-          allow(state_service).to receive(:allows_modification?).and_raise('oops')
+          allow(state_service).to receive(:open?).and_raise('oops')
         end
 
         it 'logs' do
@@ -216,7 +216,7 @@ RSpec.describe SetCatalogRecordIdsAndBarcodesJob do
       end
 
       context 'when modification is not allowed' do
-        let(:state_service) { instance_double(StateService, allows_modification?: false) }
+        let(:state_service) { instance_double(StateService, open?: false) }
 
         it 'updates catalog_record_id and barcode and versions objects' do
           expect(subject).to receive(:open_new_version).with(previous_version,
@@ -229,7 +229,7 @@ RSpec.describe SetCatalogRecordIdsAndBarcodesJob do
       end
 
       context 'when modification is allowed' do
-        let(:state_service) { instance_double(StateService, allows_modification?: true) }
+        let(:state_service) { instance_double(StateService, open?: true) }
 
         it 'updates catalog_record_id and barcode and does not version objects if not needed' do
           expect(subject).not_to receive(:open_new_version).with(previous_version,
@@ -242,7 +242,7 @@ RSpec.describe SetCatalogRecordIdsAndBarcodesJob do
       end
 
       context 'when catalog_record_ids are empty and barcode is nil' do
-        let(:state_service) { instance_double(StateService, allows_modification?: false) }
+        let(:state_service) { instance_double(StateService, open?: false) }
         let(:catalog_record_ids_arg) { [] }
         let(:barcode) { nil }
         let(:updated_model) do
@@ -299,7 +299,7 @@ RSpec.describe SetCatalogRecordIdsAndBarcodesJob do
           end
         end
 
-        let(:state_service) { instance_double(StateService, allows_modification?: true) }
+        let(:state_service) { instance_double(StateService, open?: true) }
 
         it 'updates catalog_record_id and barcode and does not version objects if not needed' do
           expect(subject).not_to receive(:open_new_version).with(previous_version,

--- a/spec/jobs/set_collection_job_spec.rb
+++ b/spec/jobs/set_collection_job_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe SetCollectionJob do
     end
     let(:object_client1) { instance_double(Dor::Services::Client::Object, find: cocina1, update: true) }
     let(:object_client2) { instance_double(Dor::Services::Client::Object, find: cocina2, update: true) }
-    let(:state_service) { instance_double(StateService, allows_modification?: true) }
+    let(:state_service) { instance_double(StateService, open?: true) }
 
     context 'with authorization' do
       before do
@@ -76,7 +76,7 @@ RSpec.describe SetCollectionJob do
         end
 
         context 'when the version is closed' do
-          let(:state_service) { instance_double(StateService, allows_modification?: false) }
+          let(:state_service) { instance_double(StateService, open?: false) }
 
           before do
             allow(job).to receive(:open_new_version).and_return(cocina1.new(version: 2))

--- a/spec/jobs/set_content_type_job_spec.rb
+++ b/spec/jobs/set_content_type_job_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe SetContentTypeJob do
   let(:object_client2) { instance_double(Dor::Services::Client::Object, find: cocina2) }
   let(:object_client3) { instance_double(Dor::Services::Client::Object, find: cocina3) }
 
-  let(:state_service) { instance_double(StateService, allows_modification?: true) }
+  let(:state_service) { instance_double(StateService, open?: true) }
   let(:buffer) { StringIO.new }
 
   before do
@@ -224,7 +224,7 @@ RSpec.describe SetContentTypeJob do
   end
 
   context 'when modification is not allowed' do
-    let(:state_service) { instance_double(StateService, allows_modification?: false) }
+    let(:state_service) { instance_double(StateService, open?: false) }
 
     it 'does not update and logs an error' do
       subject.perform(bulk_action.id, params)

--- a/spec/jobs/set_governing_apo_job_spec.rb
+++ b/spec/jobs/set_governing_apo_job_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe SetGoverningApoJob do
     end
 
     let(:buffer) { StringIO.new }
-    let(:state_service) { instance_double(StateService, allows_modification?: true) }
+    let(:state_service) { instance_double(StateService, open?: true) }
 
     before do
       allow(BulkJobLog).to receive(:open).and_yield(buffer)
@@ -67,7 +67,7 @@ RSpec.describe SetGoverningApoJob do
       # test of #perform, to prove that common failure cases for individual objects wouldn't fail the whole run.
       it 'increments the failure and success counts and logs status of each update' do
         subject.perform(bulk_action.id, params)
-        expect(state_service).to have_received(:allows_modification?)
+        expect(state_service).to have_received(:open?)
         expect(object_client1).to have_received(:update).with(params: Cocina::Models::DROWithMetadata)
 
         expect(bulk_action.druid_count_success).to eq 1

--- a/spec/jobs/set_license_and_rights_statements_job_spec.rb
+++ b/spec/jobs/set_license_and_rights_statements_job_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SetLicenseAndRightsStatementsJob do
   let(:logger) { instance_double(File, puts: nil) }
 
   describe '#perform' do
-    let(:allows_modification) { true }
+    let(:open) { true }
     let(:params) do
       {
         copyright_statement_option: '1',
@@ -22,7 +22,7 @@ RSpec.describe SetLicenseAndRightsStatementsJob do
     end
     let(:cocina_object) { build(:dro_with_metadata) }
     let(:copyright_statement) { 'the new hotness' }
-    let(:state_service) { instance_double(StateService, allows_modification?: allows_modification) }
+    let(:state_service) { instance_double(StateService, open?: open) }
     let(:wf_status) { instance_double(DorObjectWorkflowStatus, can_open_version?: true) }
 
     before do
@@ -50,7 +50,7 @@ RSpec.describe SetLicenseAndRightsStatementsJob do
       end
 
       context 'with an item that needs to be opened first' do
-        let(:allows_modification) { false }
+        let(:open) { false }
 
         it 'updates via item change set persister' do
           expect(VersionService).to have_received(:open).twice
@@ -148,7 +148,7 @@ RSpec.describe SetLicenseAndRightsStatementsJob do
     end
 
     context 'when item cannot be opened' do
-      let(:allows_modification) { false }
+      let(:open) { false }
       let(:wf_status) { instance_double(DorObjectWorkflowStatus, can_open_version?: false) }
 
       before do

--- a/spec/jobs/set_rights_job_spec.rb
+++ b/spec/jobs/set_rights_job_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe SetRightsJob do
   let(:object_client1) { instance_double(Dor::Services::Client::Object, find: cocina1) }
   let(:object_client2) { instance_double(Dor::Services::Client::Object, find: cocina2) }
 
-  let(:state_service) { instance_double(StateService, allows_modification?: true) }
+  let(:state_service) { instance_double(StateService, open?: true) }
   let(:buffer) { StringIO.new }
 
   before do

--- a/spec/jobs/set_source_ids_csv_job_spec.rb
+++ b/spec/jobs/set_source_ids_csv_job_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe SetSourceIdsCsvJob do
   let(:object_client1) { instance_double(Dor::Services::Client::Object, find: item1, update: true) }
   let(:object_client2) { instance_double(Dor::Services::Client::Object, find: item2, update: true) }
   let(:object_client3) { instance_double(Dor::Services::Client::Object, find: item3, update: true) }
-  let(:state_service) { instance_double(StateService, allows_modification?: true) }
+  let(:state_service) { instance_double(StateService, open?: true) }
 
   before do
     allow(subject).to receive(:bulk_action).and_return(bulk_action)
@@ -77,7 +77,7 @@ RSpec.describe SetSourceIdsCsvJob do
       end
 
       context 'when the version is closed' do
-        let(:state_service) { instance_double(StateService, allows_modification?: false) }
+        let(:state_service) { instance_double(StateService, open?: false) }
 
         before do
           allow(job).to receive(:open_new_version).and_return(item1.new(version: 2), item2.new(version: 2),

--- a/spec/requests/manage_collection_membership_spec.rb
+++ b/spec/requests/manage_collection_membership_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Collection membership' do
   end
 
   let(:druid) { 'druid:bc123df4567' }
-  let(:state_service) { instance_double(StateService, allows_modification?: true) }
+  let(:state_service) { instance_double(StateService, open?: true) }
 
   describe 'adding a new collection' do
     let(:cocina_collection) { build(:dro_with_metadata, id: druid, collection_ids:) }

--- a/spec/requests/refresh_metadata_spec.rb
+++ b/spec/requests/refresh_metadata_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Refresh metadata' do
   let(:druid) { 'druid:bc123df4567' }
-  let(:state_service) { instance_double(StateService, allows_modification?: true) }
+  let(:state_service) { instance_double(StateService, open?: true) }
   let(:object_service) { instance_double(Dor::Services::Client::Object, refresh_metadata: true, find: cocina_model) }
   let(:cocina_model) do
     build(:dro_with_metadata, id: druid, folio_instance_hrids: ['a12345'])
@@ -42,7 +42,7 @@ RSpec.describe 'Refresh metadata' do
     end
 
     context "when the object doesn't allow modification" do
-      let(:state_service) { instance_double(StateService, allows_modification?: false) }
+      let(:state_service) { instance_double(StateService, open?: false) }
 
       it 'redirects with an error message' do
         post "/items/#{druid}/refresh_metadata"

--- a/spec/requests/set_content_types_spec.rb
+++ b/spec/requests/set_content_types_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'Set content type for an item' do
       allow(StateService).to receive(:new).and_return(state_service)
     end
 
-    let(:state_service) { instance_double(StateService, allows_modification?: true) }
+    let(:state_service) { instance_double(StateService, open?: true) }
 
     context 'with access' do
       before do
@@ -183,7 +183,7 @@ RSpec.describe 'Set content type for an item' do
       end
 
       context 'when modification not allowed' do
-        let(:state_service) { instance_double(StateService, allows_modification?: false) }
+        let(:state_service) { instance_double(StateService, open?: false) }
 
         it 'is forbidden' do
           patch "/items/#{druid}/content_type",

--- a/spec/requests/set_governing_apo_spec.rb
+++ b/spec/requests/set_governing_apo_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Set APO for an object' do
     let(:new_apo_id) { 'druid:bc123cd4567' }
     let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, update: true) }
     let(:cocina_model) { build(:dro_with_metadata, id: druid) }
-    let(:state_service) { instance_double(StateService, allows_modification?: true) }
+    let(:state_service) { instance_double(StateService, open?: true) }
 
     before do
       allow(Dor::Services::Client).to receive(:object).and_return(object_client)
@@ -19,7 +19,7 @@ RSpec.describe 'Set APO for an object' do
     end
 
     context 'when object modification not allowed' do
-      let(:state_service) { instance_double(StateService, allows_modification?: false) }
+      let(:state_service) { instance_double(StateService, open?: false) }
 
       it 'redirects with an error' do
         post "/items/#{druid}/set_governing_apo", params: { new_apo_id: }

--- a/spec/requests/upload_structural_csv_spec.rb
+++ b/spec/requests/upload_structural_csv_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe 'Upload the structural CSV' do
 
   before do
     allow(Repository).to receive(:find).and_return(cocina_model)
-    allow(StateService).to receive(:new).and_return(state_service, allows_modification?: modifiable)
+    allow(StateService).to receive(:new).and_return(state_service, open?: modifiable)
     allow(Argo::Indexer).to receive(:reindex_druid_remotely)
   end
 
   context 'when they have manage access' do
     before do
-      allow(state_service).to receive(:allows_modification?).and_return(modifiable)
+      allow(state_service).to receive(:open?).and_return(modifiable)
 
       sign_in user, groups: ['sdr:administrator-role']
     end

--- a/spec/services/state_service_spec.rb
+++ b/spec/services/state_service_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe StateService do
   let(:cocina) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, version: 3) }
   let(:service) { described_class.new(cocina) }
 
-  describe '#allows_modification?' do
+  describe '#open?' do
     before do
       allow(service).to receive(:object_state).and_return(:unlock)
     end
@@ -26,7 +26,7 @@ RSpec.describe StateService do
       end
 
       it 'returns true' do
-        expect(service).to be_allows_modification
+        expect(service).to be_open
       end
     end
 
@@ -36,7 +36,7 @@ RSpec.describe StateService do
       end
 
       it 'returns true' do
-        expect(service).to be_allows_modification
+        expect(service).to be_open
       end
     end
 
@@ -46,7 +46,7 @@ RSpec.describe StateService do
       end
 
       it 'returns false' do
-        expect(service).not_to be_allows_modification
+        expect(service).not_to be_open
       end
     end
 
@@ -56,7 +56,7 @@ RSpec.describe StateService do
       end
 
       it 'returns false' do
-        expect(service).not_to be_allows_modification
+        expect(service).not_to be_open
       end
     end
   end


### PR DESCRIPTION
# Why was this change made?

This is a straight search and replace. "allows modification" is not part of the nomalized versioning vocab; "open" is.


# How was this change tested?

Unit
<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


