### PR TITLE
Refactor state service open

### DIFF
--- a/app/components/contents_component.rb
+++ b/app/components/contents_component.rb
@@ -4,7 +4,7 @@ class ContentsComponent < ApplicationComponent
   def initialize(presenter:)
     @document = presenter.document
     @cocina = presenter.cocina
-    @state_service = presenter.state_service
+    @presenter = presenter
     @view_token = presenter.view_token
   end
 
@@ -12,5 +12,5 @@ class ContentsComponent < ApplicationComponent
     @cocina.respond_to?(:structural)
   end
 
-  delegate :open?, to: :@state_service
+  delegate :open?, to: :@presenter
 end

--- a/app/components/show/agreement/details_component.html.erb
+++ b/app/components/show/agreement/details_component.html.erb
@@ -11,7 +11,7 @@
       <tr>
         <th class="col-3" scope="row">Content type</th>
         <td>
-          <%= render Show::ContentTypeComponent.new(document: @solr_document, state_service:) %>
+          <%= render Show::ContentTypeComponent.new(document: @solr_document, version_service: @presenter.version_service) %>
         </td>
       </tr>
 
@@ -25,7 +25,7 @@
       <tr>
         <th class="col-3" scope="row">Source IDs</th>
         <td>
-          <%= render Show::SourceIdComponent.new(document: @solr_document, state_service:) %>
+          <%= render Show::SourceIdComponent.new(document: @solr_document, version_service: @presenter.version_service) %>
         </td>
       </tr>
 

--- a/app/components/show/agreement/overview_component.html.erb
+++ b/app/components/show/agreement/overview_component.html.erb
@@ -11,14 +11,14 @@
       <tr>
         <th class="col-3" scope="row">Admin policy</th>
         <td>
-          <%= render Show::GovernedByComponent.new(document: @solr_document, state_service:) %>
+          <%= render Show::GovernedByComponent.new(document: @solr_document, version_service: @presenter.version_service) %>
         </td>
       </tr>
 
       <tr>
         <th class="col-3" scope="row">Collection</th>
         <td>
-          <%= render Show::IsMemberOfComponent.new(document: @solr_document, state_service:) %>
+          <%= render Show::IsMemberOfComponent.new(document: @solr_document, version_service: @presenter.version_service) %>
         </td>
       </tr>
 
@@ -32,7 +32,7 @@
       <tr>
         <th class="col-3" scope="row">Access rights</th>
         <td>
-          <%= render Show::Item::AccessRightsComponent.new(change_set: @presenter.change_set, state_service:) %>
+          <%= render Show::Item::AccessRightsComponent.new(change_set: @presenter.change_set, version_service: @presenter.version_service) %>
         </td>
       </tr>
     </tbody>

--- a/app/components/show/apo/overview_component.rb
+++ b/app/components/show/apo/overview_component.rb
@@ -15,7 +15,6 @@ module Show
       end
 
       delegate :id, :status, to: :@solr_document
-      delegate :state_service, to: :@presenter
     end
   end
 end

--- a/app/components/show/barcode_component.rb
+++ b/app/components/show/barcode_component.rb
@@ -2,16 +2,16 @@
 
 module Show
   class BarcodeComponent < ApplicationComponent
-    def initialize(change_set:, state_service:)
+    def initialize(change_set:, version_service:)
       @change_set = change_set
-      @state_service = state_service
+      @version_service = version_service
     end
 
     def barcode
       @change_set.barcode || 'Not recorded'
     end
 
-    delegate :open?, to: :@state_service
+    delegate :open?, to: :@version_service
     delegate :id, to: :@change_set
   end
 end

--- a/app/components/show/catalog_record_id_component.rb
+++ b/app/components/show/catalog_record_id_component.rb
@@ -2,16 +2,16 @@
 
 module Show
   class CatalogRecordIdComponent < ApplicationComponent
-    def initialize(change_set:, state_service:)
+    def initialize(change_set:, version_service:)
       @change_set = change_set
-      @state_service = state_service
+      @version_service = version_service
     end
 
     def catalog_record_id
       @change_set.catalog_record_ids.presence&.join(', ') || 'None assigned'
     end
 
-    delegate :open?, to: :@state_service
+    delegate :open?, to: :@version_service
     delegate :id, to: :@change_set
     delegate :manage_label, to: CatalogRecordId
   end

--- a/app/components/show/collection/access_rights_component.rb
+++ b/app/components/show/collection/access_rights_component.rb
@@ -3,16 +3,16 @@
 module Show
   module Collection
     class AccessRightsComponent < ApplicationComponent
-      def initialize(change_set:, state_service:)
+      def initialize(change_set:, version_service:)
         @change_set = change_set
-        @state_service = state_service
+        @version_service = version_service
       end
 
       def access_rights
         view_access.capitalize
       end
 
-      delegate :open?, to: :@state_service
+      delegate :open?, to: :@version_service
       delegate :id, :view_access, to: :@change_set
     end
   end

--- a/app/components/show/collection/details_component.html.erb
+++ b/app/components/show/collection/details_component.html.erb
@@ -39,7 +39,7 @@
       <tr>
         <th class="col-3" scope="row"><%= catalog_record_id_label %></th>
         <td>
-          <%= render Show::CatalogRecordIdComponent.new(change_set: @presenter.change_set, state_service:) %>
+          <%= render Show::CatalogRecordIdComponent.new(change_set: @presenter.change_set, version_service: @presenter.version_service) %>
         </td>
       </tr>
 

--- a/app/components/show/collection/overview_component.html.erb
+++ b/app/components/show/collection/overview_component.html.erb
@@ -11,7 +11,7 @@
       <tr>
         <th class="col-3" scope="row">Admin policy</th>
         <td>
-          <%= render Show::GovernedByComponent.new(document: @solr_document, state_service:) %>
+          <%= render Show::GovernedByComponent.new(document: @solr_document, version_service: @presenter.version_service) %>
         </td>
       </tr>
 
@@ -25,28 +25,28 @@
       <tr>
         <th class="col-3" scope="row">Access rights</th>
         <td>
-          <%= render Show::Collection::AccessRightsComponent.new(change_set: @presenter.change_set, state_service:) %>
+          <%= render Show::Collection::AccessRightsComponent.new(change_set: @presenter.change_set, version_service: @presenter.version_service) %>
         </td>
       </tr>
 
       <tr>
         <th class="col-3" scope="row">Copyright</th>
         <td>
-          <%= render Show::CopyrightComponent.new(change_set: @presenter.change_set, state_service:) %>
+          <%= render Show::CopyrightComponent.new(change_set: @presenter.change_set, version_service: @presenter.version_service) %>
         </td>
       </tr>
 
       <tr>
         <th class="col-3" scope="row">License</th>
         <td>
-          <%= render Show::LicenseComponent.new(change_set: @presenter.change_set, state_service:) %>
+          <%= render Show::LicenseComponent.new(change_set: @presenter.change_set, version_service: @presenter.version_service) %>
         </td>
       </tr>
 
       <tr>
         <th class="col-3" scope="row">Use and reproduction</th>
         <td>
-          <%= render Show::UseStatementComponent.new(change_set: @presenter.change_set, state_service:) %>
+          <%= render Show::UseStatementComponent.new(change_set: @presenter.change_set, version_service: @presenter.version_service) %>
         </td>
       </tr>
     </tbody>

--- a/app/components/show/content_type_component.rb
+++ b/app/components/show/content_type_component.rb
@@ -2,12 +2,12 @@
 
 module Show
   class ContentTypeComponent < ApplicationComponent
-    def initialize(document:, state_service:)
+    def initialize(document:, version_service:)
       @document = document
-      @state_service = state_service
+      @version_service = version_service
     end
 
-    delegate :open?, to: :@state_service
+    delegate :open?, to: :@version_service
     delegate :id, :content_type, to: :@document
   end
 end

--- a/app/components/show/copyright_component.rb
+++ b/app/components/show/copyright_component.rb
@@ -2,16 +2,16 @@
 
 module Show
   class CopyrightComponent < ApplicationComponent
-    def initialize(change_set:, state_service:)
+    def initialize(change_set:, version_service:)
       @change_set = change_set
-      @state_service = state_service
+      @version_service = version_service
     end
 
     def copyright
       @change_set.copyright || 'Not entered'
     end
 
-    delegate :open?, to: :@state_service
+    delegate :open?, to: :@version_service
     delegate :id, to: :@change_set
   end
 end

--- a/app/components/show/governed_by_component.rb
+++ b/app/components/show/governed_by_component.rb
@@ -2,9 +2,9 @@
 
 module Show
   class GovernedByComponent < ApplicationComponent
-    def initialize(document:, state_service:)
+    def initialize(document:, version_service:)
       @document = document
-      @state_service = state_service
+      @version_service = version_service
     end
 
     def admin_policy
@@ -13,7 +13,7 @@ module Show
       helpers.link_to_admin_policy_with_objs(document: @document, value: @document.apo_id)
     end
 
-    delegate :open?, to: :@state_service
+    delegate :open?, to: :@version_service
     delegate :id, to: :@document
   end
 end

--- a/app/components/show/is_member_of_component.rb
+++ b/app/components/show/is_member_of_component.rb
@@ -2,9 +2,9 @@
 
 module Show
   class IsMemberOfComponent < ApplicationComponent
-    def initialize(document:, state_service:)
+    def initialize(document:, version_service:)
       @document = document
-      @state_service = state_service
+      @version_service = version_service
     end
 
     def collection
@@ -13,7 +13,7 @@ module Show
       helpers.links_to_collections_with_objs(document: @document, value: Array(@document.collection_ids))
     end
 
-    delegate :open?, to: :@state_service
+    delegate :open?, to: :@version_service
     delegate :id, to: :@document
   end
 end

--- a/app/components/show/item/access_rights_component.rb
+++ b/app/components/show/item/access_rights_component.rb
@@ -3,9 +3,9 @@
 module Show
   module Item
     class AccessRightsComponent < ApplicationComponent
-      def initialize(change_set:, state_service:)
+      def initialize(change_set:, version_service:)
         @change_set = change_set
-        @state_service = state_service
+        @version_service = version_service
       end
 
       def access_rights
@@ -18,7 +18,7 @@ module Show
         val
       end
 
-      delegate :open?, to: :@state_service
+      delegate :open?, to: :@version_service
       delegate :id, :view_access, :download_access, :access_location, :controlled_digital_lending, to: :@change_set
 
       def humanize_value(val)

--- a/app/components/show/item/details_component.html.erb
+++ b/app/components/show/item/details_component.html.erb
@@ -11,7 +11,7 @@
       <tr>
         <th class="col-3" scope="row">Content type</th>
         <td>
-          <%= render Show::ContentTypeComponent.new(document: @solr_document, state_service:) %>
+          <%= render Show::ContentTypeComponent.new(document: @solr_document, version_service: @presenter.version_service) %>
         </td>
       </tr>
 
@@ -25,7 +25,7 @@
       <tr>
         <th class="col-3" scope="row">Source IDs</th>
         <td>
-          <%= render Show::SourceIdComponent.new(document: @solr_document, state_service:) %>
+          <%= render Show::SourceIdComponent.new(document: @solr_document, version_service: @presenter.version_service) %>
         </td>
       </tr>
 
@@ -53,14 +53,14 @@
       <tr>
         <th class="col-3" scope="row"><%= catalog_record_id_label %></th>
         <td>
-          <%= render Show::CatalogRecordIdComponent.new(change_set: @presenter.change_set, state_service:) %>
+          <%= render Show::CatalogRecordIdComponent.new(change_set: @presenter.change_set, version_service: @presenter.version_service) %>
         </td>
       </tr>
 
       <tr>
         <th class="col-3" scope="row">Barcode</th>
         <td>
-          <%= render Show::BarcodeComponent.new(change_set: @presenter.change_set, state_service:) %>
+          <%= render Show::BarcodeComponent.new(change_set: @presenter.change_set, version_service: @presenter.version_service) %>
         </td>
       </tr>
 

--- a/app/components/show/item/overview_component.html.erb
+++ b/app/components/show/item/overview_component.html.erb
@@ -11,14 +11,14 @@
       <tr>
         <th class="col-3" scope="row">Admin policy</th>
         <td>
-          <%= render Show::GovernedByComponent.new(document: @solr_document, state_service:) %>
+          <%= render Show::GovernedByComponent.new(document: @solr_document, version_service: @presenter.version_service) %>
         </td>
       </tr>
 
       <tr>
         <th class="col-3" scope="row">Collection</th>
         <td>
-          <%= render Show::IsMemberOfComponent.new(document: @solr_document, state_service:) %>
+          <%= render Show::IsMemberOfComponent.new(document: @solr_document, version_service: @presenter.version_service) %>
         </td>
       </tr>
 
@@ -32,28 +32,28 @@
       <tr>
         <th class="col-3" scope="row">Access rights</th>
         <td>
-          <%= render Show::Item::AccessRightsComponent.new(change_set: @presenter.change_set, state_service:) %>
+          <%= render Show::Item::AccessRightsComponent.new(change_set: @presenter.change_set, version_service: @presenter.version_service) %>
         </td>
       </tr>
 
       <tr>
         <th class="col-3" scope="row">Copyright</th>
         <td>
-          <%= render Show::CopyrightComponent.new(change_set: @presenter.change_set, state_service:) %>
+          <%= render Show::CopyrightComponent.new(change_set: @presenter.change_set, version_service: @presenter.version_service) %>
         </td>
       </tr>
 
       <tr>
         <th class="col-3" scope="row">License</th>
         <td>
-          <%= render Show::LicenseComponent.new(change_set: @presenter.change_set, state_service:) %>
+          <%= render Show::LicenseComponent.new(change_set: @presenter.change_set, version_service: @presenter.version_service) %>
         </td>
       </tr>
 
       <tr>
         <th class="col-3" scope="row">Use and reproduction</th>
         <td>
-          <%= render Show::UseStatementComponent.new(change_set: @presenter.change_set, state_service:) %>
+          <%= render Show::UseStatementComponent.new(change_set: @presenter.change_set, version_service: @presenter.version_service) %>
         </td>
       </tr>
     </tbody>

--- a/app/components/show/license_component.rb
+++ b/app/components/show/license_component.rb
@@ -2,9 +2,9 @@
 
 module Show
   class LicenseComponent < ApplicationComponent
-    def initialize(change_set:, state_service:)
+    def initialize(change_set:, version_service:)
       @change_set = change_set
-      @state_service = state_service
+      @version_service = version_service
     end
 
     def license
@@ -15,7 +15,7 @@ module Show
       value.fetch(:label)
     end
 
-    delegate :open?, to: :@state_service
+    delegate :open?, to: :@version_service
     delegate :id, to: :@change_set
   end
 end

--- a/app/components/show/source_id_component.rb
+++ b/app/components/show/source_id_component.rb
@@ -2,12 +2,12 @@
 
 module Show
   class SourceIdComponent < ApplicationComponent
-    def initialize(document:, state_service:)
+    def initialize(document:, version_service:)
       @document = document
-      @state_service = state_service
+      @version_service = version_service
     end
 
-    delegate :open?, to: :@state_service
+    delegate :open?, to: :@version_service
     delegate :id, :source_id, :item?, to: :@document
   end
 end

--- a/app/components/show/use_statement_component.rb
+++ b/app/components/show/use_statement_component.rb
@@ -2,16 +2,16 @@
 
 module Show
   class UseStatementComponent < ApplicationComponent
-    def initialize(change_set:, state_service:)
+    def initialize(change_set:, version_service:)
       @change_set = change_set
-      @state_service = state_service
+      @version_service = version_service
     end
 
     def use_statement
       @change_set.use_statement || 'Not entered'
     end
 
-    delegate :open?, to: :@state_service
+    delegate :open?, to: :@version_service
     delegate :id, to: :@change_set
   end
 end

--- a/app/components/show_embargo_component.rb
+++ b/app/components/show_embargo_component.rb
@@ -3,11 +3,11 @@
 class ShowEmbargoComponent < ApplicationComponent
   def initialize(presenter:)
     @solr_document = presenter.document
-    @state_service = presenter.state_service
+    @presenter = presenter
   end
 
   delegate :id, :embargoed?, :embargo_release_date, to: :@solr_document
-  delegate :open?, to: :@state_service
+  delegate :open?, to: :@presenter
 
   def render?
     embargoed? && embargo_release_date.present?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,8 +11,7 @@ class ApplicationController < ActionController::Base
   layout :determine_layout
 
   def open?(cocina_object)
-    state_service = StateService.new(cocina_object)
-    state_service.open?
+    VersionService.open?(druid: cocina_object.externalIdentifier)
   end
 
   def current_user

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -164,8 +164,8 @@ class ItemsController < ApplicationController
 
   def show_barcode
     change_set = ItemChangeSet.new(@cocina)
-    state_service = StateService.new(@cocina)
-    render Show::BarcodeComponent.new(change_set:, state_service:)
+    version_service = VersionService.new(@cocina.externalIdentifier)
+    render Show::BarcodeComponent.new(change_set:, version_service:)
   end
 
   # Draw form for copyright
@@ -175,8 +175,8 @@ class ItemsController < ApplicationController
 
   def show_copyright
     change_set = build_change_set
-    state_service = StateService.new(@cocina)
-    render Show::CopyrightComponent.new(change_set:, state_service:)
+    version_service = VersionService.new(druid: @cocina.externalIdentifier)
+    render Show::CopyrightComponent.new(change_set:, version_service:)
   end
 
   # Draw form for use and reproduction statement
@@ -186,8 +186,8 @@ class ItemsController < ApplicationController
 
   def show_use_statement
     change_set = build_change_set
-    state_service = StateService.new(@cocina)
-    render Show::UseStatementComponent.new(change_set:, state_service:)
+    version_service = VersionService.new(druid: @cocina.externalIdentifier)
+    render Show::UseStatementComponent.new(change_set:, version_service:)
   end
 
   # Draw form for setting license
@@ -197,8 +197,8 @@ class ItemsController < ApplicationController
 
   def show_license
     change_set = build_change_set
-    state_service = StateService.new(@cocina)
-    render Show::LicenseComponent.new(change_set:, state_service:)
+    version_service = VersionService.new(druid: @cocina.externalIdentifier)
+    render Show::LicenseComponent.new(change_set:, version_service:)
   end
 
   # save the form
@@ -224,13 +224,13 @@ class ItemsController < ApplicationController
 
   def show_rights
     @change_set = build_change_set
-    state_service = StateService.new(@cocina)
+    version_service = VersionService.new(druid: @cocina.externalIdentifier)
     if @cocina.collection?
       change_set = CollectionChangeSet.new(@cocina)
-      render Show::Collection::AccessRightsComponent.new(change_set:, state_service:)
+      render Show::Collection::AccessRightsComponent.new(change_set:, version_service:)
     else
       change_set = ItemChangeSet.new(@cocina)
-      render Show::Item::AccessRightsComponent.new(change_set:, state_service:)
+      render Show::Item::AccessRightsComponent.new(change_set:, version_service:)
     end
   end
 

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -12,6 +12,7 @@ module ItemsHelper
       if presenter.respond_to? :cocina
         presenter.cocina = @cocina
         presenter.state_service = StateService.new(@cocina)
+        presenter.version_service = VersionService.new(druid: @cocina.externalIdentifier)
       end
     end
   end

--- a/app/jobs/import_structural_job.rb
+++ b/app/jobs/import_structural_job.rb
@@ -10,8 +10,7 @@ class ImportStructuralJob < GenericJob
     with_items(grouped.keys, name: 'Import structural') do |cocina_item, success, failure|
       next failure.call('Not authorized') unless ability.can?(:update, cocina_item)
 
-      state_service = StateService.new(cocina_item)
-      next failure.call('Object cannot be modified in its current state.') unless state_service.open?
+      next failure.call('Object cannot be modified in its current state.') unless VersionService.open?(druid: cocina_item.externalIdentifier)
 
       druid = cocina_item.externalIdentifier
       result = StructureUpdater.from_csv(cocina_item, item_csv(csv.headers, grouped.fetch(druid)))

--- a/app/jobs/set_content_type_job.rb
+++ b/app/jobs/set_content_type_job.rb
@@ -35,8 +35,7 @@ class SetContentTypeJob < GenericJob
 
     return failure.call('Not authorized') unless ability.can?(:update, cocina_object)
 
-    state_service = StateService.new(cocina_object)
-    return failure.call('Object cannot be modified in its current state.') unless state_service.open?
+    return failure.call('Object cannot be modified in its current state.') unless VersionService.open?(druid: cocina_object.externalIdentifier)
 
     # use dor services client to pass a hash for structural metadata and update the cocina object
     new_model = cocina_object.new(cocina_update_attributes(cocina_object))

--- a/app/jobs/set_rights_job.rb
+++ b/app/jobs/set_rights_job.rb
@@ -16,8 +16,7 @@ class SetRightsJob < GenericJob
     with_items(params[:druids], name: 'Set rights') do |cocina_object, success, failure|
       next failure.call('Not authorized') unless ability.can?(:update, cocina_object)
 
-      state_service = StateService.new(cocina_object)
-      next failure.call('Object cannot be modified in its current state.') unless state_service.open?
+      next failure.call('Object cannot be modified in its current state.') unless VersionService.open?(druid: cocina_object.externalIdentifier)
 
       change_set = if cocina_object.collection?
                      # Collection only allows setting view access to dark or world

--- a/app/presenters/argo_show_presenter.rb
+++ b/app/presenters/argo_show_presenter.rb
@@ -17,7 +17,7 @@ class ArgoShowPresenter < Blacklight::ShowPresenter
     cocina.externalIdentifier
   end
 
-  delegate :open?, to: :state_service
+  delegate :open?, to: :version_service
 
-  attr_accessor :cocina, :view_token, :state_service
+  attr_accessor :cocina, :view_token, :state_service, :version_service
 end

--- a/app/services/state_service.rb
+++ b/app/services/state_service.rb
@@ -14,10 +14,6 @@ class StateService
     @version = cocina.version
   end
 
-  def open?
-    UNLOCKED_STATES.include? object_state
-  end
-
   def object_state
     # This item is currently unlocked and can be edited and moved to a locked state
     return STATES[:unlock] if !active_assembly_wf? && opened? && !submitted?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       SETTINGS__SOLRIZER_URL: http://solr:8983/solr/argo
       SETTINGS__WORKFLOW_URL: http://workflow:3000
       SETTINGS__TECH_MD_SERVICE__URL: http://techmd:3000
+      SETTINGS__VERSION_SERVICE__SYNC_WITH_PRESERVATION: false
       SOLR_URL: http://solr:8983/solr/argo
       # Docker doesn't allow rails server to remove PID on shutdown
       PID_FILE: /dev/null

--- a/spec/components/contents_component_spec.rb
+++ b/spec/components/contents_component_spec.rb
@@ -7,10 +7,9 @@ RSpec.describe ContentsComponent, type: :component do
     instance_double(ArgoShowPresenter,
                     document: solr_doc, cocina:,
                     view_token: 'skret-t0k3n',
-                    state_service:)
+                    open?: open)
   end
   let(:component) { described_class.new(presenter:) }
-  let(:state_service) { instance_double(StateService, open?: open) }
 
   let(:rendered) { render_inline(component) }
 

--- a/spec/components/show/apo/details_component_spec.rb
+++ b/spec/components/show/apo/details_component_spec.rb
@@ -4,11 +4,9 @@ require 'rails_helper'
 
 RSpec.describe Show::Apo::DetailsComponent, type: :component do
   let(:component) { described_class.new(presenter:) }
-  let(:presenter) { instance_double(ArgoShowPresenter, document: doc, cocina:, state_service:) }
+  let(:presenter) { instance_double(ArgoShowPresenter, document: doc, cocina:) }
   let(:cocina) { build(:admin_policy) }
   let(:rendered) { render_inline(component) }
-  let(:open) { true }
-  let(:state_service) { instance_double(StateService, open?: open) }
   let(:doc) do
     SolrDocument.new('id' => 'druid:kv840xx0000',
                      SolrDocument::FIELD_REGISTERED_DATE => ['2012-04-05T01:00:04.148Z'],

--- a/spec/components/show/apo/overview_component_spec.rb
+++ b/spec/components/show/apo/overview_component_spec.rb
@@ -4,13 +4,11 @@ require 'rails_helper'
 
 RSpec.describe Show::Apo::OverviewComponent, type: :component do
   let(:component) { described_class.new(presenter:) }
-  let(:presenter) { instance_double(ArgoShowPresenter, document: doc, cocina:, state_service:) }
+  let(:presenter) { instance_double(ArgoShowPresenter, document: doc, cocina:) }
   let(:cocina) do
     build(:admin_policy, registration_workflow: %w[registrationWF goobiWF])
   end
   let(:rendered) { render_inline(component) }
-  let(:open) { true }
-  let(:state_service) { instance_double(StateService, open?: open) }
 
   let(:doc) do
     SolrDocument.new('id' => 'druid:kv840xx0000',

--- a/spec/components/show/collection/details_component_spec.rb
+++ b/spec/components/show/collection/details_component_spec.rb
@@ -4,13 +4,12 @@ require 'rails_helper'
 
 RSpec.describe Show::Collection::DetailsComponent, type: :component do
   let(:component) { described_class.new(presenter:) }
-  let(:presenter) { instance_double(ArgoShowPresenter, document: doc, change_set:, cocina:, state_service:) }
+  let(:presenter) { instance_double(ArgoShowPresenter, document: doc, change_set:, cocina:, version_service:) }
   let(:cocina) { instance_double(Cocina::Models::Collection) }
 
   let(:change_set) { instance_double(ItemChangeSet, barcode: nil, id: doc.id, catalog_record_ids: []) }
   let(:rendered) { render_inline(component) }
-  let(:open) { true }
-  let(:state_service) { instance_double(StateService, open?: open) }
+  let(:version_service) { instance_double(VersionService, open?: true) }
   let(:doc) do
     SolrDocument.new('id' => 'druid:kv840xx0000',
                      SolrDocument::FIELD_REGISTERED_DATE => ['2012-04-05T01:00:04.148Z'],

--- a/spec/components/show/collection/overview_component_spec.rb
+++ b/spec/components/show/collection/overview_component_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Show::Collection::OverviewComponent, type: :component do
   let(:component) { described_class.new(presenter:) }
-  let(:presenter) { instance_double(ArgoShowPresenter, document: doc, cocina:, change_set:, state_service:) }
+  let(:presenter) { instance_double(ArgoShowPresenter, document: doc, cocina:, change_set:, version_service:) }
   let(:change_set) { CollectionChangeSet.new(cocina) }
   let(:cocina) do
     Cocina::Models::Collection.new(externalIdentifier: 'druid:bc234fg5678',
@@ -27,8 +27,7 @@ RSpec.describe Show::Collection::OverviewComponent, type: :component do
                                    })
   end
   let(:rendered) { render_inline(component) }
-  let(:open) { true }
-  let(:state_service) { instance_double(StateService, open?: open) }
+  let(:version_service) { instance_double(VersionService, open?: true) }
 
   let(:edit_copyright_button) { rendered.css("a[aria-label='Edit copyright']") }
   let(:edit_license_button) { rendered.css("a[aria-label='Edit license']") }

--- a/spec/components/show/item/access_rights_component_spec.rb
+++ b/spec/components/show/item/access_rights_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Show::Item::AccessRightsComponent, type: :component do
-  let(:component) { described_class.new(change_set:, state_service:) }
+  let(:component) { described_class.new(change_set:, version_service:) }
   let(:change_set) { ItemChangeSet.new(cocina) }
   let(:cocina) do
     Cocina::Models::DRO.new(externalIdentifier: 'druid:bc234fg5678',
@@ -22,8 +22,7 @@ RSpec.describe Show::Item::AccessRightsComponent, type: :component do
                             structural: {})
   end
   let(:rendered) { render_inline(component) }
-  let(:open) { true }
-  let(:state_service) { instance_double(StateService, open?: open) }
+  let(:version_service) { instance_double(VersionService, open?: true) }
 
   context 'with view location' do
     let(:access) do

--- a/spec/components/show/item/details_component_spec.rb
+++ b/spec/components/show/item/details_component_spec.rb
@@ -4,13 +4,13 @@ require 'rails_helper'
 
 RSpec.describe Show::Item::DetailsComponent, type: :component do
   let(:component) { described_class.new(presenter:) }
-  let(:presenter) { instance_double(ArgoShowPresenter, document: doc, change_set:, cocina:, state_service:) }
+  let(:presenter) { instance_double(ArgoShowPresenter, document: doc, change_set:, cocina:, version_service:) }
   let(:cocina) { instance_double(Cocina::Models::DRO) }
 
   let(:change_set) { instance_double(ItemChangeSet, barcode: nil, id: doc.id, catalog_record_ids: []) }
   let(:rendered) { render_inline(component) }
   let(:open) { true }
-  let(:state_service) { instance_double(StateService, open?: open) }
+  let(:version_service) { instance_double(VersionService, open?: open) }
   let(:doc) do
     SolrDocument.new('id' => 'druid:kv840xx0000',
                      SolrDocument::FIELD_REGISTERED_DATE => ['2012-04-05T01:00:04.148Z'],

--- a/spec/components/show/item/overview_component_spec.rb
+++ b/spec/components/show/item/overview_component_spec.rb
@@ -4,14 +4,14 @@ require 'rails_helper'
 
 RSpec.describe Show::Item::OverviewComponent, type: :component do
   let(:component) { described_class.new(presenter:) }
-  let(:presenter) { instance_double(ArgoShowPresenter, document: doc, cocina:, change_set:, state_service:) }
+  let(:presenter) { instance_double(ArgoShowPresenter, document: doc, cocina:, change_set:, version_service:) }
   let(:change_set) { ItemChangeSet.new(cocina) }
   let(:cocina) do
     build(:dro)
   end
   let(:rendered) { render_inline(component) }
   let(:open) { true }
-  let(:state_service) { instance_double(StateService, open?: open) }
+  let(:version_service) { instance_double(VersionService, open?: open) }
   let(:edit_collection_button) { rendered.css("a[aria-label='Edit collections']") }
   let(:edit_copyright_button) { rendered.css("a[aria-label='Edit copyright']") }
   let(:edit_license_button) { rendered.css("a[aria-label='Edit license']") }

--- a/spec/components/show_embargo_component_spec.rb
+++ b/spec/components/show_embargo_component_spec.rb
@@ -5,8 +5,7 @@ require 'rails_helper'
 RSpec.describe ShowEmbargoComponent, type: :component do
   let(:component) { described_class.new(presenter:) }
   let(:rendered) { render_inline(component) }
-  let(:presenter) { instance_double(ArgoShowPresenter, document:, state_service:) }
-  let(:state_service) { instance_double(StateService, open?: open) }
+  let(:presenter) { instance_double(ArgoShowPresenter, document:, open?: open) }
 
   describe 'embargo with release date' do
     let(:document) do

--- a/spec/features/add_workflow_to_item_spec.rb
+++ b/spec/features/add_workflow_to_item_spec.rb
@@ -31,8 +31,10 @@ RSpec.describe 'Add a workflow to an item' do
   let(:item_id) { 'druid:bg444xg6666' }
   let(:blacklight_config) { CatalogController.blacklight_config }
   let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
+  let(:version_service) { instance_double(VersionService, open?: true) }
 
   before do
+    allow(VersionService).to receive(:new).and_return(version_service)
     solr_conn.add(id: item_id, objectType_ssim: 'item')
     solr_conn.commit
     sign_in create(:user), groups: ['sdr:administrator-role']

--- a/spec/features/collection_manage_release_spec.rb
+++ b/spec/features/collection_manage_release_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Collection manage release' do
   let(:current_user) { create(:user, sunetid: 'esnowden') }
   let(:blacklight_config) { CatalogController.blacklight_config }
   let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
-  let(:state_service) { instance_double(StateService, open?: true) }
+  let(:version_service) { instance_double(VersionService, open?: true) }
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
   let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: []) }
@@ -25,7 +25,7 @@ RSpec.describe 'Collection manage release' do
   let(:collection_id) { 'druid:gg232vv1111' }
 
   before do
-    allow(StateService).to receive(:new).and_return(state_service)
+    allow(VersionService).to receive(:new).and_return(version_service)
     sign_in current_user, groups: ['sdr:administrator-role']
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
     solr_conn.add(id: 'druid:gg232vv1111',

--- a/spec/features/enable_buttons_spec.rb
+++ b/spec/features/enable_buttons_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Enable buttons' do
     solr_conn.add(id: item_id, objectType_ssim: 'item')
     solr_conn.commit
     allow(StateService).to receive(:new).and_return(state_service)
-    allow(state_service).to receive_messages(object_state: :unlock)
+    allow(VersionService).to receive(:new).and_return(version_service)
     allow(WorkflowService).to receive_messages(accessioned?: true, published?: true)
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
   end
@@ -16,7 +16,8 @@ RSpec.describe 'Enable buttons' do
   let(:blacklight_config) { CatalogController.blacklight_config }
   let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
   let(:item_id) { 'druid:hj185xx2222' }
-  let(:state_service) { instance_double(StateService, open?: true) }
+  let(:state_service) { instance_double(StateService, object_state: :unlock) }
+  let(:version_service) { instance_double(VersionService, open?: true) }
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: [], current: 1) }
   let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: []) }

--- a/spec/features/item_catalog_record_id_change_spec.rb
+++ b/spec/features/item_catalog_record_id_change_spec.rb
@@ -5,14 +5,14 @@ require 'rails_helper'
 RSpec.describe 'Item catalog_record_id change' do
   before do
     sign_in create(:user), groups: ['sdr:administrator-role']
-    allow(StateService).to receive(:new).and_return(state_service)
+    allow(VersionService).to receive(:new).and_return(version_service)
     allow(WorkflowService).to receive(:accessioned?).and_return(false)
   end
 
   describe 'when modification is not allowed' do
     let(:item) { FactoryBot.create_for_repository(:persisted_item) }
     let(:druid) { item.externalIdentifier }
-    let(:state_service) { instance_double(StateService, open?: false) }
+    let(:version_service) { instance_double(VersionService, open?: false) }
 
     it 'cannot change the catalog_record_id' do
       visit edit_item_catalog_record_id_path druid
@@ -30,7 +30,7 @@ RSpec.describe 'Item catalog_record_id change' do
     let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
     let(:druid) { 'druid:kv840xx0000' }
     let(:cocina_model) { build(:dro_with_metadata, id: druid) }
-    let(:state_service) { instance_double(StateService, open?: true) }
+    let(:version_service) { instance_double(VersionService, open?: true) }
     let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
     let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
     let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: []) }

--- a/spec/features/item_manage_release_spec.rb
+++ b/spec/features/item_manage_release_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Item manage release' do
   let(:current_user) { create(:user, sunetid: 'esnowden') }
-  let(:state_service) { instance_double(StateService, open?: true) }
+  let(:version_service) { instance_double(VersionService, open?: true) }
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
   let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: []) }
@@ -22,7 +22,7 @@ RSpec.describe 'Item manage release' do
 
   before do
     sign_in current_user, groups: ['sdr:administrator-role']
-    allow(StateService).to receive(:new).and_return(state_service)
+    allow(VersionService).to receive(:new).and_return(version_service)
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
     allow(WorkflowService).to receive(:accessioned?).and_return(true)
   end

--- a/spec/features/item_source_id_change_spec.rb
+++ b/spec/features/item_source_id_change_spec.rb
@@ -5,13 +5,13 @@ require 'rails_helper'
 RSpec.describe 'Item source id change' do
   before do
     sign_in create(:user), groups: ['sdr:administrator-role']
-    allow(StateService).to receive(:new).and_return(state_service)
+    allow(VersionService).to receive(:new).and_return(version_service)
   end
 
   describe 'when modification is not allowed' do
     let(:item) { FactoryBot.create_for_repository(:persisted_item) }
     let(:druid) { item.externalIdentifier }
-    let(:state_service) { instance_double(StateService, open?: false) }
+    let(:version_service) { instance_double(VersionService, open?: false) }
 
     before do
       allow(WorkflowService).to receive(:accessioned?).and_return(false)
@@ -33,7 +33,7 @@ RSpec.describe 'Item source id change' do
     let(:cocina_model) do
       build(:dro_with_metadata, id: druid)
     end
-    let(:state_service) { instance_double(StateService, open?: true) }
+    let(:version_service) { instance_double(VersionService, open?: true) }
     let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
     let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
     let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: []) }

--- a/spec/features/item_view_spec.rb
+++ b/spec/features/item_view_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Item view', :js do
   before do
+    allow(VersionService).to receive(:new).and_return(version_service)
     sign_in create(:user), groups: ['sdr:administrator-role']
   end
 
@@ -42,6 +43,7 @@ RSpec.describe 'Item view', :js do
                                      release: true)
     ]
   end
+  let(:version_service) { instance_double(VersionService, open?: true) }
 
   context 'when navigating to an object' do
     before do

--- a/spec/features/open_and_close_a_version_spec.rb
+++ b/spec/features/open_and_close_a_version_spec.rb
@@ -16,8 +16,7 @@ RSpec.describe 'Open and close a version' do
 
   it 'opens an object', :js do
     visit solr_document_path item.externalIdentifier
-    # The initial accessioning step will already be complete; this completes the rest.
-    (accession_step_count - 1).times do
+    accession_step_count.times do
       # Ensure every step of accessionWF is completed, this will allow us to open a new version.
       click_link 'accessionWF'
       click_button 'Set to completed', match: :first

--- a/spec/features/set_governing_apo_spec.rb
+++ b/spec/features/set_governing_apo_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Set governing APO' do
   end
 
   let(:identity_md) { instance_double(Nokogiri::XML::Document, xpath: []) }
-  let(:state_service) { instance_double(StateService, open?: true) }
+  let(:version_service) { instance_double(VersionService, open?: true) }
 
   let(:item) do
     FactoryBot.create_for_repository(:persisted_item, label: 'Foo', title: 'Test')
@@ -25,7 +25,7 @@ RSpec.describe 'Set governing APO' do
     new_apo
     item
 
-    allow(StateService).to receive(:new).and_return(state_service)
+    allow(VersionService).to receive(:new).and_return(version_service)
     allow(WorkflowService).to receive(:accessioned?).and_return(true)
     sign_in create(:user), groups:
   end

--- a/spec/features/update_serials_metadata_spec.rb
+++ b/spec/features/update_serials_metadata_spec.rb
@@ -12,8 +12,10 @@ RSpec.describe 'Update serials metadata', :js do
   let(:item) do
     FactoryBot.create_for_repository(:persisted_item)
   end
+  let(:version_service) { instance_double(VersionService, open?: true) }
 
   before do
+    allow(VersionService).to receive(:new).and_return(version_service)
     sign_in user, groups: ['sdr:administrator-role']
     visit solr_document_path(item.externalIdentifier)
   end

--- a/spec/jobs/import_structural_job_spec.rb
+++ b/spec/jobs/import_structural_job_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe ImportStructuralJob do
     allow(Dor::Services::Client).to receive(:object).with(druid1).and_return(object_client1)
     allow(Dor::Services::Client).to receive(:object).with(druid2).and_return(object_client2)
     allow(Argo::Indexer).to receive(:reindex_druid_remotely)
+    allow(VersionService).to receive(:open?).and_return(true)
   end
 
   describe '#perform' do

--- a/spec/jobs/set_content_type_job_spec.rb
+++ b/spec/jobs/set_content_type_job_spec.rb
@@ -51,14 +51,13 @@ RSpec.describe SetContentTypeJob do
   let(:object_client2) { instance_double(Dor::Services::Client::Object, find: cocina2) }
   let(:object_client3) { instance_double(Dor::Services::Client::Object, find: cocina3) }
 
-  let(:state_service) { instance_double(StateService, open?: true) }
   let(:buffer) { StringIO.new }
 
   before do
     allow(subject).to receive(:bulk_action).and_return(bulk_action)
     allow(BulkJobLog).to receive(:open).and_yield(buffer)
     allow(subject.ability).to receive(:can?).and_return(true)
-    allow(StateService).to receive(:new).and_return(state_service)
+    allow(VersionService).to receive(:open?).and_return(true)
     allow(Dor::Services::Client).to receive(:object).with(druids[0]).and_return(object_client1)
     allow(Dor::Services::Client).to receive(:object).with(druids[1]).and_return(object_client2)
     allow(Dor::Services::Client).to receive(:object).with(druids[2]).and_return(object_client3)
@@ -224,7 +223,9 @@ RSpec.describe SetContentTypeJob do
   end
 
   context 'when modification is not allowed' do
-    let(:state_service) { instance_double(StateService, open?: false) }
+    before do
+      allow(VersionService).to receive(:open?).and_return(false)
+    end
 
     it 'does not update and logs an error' do
       subject.perform(bulk_action.id, params)

--- a/spec/jobs/set_rights_job_spec.rb
+++ b/spec/jobs/set_rights_job_spec.rb
@@ -152,14 +152,13 @@ RSpec.describe SetRightsJob do
   let(:object_client1) { instance_double(Dor::Services::Client::Object, find: cocina1) }
   let(:object_client2) { instance_double(Dor::Services::Client::Object, find: cocina2) }
 
-  let(:state_service) { instance_double(StateService, open?: true) }
   let(:buffer) { StringIO.new }
 
   before do
     allow(subject).to receive(:bulk_action).and_return(bulk_action)
     allow(BulkJobLog).to receive(:open).and_yield(buffer)
     allow(subject.ability).to receive(:can?).and_return(true)
-    allow(StateService).to receive(:new).and_return(state_service)
+    allow(VersionService).to receive(:open?).and_return(true)
     allow(Dor::Services::Client).to receive(:object).with(druids[0]).and_return(object_client1)
     allow(Dor::Services::Client).to receive(:object).with(druids[1]).and_return(object_client2)
     allow(object_client1).to receive(:update)

--- a/spec/requests/collection_update_spec.rb
+++ b/spec/requests/collection_update_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'Set the properties for a collection' do
   before do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
     allow(Argo::Indexer).to receive(:reindex_druid_remotely)
+    allow(VersionService).to receive(:open?).and_return(true)
   end
 
   context 'when they have manage access' do

--- a/spec/requests/edit_barcode_spec.rb
+++ b/spec/requests/edit_barcode_spec.rb
@@ -13,8 +13,10 @@ RSpec.describe 'Edit barcode' do
     { 'Accept' => "#{Mime[:turbo_stream]},#{Mime[:html]}",
       'Turbo-Frame' => 'edit_copyright' }
   end
+  let(:version_service) { instance_double(VersionService, open?: true) }
 
   before do
+    allow(VersionService).to receive(:new).and_return(version_service)
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
     sign_in user, groups: ['sdr:administrator-role']
   end

--- a/spec/requests/edit_copyright_spec.rb
+++ b/spec/requests/edit_copyright_spec.rb
@@ -11,9 +11,11 @@ RSpec.describe 'Edit copyright' do
     { 'Accept' => "#{Mime[:turbo_stream]},#{Mime[:html]}",
       'Turbo-Frame' => 'edit_copyright' }
   end
+  let(:version_service) { instance_double(VersionService, open?: true) }
 
   before do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+    allow(VersionService).to receive(:new).and_return(version_service)
     sign_in user, groups: ['sdr:administrator-role']
   end
 

--- a/spec/requests/edit_license_spec.rb
+++ b/spec/requests/edit_license_spec.rb
@@ -10,9 +10,11 @@ RSpec.describe 'Edit license' do
   let(:turbo_stream_headers) do
     { 'Accept' => "#{Mime[:turbo_stream]},#{Mime[:html]}" }
   end
+  let(:version_service) { instance_double(VersionService, open?: true) }
 
   before do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+    allow(VersionService).to receive(:new).and_return(version_service)
     sign_in user, groups: ['sdr:administrator-role']
   end
 

--- a/spec/requests/edit_rights_spec.rb
+++ b/spec/requests/edit_rights_spec.rb
@@ -10,9 +10,11 @@ RSpec.describe 'Edit rights' do
   let(:turbo_stream_headers) do
     { 'Accept' => "#{Mime[:turbo_stream]},#{Mime[:html]}" }
   end
+  let(:version_service) { instance_double(VersionService, open?: true) }
 
   before do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+    allow(VersionService).to receive(:new).and_return(version_service)
     sign_in user, groups: ['sdr:administrator-role']
   end
 

--- a/spec/requests/edit_use_statement_spec.rb
+++ b/spec/requests/edit_use_statement_spec.rb
@@ -7,12 +7,14 @@ RSpec.describe 'Edit use statement' do
   let(:druid) { 'druid:dc243mg0841' }
 
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, update: true) }
+  let(:version_service) { instance_double(VersionService, open?: true) }
   let(:turbo_stream_headers) do
     { 'Accept' => "#{Mime[:turbo_stream]},#{Mime[:html]}" }
   end
 
   before do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+    allow(VersionService).to receive(:new).and_return(version_service)
     sign_in user, groups: ['sdr:administrator-role']
   end
 

--- a/spec/requests/item_update_spec.rb
+++ b/spec/requests/item_update_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'Set the properties for an item' do
   before do
     allow(Repository).to receive(:find).and_return(cocina_model)
     allow(Argo::Indexer).to receive(:reindex_druid_remotely)
+    allow(VersionService).to receive(:open?).and_return(true)
   end
 
   context 'when they have manage access' do

--- a/spec/requests/manage_collection_membership_spec.rb
+++ b/spec/requests/manage_collection_membership_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe 'Collection membership' do
   before do
     allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_service)
     allow(Argo::Indexer).to receive(:reindex_druid_remotely)
-    allow(StateService).to receive(:new).and_return(state_service)
+    allow(VersionService).to receive(:new).and_return(version_service)
   end
 
   let(:druid) { 'druid:bc123df4567' }
-  let(:state_service) { instance_double(StateService, open?: true) }
+  let(:version_service) { instance_double(VersionService, open?: true) }
 
   describe 'adding a new collection' do
     let(:cocina_collection) { build(:dro_with_metadata, id: druid, collection_ids:) }

--- a/spec/requests/refresh_metadata_spec.rb
+++ b/spec/requests/refresh_metadata_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 RSpec.describe 'Refresh metadata' do
   let(:druid) { 'druid:bc123df4567' }
-  let(:state_service) { instance_double(StateService, open?: true) }
   let(:object_service) { instance_double(Dor::Services::Client::Object, refresh_metadata: true, find: cocina_model) }
   let(:cocina_model) do
     build(:dro_with_metadata, id: druid, folio_instance_hrids: ['a12345'])
@@ -12,7 +11,7 @@ RSpec.describe 'Refresh metadata' do
 
   before do
     allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_service)
-    allow(StateService).to receive(:new).and_return(state_service)
+    allow(VersionService).to receive(:open?).and_return(true)
   end
 
   context 'when they have manage access' do
@@ -42,7 +41,9 @@ RSpec.describe 'Refresh metadata' do
     end
 
     context "when the object doesn't allow modification" do
-      let(:state_service) { instance_double(StateService, open?: false) }
+      before do
+        allow(VersionService).to receive(:open?).and_return(false)
+      end
 
       it 'redirects with an error message' do
         post "/items/#{druid}/refresh_metadata"

--- a/spec/requests/set_catalog_record_id_spec.rb
+++ b/spec/requests/set_catalog_record_id_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe 'Set catalog record ID' do
       'Turbo-Frame' => 'edit_copyright' }
   end
   let(:cocina_model) { build(:dro_with_metadata, id: druid) }
+  let(:version_service) { instance_double(VersionService, open?: true) }
+
+  before do
+    allow(VersionService).to receive(:new).and_return(version_service)
+  end
 
   context 'without manage content access' do
     let(:cocina) { instance_double(Cocina::Models::DROWithMetadata) }

--- a/spec/requests/set_content_types_spec.rb
+++ b/spec/requests/set_content_types_spec.rb
@@ -74,10 +74,8 @@ RSpec.describe 'Set content type for an item' do
 
   describe 'save the updated value' do
     before do
-      allow(StateService).to receive(:new).and_return(state_service)
+      allow(VersionService).to receive(:open?).and_return(true)
     end
-
-    let(:state_service) { instance_double(StateService, open?: true) }
 
     context 'with access' do
       before do
@@ -183,7 +181,9 @@ RSpec.describe 'Set content type for an item' do
       end
 
       context 'when modification not allowed' do
-        let(:state_service) { instance_double(StateService, open?: false) }
+        before do
+          allow(VersionService).to receive(:open?).and_return(false)
+        end
 
         it 'is forbidden' do
           patch "/items/#{druid}/content_type",

--- a/spec/requests/set_governing_apo_spec.rb
+++ b/spec/requests/set_governing_apo_spec.rb
@@ -9,17 +9,17 @@ RSpec.describe 'Set APO for an object' do
     let(:new_apo_id) { 'druid:bc123cd4567' }
     let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, update: true) }
     let(:cocina_model) { build(:dro_with_metadata, id: druid) }
-    let(:state_service) { instance_double(StateService, open?: true) }
+    let(:version_service) { instance_double(VersionService, open?: true) }
 
     before do
       allow(Dor::Services::Client).to receive(:object).and_return(object_client)
       allow(Argo::Indexer).to receive(:reindex_druid_remotely)
       sign_in user, groups: ['sdr:administrator-role']
-      allow(StateService).to receive(:new).and_return(state_service)
+      allow(VersionService).to receive(:new).and_return(version_service)
     end
 
     context 'when object modification not allowed' do
-      let(:state_service) { instance_double(StateService, open?: false) }
+      let(:version_service) { instance_double(VersionService, open?: false) }
 
       it 'redirects with an error' do
         post "/items/#{druid}/set_governing_apo", params: { new_apo_id: }

--- a/spec/requests/set_source_id_spec.rb
+++ b/spec/requests/set_source_id_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Set source id for an object' do
     let(:druid) { 'druid:cc243mg0841' }
     let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, update: true) }
     let(:cocina_model) { build(:dro_with_metadata, id: druid) }
+    let(:version_service) { instance_double(VersionService, open?: true) }
 
     let(:updated_model) do
       cocina_model.new(
@@ -22,6 +23,7 @@ RSpec.describe 'Set source id for an object' do
     before do
       allow(Dor::Services::Client).to receive(:object).and_return(object_client)
       allow(Argo::Indexer).to receive(:reindex_druid_remotely)
+      allow(VersionService).to receive(:new).and_return(version_service)
       sign_in user, groups: ['sdr:administrator-role']
     end
 

--- a/spec/requests/upload_structural_csv_spec.rb
+++ b/spec/requests/upload_structural_csv_spec.rb
@@ -7,18 +7,16 @@ RSpec.describe 'Upload the structural CSV' do
 
   let(:user) { create(:user) }
   let(:druid) { cocina_model.externalIdentifier }
-  let(:state_service) { instance_double(StateService) }
+  let(:version_service) { instance_double(VersionService, open?: open) }
 
   before do
     allow(Repository).to receive(:find).and_return(cocina_model)
-    allow(StateService).to receive(:new).and_return(state_service, open?: modifiable)
+    allow(VersionService).to receive(:new).and_return(version_service)
     allow(Argo::Indexer).to receive(:reindex_druid_remotely)
   end
 
   context 'when they have manage access' do
     before do
-      allow(state_service).to receive(:open?).and_return(modifiable)
-
       sign_in user, groups: ['sdr:administrator-role']
     end
 
@@ -26,7 +24,7 @@ RSpec.describe 'Upload the structural CSV' do
     let(:file) { fixture_file_upload('structure-upload.csv') }
 
     context 'when object is unlocked' do
-      let(:modifiable) { true }
+      let(:open) { true }
 
       context 'when valid' do
         before do
@@ -114,7 +112,7 @@ RSpec.describe 'Upload the structural CSV' do
     end
 
     context 'when object is locked' do
-      let(:modifiable) { false }
+      let(:open) { false }
 
       before do
         allow(Repository).to receive(:store)

--- a/spec/services/state_service_spec.rb
+++ b/spec/services/state_service_spec.rb
@@ -15,52 +15,6 @@ RSpec.describe StateService do
   let(:cocina) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, version: 3) }
   let(:service) { described_class.new(cocina) }
 
-  describe '#open?' do
-    before do
-      allow(service).to receive(:object_state).and_return(:unlock)
-    end
-
-    context 'if the object state is unlock' do
-      before do
-        allow(service).to receive(:object_state).and_return(:unlock)
-      end
-
-      it 'returns true' do
-        expect(service).to be_open
-      end
-    end
-
-    context 'if the object state is unlock_inactive' do
-      before do
-        allow(service).to receive(:object_state).and_return(:unlock_inactive)
-      end
-
-      it 'returns true' do
-        expect(service).to be_open
-      end
-    end
-
-    context 'if the object state is lock' do
-      before do
-        allow(service).to receive(:object_state).and_return(:lock)
-      end
-
-      it 'returns false' do
-        expect(service).not_to be_open
-      end
-    end
-
-    context 'if the object state is lock_inactive' do
-      before do
-        allow(service).to receive(:object_state).and_return(:lock_inactive)
-      end
-
-      it 'returns false' do
-        expect(service).not_to be_open
-      end
-    end
-  end
-
   describe '#object_state' do
     context "if the object is not opened and hasn't been submitted" do
       before do


### PR DESCRIPTION
# Why was this change made?

Determining if an item is open is the responsibility of VersionService, not StateService.

# How was this change tested?

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


