### PR TITLE
Require version to be open to edit APO or create collection.

### DIFF
--- a/app/components/show/controls_component.rb
+++ b/app/components/show/controls_component.rb
@@ -80,14 +80,17 @@ module Show
 
     def edit_apo
       render ActionButton.new(
-        url: edit_apo_path(druid), label: 'Edit APO'
+        url: edit_apo_path(druid),
+        label: 'Edit APO',
+        disabled: button_disabled?
       )
     end
 
     def create_collection
       render ActionButton.new(
         url: new_apo_collection_path(apo_id: druid), label: 'Create Collection',
-        open_modal: true
+        open_modal: true,
+        disabled: button_disabled?
       )
     end
 


### PR DESCRIPTION
# Why was this change made?
APOs aren't special. They have to be versioned like every other object.

# How was this change tested?

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->

Unit

