### PR TITLE
Disable Create collection button only when APO not open and not openable

### DIFF
--- a/app/components/show/controls_component.rb
+++ b/app/components/show/controls_component.rb
@@ -42,10 +42,14 @@ module Show
     end
 
     delegate :admin_policy?, :agreement?, :item?, :collection?, :embargoed?, to: :doc
-    delegate :open?, to: :presenter
+    delegate :open?, :openable?, to: :presenter
 
     def button_disabled?
       !open?
+    end
+
+    def collection_button_disabled?
+      !open? && !openable?
     end
 
     def refresh_button_label
@@ -90,7 +94,7 @@ module Show
       render ActionButton.new(
         url: new_apo_collection_path(apo_id: druid), label: 'Create Collection',
         open_modal: true,
-        disabled: button_disabled?
+        disabled: collection_button_disabled?
       )
     end
 

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -21,12 +21,12 @@ class CollectionsController < ApplicationController
     return render 'new' unless form.validate(params.merge(apo_druid: params[:apo_id]))
 
     form.save
+    collection_druid = form.model.externalIdentifier
     # open version for APO if not already open
     version_service = VersionService.new(druid: cocina_admin_policy.externalIdentifier)
-    version_service.open unless version_service.open?
+    cocina_admin_policy = version_service.open(description: "Created new collection: #{collection_druid}") unless version_service.open?
 
     # update APO
-    collection_druid = form.model.externalIdentifier
     collections = Array(cocina_admin_policy.administrative.collectionsForRegistration).dup
     # The following two steps mimic the behavior of `Dor::AdministrativeMetadataDS#add_default_collection` (from the now de-coupled dor-services gem)
     # 1. If collection is already listed, remove it temporarily

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -40,7 +40,7 @@ class CollectionsController < ApplicationController
     )
     Repository.store(updated_cocina_admin_policy)
     # Close the APO version and reindex
-    version_service.close(description: "Created new collection: #{collection_druid}")
+    version_service.close
     Argo::Indexer.reindex_druid_remotely(params[:apo_id])
     redirect_to solr_document_path(params[:apo_id]), notice: "Created collection #{collection_druid}"
   end

--- a/app/presenters/argo_show_presenter.rb
+++ b/app/presenters/argo_show_presenter.rb
@@ -17,7 +17,7 @@ class ArgoShowPresenter < Blacklight::ShowPresenter
     cocina.externalIdentifier
   end
 
-  delegate :open?, to: :version_service
+  delegate :open?, :openable?, to: :version_service
 
   attr_accessor :cocina, :view_token, :state_service, :version_service
 end

--- a/app/views/collections/new.html.erb
+++ b/app/views/collections/new.html.erb
@@ -66,12 +66,6 @@
             Register Collection
           <% end %>
         </div>
-
-        <% if !request.xhr? %>
-          <div class="mb-3">
-            <%= button_to 'Cancel', solr_document_path(@cocina.externalIdentifier), method: :get, class: 'btn btn-secondary' %>
-          </div>
-        <% end %>
       <% end %>
     </div>
   <% end %>

--- a/spec/requests/create_collections_spec.rb
+++ b/spec/requests/create_collections_spec.rb
@@ -34,9 +34,11 @@ RSpec.describe 'Create collections' do
     let(:cocina_model) do
       build(:admin_policy_with_metadata)
     end
+    let(:version_service) { instance_double(VersionService, open?: false, openable?: true, open: true, close: true) }
 
     before do
       allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+      allow(VersionService).to receive(:new).and_return(version_service)
       allow(CollectionForm).to receive(:new).and_return(form)
       allow(Argo::Indexer).to receive(:reindex_druid_remotely)
     end
@@ -48,6 +50,8 @@ RSpec.describe 'Create collections' do
       expect(response).to be_redirect # redirects to catalog page
       expect(form).to have_received(:save)
       expect(object_client).to have_received(:update).with(params: cocina_admin_policy_with_registration_collections([collection_id]))
+      expect(version_service).to have_received(:open)
+      expect(version_service).to have_received(:close)
       expect(Argo::Indexer).to have_received(:reindex_druid_remotely).with(apo_id)
     end
   end

--- a/spec/requests/create_collections_spec.rb
+++ b/spec/requests/create_collections_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Create collections' do
     let(:cocina_model) do
       build(:admin_policy_with_metadata)
     end
-    let(:version_service) { instance_double(VersionService, open?: false, openable?: true, open: true, close: true) }
+    let(:version_service) { instance_double(VersionService, open?: false, openable?: true, open: cocina_model, close: true) }
 
     before do
       allow(Dor::Services::Client).to receive(:object).and_return(object_client)


### PR DESCRIPTION
# Why was this change made?
Resolves #4410 to adjust Create Collection button.

# How was this change tested?
Unit and testing on QA. Passed the `apo_creation_spec` and `collection_create_spec` integration tests. Will require PO testing.


