### PR TITLE
Allow closing version 1

### DIFF
--- a/app/services/state_service.rb
+++ b/app/services/state_service.rb
@@ -15,9 +15,7 @@ class StateService
 
   def object_state
     # This item is currently unlocked and can be edited and moved to a locked state
-    # In Argo, the user can't close a version if it's the first version
-    # (though, technically, the version is closeeable).
-    return STATES[:unlock] if open? && closeable? && !first_version?
+    return STATES[:unlock] if open? && closeable?
 
     # This item is currently locked and cannot be edited, and can be moved to an unlocked state
     return STATES[:lock] if closed? && openable?

--- a/spec/services/state_service_spec.rb
+++ b/spec/services/state_service_spec.rb
@@ -35,18 +35,6 @@ RSpec.describe StateService do
       end
     end
 
-    context 'when object is open and closeable but first version' do
-      let(:version) { 1 }
-
-      before do
-        allow(version_service).to receive_messages(open?: true, closeable?: true, closed?: false)
-      end
-
-      it 'returns unlock' do
-        expect(service.object_state).to eq :unlock_inactive
-      end
-    end
-
     context 'when object is closed and not openable' do
       before do
         allow(version_service).to receive_messages(open?: false, closed?: true, openable?: false)


### PR DESCRIPTION
# Why was this change made?
Otherwise there is no way to close an item with no files, since accessionWF can no longer be used to close an item.

Per @andrewjbtw 

# How was this change tested?

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->

Unit
