### PR TITLE
Remove dor-indexing-app.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,35 +43,6 @@ executors:
         <<: *ruby_envs
       - image: cimg/postgres:<< parameters.postgres_tag >>
         <<: *postgres_envs
-      - image: rabbitmq:3
-        name: rabbitmq
-      - image: suldlss/dor-indexing-app:latest
-        name: dor-indexing-app
-        environment:
-          SOLR_URL: http://solr:8983/solr/argo
-          SETTINGS__SOLR__URL: http://solr:8983/solr/argo
-          SETTINGS__DOR_SERVICES__URL: http://dor-services-app:3000/
-          # To generate the token: docker-compose run dor-services-app rake generate_token
-          SETTINGS__DOR_SERVICES__TOKEN: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJGb28ifQ.-BVfLTW9Q1_ZQEsGv4tuzGLs5rESN7LgdtEwUltnKv4
-          SETTINGS__SOLRIZER_URL: http://solr:8983/solr/argo
-          SETTINGS__WORKFLOW_URL: http://workflow:3000
-      - image: suldlss/dor-indexing-app:latest
-        name: dor-indexing-workers
-        command:
-          [
-            'sh',
-            '-c',
-            'timeout 30 docker/wait-port.sh rabbitmq 5672 ; bin/rake rabbitmq:setup sneakers:run',
-          ]
-        environment:
-          SOLR_URL: http://solr:8983/solr/argo
-          SETTINGS__SOLR__URL: http://solr:8983/solr/argo
-          SETTINGS__DOR_SERVICES__URL: http://dor-services-app:3000/
-          # To generate the token: docker-compose run dor-services-app rake generate_token
-          SETTINGS__DOR_SERVICES__TOKEN: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJGb28ifQ.-BVfLTW9Q1_ZQEsGv4tuzGLs5rESN7LgdtEwUltnKv4
-          SETTINGS__SOLRIZER_URL: http://solr:8983/solr/argo
-          SETTINGS__WORKFLOW_URL: http://workflow:3000
-          SETTINGS__RABBITMQ__HOSTNAME: rabbitmq
       - image: suldlss/dor-services-app:latest
         name: dor-services-app
         environment:
@@ -88,8 +59,7 @@ executors:
           SETTINGS__WORKFLOW_URL: http://workflow:3000
           SETTINGS__ENABLED_FEATURES__CREATE_UR_ADMIN_POLICY: 'true'
           SETTINGS__VERSION_SERVICE__SYNC_WITH_PRESERVATION: 'false'
-          SETTINGS__RABBITMQ__ENABLED: 'true'
-          SETTINGS__RABBITMQ__HOSTNAME: rabbitmq
+          SETTINGS__RABBITMQ__ENABLED: 'false'
           SETTINGS__REDIS_URL: redis://redis:6379/
       - image: suldlss/sdr-api:latest
         name: sdr-api

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ CI runs a series of steps;  this the sequence to do it locally, along with some 
     Once everything has been successfully pulled, start up the docker services needed for testing (all but the web container)
 
     ```
-    docker compose up -d sdr-api techmd dor-indexing-workers
+    docker compose up -d sdr-api techmd workflow
     ```
 
     You should do the following to make sure all the services are up:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,4 @@
-version: '3.6'
-
-x-dor-indexing: &dor-indexing-backend
-  image: suldlss/dor-indexing-app:latest
-  environment:
-    SOLR_URL: http://solr:8983/solr/argo
-    SETTINGS__SOLR__URL: http://solr:8983/solr/argo
-    SETTINGS__DOR_SERVICES__URL: http://dor-services-app:3000/
-    # To generate the token: docker-compose run dor-services-app rake generate_token
-    SETTINGS__DOR_SERVICES__TOKEN: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJGb28ifQ.-BVfLTW9Q1_ZQEsGv4tuzGLs5rESN7LgdtEwUltnKv4
-    SETTINGS__SOLRIZER_URL: http://solr:8983/solr/argo
-    SETTINGS__WORKFLOW_URL: http://workflow:3000
-    SETTINGS__RABBITMQ__HOSTNAME: rabbitmq
-    WORKERS: ReindexJob,ReindexByDruidJob,DeleteByDruidJob
-  depends_on:
-    - solr
-    - workflow
-    - rabbitmq
+name: 'argo'
 
 services:
   web:
@@ -34,7 +17,6 @@ services:
       # Allow bulk action logs to be written (can't write to /tmp)
       SETTINGS__BULK_METADATA__DIRECTORY: '/app/tmp'
       SETTINGS__BULK_METADATA__TEMPORARY_DIRECTORY: '/app/tmp/tmp'
-      SETTINGS__DOR_INDEXING_URL: http://dor-indexing-app:3000/dor
       # To generate the token: docker-compose run dor-services-app rake generate_token
       SETTINGS__DOR_SERVICES__TOKEN: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJGb28ifQ.-BVfLTW9Q1_ZQEsGv4tuzGLs5rESN7LgdtEwUltnKv4
       SETTINGS__DOR_SERVICES__URL: http://dor-services-app:3000
@@ -46,24 +28,8 @@ services:
       SOLR_URL: http://solr:8983/solr/argo
       # Docker doesn't allow rails server to remove PID on shutdown
       PID_FILE: /dev/null
-    depends_on:
-      - dor-indexing-app
     # To allow yarn --watch from Procfile.dev to continue after stdin is closed
     tty: true
-
-  rabbitmq:
-    image: rabbitmq:3
-    ports:
-      - 5672:5672
-
-  dor-indexing-app:
-    <<: *dor-indexing-backend
-    ports:
-      - 3004:3000
-
-  dor-indexing-workers:
-    <<: *dor-indexing-backend
-    command: ['sh', '-c', 'timeout 30 docker/wait-port.sh rabbitmq 5672 ; bin/rake rabbitmq:setup sneakers:run']
   
   dor-services-app:
     image: suldlss/dor-services-app:latest
@@ -79,20 +45,18 @@ services:
       SECRET_KEY_BASE: 769171f88c527d564fb65b4b7ef712d5ae9761a21e26a41cd7c88eb0af89c74f857b9be4089119f71cf806dfc8bf9d9d2f0df91c00b119c96f462b46ebf43b0f
       SOLR_URL: http://solr:8983/solr/argo
       SETTINGS__ENABLED_FEATURES__CREATE_UR_ADMIN_POLICY: 'true'
-      SETTINGS__DOR_INDEXING__URL: http://dor-indexing-app:3000/dor
       SETTINGS__SOLR__URL: http://solr:8983/solr/argo
       SETTINGS__SURI__URL: http://suri:3000
       SETTINGS__WORKFLOW_URL: http://workflow:3000
       SETTINGS__WORKFLOW__LOGFILE: rails
-      SETTINGS__RABBITMQ__ENABLED: 'true'
-      SETTINGS__RABBITMQ__HOSTNAME: rabbitmq
+      SETTINGS__RABBITMQ__ENABLED: 'false'
       SETTINGS__VERSION_SERVICE__SYNC_WITH_PRESERVATION: 'false'
       SETTINGS__REDIS_URL: redis://redis:6379/
     depends_on:
       - db
-      - dor-indexing-app
       - suri
       - redis
+      - solr
 
   sdr-api:
     image: suldlss/sdr-api:latest

--- a/spec/factories/apos.rb
+++ b/spec/factories/apos.rb
@@ -21,10 +21,7 @@ FactoryBot.define do
     end
 
     to_create do |builder|
-      Dor::Services::Client.objects.register(params: builder.cocina_model).tap do |apo|
-        # Since we don't run the rabbitMQ service in our cluster, we have to index these manually
-        Dor::Services::Client.object(apo.externalIdentifier).reindex
-      end
+      Dor::Services::Client.objects.register(params: builder.cocina_model)
     end
 
     admin_policy_id { 'druid:hv992ry2431' }

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -18,10 +18,7 @@ FactoryBot.define do
     end
 
     to_create do |builder|
-      Dor::Services::Client.objects.register(params: builder.cocina_model).tap do |collection|
-        # Since we don't run the rabbitMQ service in our cluster, we have to index these manually
-        Dor::Services::Client.object(collection.externalIdentifier).reindex
-      end
+      Dor::Services::Client.objects.register(params: builder.cocina_model)
     end
 
     admin_policy_id { 'druid:hv992ry2431' }

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -22,10 +22,7 @@ FactoryBot.define do
     end
 
     to_create do |builder|
-      Dor::Services::Client.objects.register(params: builder.cocina_model).tap do |item|
-        # Since we don't run the rabbitMQ service in our cluster, we have to index these manually
-        Dor::Services::Client.object(item.externalIdentifier).reindex
-      end
+      Dor::Services::Client.objects.register(params: builder.cocina_model)
     end
 
     admin_policy_id { 'druid:hv992ry2431' }


### PR DESCRIPTION
# Why was this change made?
DIA is deprecated and not necessary for Argo tests.

# How was this change tested?

Local, CI

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


