### PR TITLE
show workflow context in workflow view

### DIFF
--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 class WorkflowsController < ApplicationController
-  # Called from "Add Workflow" button. This is content for a modal invoked via XHR
-  # so we don't want a layout.
+  ##
+  # Renders a view with process-level state information for a given object's workflow.
+  #
+  # @option params [String] `:item_id` The druid for the object.
+  # @option params [String] `:id` The workflow name. e.g., accessionWF.
   def show
     workflow = WorkflowClientFactory.build.workflow(pid: params[:item_id], workflow_name: params[:id])
     respond_to do |format|
@@ -14,22 +17,13 @@ class WorkflowsController < ApplicationController
     end
   end
 
-  ##
-  # Renders a view with process-level state information for a given object's workflow.
-  #
-  # @option params [String] `:item_id` The druid for the object.
-  # @option params [String] `:id` The workflow name. e.g., accessionWF.
+  # Called from "Add Workflow" button. This is content for a modal invoked via XHR
+  # so we don't want a layout.
   def new
     render 'new', layout: false
   end
 
-  ##
-  # Updates the status of a specific workflow process step to a given status.
-  #
-  # @option params [String] `:item_id` The druid for the object.
-  # @option params [String] `:id` The workflow name. e.g., accessionWF.
-  # @option params [String] `:process` The workflow step. e.g., publish.
-  # @option params [String] `:status` The status to which we want to reset the workflow.
+  # add a workflow to an object if the workflow is not present in the active table
   def create
     cocina_object = Repository.find(params[:item_id])
 
@@ -57,7 +51,13 @@ class WorkflowsController < ApplicationController
     redirect_to solr_document_path(cocina_object.externalIdentifier), notice: msg
   end
 
-  # add a workflow to an object if the workflow is not present in the active table
+  ##
+  # Updates the status of a specific workflow process step to a given status.
+  #
+  # @option params [String] `:item_id` The druid for the object.
+  # @option params [String] `:id` The workflow name. e.g., accessionWF.
+  # @option params [String] `:process` The workflow step. e.g., publish.
+  # @option params [String] `:status` The status to which we want to reset the workflow.
   def update
     params.require %i[process status]
     cocina = Repository.find(params[:item_id])

--- a/app/models/workflow_status.rb
+++ b/app/models/workflow_status.rb
@@ -23,6 +23,11 @@ class WorkflowStatus
     end
   end
 
+  # any workflow context that is set... context is returned with each process step, but is the same for all steps, so just return the first one
+  def workflow_context
+    process_statuses.filter_map(&:context).first
+  end
+
   private
 
   attr_reader :workflow_steps, :workflow

--- a/app/presenters/workflow_presenter.rb
+++ b/app/presenters/workflow_presenter.rb
@@ -10,7 +10,7 @@ class WorkflowPresenter
     @cocina_object = cocina_object
   end
 
-  delegate :druid, :workflow_name, to: :workflow_status
+  delegate :druid, :workflow_name, :workflow_context, to: :workflow_status
 
   # @return [Array] all the steps in the workflow definition
   def processes

--- a/app/views/workflows/_show.html.erb
+++ b/app/views/workflows/_show.html.erb
@@ -5,9 +5,6 @@
               data: { blacklight_modal: 'trigger' } %>
 </span>
 <%= @presenter.druid %>
-<% if @presenter.workflow_context.present? %>
-  <div id="workflow-context">Context: <%= @presenter.workflow_context %></div>
-<% end %>
 
 <table class="detail table">
   <thead>
@@ -32,3 +29,6 @@
     <% end %>
   </tbody>
 </table>
+<% if @presenter.workflow_context.present? %>
+  <div id="workflow-context">Context: <%= @presenter.workflow_context %></div>
+<% end %>

--- a/app/views/workflows/_show.html.erb
+++ b/app/views/workflows/_show.html.erb
@@ -6,7 +6,7 @@
 </span>
 <%= @presenter.druid %>
 <% if @presenter.workflow_context.present? %>
-  <div>Context: <%= @presenter.workflow_context %></div>
+  <div id="workflow-context">Context: <%= @presenter.workflow_context %></div>
 <% end %>
 
 <table class="detail table">

--- a/app/views/workflows/_show.html.erb
+++ b/app/views/workflows/_show.html.erb
@@ -5,6 +5,9 @@
               data: { blacklight_modal: 'trigger' } %>
 </span>
 <%= @presenter.druid %>
+<% if @presenter.workflow_context.present? %>
+  <div>Context: <%= @presenter.workflow_context %></div>
+<% end %>
 
 <table class="detail table">
   <thead>

--- a/spec/views/workflows/_show.html.erb_spec.rb
+++ b/spec/views/workflows/_show.html.erb_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'workflows/_show' do
                     attempts: nil,
                     lifecycle: nil,
                     error_message: 'broken',
+                    context: nil,
                     note: nil)
   end
 
@@ -24,6 +25,7 @@ RSpec.describe 'workflows/_show' do
                     druid:,
                     workflow_name:,
                     processes: [process_status],
+                    workflow_context: nil,
                     cocina_object: nil)
   end
 


### PR DESCRIPTION
# Why was this change made?

Fixes #4436 - show workflow context in workflow detail view (if it's there).

Here is what it would look like if there is context:

![Screenshot 2024-05-13 at 2 24 11 PM](https://github.com/sul-dlss/argo/assets/47137/f820934f-1d42-4010-9a86-b640bd93ca91)

And no context:

![Screenshot 2024-05-13 at 2 24 32 PM](https://github.com/sul-dlss/argo/assets/47137/4da40e4b-9adc-468b-9a26-bd106169f205)

# How was this change tested?

Localhost