### PR TITLE
Display user version when present.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'zip_tricks'
 # Stanford related gems
 gem 'blacklight', '~> 7.25', '< 7.34' # Avoid 7.34 until we have time to troubleshoot test failures
 gem 'blacklight-hierarchy', '~> 6.1'
-gem 'dor-services-client', '~> 14.7'
+gem 'dor-services-client', '~> 14.9'
 gem 'dor-workflow-client', '~> 7.0'
 gem 'druid-tools'
 gem 'folio_client', '~> 0.13'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -676,7 +676,7 @@ DEPENDENCIES
   devise
   devise-remote-user (~> 1.0)
   dlss-capistrano
-  dor-services-client (~> 14.7)
+  dor-services-client (~> 14.9)
   dor-workflow-client (~> 7.0)
   druid-tools
   dry-monads

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -369,7 +369,8 @@ class CatalogController < ApplicationController
     milestones = MilestoneService.milestones_for(druid: params[:id])
     object_client = Dor::Services::Client.object(params[:id])
     versions = object_client.version.inventory
-    @milestones_presenter = MilestonesPresenter.new(milestones:, versions:)
+    user_versions = object_client.user_version.inventory
+    @milestones_presenter = MilestonesPresenter.new(milestones:, versions:, user_versions:)
     @release_tags = @cocina.instance_of?(NilModel) || @cocina.admin_policy? ? [] : object_client.release_tags.list
 
     # If you have this token, it indicates you have read access to the object

--- a/app/presenters/milestones_presenter.rb
+++ b/app/presenters/milestones_presenter.rb
@@ -4,9 +4,11 @@
 class MilestonesPresenter
   # @param [Hash<String,Hash>] milestones the milestone data
   # @param [Array<Dor::Services::Client::ObjectVersion::Version>] versions the version tag data
-  def initialize(milestones:, versions:)
+  # @param [Array<Dor::Services::Client::UserVersion::UserVersion>] user_versions the user versions data
+  def initialize(milestones:, versions:, user_versions:)
     @milestones = milestones
     @versions = versions
+    @user_versions = user_versions
   end
 
   def each_version(&)
@@ -21,10 +23,21 @@ class MilestonesPresenter
     val = versions.find { |this| this.versionId == version.to_i }
     return version unless val
 
-    "#{version} #{val.message}"
+    "#{version} #{val.message}#{user_version_title_part(version)}"
   end
 
   private
 
-  attr_reader :milestones, :versions
+  attr_reader :milestones, :versions, :user_versions
+
+  def user_version_title_part(version)
+    user_version = user_version_for(version)
+    return '' unless user_version
+
+    " (User version #{user_version})"
+  end
+
+  def user_version_for(version)
+    user_versions.find { |user_version| user_version.version == version.to_i }&.userVersion
+  end
 end

--- a/spec/features/add_workflow_to_item_spec.rb
+++ b/spec/features/add_workflow_to_item_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'Add a workflow to an item' do
   end
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
+  let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: []) }
   let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: []) }
   let(:object_client) do
     instance_double(Dor::Services::Client::Object,
@@ -25,6 +26,7 @@ RSpec.describe 'Add a workflow to an item' do
                     find_lite: cocina_model, # NOTE: This should really be a DROLite
                     events: events_client,
                     version: version_client,
+                    user_version: user_version_client,
                     release_tags: release_tags_client,
                     reindex: true)
   end

--- a/spec/features/collection_manage_release_spec.rb
+++ b/spec/features/collection_manage_release_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'Collection manage release' do
   let(:version_service) { instance_double(VersionService, open?: true) }
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
+  let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: []) }
   let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: []) }
   let(:object_client) do
     instance_double(Dor::Services::Client::Object,
@@ -16,6 +17,7 @@ RSpec.describe 'Collection manage release' do
                     find: cocina_model,
                     events: events_client,
                     version: version_client,
+                    user_version: user_version_client,
                     release_tags: release_tags_client)
   end
   let(:cocina_model) do

--- a/spec/features/enable_buttons_spec.rb
+++ b/spec/features/enable_buttons_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'Enable buttons' do
   let(:version_service) { instance_double(VersionService, open?: true) }
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: [], current: 1) }
+  let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: []) }
   let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: []) }
   let(:cocina_model) { build(:dro_lite, id: item_id) }
   let(:object_client) do
@@ -27,6 +28,7 @@ RSpec.describe 'Enable buttons' do
                     find_lite: cocina_model,
                     events: events_client,
                     version: version_client,
+                    user_version: user_version_client,
                     release_tags: release_tags_client)
   end
 

--- a/spec/features/item_catalog_record_id_change_spec.rb
+++ b/spec/features/item_catalog_record_id_change_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe 'Item catalog_record_id change' do
     let(:version_service) { instance_double(VersionService, open?: true) }
     let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
     let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
+    let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: []) }
     let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: []) }
     let(:object_client) do
       instance_double(Dor::Services::Client::Object,
@@ -41,6 +42,7 @@ RSpec.describe 'Item catalog_record_id change' do
                       events: events_client,
                       update: true,
                       version: version_client,
+                      user_version: user_version_client,
                       release_tags: release_tags_client,
                       reindex: true)
     end

--- a/spec/features/item_manage_release_spec.rb
+++ b/spec/features/item_manage_release_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'Item manage release' do
   let(:version_service) { instance_double(VersionService, open?: true) }
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
+  let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: []) }
   let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: []) }
   let(:object_client) do
     instance_double(Dor::Services::Client::Object,
@@ -14,6 +15,7 @@ RSpec.describe 'Item manage release' do
                     find_lite: item,
                     events: events_client,
                     version: version_client,
+                    user_version: user_version_client,
                     release_tags: release_tags_client)
   end
   let(:item) do

--- a/spec/features/item_source_id_change_spec.rb
+++ b/spec/features/item_source_id_change_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe 'Item source id change' do
     let(:version_service) { instance_double(VersionService, open?: true) }
     let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
     let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
+    let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: []) }
     let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: []) }
     let(:object_client) do
       instance_double(Dor::Services::Client::Object,
@@ -43,6 +44,7 @@ RSpec.describe 'Item source id change' do
                       find_lite: cocina_model, # NOTE: This should really be a DROLite
                       events: events_client,
                       version: version_client,
+                      user_version: user_version_client,
                       release_tags: release_tags_client,
                       update: true,
                       reindex: true)

--- a/spec/features/item_view_spec.rb
+++ b/spec/features/item_view_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'Item view', :js do
   end
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: [event]) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, current: 1, inventory: [version1]) }
+  let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: []) }
   let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: release_tags_list) }
   let(:version1) { Dor::Services::Client::ObjectVersion::Version.new }
   let(:all_workflows) { instance_double(Dor::Workflow::Response::Workflows, workflows: []) }
@@ -79,6 +80,7 @@ RSpec.describe 'Item view', :js do
         let(:object_client) do
           instance_double(Dor::Services::Client::Object,
                           version: version_client,
+                          user_version: user_version_client,
                           events: events_client,
                           release_tags: release_tags_client)
         end
@@ -99,6 +101,7 @@ RSpec.describe 'Item view', :js do
                           find_lite: cocina_object_lite,
                           find: cocina_object,
                           version: version_client,
+                          user_version: user_version_client,
                           events: events_client,
                           release_tags: release_tags_client)
         end

--- a/spec/presenters/milestones_presenter_spec.rb
+++ b/spec/presenters/milestones_presenter_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe MilestonesPresenter do
   subject(:presenter) do
-    described_class.new(milestones:, versions:)
+    described_class.new(milestones:, versions:, user_versions:)
   end
 
   let(:milestone2) do
@@ -34,6 +34,12 @@ RSpec.describe MilestonesPresenter do
     ]
   end
 
+  let(:user_versions) do
+    [
+      Dor::Services::Client::UserVersion::Version.new(version: 2, userVersion: 1)
+    ]
+  end
+
   describe '#each_version' do
     let(:actual_versions) do
       versions = []
@@ -58,7 +64,7 @@ RSpec.describe MilestonesPresenter do
     context 'when the version is 2' do
       let(:version) { '2' }
 
-      it { is_expected.to eq '2 Minor change' }
+      it { is_expected.to eq '2 Minor change (User version 1)' }
     end
   end
 


### PR DESCRIPTION
closes #4438

# Why was this change made?
So that user versions can be tested.
<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->

Unit, QA

![image](https://github.com/sul-dlss/argo/assets/588335/3b7e012d-0e90-43cd-99e3-b1ef5a8f4672)


