### PR TITLE
Notifies user when workflow already exists.

### DIFF
--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -35,10 +35,7 @@ class WorkflowsController < ApplicationController
     wf_name = params[:wf]
 
     # check the workflow is present and active (not archived)
-    if workflow_active?(wf_name, cocina_object.externalIdentifier, cocina_object.version)
-      render status: :forbidden, plain: "#{wf_name} already exists!"
-      return
-    end
+    return redirect_to solr_document_path(cocina_object.externalIdentifier), flash: { error: "#{wf_name} already exists!" } if workflow_active?(wf_name, cocina_object.externalIdentifier, cocina_object.version)
 
     WorkflowClientFactory.build.create_workflow_by_name(cocina_object.externalIdentifier,
                                                         wf_name,

--- a/spec/requests/workflows_spec.rb
+++ b/spec/requests/workflows_spec.rb
@@ -46,6 +46,8 @@ RSpec.describe 'WorkflowsController' do
           post "/items/#{druid}/workflows", params: { wf: 'accessionWF' }
 
           expect(workflow_client).not_to have_received(:create_workflow_by_name)
+          expect(response).to redirect_to(solr_document_path(druid))
+          expect(flash[:error]).to eq 'accessionWF already exists!'
         end
       end
     end


### PR DESCRIPTION
closes #4450

# Why was this change made?

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->
Let the user know when a problem occurs.

# How was this change tested?
Unit, local

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


