### PR TITLE
Remove accessionWF and registrationWF from workflows that can be started by user

### DIFF
--- a/app/helpers/apo_helper.rb
+++ b/app/helpers/apo_helper.rb
@@ -1,23 +1,6 @@
 # frozen_string_literal: true
 
 module ApoHelper
-  # @return [Array<Array<String, String>] array suitable for select_tag options
-  def workflow_options
-    # per https://github.com/sul-dlss/argo/issues/3741, this should be hardcoded
-    %w[
-      accessionWF
-      gisAssemblyWF
-      gisDeliveryWF
-      goobiWF
-      registrationWF
-      wasCrawlDisseminationWF
-      wasCrawlPreassemblyWF
-      wasSeedPreassemblyWF
-    ].map do |workflow|
-      [workflow, workflow]
-    end
-  end
-
   def agreement_options
     q = 'objectType_ssim:agreement'
     result = SearchService.query(q, rows: 99_999, fl: 'id,tag_ssim,display_title_ss')['response']['docs']

--- a/app/helpers/workflow_helper.rb
+++ b/app/helpers/workflow_helper.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module WorkflowHelper
+  # Workflows that can be set for an APO.
+  # @return [Array<Array<String, String>] array suitable for select_tag options
+  def workflow_options(except: [])
+    # per https://github.com/sul-dlss/argo/issues/3741, this should be hardcoded
+    %w[
+      accessionWF
+      gisAssemblyWF
+      gisDeliveryWF
+      goobiWF
+      registrationWF
+      wasCrawlDisseminationWF
+      wasCrawlPreassemblyWF
+      wasSeedPreassemblyWF
+    ].reject { |workflow| except.include?(workflow) }.map do |workflow|
+      [workflow, workflow]
+    end
+  end
+
+  # Workflows that can be started by a user.
+  # @return [Array<Array<String, String>] array suitable for select_tag options
+  def start_workflow_options
+    workflow_options(except: %w[accessionWF registrationWF])
+  end
+end

--- a/app/views/bulk_actions/add_workflow_jobs/_new.html.erb
+++ b/app/views/bulk_actions/add_workflow_jobs/_new.html.erb
@@ -7,7 +7,7 @@
 
   <div class='mt-2 mb-3'>
     <%= f.label :workflow %>
-    <%= f.select :workflow, workflow_options, {}, class: 'form-select' %>
+    <%= f.select :workflow, start_workflow_options, {}, class: 'form-select' %>
   </div>
 
   <%= render 'bulk_actions/druids', f: %>

--- a/app/views/workflows/_new.html.erb
+++ b/app/views/workflows/_new.html.erb
@@ -1,6 +1,6 @@
 <%= form_tag item_workflows_path do %>
   <div class='mb-3'>
-    <%= select_tag :wf, options_for_select(workflow_options, Settings.apo.default_workflow_option), class: 'form-select' %>
+    <%= select_tag :wf, options_for_select(start_workflow_options), class: 'form-select' %>
   </div>
   <button class='btn btn-primary'>
     Add

--- a/spec/features/add_workflow_to_item_spec.rb
+++ b/spec/features/add_workflow_to_item_spec.rb
@@ -49,10 +49,11 @@ RSpec.describe 'Add a workflow to an item' do
 
   it 'redirect and display on show page' do
     visit new_item_workflow_path item_id
+    expect(page).to have_no_css 'option[value="registrationWF"]'
+    expect(page).to have_no_css 'option[value="accessionWF"]'
     click_button 'Add'
     within '.flash_messages' do
-      # The selected workflow defaults to Settings.apo.default_workflow_option (registrationWF)
-      expect(page).to have_css '.alert.alert-info', text: 'Added registrationWF'
+      expect(page).to have_css '.alert.alert-info', text: 'Added gisAssemblyWF'
     end
     expect(workflow_client).to have_received(:create_workflow_by_name)
   end


### PR DESCRIPTION
closes #4452

# Why was this change made?
Keep users from getting in trouble.

# How was this change tested?
Unit, local

![image](https://github.com/sul-dlss/argo/assets/588335/124ba154-2947-4f93-ae1c-6518c2b11482)



<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


