### PR TITLE
Restrict editing while assembling.

### DIFF
--- a/app/components/contents_component.html.erb
+++ b/app/components/contents_component.html.erb
@@ -8,7 +8,7 @@
     <div class="accordion-body" data-controller="structural">
       <div class="mb-3">
         <%= render DownloadAllButtonComponent.new(cocina: @cocina, document: @document) %>
-        <% if open? %>
+        <% if open_and_not_assembling? %>
           <%= button_tag class: 'btn btn-link float-end', data: { action: 'click->structural#open' } do %>
             <span class="bi-upload"></span> Upload CSV
           <% end %>

--- a/app/components/contents_component.rb
+++ b/app/components/contents_component.rb
@@ -12,5 +12,5 @@ class ContentsComponent < ApplicationComponent
     @cocina.respond_to?(:structural)
   end
 
-  delegate :open?, to: :@presenter
+  delegate :open_and_not_assembling?, to: :@presenter
 end

--- a/app/components/show/barcode_component.html.erb
+++ b/app/components/show/barcode_component.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="barcode">
   <%= barcode %>
-  <% if open? %>
+  <% if open_and_not_assembling? %>
     <%= link_to edit_barcode_item_path(id:), aria: { label: 'Edit barcode' } do %>
       <span class="bi-pencil"></span>
     <% end %>

--- a/app/components/show/barcode_component.rb
+++ b/app/components/show/barcode_component.rb
@@ -11,7 +11,7 @@ module Show
       @change_set.barcode || 'Not recorded'
     end
 
-    delegate :open?, to: :@version_service
+    delegate :open_and_not_assembling?, to: :@version_service
     delegate :id, to: :@change_set
   end
 end

--- a/app/components/show/catalog_record_id_component.html.erb
+++ b/app/components/show/catalog_record_id_component.html.erb
@@ -1,6 +1,6 @@
 <%= catalog_record_id %>
 
-<% if open? %>
+<% if open_and_not_assembling? %>
   <%= link_to edit_item_catalog_record_id_path(item_id: id),
               aria: { label: manage_label },
               data: { controller: 'button', action: 'click->button#open' } do %>

--- a/app/components/show/catalog_record_id_component.rb
+++ b/app/components/show/catalog_record_id_component.rb
@@ -11,7 +11,7 @@ module Show
       @change_set.catalog_record_ids.presence&.join(', ') || 'None assigned'
     end
 
-    delegate :open?, to: :@version_service
+    delegate :open_and_not_assembling?, to: :@version_service
     delegate :id, to: :@change_set
     delegate :manage_label, to: CatalogRecordId
   end

--- a/app/components/show/content_type_component.html.erb
+++ b/app/components/show/content_type_component.html.erb
@@ -1,6 +1,6 @@
 <%= content_type %>
 
-<% if open? %>
+<% if open_and_not_assembling? %>
   <%= link_to edit_item_content_type_path(item_id: id),
               aria: { label: 'Set content type' },
               data: { controller: 'button', action: 'click->button#open' } do %>

--- a/app/components/show/content_type_component.rb
+++ b/app/components/show/content_type_component.rb
@@ -7,7 +7,7 @@ module Show
       @version_service = version_service
     end
 
-    delegate :open?, to: :@version_service
+    delegate :open_and_not_assembling?, to: :@version_service
     delegate :id, :content_type, to: :@document
   end
 end

--- a/app/components/show/controls_component.html.erb
+++ b/app/components/show/controls_component.html.erb
@@ -25,7 +25,7 @@
                           data: { turbo_method: 'post' } %></li>
         <% end %>
         <li><%= link_to 'Download Cocina spreadsheet', item_descriptive_path(doc, format: :csv), class: 'dropdown-item' %></li>
-        <% if open? %>
+        <% unless button_disabled? %>
           <li><%= link_to 'Upload Cocina spreadsheet', edit_item_descriptive_path(doc),
                           class: 'dropdown-item',
                           data: { controller: 'button', action: 'click->button#open' } %></li>

--- a/app/components/show/controls_component.rb
+++ b/app/components/show/controls_component.rb
@@ -43,10 +43,10 @@ module Show
     end
 
     delegate :admin_policy?, :agreement?, :item?, :collection?, :embargoed?, to: :doc
-    delegate :open?, :openable?, to: :presenter
+    delegate :open?, :openable?, :open_and_not_assembling?, to: :presenter
 
     def button_disabled?
-      !open?
+      !open_and_not_assembling?
     end
 
     def collection_button_disabled?

--- a/app/components/show/copyright_component.html.erb
+++ b/app/components/show/copyright_component.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="copyright">
   <%= copyright %>
-  <% if open? %>
+  <% if open_and_not_assembling? %>
     <%= link_to edit_copyright_item_path(id:), aria: { label: 'Edit copyright' } do %>
       <span class="bi-pencil"></span>
     <% end %>

--- a/app/components/show/copyright_component.rb
+++ b/app/components/show/copyright_component.rb
@@ -11,7 +11,7 @@ module Show
       @change_set.copyright || 'Not entered'
     end
 
-    delegate :open?, to: :@version_service
+    delegate :open_and_not_assembling?, to: :@version_service
     delegate :id, to: :@change_set
   end
 end

--- a/app/components/show/governed_by_component.html.erb
+++ b/app/components/show/governed_by_component.html.erb
@@ -1,6 +1,6 @@
 <%= admin_policy %>
 
-<% if open? %>
+<% if open_and_not_assembling? %>
   <%= link_to set_governing_apo_ui_item_path(id:),
               aria: { label: 'Set governing APO' },
               data: { controller: 'button', action: 'click->button#open' } do %>

--- a/app/components/show/governed_by_component.rb
+++ b/app/components/show/governed_by_component.rb
@@ -13,7 +13,7 @@ module Show
       helpers.link_to_admin_policy_with_objs(document: @document, value: @document.apo_id)
     end
 
-    delegate :open?, to: :@version_service
+    delegate :open_and_not_assembling?, to: :@version_service
     delegate :id, to: :@document
   end
 end

--- a/app/components/show/is_member_of_component.html.erb
+++ b/app/components/show/is_member_of_component.html.erb
@@ -1,6 +1,6 @@
 <%= collection %>
 
-<% if open? %>
+<% if open_and_not_assembling? %>
   <%= link_to collection_ui_item_path(id:),
               aria: { label: 'Edit collections' },
               data: { controller: 'button', action: 'click->button#open' } do %>

--- a/app/components/show/is_member_of_component.rb
+++ b/app/components/show/is_member_of_component.rb
@@ -13,7 +13,7 @@ module Show
       helpers.links_to_collections_with_objs(document: @document, value: Array(@document.collection_ids))
     end
 
-    delegate :open?, to: :@version_service
+    delegate :open_and_not_assembling?, to: :@version_service
     delegate :id, to: :@document
   end
 end

--- a/app/components/show/item/access_rights_component.html.erb
+++ b/app/components/show/item/access_rights_component.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="access-rights">
   <%= access_rights %>
-  <% if open? %>
+  <% if open_and_not_assembling? %>
     <%= link_to edit_rights_item_path(id:), aria: { label: 'Edit rights' } do %>
       <span class="bi-pencil"></span>
     <% end %>

--- a/app/components/show/item/access_rights_component.rb
+++ b/app/components/show/item/access_rights_component.rb
@@ -18,7 +18,7 @@ module Show
         val
       end
 
-      delegate :open?, to: :@version_service
+      delegate :open_and_not_assembling?, to: :@version_service
       delegate :id, :view_access, :download_access, :access_location, :controlled_digital_lending, to: :@change_set
 
       def humanize_value(val)

--- a/app/components/show/license_component.html.erb
+++ b/app/components/show/license_component.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="license">
   <%= license %>
-  <% if open? %>
+  <% if open_and_not_assembling? %>
     <%= link_to edit_license_item_path(id:), aria: { label: 'Edit license' } do %>
       <span class="bi-pencil"></span>
     <% end %>

--- a/app/components/show/license_component.rb
+++ b/app/components/show/license_component.rb
@@ -15,7 +15,7 @@ module Show
       value.fetch(:label)
     end
 
-    delegate :open?, to: :@version_service
+    delegate :open_and_not_assembling?, to: :@version_service
     delegate :id, to: :@change_set
   end
 end

--- a/app/components/show/source_id_component.html.erb
+++ b/app/components/show/source_id_component.html.erb
@@ -1,6 +1,6 @@
 <%= source_id %>
 
-<% if open? && item? %>
+<% if open_and_not_assembling? && item? %>
   <%= link_to source_id_ui_item_path(id:),
               aria: { label: 'Change source id' },
               data: { controller: 'button', action: 'click->button#open' } do %>

--- a/app/components/show/source_id_component.rb
+++ b/app/components/show/source_id_component.rb
@@ -7,7 +7,7 @@ module Show
       @version_service = version_service
     end
 
-    delegate :open?, to: :@version_service
+    delegate :open_and_not_assembling?, to: :@version_service
     delegate :id, :source_id, :item?, to: :@document
   end
 end

--- a/app/components/show/use_statement_component.html.erb
+++ b/app/components/show/use_statement_component.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="use_statement">
   <%= use_statement %>
-  <% if open? %>
+  <% if open_and_not_assembling? %>
     <%= link_to edit_use_statement_item_path(id:), aria: { label: 'Edit use and reproduction' } do %>
       <span class="bi-pencil"></span>
     <% end %>

--- a/app/components/show/use_statement_component.rb
+++ b/app/components/show/use_statement_component.rb
@@ -11,7 +11,7 @@ module Show
       @change_set.use_statement || 'Not entered'
     end
 
-    delegate :open?, to: :@version_service
+    delegate :open_and_not_assembling?, to: :@version_service
     delegate :id, to: :@change_set
   end
 end

--- a/app/components/show_embargo_component.rb
+++ b/app/components/show_embargo_component.rb
@@ -7,14 +7,14 @@ class ShowEmbargoComponent < ApplicationComponent
   end
 
   delegate :id, :embargoed?, :embargo_release_date, to: :@solr_document
-  delegate :open?, to: :@presenter
+  delegate :open_and_not_assembling?, to: :@presenter
 
   def render?
     embargoed? && embargo_release_date.present?
   end
 
   def edit_embargo
-    return unless open?
+    return unless open_and_not_assembling?
 
     link_to edit_item_embargo_path(id),
             class: 'text-white',

--- a/app/presenters/argo_show_presenter.rb
+++ b/app/presenters/argo_show_presenter.rb
@@ -17,7 +17,7 @@ class ArgoShowPresenter < Blacklight::ShowPresenter
     cocina.externalIdentifier
   end
 
-  delegate :open?, :openable?, to: :version_service
+  delegate :open?, :openable?, :open_and_not_assembling?, to: :version_service
 
   attr_accessor :cocina, :view_token, :state_service, :version_service
 end

--- a/app/services/state_service.rb
+++ b/app/services/state_service.rb
@@ -6,7 +6,7 @@ end
 
 class StateService
   # NOTE: each of these states must have a corresponding view with the same name in app/views/workflow_service: the names are used to render lock/unlock icons/links
-  STATES = Types::Symbol.enum(:unlock, :lock, :lock_inactive, :unlock_inactive)
+  STATES = Types::Symbol.enum(:unlock, :lock, :lock_inactive, :unlock_inactive, :lock_assembling)
 
   def initialize(cocina)
     @druid = cocina.externalIdentifier
@@ -23,6 +23,9 @@ class StateService
     # This item is being accessioned, so is locked but cannot currently be unlocked or edited
     return STATES[:lock_inactive] if closed? && !openable?
 
+    # This item is being assembled, so is locked but cannot currently be unlocked or edited
+    return STATES[:lock_assembling] if assembling?
+
     # This item is registered, so it can be edited, but cannot currently be moved to a locked state
     STATES[:unlock_inactive] # if open? && !closeable?
   end
@@ -35,9 +38,5 @@ class StateService
     @version_service ||= VersionService.new(druid:)
   end
 
-  delegate :open?, :openable?, :closed?, :closeable?, :version, to: :version_service
-
-  def first_version?
-    version == 1
-  end
+  delegate :open?, :openable?, :closed?, :closeable?, :assembling?, :version, to: :version_service
 end

--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -20,6 +20,10 @@ class VersionService
       new(...).open?
     end
 
+    def open_and_not_assembling?(...)
+      new(...).open_and_not_assembling?
+    end
+
     def assembling?(...)
       new(...).assembling?
     end
@@ -48,6 +52,10 @@ class VersionService
 
   def initialize(druid:)
     @druid = druid
+  end
+
+  def open_and_not_assembling?
+    open? && !assembling?
   end
 
   private

--- a/app/views/workflow_service/lock_assembling.html.erb
+++ b/app/views/workflow_service/lock_assembling.html.erb
@@ -1,0 +1,7 @@
+<turbo-frame id="lock">
+  <%= link_to '#',
+              title: 'Item is in assembly',
+              class: 'btn disabled' do %>
+  <%= tag.span class: 'bi-lock-fill' %>
+  <% end %>
+</turbo-frame>

--- a/spec/components/contents_component_spec.rb
+++ b/spec/components/contents_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ContentsComponent, type: :component do
     instance_double(ArgoShowPresenter,
                     document: solr_doc, cocina:,
                     view_token: 'skret-t0k3n',
-                    open?: open)
+                    open_and_not_assembling?: open)
   end
   let(:component) { described_class.new(presenter:) }
 

--- a/spec/components/show/collection/details_component_spec.rb
+++ b/spec/components/show/collection/details_component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Show::Collection::DetailsComponent, type: :component do
 
   let(:change_set) { instance_double(ItemChangeSet, barcode: nil, id: doc.id, catalog_record_ids: []) }
   let(:rendered) { render_inline(component) }
-  let(:version_service) { instance_double(VersionService, open?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true) }
   let(:doc) do
     SolrDocument.new('id' => 'druid:kv840xx0000',
                      SolrDocument::FIELD_REGISTERED_DATE => ['2012-04-05T01:00:04.148Z'],

--- a/spec/components/show/collection/overview_component_spec.rb
+++ b/spec/components/show/collection/overview_component_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Show::Collection::OverviewComponent, type: :component do
                                    })
   end
   let(:rendered) { render_inline(component) }
-  let(:version_service) { instance_double(VersionService, open?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true, open?: true) }
 
   let(:edit_copyright_button) { rendered.css("a[aria-label='Edit copyright']") }
   let(:edit_license_button) { rendered.css("a[aria-label='Edit license']") }

--- a/spec/components/show/controls_component_spec.rb
+++ b/spec/components/show/controls_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Show::ControlsComponent, type: :component do
   let(:governing_apo_id) { 'druid:hv992yv2222' }
   let(:manager) { true }
   let(:rendered) { render_inline(component) }
-  let(:presenter) { instance_double(ArgoShowPresenter, document: doc, open?: open, cocina:, openable?: true) }
+  let(:presenter) { instance_double(ArgoShowPresenter, document: doc, open?: open, cocina:, openable?: true, open_and_not_assembling?: open) }
   let(:cocina) { instance_double(Cocina::Models::DRO, dro?: dro, type: 'https://cocina.sul.stanford.edu/models/book') }
 
   before do

--- a/spec/components/show/item/access_rights_component_spec.rb
+++ b/spec/components/show/item/access_rights_component_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Show::Item::AccessRightsComponent, type: :component do
                             structural: {})
   end
   let(:rendered) { render_inline(component) }
-  let(:version_service) { instance_double(VersionService, open?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true) }
 
   context 'with view location' do
     let(:access) do

--- a/spec/components/show/item/details_component_spec.rb
+++ b/spec/components/show/item/details_component_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Show::Item::DetailsComponent, type: :component do
   let(:change_set) { instance_double(ItemChangeSet, barcode: nil, id: doc.id, catalog_record_ids: []) }
   let(:rendered) { render_inline(component) }
   let(:open) { true }
-  let(:version_service) { instance_double(VersionService, open?: open) }
+  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: open) }
   let(:doc) do
     SolrDocument.new('id' => 'druid:kv840xx0000',
                      SolrDocument::FIELD_REGISTERED_DATE => ['2012-04-05T01:00:04.148Z'],

--- a/spec/components/show/item/overview_component_spec.rb
+++ b/spec/components/show/item/overview_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Show::Item::OverviewComponent, type: :component do
   end
   let(:rendered) { render_inline(component) }
   let(:open) { true }
-  let(:version_service) { instance_double(VersionService, open?: open) }
+  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: open, open?: open) }
   let(:edit_collection_button) { rendered.css("a[aria-label='Edit collections']") }
   let(:edit_copyright_button) { rendered.css("a[aria-label='Edit copyright']") }
   let(:edit_license_button) { rendered.css("a[aria-label='Edit license']") }

--- a/spec/components/show_embargo_component_spec.rb
+++ b/spec/components/show_embargo_component_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ShowEmbargoComponent, type: :component do
   let(:component) { described_class.new(presenter:) }
   let(:rendered) { render_inline(component) }
-  let(:presenter) { instance_double(ArgoShowPresenter, document:, open?: open) }
+  let(:presenter) { instance_double(ArgoShowPresenter, document:, open_and_not_assembling?: open) }
 
   describe 'embargo with release date' do
     let(:document) do

--- a/spec/features/add_workflow_to_item_spec.rb
+++ b/spec/features/add_workflow_to_item_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Add a workflow to an item' do
   let(:item_id) { 'druid:bg444xg6666' }
   let(:blacklight_config) { CatalogController.blacklight_config }
   let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
-  let(:version_service) { instance_double(VersionService, open?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true) }
 
   before do
     allow(VersionService).to receive(:new).and_return(version_service)

--- a/spec/features/collection_manage_release_spec.rb
+++ b/spec/features/collection_manage_release_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Collection manage release' do
   let(:current_user) { create(:user, sunetid: 'esnowden') }
   let(:blacklight_config) { CatalogController.blacklight_config }
   let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
-  let(:version_service) { instance_double(VersionService, open?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true, open?: true) }
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
   let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: []) }

--- a/spec/features/enable_buttons_spec.rb
+++ b/spec/features/enable_buttons_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Enable buttons' do
   let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
   let(:item_id) { 'druid:hj185xx2222' }
   let(:state_service) { instance_double(StateService, object_state: :unlock) }
-  let(:version_service) { instance_double(VersionService, open?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true) }
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: [], current: 1) }
   let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: []) }

--- a/spec/features/item_catalog_record_id_change_spec.rb
+++ b/spec/features/item_catalog_record_id_change_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Item catalog_record_id change' do
   describe 'when modification is not allowed' do
     let(:item) { FactoryBot.create_for_repository(:persisted_item) }
     let(:druid) { item.externalIdentifier }
-    let(:version_service) { instance_double(VersionService, open?: false) }
+    let(:version_service) { instance_double(VersionService, open_and_not_assembling?: false, open?: false) }
 
     it 'cannot change the catalog_record_id' do
       visit edit_item_catalog_record_id_path druid
@@ -30,7 +30,7 @@ RSpec.describe 'Item catalog_record_id change' do
     let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
     let(:druid) { 'druid:kv840xx0000' }
     let(:cocina_model) { build(:dro_with_metadata, id: druid) }
-    let(:version_service) { instance_double(VersionService, open?: true) }
+    let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true, open?: true) }
     let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
     let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
     let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: []) }

--- a/spec/features/item_manage_release_spec.rb
+++ b/spec/features/item_manage_release_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Item manage release' do
   let(:current_user) { create(:user, sunetid: 'esnowden') }
-  let(:version_service) { instance_double(VersionService, open?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true) }
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
   let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: []) }

--- a/spec/features/item_source_id_change_spec.rb
+++ b/spec/features/item_source_id_change_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Item source id change' do
   describe 'when modification is not allowed' do
     let(:item) { FactoryBot.create_for_repository(:persisted_item) }
     let(:druid) { item.externalIdentifier }
-    let(:version_service) { instance_double(VersionService, open?: false) }
+    let(:version_service) { instance_double(VersionService, open_and_not_assembling?: false, open?: false) }
 
     before do
       allow(WorkflowService).to receive(:accessioned?).and_return(false)
@@ -33,7 +33,7 @@ RSpec.describe 'Item source id change' do
     let(:cocina_model) do
       build(:dro_with_metadata, id: druid)
     end
-    let(:version_service) { instance_double(VersionService, open?: true) }
+    let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true, open?: true) }
     let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
     let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
     let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: []) }

--- a/spec/features/item_view_spec.rb
+++ b/spec/features/item_view_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Item view', :js do
                                             release: true)
     ]
   end
-  let(:version_service) { instance_double(VersionService, open?: true, openable?: false) }
+  let(:version_service) { instance_double(VersionService, open?: true, openable?: false, open_and_not_assembling?: true) }
 
   context 'when navigating to an object' do
     before do

--- a/spec/features/set_governing_apo_spec.rb
+++ b/spec/features/set_governing_apo_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Set governing APO' do
   end
 
   let(:identity_md) { instance_double(Nokogiri::XML::Document, xpath: []) }
-  let(:version_service) { instance_double(VersionService, open?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true, open?: true) }
 
   let(:item) do
     FactoryBot.create_for_repository(:persisted_item, label: 'Foo', title: 'Test')

--- a/spec/features/update_serials_metadata_spec.rb
+++ b/spec/features/update_serials_metadata_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Update serials metadata', :js do
   let(:item) do
     FactoryBot.create_for_repository(:persisted_item)
   end
-  let(:version_service) { instance_double(VersionService, open?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true, open?: true) }
 
   before do
     allow(VersionService).to receive(:new).and_return(version_service)

--- a/spec/requests/edit_barcode_spec.rb
+++ b/spec/requests/edit_barcode_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Edit barcode' do
     { 'Accept' => "#{Mime[:turbo_stream]},#{Mime[:html]}",
       'Turbo-Frame' => 'edit_copyright' }
   end
-  let(:version_service) { instance_double(VersionService, open?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true) }
 
   before do
     allow(VersionService).to receive(:new).and_return(version_service)

--- a/spec/requests/edit_copyright_spec.rb
+++ b/spec/requests/edit_copyright_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Edit copyright' do
     { 'Accept' => "#{Mime[:turbo_stream]},#{Mime[:html]}",
       'Turbo-Frame' => 'edit_copyright' }
   end
-  let(:version_service) { instance_double(VersionService, open?: true) }
+  let(:version_service) { instance_double(VersionService, open?: true, open_and_not_assembling?: true) }
 
   before do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)

--- a/spec/requests/edit_license_spec.rb
+++ b/spec/requests/edit_license_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Edit license' do
   let(:turbo_stream_headers) do
     { 'Accept' => "#{Mime[:turbo_stream]},#{Mime[:html]}" }
   end
-  let(:version_service) { instance_double(VersionService, open?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true, open?: true) }
 
   before do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)

--- a/spec/requests/edit_rights_spec.rb
+++ b/spec/requests/edit_rights_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Edit rights' do
   let(:turbo_stream_headers) do
     { 'Accept' => "#{Mime[:turbo_stream]},#{Mime[:html]}" }
   end
-  let(:version_service) { instance_double(VersionService, open?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true, open?: true) }
 
   before do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)

--- a/spec/requests/edit_use_statement_spec.rb
+++ b/spec/requests/edit_use_statement_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Edit use statement' do
   let(:druid) { 'druid:dc243mg0841' }
 
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, update: true) }
-  let(:version_service) { instance_double(VersionService, open?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true, open?: true) }
   let(:turbo_stream_headers) do
     { 'Accept' => "#{Mime[:turbo_stream]},#{Mime[:html]}" }
   end

--- a/spec/services/state_service_spec.rb
+++ b/spec/services/state_service_spec.rb
@@ -15,13 +15,23 @@ RSpec.describe StateService do
   end
 
   describe '#object_state' do
-    context 'when object is open but not closeable' do
+    context 'when object is open, not assembling, but not closeable' do
       before do
-        allow(version_service).to receive_messages(open?: true, closeable?: false, closed?: false)
+        allow(version_service).to receive_messages(open?: true, closeable?: false, closed?: false, assembling?: false)
       end
 
       it 'returns unlock_inactive' do
         expect(service.object_state).to eq :unlock_inactive
+      end
+    end
+
+    context 'when object is open and assembling' do
+      before do
+        allow(version_service).to receive_messages(open?: true, closeable?: false, closed?: false, assembling?: true)
+      end
+
+      it 'returns unlock_inactive' do
+        expect(service.object_state).to eq :lock_assembling
       end
     end
 


### PR DESCRIPTION
closes #4458

# Why was this change made?
Per @andrewjbtw keep users from getting in trouble.

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?

Unit, integration, Andrew
<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


