### PR TITLE
[HOLD] Disable text extraction and editing if OCR workflow is running

### DIFF
--- a/app/components/contents_component.html.erb
+++ b/app/components/contents_component.html.erb
@@ -8,7 +8,7 @@
     <div class="accordion-body" data-controller="structural">
       <div class="mb-3">
         <%= render DownloadAllButtonComponent.new(cocina: @cocina, document: @document) %>
-        <% if open_and_not_assembling? %>
+        <% if open_and_not_processing? %>
           <%= button_tag class: 'btn btn-link float-end', data: { action: 'click->structural#open' } do %>
             <span class="bi-upload"></span> Upload CSV
           <% end %>

--- a/app/components/contents_component.rb
+++ b/app/components/contents_component.rb
@@ -12,5 +12,5 @@ class ContentsComponent < ApplicationComponent
     @cocina.respond_to?(:structural)
   end
 
-  delegate :open_and_not_assembling?, to: :@presenter
+  delegate :open_and_not_processing?, to: :@presenter
 end

--- a/app/components/show/barcode_component.html.erb
+++ b/app/components/show/barcode_component.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="barcode">
   <%= barcode %>
-  <% if open_and_not_assembling? %>
+  <% if open_and_not_processing? %>
     <%= link_to edit_barcode_item_path(id:), aria: { label: 'Edit barcode' } do %>
       <span class="bi-pencil"></span>
     <% end %>

--- a/app/components/show/barcode_component.rb
+++ b/app/components/show/barcode_component.rb
@@ -11,7 +11,7 @@ module Show
       @change_set.barcode || 'Not recorded'
     end
 
-    delegate :open_and_not_assembling?, to: :@version_service
+    delegate :open_and_not_processing?, to: :@version_service
     delegate :id, to: :@change_set
   end
 end

--- a/app/components/show/catalog_record_id_component.html.erb
+++ b/app/components/show/catalog_record_id_component.html.erb
@@ -1,6 +1,6 @@
 <%= catalog_record_id %>
 
-<% if open_and_not_assembling? %>
+<% if open_and_not_processing? %>
   <%= link_to edit_item_catalog_record_id_path(item_id: id),
               aria: { label: manage_label },
               data: { controller: 'button', action: 'click->button#open' } do %>

--- a/app/components/show/catalog_record_id_component.rb
+++ b/app/components/show/catalog_record_id_component.rb
@@ -11,7 +11,7 @@ module Show
       @change_set.catalog_record_ids.presence&.join(', ') || 'None assigned'
     end
 
-    delegate :open_and_not_assembling?, to: :@version_service
+    delegate :open_and_not_processing?, to: :@version_service
     delegate :id, to: :@change_set
     delegate :manage_label, to: CatalogRecordId
   end

--- a/app/components/show/content_type_component.html.erb
+++ b/app/components/show/content_type_component.html.erb
@@ -1,6 +1,6 @@
 <%= content_type %>
 
-<% if open_and_not_assembling? %>
+<% if open_and_not_processing? %>
   <%= link_to edit_item_content_type_path(item_id: id),
               aria: { label: 'Set content type' },
               data: { controller: 'button', action: 'click->button#open' } do %>

--- a/app/components/show/content_type_component.rb
+++ b/app/components/show/content_type_component.rb
@@ -7,7 +7,7 @@ module Show
       @version_service = version_service
     end
 
-    delegate :open_and_not_assembling?, to: :@version_service
+    delegate :open_and_not_processing?, to: :@version_service
     delegate :id, :content_type, to: :@document
   end
 end

--- a/app/components/show/controls_component.rb
+++ b/app/components/show/controls_component.rb
@@ -43,10 +43,10 @@ module Show
     end
 
     delegate :admin_policy?, :agreement?, :item?, :collection?, :embargoed?, to: :doc
-    delegate :open?, :openable?, :open_and_not_assembling?, to: :presenter
+    delegate :open?, :openable?, :open_and_not_processing?, to: :presenter
 
     def button_disabled?
-      !open_and_not_assembling?
+      !open_and_not_processing?
     end
 
     def collection_button_disabled?

--- a/app/components/show/controls_component.rb
+++ b/app/components/show/controls_component.rb
@@ -43,7 +43,7 @@ module Show
     end
 
     delegate :admin_policy?, :agreement?, :item?, :collection?, :embargoed?, to: :doc
-    delegate :open?, :openable?, :open_and_not_processing?, to: :presenter
+    delegate :open?, :openable?, :open_and_not_processing?, :text_extracting?, to: :presenter
 
     def button_disabled?
       !open_and_not_processing?
@@ -90,7 +90,7 @@ module Show
       render ActionButton.new url: new_item_text_extraction_path(druid),
                               label: 'Text extraction',
                               open_modal: true,
-                              disabled: in_accessioning? || workflow_errors?
+                              disabled: in_accessioning? || workflow_errors? || text_extracting?
     end
 
     def edit_apo

--- a/app/components/show/copyright_component.html.erb
+++ b/app/components/show/copyright_component.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="copyright">
   <%= copyright %>
-  <% if open_and_not_assembling? %>
+  <% if open_and_not_processing? %>
     <%= link_to edit_copyright_item_path(id:), aria: { label: 'Edit copyright' } do %>
       <span class="bi-pencil"></span>
     <% end %>

--- a/app/components/show/copyright_component.rb
+++ b/app/components/show/copyright_component.rb
@@ -11,7 +11,7 @@ module Show
       @change_set.copyright || 'Not entered'
     end
 
-    delegate :open_and_not_assembling?, to: :@version_service
+    delegate :open_and_not_processing?, to: :@version_service
     delegate :id, to: :@change_set
   end
 end

--- a/app/components/show/governed_by_component.html.erb
+++ b/app/components/show/governed_by_component.html.erb
@@ -1,6 +1,6 @@
 <%= admin_policy %>
 
-<% if open_and_not_assembling? %>
+<% if open_and_not_processing? %>
   <%= link_to set_governing_apo_ui_item_path(id:),
               aria: { label: 'Set governing APO' },
               data: { controller: 'button', action: 'click->button#open' } do %>

--- a/app/components/show/governed_by_component.rb
+++ b/app/components/show/governed_by_component.rb
@@ -13,7 +13,7 @@ module Show
       helpers.link_to_admin_policy_with_objs(document: @document, value: @document.apo_id)
     end
 
-    delegate :open_and_not_assembling?, to: :@version_service
+    delegate :open_and_not_processing?, to: :@version_service
     delegate :id, to: :@document
   end
 end

--- a/app/components/show/is_member_of_component.html.erb
+++ b/app/components/show/is_member_of_component.html.erb
@@ -1,6 +1,6 @@
 <%= collection %>
 
-<% if open_and_not_assembling? %>
+<% if open_and_not_processing? %>
   <%= link_to collection_ui_item_path(id:),
               aria: { label: 'Edit collections' },
               data: { controller: 'button', action: 'click->button#open' } do %>

--- a/app/components/show/is_member_of_component.rb
+++ b/app/components/show/is_member_of_component.rb
@@ -13,7 +13,7 @@ module Show
       helpers.links_to_collections_with_objs(document: @document, value: Array(@document.collection_ids))
     end
 
-    delegate :open_and_not_assembling?, to: :@version_service
+    delegate :open_and_not_processing?, to: :@version_service
     delegate :id, to: :@document
   end
 end

--- a/app/components/show/item/access_rights_component.html.erb
+++ b/app/components/show/item/access_rights_component.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="access-rights">
   <%= access_rights %>
-  <% if open_and_not_assembling? %>
+  <% if open_and_not_processing? %>
     <%= link_to edit_rights_item_path(id:), aria: { label: 'Edit rights' } do %>
       <span class="bi-pencil"></span>
     <% end %>

--- a/app/components/show/item/access_rights_component.rb
+++ b/app/components/show/item/access_rights_component.rb
@@ -18,7 +18,7 @@ module Show
         val
       end
 
-      delegate :open_and_not_assembling?, to: :@version_service
+      delegate :open_and_not_processing?, to: :@version_service
       delegate :id, :view_access, :download_access, :access_location, :controlled_digital_lending, to: :@change_set
 
       def humanize_value(val)

--- a/app/components/show/license_component.html.erb
+++ b/app/components/show/license_component.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="license">
   <%= license %>
-  <% if open_and_not_assembling? %>
+  <% if open_and_not_processing? %>
     <%= link_to edit_license_item_path(id:), aria: { label: 'Edit license' } do %>
       <span class="bi-pencil"></span>
     <% end %>

--- a/app/components/show/license_component.rb
+++ b/app/components/show/license_component.rb
@@ -15,7 +15,7 @@ module Show
       value.fetch(:label)
     end
 
-    delegate :open_and_not_assembling?, to: :@version_service
+    delegate :open_and_not_processing?, to: :@version_service
     delegate :id, to: :@change_set
   end
 end

--- a/app/components/show/source_id_component.html.erb
+++ b/app/components/show/source_id_component.html.erb
@@ -1,6 +1,6 @@
 <%= source_id %>
 
-<% if open_and_not_assembling? && item? %>
+<% if open_and_not_processing? && item? %>
   <%= link_to source_id_ui_item_path(id:),
               aria: { label: 'Change source id' },
               data: { controller: 'button', action: 'click->button#open' } do %>

--- a/app/components/show/source_id_component.rb
+++ b/app/components/show/source_id_component.rb
@@ -7,7 +7,7 @@ module Show
       @version_service = version_service
     end
 
-    delegate :open_and_not_assembling?, to: :@version_service
+    delegate :open_and_not_processing?, to: :@version_service
     delegate :id, :source_id, :item?, to: :@document
   end
 end

--- a/app/components/show/use_statement_component.html.erb
+++ b/app/components/show/use_statement_component.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="use_statement">
   <%= use_statement %>
-  <% if open_and_not_assembling? %>
+  <% if open_and_not_processing? %>
     <%= link_to edit_use_statement_item_path(id:), aria: { label: 'Edit use and reproduction' } do %>
       <span class="bi-pencil"></span>
     <% end %>

--- a/app/components/show/use_statement_component.rb
+++ b/app/components/show/use_statement_component.rb
@@ -11,7 +11,7 @@ module Show
       @change_set.use_statement || 'Not entered'
     end
 
-    delegate :open_and_not_assembling?, to: :@version_service
+    delegate :open_and_not_processing?, to: :@version_service
     delegate :id, to: :@change_set
   end
 end

--- a/app/components/show_embargo_component.rb
+++ b/app/components/show_embargo_component.rb
@@ -7,14 +7,14 @@ class ShowEmbargoComponent < ApplicationComponent
   end
 
   delegate :id, :embargoed?, :embargo_release_date, to: :@solr_document
-  delegate :open_and_not_assembling?, to: :@presenter
+  delegate :open_and_not_processing?, to: :@presenter
 
   def render?
     embargoed? && embargo_release_date.present?
   end
 
   def edit_embargo
-    return unless open_and_not_assembling?
+    return unless open_and_not_processing?
 
     link_to edit_item_embargo_path(id),
             class: 'text-white',

--- a/app/presenters/argo_show_presenter.rb
+++ b/app/presenters/argo_show_presenter.rb
@@ -17,7 +17,7 @@ class ArgoShowPresenter < Blacklight::ShowPresenter
     cocina.externalIdentifier
   end
 
-  delegate :open?, :openable?, :open_and_not_processing?, to: :version_service
+  delegate :open?, :openable?, :text_extracting?, :open_and_not_processing?, to: :version_service
 
   attr_accessor :cocina, :view_token, :state_service, :version_service
 end

--- a/app/presenters/argo_show_presenter.rb
+++ b/app/presenters/argo_show_presenter.rb
@@ -17,7 +17,7 @@ class ArgoShowPresenter < Blacklight::ShowPresenter
     cocina.externalIdentifier
   end
 
-  delegate :open?, :openable?, :open_and_not_assembling?, to: :version_service
+  delegate :open?, :openable?, :open_and_not_processing?, to: :version_service
 
   attr_accessor :cocina, :view_token, :state_service, :version_service
 end

--- a/app/services/state_service.rb
+++ b/app/services/state_service.rb
@@ -23,8 +23,8 @@ class StateService
     # This item is being accessioned, so is locked but cannot currently be unlocked or edited
     return STATES[:lock_inactive] if closed? && !openable?
 
-    # This item is being assembled, so is locked but cannot currently be unlocked or edited
-    return STATES[:lock_assembling] if assembling?
+    # This item is being assembled or text extracted, so is locked but cannot currently be unlocked or edited
+    return STATES[:lock_assembling] if assembling? || text_extracting?
 
     # This item is registered, so it can be edited, but cannot currently be moved to a locked state
     STATES[:unlock_inactive] # if open? && !closeable?
@@ -38,5 +38,5 @@ class StateService
     @version_service ||= VersionService.new(druid:)
   end
 
-  delegate :open?, :openable?, :closed?, :closeable?, :assembling?, :version, to: :version_service
+  delegate :open?, :openable?, :closed?, :closeable?, :assembling?, :text_extracting?, :version, to: :version_service
 end

--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -20,12 +20,16 @@ class VersionService
       new(...).open?
     end
 
-    def open_and_not_assembling?(...)
-      new(...).open_and_not_assembling?
+    def open_and_not_processing?(...)
+      new(...).open_and_not_processing?
     end
 
     def assembling?(...)
       new(...).assembling?
+    end
+
+    def text_extracting?(...)
+      new(...).text_extracting?
     end
 
     def accessioning?(...)
@@ -48,14 +52,14 @@ class VersionService
   attr_reader :druid
 
   delegate :close, :open, to: :version_client
-  delegate :open?, :openable?, :assembling?, :accessioning?, :closed?, :closeable?, :version, to: :status
+  delegate :open?, :openable?, :assembling?, :text_extracting?, :accessioning?, :closed?, :closeable?, :version, to: :status
 
   def initialize(druid:)
     @druid = druid
   end
 
-  def open_and_not_assembling?
-    open? && !assembling?
+  def open_and_not_processing?
+    open? && !assembling? && !text_extracting?
   end
 
   private

--- a/spec/components/contents_component_spec.rb
+++ b/spec/components/contents_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ContentsComponent, type: :component do
     instance_double(ArgoShowPresenter,
                     document: solr_doc, cocina:,
                     view_token: 'skret-t0k3n',
-                    open_and_not_assembling?: open)
+                    open_and_not_processing?: open)
   end
   let(:component) { described_class.new(presenter:) }
 

--- a/spec/components/show/collection/details_component_spec.rb
+++ b/spec/components/show/collection/details_component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Show::Collection::DetailsComponent, type: :component do
 
   let(:change_set) { instance_double(ItemChangeSet, barcode: nil, id: doc.id, catalog_record_ids: []) }
   let(:rendered) { render_inline(component) }
-  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_processing?: true) }
   let(:doc) do
     SolrDocument.new('id' => 'druid:kv840xx0000',
                      SolrDocument::FIELD_REGISTERED_DATE => ['2012-04-05T01:00:04.148Z'],

--- a/spec/components/show/collection/overview_component_spec.rb
+++ b/spec/components/show/collection/overview_component_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Show::Collection::OverviewComponent, type: :component do
                                    })
   end
   let(:rendered) { render_inline(component) }
-  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true, open?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_processing?: true, open?: true) }
 
   let(:edit_copyright_button) { rendered.css("a[aria-label='Edit copyright']") }
   let(:edit_license_button) { rendered.css("a[aria-label='Edit license']") }

--- a/spec/components/show/controls_component_spec.rb
+++ b/spec/components/show/controls_component_spec.rb
@@ -11,8 +11,9 @@ RSpec.describe Show::ControlsComponent, type: :component do
   let(:governing_apo_id) { 'druid:hv992yv2222' }
   let(:manager) { true }
   let(:rendered) { render_inline(component) }
-  let(:presenter) { instance_double(ArgoShowPresenter, document: doc, open?: open, cocina:, openable?: true, open_and_not_processing?: open) }
+  let(:presenter) { instance_double(ArgoShowPresenter, document: doc, open?: open, cocina:, openable?: true, open_and_not_processing?: open, text_extracting?: text_extracting) }
   let(:cocina) { instance_double(Cocina::Models::DRO, dro?: dro, type: 'https://cocina.sul.stanford.edu/models/book') }
+  let(:text_extracting) { false }
 
   before do
     rendered
@@ -111,6 +112,16 @@ RSpec.describe Show::ControlsComponent, type: :component do
     context 'when the object is in accessioning' do
       let(:open) { false }
       let(:processing_status) { 'V2 In accessioning' }
+
+      it 'the text extraction button exists but is disabled' do
+        expect(page).to have_link 'Text extraction', href: '/items/druid:kv840xx0000/text_extraction/new'
+        expect(page).to have_css 'a.disabled', text: 'Text extraction'
+      end
+    end
+
+    context 'when the object is text extracting' do
+      let(:open) { false }
+      let(:text_extracting) { true }
 
       it 'the text extraction button exists but is disabled' do
         expect(page).to have_link 'Text extraction', href: '/items/druid:kv840xx0000/text_extraction/new'

--- a/spec/components/show/controls_component_spec.rb
+++ b/spec/components/show/controls_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Show::ControlsComponent, type: :component do
   let(:governing_apo_id) { 'druid:hv992yv2222' }
   let(:manager) { true }
   let(:rendered) { render_inline(component) }
-  let(:presenter) { instance_double(ArgoShowPresenter, document: doc, open?: open, cocina:, openable?: true, open_and_not_assembling?: open) }
+  let(:presenter) { instance_double(ArgoShowPresenter, document: doc, open?: open, cocina:, openable?: true, open_and_not_processing?: open) }
   let(:cocina) { instance_double(Cocina::Models::DRO, dro?: dro, type: 'https://cocina.sul.stanford.edu/models/book') }
 
   before do

--- a/spec/components/show/item/access_rights_component_spec.rb
+++ b/spec/components/show/item/access_rights_component_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Show::Item::AccessRightsComponent, type: :component do
                             structural: {})
   end
   let(:rendered) { render_inline(component) }
-  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_processing?: true) }
 
   context 'with view location' do
     let(:access) do

--- a/spec/components/show/item/details_component_spec.rb
+++ b/spec/components/show/item/details_component_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Show::Item::DetailsComponent, type: :component do
   let(:change_set) { instance_double(ItemChangeSet, barcode: nil, id: doc.id, catalog_record_ids: []) }
   let(:rendered) { render_inline(component) }
   let(:open) { true }
-  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: open) }
+  let(:version_service) { instance_double(VersionService, open_and_not_processing?: open) }
   let(:doc) do
     SolrDocument.new('id' => 'druid:kv840xx0000',
                      SolrDocument::FIELD_REGISTERED_DATE => ['2012-04-05T01:00:04.148Z'],

--- a/spec/components/show/item/overview_component_spec.rb
+++ b/spec/components/show/item/overview_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Show::Item::OverviewComponent, type: :component do
   end
   let(:rendered) { render_inline(component) }
   let(:open) { true }
-  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: open, open?: open) }
+  let(:version_service) { instance_double(VersionService, open_and_not_processing?: open, open?: open) }
   let(:edit_collection_button) { rendered.css("a[aria-label='Edit collections']") }
   let(:edit_copyright_button) { rendered.css("a[aria-label='Edit copyright']") }
   let(:edit_license_button) { rendered.css("a[aria-label='Edit license']") }

--- a/spec/components/show_embargo_component_spec.rb
+++ b/spec/components/show_embargo_component_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ShowEmbargoComponent, type: :component do
   let(:component) { described_class.new(presenter:) }
   let(:rendered) { render_inline(component) }
-  let(:presenter) { instance_double(ArgoShowPresenter, document:, open_and_not_assembling?: open) }
+  let(:presenter) { instance_double(ArgoShowPresenter, document:, open_and_not_processing?: open) }
 
   describe 'embargo with release date' do
     let(:document) do

--- a/spec/features/add_workflow_to_item_spec.rb
+++ b/spec/features/add_workflow_to_item_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Add a workflow to an item' do
   let(:item_id) { 'druid:bg444xg6666' }
   let(:blacklight_config) { CatalogController.blacklight_config }
   let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
-  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_processing?: true) }
 
   before do
     allow(VersionService).to receive(:new).and_return(version_service)

--- a/spec/features/collection_manage_release_spec.rb
+++ b/spec/features/collection_manage_release_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Collection manage release' do
   let(:current_user) { create(:user, sunetid: 'esnowden') }
   let(:blacklight_config) { CatalogController.blacklight_config }
   let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
-  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true, open?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_processing?: true, open?: true) }
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
   let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: []) }

--- a/spec/features/enable_buttons_spec.rb
+++ b/spec/features/enable_buttons_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Enable buttons' do
   let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
   let(:item_id) { 'druid:hj185xx2222' }
   let(:state_service) { instance_double(StateService, object_state: :unlock) }
-  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_processing?: true) }
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: [], current: 1) }
   let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: []) }

--- a/spec/features/item_catalog_record_id_change_spec.rb
+++ b/spec/features/item_catalog_record_id_change_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Item catalog_record_id change' do
   describe 'when modification is not allowed' do
     let(:item) { FactoryBot.create_for_repository(:persisted_item) }
     let(:druid) { item.externalIdentifier }
-    let(:version_service) { instance_double(VersionService, open_and_not_assembling?: false, open?: false) }
+    let(:version_service) { instance_double(VersionService, open_and_not_processing?: false, open?: false) }
 
     it 'cannot change the catalog_record_id' do
       visit edit_item_catalog_record_id_path druid
@@ -30,7 +30,7 @@ RSpec.describe 'Item catalog_record_id change' do
     let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
     let(:druid) { 'druid:kv840xx0000' }
     let(:cocina_model) { build(:dro_with_metadata, id: druid) }
-    let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true, open?: true) }
+    let(:version_service) { instance_double(VersionService, open_and_not_processing?: true, open?: true) }
     let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
     let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
     let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: []) }

--- a/spec/features/item_manage_release_spec.rb
+++ b/spec/features/item_manage_release_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Item manage release' do
   let(:current_user) { create(:user, sunetid: 'esnowden') }
-  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_processing?: true) }
   let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
   let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: []) }

--- a/spec/features/item_source_id_change_spec.rb
+++ b/spec/features/item_source_id_change_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Item source id change' do
   describe 'when modification is not allowed' do
     let(:item) { FactoryBot.create_for_repository(:persisted_item) }
     let(:druid) { item.externalIdentifier }
-    let(:version_service) { instance_double(VersionService, open_and_not_assembling?: false, open?: false) }
+    let(:version_service) { instance_double(VersionService, open_and_not_processing?: false, open?: false) }
 
     before do
       allow(WorkflowService).to receive(:accessioned?).and_return(false)
@@ -33,7 +33,7 @@ RSpec.describe 'Item source id change' do
     let(:cocina_model) do
       build(:dro_with_metadata, id: druid)
     end
-    let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true, open?: true) }
+    let(:version_service) { instance_double(VersionService, open_and_not_processing?: true, open?: true) }
     let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
     let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
     let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: []) }

--- a/spec/features/item_view_spec.rb
+++ b/spec/features/item_view_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Item view', :js do
                                             release: true)
     ]
   end
-  let(:version_service) { instance_double(VersionService, open?: true, openable?: false, open_and_not_assembling?: true) }
+  let(:version_service) { instance_double(VersionService, open?: true, openable?: false, open_and_not_processing?: true) }
 
   context 'when navigating to an object' do
     before do

--- a/spec/features/set_governing_apo_spec.rb
+++ b/spec/features/set_governing_apo_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Set governing APO' do
   end
 
   let(:identity_md) { instance_double(Nokogiri::XML::Document, xpath: []) }
-  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true, open?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_processing?: true, open?: true) }
 
   let(:item) do
     FactoryBot.create_for_repository(:persisted_item, label: 'Foo', title: 'Test')

--- a/spec/features/update_serials_metadata_spec.rb
+++ b/spec/features/update_serials_metadata_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Update serials metadata', :js do
   let(:item) do
     FactoryBot.create_for_repository(:persisted_item)
   end
-  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true, open?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_processing?: true, open?: true) }
 
   before do
     allow(VersionService).to receive(:new).and_return(version_service)

--- a/spec/requests/edit_barcode_spec.rb
+++ b/spec/requests/edit_barcode_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Edit barcode' do
     { 'Accept' => "#{Mime[:turbo_stream]},#{Mime[:html]}",
       'Turbo-Frame' => 'edit_copyright' }
   end
-  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_processing?: true) }
 
   before do
     allow(VersionService).to receive(:new).and_return(version_service)

--- a/spec/requests/edit_copyright_spec.rb
+++ b/spec/requests/edit_copyright_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Edit copyright' do
     { 'Accept' => "#{Mime[:turbo_stream]},#{Mime[:html]}",
       'Turbo-Frame' => 'edit_copyright' }
   end
-  let(:version_service) { instance_double(VersionService, open?: true, open_and_not_assembling?: true) }
+  let(:version_service) { instance_double(VersionService, open?: true, open_and_not_processing?: true) }
 
   before do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)

--- a/spec/requests/edit_license_spec.rb
+++ b/spec/requests/edit_license_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Edit license' do
   let(:turbo_stream_headers) do
     { 'Accept' => "#{Mime[:turbo_stream]},#{Mime[:html]}" }
   end
-  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true, open?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_processing?: true, open?: true) }
 
   before do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)

--- a/spec/requests/edit_rights_spec.rb
+++ b/spec/requests/edit_rights_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Edit rights' do
   let(:turbo_stream_headers) do
     { 'Accept' => "#{Mime[:turbo_stream]},#{Mime[:html]}" }
   end
-  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true, open?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_processing?: true, open?: true) }
 
   before do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)

--- a/spec/requests/edit_use_statement_spec.rb
+++ b/spec/requests/edit_use_statement_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Edit use statement' do
   let(:druid) { 'druid:dc243mg0841' }
 
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model, update: true) }
-  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true, open?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_processing?: true, open?: true) }
   let(:turbo_stream_headers) do
     { 'Accept' => "#{Mime[:turbo_stream]},#{Mime[:html]}" }
   end

--- a/spec/services/state_service_spec.rb
+++ b/spec/services/state_service_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe StateService do
   end
 
   describe '#object_state' do
-    context 'when object is open, not assembling, but not closeable' do
+    context 'when object is open, not assembling, not text extracting, but not closeable' do
       before do
-        allow(version_service).to receive_messages(open?: true, closeable?: false, closed?: false, assembling?: false)
+        allow(version_service).to receive_messages(open?: true, closeable?: false, closed?: false, assembling?: false, text_extracting?: false)
       end
 
       it 'returns unlock_inactive' do
@@ -27,7 +27,17 @@ RSpec.describe StateService do
 
     context 'when object is open and assembling' do
       before do
-        allow(version_service).to receive_messages(open?: true, closeable?: false, closed?: false, assembling?: true)
+        allow(version_service).to receive_messages(open?: true, closeable?: false, closed?: false, assembling?: true, text_extracting?: false)
+      end
+
+      it 'returns unlock_inactive' do
+        expect(service.object_state).to eq :lock_assembling
+      end
+    end
+
+    context 'when object is open and text extracting' do
+      before do
+        allow(version_service).to receive_messages(open?: true, closeable?: false, closed?: false, assembling?: false, text_extracting?: true)
       end
 
       it 'returns unlock_inactive' do

--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe VersionService do
 
   describe 'status methods' do
     it 'delegates to the version client' do
-      %i[open? openable? assembling? accessioning? closed? closeable? version].each do |method|
+      %i[open? openable? assembling? text_extracting? accessioning? closed? closeable? version].each do |method|
         allow(status).to receive(method)
         service.send(method)
         expect(status).to have_received(method).once


### PR DESCRIPTION
# Why was this change made?

Fixes #4470 and fixes #4472

Disable text extraction button and editing editing if a text extraction workflow is running, similar to if assembly is running.

HOLD for https://github.com/sul-dlss/dor-services-app/pull/5080 for the DSA related change

# How was this change tested?

CI (fix the build)
and QA (eventually)