### PR TITLE
text extraction job needs to determine if object is opened or not

### DIFF
--- a/app/services/text_extraction.rb
+++ b/app/services/text_extraction.rb
@@ -2,23 +2,30 @@
 
 # Start the correct text extraction workflow for a given object
 class TextExtraction
-  attr_reader :cocina_object, :languages
+  attr_reader :cocina_object, :languages, :already_opened
 
-  # param [Cocina::Models::DRO] cocina_object the object to start text extraction for
+  # @param [Cocina::Models::DRO] cocina_object the object to start text extraction for
   # @param [Array<String>] languages the languages to extract text for, default to empty
-  def initialize(cocina_object, languages: [])
+  # @param [Boolean] already_opened whether the object has already been opened, default to true
+  def initialize(cocina_object, languages: [], already_opened: true)
     @cocina_object = cocina_object
     @languages = languages
+    @already_opened = already_opened
   end
 
   # start the correct text extraction workflow for the object if possible
   def start
     return false unless possible?
 
+    version = cocina_object.version
+    # if the object has already been opened, don't increment the version for the new workflow
+    # this is to ensure the new workflow is started with the same version as the existing object
+    # if the object is already open, they are the same; if not, ocrWF will open the object version, incrementing it
+    version += 1 unless @already_opened
     WorkflowClientFactory.build.create_workflow_by_name(cocina_object.externalIdentifier,
                                                         wf_name,
                                                         context:,
-                                                        version: cocina_object.version)
+                                                        version:)
   end
 
   def possible?

--- a/spec/jobs/text_extraction_job_spec.rb
+++ b/spec/jobs/text_extraction_job_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe TextExtractionJob do
   let(:text_extraction_document) { instance_double(TextExtraction, start: true, possible?: true, wf_name: 'ocrWF') }
   let(:text_extraction_map) { instance_double(TextExtraction, start: false, possible?: false) }
   let(:ability) { instance_double(Ability, can?: true) }
+  let(:version_service) { instance_double(VersionService, open?: false, assembling?: false) }
+  let(:already_opened) { false }
 
   let(:params) do
     {
@@ -32,16 +34,18 @@ RSpec.describe TextExtractionJob do
 
   before do
     allow(Ability).to receive(:new).and_return(ability)
-    allow(TextExtraction).to receive(:new).with(document, languages:).and_return(text_extraction_document)
-    allow(TextExtraction).to receive(:new).with(map, languages:).and_return(text_extraction_map)
+    allow(TextExtraction).to receive(:new).with(document, languages:, already_opened:).and_return(text_extraction_document)
+    allow(TextExtraction).to receive(:new).with(map, languages:, already_opened:).and_return(text_extraction_map)
     allow(Dor::Services::Client).to receive(:object).with(druids[0]).and_return(document_client)
     allow(Dor::Services::Client).to receive(:object).with(druids[1]).and_return(map_client)
+    allow(VersionService).to receive(:new).and_return(version_service)
   end
 
   context 'when objects do not have active text extraction workflows already' do
     describe '#perform' do
       it 'starts text extraction for only the document (skips map)' do
         described_class.perform_now(bulk_action.id, params)
+        expect(TextExtraction).to have_received(:new).with(document, languages:, already_opened: false)
         expect(text_extraction_document).to have_received(:start)
         expect(text_extraction_map).not_to have_received(:start)
       end
@@ -49,15 +53,26 @@ RSpec.describe TextExtractionJob do
   end
 
   context 'when objects have active text extraction workflows already' do
-    before do
-      allow(WorkflowService).to receive(:workflow_active?).with(druid: document.externalIdentifier, version: document.version, wf_name: 'ocrWF').and_return(true)
-      allow(WorkflowService).to receive(:workflow_active?).with(druid: map.externalIdentifier, version: map.version, wf_name: 'ocrWF').and_return(true)
-    end
+    let(:version_service) { instance_double(VersionService, open?: false, assembling?: true) }
 
     describe '#perform' do
       it 'does not start text extraction for either object' do
         described_class.perform_now(bulk_action.id, params)
         expect(text_extraction_document).not_to have_received(:start)
+        expect(text_extraction_map).not_to have_received(:start)
+      end
+    end
+  end
+
+  context 'when objects are already open' do
+    let(:already_opened) { true }
+    let(:version_service) { instance_double(VersionService, open?: true, assembling?: false) }
+
+    describe '#perform' do
+      it 'starts text extraction for only the document (skips map)' do
+        described_class.perform_now(bulk_action.id, params)
+        expect(TextExtraction).to have_received(:new).with(document, languages:, already_opened: true)
+        expect(text_extraction_document).to have_received(:start)
         expect(text_extraction_map).not_to have_received(:start)
       end
     end

--- a/spec/services/text_extraction_spec.rb
+++ b/spec/services/text_extraction_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe TextExtraction do
-  subject(:text_extraction) { described_class.new(cocina_object, languages:) }
+  subject(:text_extraction) { described_class.new(cocina_object, languages:, already_opened:) }
 
   let(:druid) { 'druid:bg139xz7624' }
   let(:version) { 2 }
@@ -12,6 +12,7 @@ RSpec.describe TextExtraction do
   let(:dro) { true }
   let(:object_type) { 'https://cocina.sul.stanford.edu/models/document' }
   let(:ocr_wf) { 'ocrWF' }
+  let(:already_opened) { true }
 
   describe '#possible?' do
     context 'when the object is a document' do
@@ -101,28 +102,59 @@ RSpec.describe TextExtraction do
       allow(WorkflowClientFactory).to receive(:build).and_return(client)
     end
 
-    context 'when the object is a document' do
-      it 'starts ocrWF and returns true' do
-        expect(text_extraction.start).to be true
-        expect(client).to have_received(:create_workflow_by_name).with(druid, ocr_wf, version:, context:)
+    context 'when the object is already opened' do
+      context 'when the object is a document' do
+        it 'starts ocrWF and returns true' do
+          expect(text_extraction.start).to be true
+          expect(client).to have_received(:create_workflow_by_name).with(druid, ocr_wf, version:, context:)
+        end
+      end
+
+      context 'when the object is an image' do
+        let(:object_type) { 'https://cocina.sul.stanford.edu/models/image' }
+
+        it 'starts ocrWF and returns true' do
+          expect(text_extraction.start).to be true
+          expect(client).to have_received(:create_workflow_by_name).with(druid, ocr_wf, version:, context:)
+        end
+      end
+
+      context 'when the object is a book' do
+        let(:object_type) { 'https://cocina.sul.stanford.edu/models/book' }
+
+        it 'starts ocrWF and returns true' do
+          expect(text_extraction.start).to be true
+          expect(client).to have_received(:create_workflow_by_name).with(druid, ocr_wf, version:, context:)
+        end
       end
     end
 
-    context 'when the object is an image' do
-      let(:object_type) { 'https://cocina.sul.stanford.edu/models/image' }
+    context 'when the object is not already opened' do
+      let(:already_opened) { false }
 
-      it 'starts ocrWF and returns true' do
-        expect(text_extraction.start).to be true
-        expect(client).to have_received(:create_workflow_by_name).with(druid, ocr_wf, version:, context:)
+      context 'when the object is a document' do
+        it 'starts ocrWF for the next version and returns true' do
+          expect(text_extraction.start).to be true
+          expect(client).to have_received(:create_workflow_by_name).with(druid, ocr_wf, version: version + 1, context:)
+        end
       end
-    end
 
-    context 'when the object is a book' do
-      let(:object_type) { 'https://cocina.sul.stanford.edu/models/book' }
+      context 'when the object is an image' do
+        let(:object_type) { 'https://cocina.sul.stanford.edu/models/image' }
 
-      it 'starts ocrWF and returns true' do
-        expect(text_extraction.start).to be true
-        expect(client).to have_received(:create_workflow_by_name).with(druid, ocr_wf, version:, context:)
+        it 'starts ocrWF and returns true' do
+          expect(text_extraction.start).to be true
+          expect(client).to have_received(:create_workflow_by_name).with(druid, ocr_wf, version: version + 1, context:)
+        end
+      end
+
+      context 'when the object is a book' do
+        let(:object_type) { 'https://cocina.sul.stanford.edu/models/book' }
+
+        it 'starts ocrWF and returns true' do
+          expect(text_extraction.start).to be true
+          expect(client).to have_received(:create_workflow_by_name).with(druid, ocr_wf, version: version + 1, context:)
+        end
       end
     end
 


### PR DESCRIPTION
# Why was this change made?

We need this for the same reason we need https://github.com/sul-dlss/common-accessioning/pull/1290 

If you start a text extraction workflow like ocrWF that can operate on both currently closed and currently opened versions, you need to know what the state is.  If the object is *not* opened yet, you need to start ocrWF with the next version up (since this is what it will be once opened by `ocrWF:start-ocr`).  If already opened, the current version is correct.

Argo can handle both situations ("text extraction" button in UI only works on already open objects but the job can handle either situation).  This allows for both to work.

# How was this change tested?

CI