### PR TITLE
Add csv dependency to bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'cancancan' # authorization
 gem 'coderay' # Pretty format for XML
 gem 'config'
 gem 'cssbundling-rails', '~> 1.1'
+gem 'csv'
 gem 'devise'
 gem 'devise-remote-user', '~> 1.0'
 gem 'dry-monads'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.0)
       railties (>= 6.0.0)
+    csv (3.2.8)
     date (3.3.4)
     debug (1.9.2)
       irb (~> 1.10)
@@ -679,6 +680,7 @@ DEPENDENCIES
   coderay
   config
   cssbundling-rails (~> 1.1)
+  csv
   debug
   devise
   devise-remote-user (~> 1.0)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'csv'
-
 # Runs a query against solr and returns the results.
 # Does exactly what blacklight does, paginates the solr requests until all results
 # have been received


### PR DESCRIPTION
# Why was this change made?

This dependency is moving out of stdlib in Ruby 3.4 so it must be managed by bundler.

# How was this change tested?

CI
