### PR TITLE
Disable add workflow button when locked.

### DIFF
--- a/app/components/show/controls_component.rb
+++ b/app/components/show/controls_component.rb
@@ -118,7 +118,10 @@ module Show
 
     def add_workflow_button
       render ActionButton.new(
-        url: new_item_workflow_path(item_id: druid), label: 'Add workflow', open_modal: true
+        url: new_item_workflow_path(item_id: druid),
+        label: 'Add workflow',
+        open_modal: true,
+        disabled: button_disabled?
       )
     end
 

--- a/spec/components/show/controls_component_spec.rb
+++ b/spec/components/show/controls_component_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Show::ControlsComponent, type: :component do
     end
 
     context 'when the object is locked' do
-      it 'the embargo and apply APO buttons are disabled' do
+      it 'various buttons are disabled' do
         expect(page).to have_link 'Reindex', href: '/dor/reindex/druid:kv840xx0000'
         expect(page).to have_link 'Add workflow', href: '/items/druid:kv840xx0000/workflows/new'
         expect(page).to have_link 'Republish', href: '/items/druid:kv840xx0000/publish'
@@ -104,9 +104,10 @@ RSpec.describe Show::ControlsComponent, type: :component do
         expect(page).to have_css 'a.disabled', text: 'Create embargo'
         expect(page).to have_css 'a.disabled', text: 'Apply APO defaults'
         expect(page).to have_css 'a.disabled', text: 'Text extraction'
+        expect(page).to have_css 'a.disabled', text: 'Add workflow'
 
         expect(rendered.css('a').size).to eq(9)
-        expect(rendered.css('a.disabled').size).to eq 5 # create embargo, apply APO defaults, text extraction, purge, republish
+        expect(rendered.css('a.disabled').size).to eq 6 # create embargo, apply APO defaults, text extraction, purge, republish, add workflow
       end
     end
 


### PR DESCRIPTION
closes #4485

# Why was this change made?

Per @andrewjbtw 

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?

Unit

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


