### PR TITLE
Inactivates buttons on user versions details page.

### DIFF
--- a/app/components/show/controls_component.rb
+++ b/app/components/show/controls_component.rb
@@ -43,10 +43,10 @@ module Show
     end
 
     delegate :admin_policy?, :agreement?, :item?, :collection?, :embargoed?, to: :doc
-    delegate :open?, :openable?, :open_and_not_assembling?, to: :presenter
+    delegate :open?, :openable?, :open_and_not_assembling?, :user_version_view?, to: :presenter
 
     def button_disabled?
-      !open_and_not_assembling?
+      !open_and_not_assembling? || user_version_view?
     end
 
     def collection_button_disabled?
@@ -60,7 +60,12 @@ module Show
     private
 
     def manage_release
-      render ActionButton.new(url: item_manage_release_path(druid), label: 'Manage release', open_modal: true)
+      render ActionButton.new(
+        url: item_manage_release_path(druid),
+        label: 'Manage release',
+        open_modal: true,
+        disabled: user_version_view?
+      )
     end
 
     def apply_apo_defaults
@@ -112,7 +117,8 @@ module Show
     def reindex_button
       render ActionButton.new(
         url: dor_reindex_path(druid:),
-        label: 'Reindex'
+        label: 'Reindex',
+        disabled: user_version_view?
       )
     end
 
@@ -131,7 +137,7 @@ module Show
         label: 'Purge',
         method: 'delete',
         confirm: 'This object will be permanently purged from DOR. This action cannot be undone. Are you sure?',
-        disabled: !registered_only?
+        disabled: !registered_only? || user_version_view?
       )
     end
 
@@ -140,7 +146,7 @@ module Show
         url: item_publish_path(doc),
         label: 'Republish',
         method: 'post',
-        disabled: !published?
+        disabled: !published? || user_version_view?
       )
     end
 

--- a/app/presenters/argo_show_presenter.rb
+++ b/app/presenters/argo_show_presenter.rb
@@ -17,6 +17,10 @@ class ArgoShowPresenter < Blacklight::ShowPresenter
     cocina.externalIdentifier
   end
 
+  def user_version_view?
+    user_version.present?
+  end
+
   delegate :open?, :openable?, :open_and_not_assembling?, to: :version_service
 
   attr_accessor :cocina, :view_token, :state_service, :version_service, :user_version

--- a/spec/components/show/controls_component_spec.rb
+++ b/spec/components/show/controls_component_spec.rb
@@ -11,10 +11,18 @@ RSpec.describe Show::ControlsComponent, type: :component do
   let(:governing_apo_id) { 'druid:hv992yv2222' }
   let(:manager) { true }
   let(:rendered) { render_inline(component) }
-  let(:presenter) { instance_double(ArgoShowPresenter, document: doc, open?: open, cocina:, openable?: true, open_and_not_assembling?: open_and_not_assembling) }
+  let(:presenter) do
+    instance_double(ArgoShowPresenter,
+                    document: doc,
+                    open?: open,
+                    cocina:, openable?: true,
+                    open_and_not_assembling?: open_and_not_assembling,
+                    user_version_view?: user_version_view)
+  end
   let(:cocina) { instance_double(Cocina::Models::DRO, dro?: dro, type: 'https://cocina.sul.stanford.edu/models/book') }
   let(:open) { false }
   let(:open_and_not_assembling) { false }
+  let(:user_version_view) { false }
 
   before do
     rendered
@@ -293,6 +301,32 @@ RSpec.describe Show::ControlsComponent, type: :component do
       end
 
       it { is_expected.to be false }
+    end
+  end
+
+  context 'when a user version view' do
+    let(:item_id) { 'druid:kv840xx0000' }
+    let(:dro) { true }
+    let(:doc) do
+      SolrDocument.new('id' => item_id,
+                       'processing_status_text_ssi' => processing_status,
+                       SolrDocument::FIELD_OBJECT_TYPE => 'item',
+                       CatalogRecordId.index_field => catalog_record_id,
+                       SolrDocument::FIELD_APO_ID => [governing_apo_id],
+                       SolrDocument::FIELD_LAST_PUBLISHED_DATE => last_published,
+                       SolrDocument::FIELD_WORKFLOW_ERRORS => workflow_errors)
+    end
+    let(:catalog_record_id) { nil }
+    let(:last_published) { nil }
+    let(:workflow_errors) { nil }
+    let(:processing_status) { 'not registered' }
+    let(:open) { true }
+    let(:open_and_not_assembling) { true }
+    let(:user_version_view) { true }
+
+    it 'draws the buttons' do
+      expect(rendered.css('a').size).to eq(9)
+      expect(rendered.css('a.disabled').size).to eq 8 # except Download Cocina spreadsheet
     end
   end
 end


### PR DESCRIPTION
closes #4497

# Why was this change made?
So that only appropriate buttons appear on the page.

# How was this change tested?
Unit

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


