### PR TITLE
Do not display techmd on user version details page.

### DIFF
--- a/app/components/show/agreement_component.html.erb
+++ b/app/components/show/agreement_component.html.erb
@@ -24,5 +24,5 @@
   <%= render 'cocina_default', view_token: %>
   <%= render 'history_default', document: %>
   <%= render ContentsComponent.new(presenter:) %>
-  <%= render TechmdComponent.new(view_token:) %>
+  <%= render TechmdComponent.new(view_token:, presenter:) %>
 </div>

--- a/app/components/show/item_component.html.erb
+++ b/app/components/show/item_component.html.erb
@@ -28,5 +28,5 @@
   <%= render 'history_default', document: %>
   <%= render ContentsComponent.new(presenter:) %>
   <%= render Show::Item::Structure::FileHierarchyComponent.new(view_token:) %>
-  <%= render TechmdComponent.new(view_token:) %>
+  <%= render TechmdComponent.new(view_token:, presenter:) %>
 </div>

--- a/app/components/techmd_component.rb
+++ b/app/components/techmd_component.rb
@@ -2,9 +2,14 @@
 
 class TechmdComponent < ViewComponent::Base
   # @params [String] view_token
-  def initialize(view_token:)
+  def initialize(view_token:, presenter:)
     @view_token = view_token
+    @presenter = presenter
   end
 
   attr_reader :view_token
+
+  def render?
+    !@presenter.user_version_view?
+  end
 end

--- a/spec/components/techmd_component_spec.rb
+++ b/spec/components/techmd_component_spec.rb
@@ -3,13 +3,24 @@
 require 'rails_helper'
 
 RSpec.describe TechmdComponent, type: :component do
-  include Dry::Monads[:result]
-
-  subject(:component) { described_class.new(view_token: 'skret-t0k3n') }
+  subject(:component) { described_class.new(view_token: 'skret-t0k3n', presenter:) }
 
   let(:rendered) { render_inline(component) }
+  let(:presenter) { instance_double(ArgoShowPresenter, user_version_view?: user_version_view) }
 
-  it 'renders a turbo frame' do
-    expect(rendered.css('turbo-frame').first['src']).to eq '/items/skret-t0k3n/technical'
+  context 'when head cocina' do
+    let(:user_version_view) { false }
+
+    it 'renders a turbo frame' do
+      expect(rendered.css('turbo-frame').first['src']).to eq '/items/skret-t0k3n/technical'
+    end
+  end
+
+  context 'when user version view' do
+    let(:user_version_view) { true }
+
+    it 'does not render' do
+      expect(rendered.text).to be_empty
+    end
   end
 end

--- a/spec/features/version_view_spec.rb
+++ b/spec/features/version_view_spec.rb
@@ -199,6 +199,7 @@ RSpec.describe 'Version view', :js do
         expect(page).to have_content(title)
         expect(page).to have_content('public version 2')
         expect(page).to have_link('Back to latest', href: "/view/#{druid}")
+        expect(page).to have_no_content('Technical metadata')
       end
     end
 


### PR DESCRIPTION
closes #4502

# Why was this change made?

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?

Unit
<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


