### PR TITLE
Change description button on item show

### DIFF
--- a/app/components/show/external_links_component.html.erb
+++ b/app/components/show/external_links_component.html.erb
@@ -2,7 +2,7 @@
   <h3 class="button-header">View in new window</h3>
   <ul class="nav flex">
     <% if publishable? %>
-      <li class="nav-item"><%= mods_link %></li>
+      <li class="nav-item"><%= description_link %></li>
       <li class="nav-item"><%= purl_link %></li>
       <li class="nav-item"><%= searchworks_link %></li>
     <% end %>

--- a/app/components/show/external_links_component.rb
+++ b/app/components/show/external_links_component.rb
@@ -40,10 +40,14 @@ module Show
               class: 'external-link-button'
     end
 
-    def mods_link
-      link_to 'MODS', descriptive_item_metadata_path(document.id),
+    def description_link
+      link_to 'Description', description_link_path,
               class: 'external-link-button',
               data: { blacklight_modal: 'trigger' }
+    end
+
+    def description_link_path
+      user_version_view? ? descriptive_item_user_version_metadata_path(document.id, user_version) : descriptive_item_metadata_path(document.id)
     end
 
     def released_to_searchworks?
@@ -52,6 +56,6 @@ module Show
 
     private
 
-    attr_reader :document
+    attr_reader :document, :presenter
   end
 end

--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -15,6 +15,10 @@ class MetadataController < ApplicationController
   private
 
   def cocina
-    Repository.find(params[:item_id])
+    if params.key?(:user_version_id)
+      Repository.find_user_version(params[:item_id], params[:user_version_id])
+    else
+      Repository.find(params[:item_id])
+    end
   end
 end

--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class MetadataController < ApplicationController
-  # Shows the modal with the MODS XML. This is triggered by the "MODS" button on
+  # Shows the modal with the descriptive metadata from MODS. This is triggered by the "Description" button on
   # the item show page.
   def descriptive
     xml = PurlFetcher::Client::Mods.create(cocina:)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -224,6 +224,11 @@ Rails.application.routes.draw do
           get 'download'
         end
       end
+      resources :metadata, only: %i[show] do
+        collection do
+          get 'descriptive'
+        end
+      end
     end
   end
 

--- a/spec/components/show/external_links_component_spec.rb
+++ b/spec/components/show/external_links_component_spec.rb
@@ -18,10 +18,13 @@ RSpec.describe Show::ExternalLinksComponent, type: :component do
                                     druid: 'ab123cd3445',
                                     publishable?: false)
     end
+    let(:presenter) { instance_double(ArgoShowPresenter, user_version_view?: user_version_view, user_version:) }
+    let(:user_version_view) { false }
+    let(:user_version) { nil }
 
     it 'links to Solr and Cocina' do
       expect(page).to have_no_link 'SearchWorks'
-      expect(page).to have_no_link 'MODS'
+      expect(page).to have_no_link 'Description'
       expect(page).to have_no_link 'PURL'
       expect(page).to have_no_link 'Dublin Core'
 
@@ -38,6 +41,9 @@ RSpec.describe Show::ExternalLinksComponent, type: :component do
                                     publishable?: true,
                                     catalog_record_id:, released_to:)
     end
+    let(:presenter) { instance_double(ArgoShowPresenter, user_version_view?: user_version_view, user_version:) }
+    let(:user_version_view) { false }
+    let(:user_version) { 2 }
     let(:catalog_record_id) { nil }
     let(:released_to) do
       []
@@ -46,10 +52,10 @@ RSpec.describe Show::ExternalLinksComponent, type: :component do
     context 'when not released' do
       it 'links to purl and the Solr document' do
         expect(page).to have_no_link 'SearchWorks'
+        expect(page).to have_link 'Description', href: '/items/druid:ab123cd3445/metadata/descriptive'
         expect(page).to have_link 'PURL', href: 'https://sul-purl-stage.stanford.edu/ab123cd3445'
         expect(page).to have_link 'Solr document', href: '/view/druid:ab123cd3445.json'
         expect(page).to have_link 'Cocina model', href: '/items/druid:ab123cd3445.json'
-        expect(page).to have_link 'PURL'
       end
     end
 
@@ -82,6 +88,15 @@ RSpec.describe Show::ExternalLinksComponent, type: :component do
         it 'links to user version' do
           expect(page).to have_link 'Cocina model', href: '/items/druid:ab123cd3445/user_versions/2.json'
         end
+      end
+    end
+
+    context 'when a user version' do
+      let(:user_version_view) { true }
+      let(:user_version) { 2 }
+
+      it 'links to user version descriptive metadata' do
+        expect(page).to have_link 'Description', href: '/items/druid:ab123cd3445/user_versions/2/metadata/descriptive'
       end
     end
   end

--- a/spec/requests/view_mods_descriptive_metadata_spec.rb
+++ b/spec/requests/view_mods_descriptive_metadata_spec.rb
@@ -2,13 +2,14 @@
 
 require 'rails_helper'
 
-RSpec.describe 'View MODS descriptive metadata' do
+RSpec.describe 'View descriptive metadata' do
   let(:user) { create(:user) }
 
   let(:cocina_object) do
     build(:dro, id: druid)
   end
-  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_object) }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_object, user_version: user_version_client) }
+  let(:user_version_client) { nil }
   let(:druid) { 'druid:bc123df4567' }
 
   let(:mods_xml) do
@@ -86,5 +87,19 @@ RSpec.describe 'View MODS descriptive metadata' do
     get "/items/#{druid}/metadata/descriptive"
     expect(response).to be_successful
     expect(response.body).to include 'PROVINCIæ BOREALIS AMERICÆ NON ITA PRIDEM DETECTÆ AVT MAGIS AB EVROPÆIS EXCVLTÆ.'
+  end
+
+  context 'when a user version' do
+    let(:cocina_object) do
+      build(:dro_with_metadata, id: druid, title: 'PROVINCIæ BOREALIS AMERICÆ NON ITA PRIDEM DETECTÆ AVT MAGIS AB EVROPÆIS EXCVLTÆ.', version: user_version)
+    end
+    let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, find: cocina_object) }
+    let(:user_version) { 2 }
+
+    it 'displays the user version descriptive metadata' do
+      get "/items/#{druid}/user_versions/2/metadata/descriptive"
+      expect(response).to be_successful
+      expect(response.body).to include 'PROVINCIæ BOREALIS AMERICÆ NON ITA PRIDEM DETECTÆ AVT MAGIS AB EVROPÆIS EXCVLTÆ.'
+    end
   end
 end


### PR DESCRIPTION
# Why was this change made?
Resolves #4495 to show user version descriptive metadata. Changes the "MODS" button to "Description". 

![Screenshot 2024-07-02 at 10 29 28 AM](https://github.com/sul-dlss/argo/assets/1619369/d4148c2f-cad3-4c64-b11a-a1a012610dcb)

# How was this change tested?
Unit and stage.
