### PR TITLE
Do not link user version when user version is current object version.

### DIFF
--- a/app/components/version_milestones_component.html.erb
+++ b/app/components/version_milestones_component.html.erb
@@ -1,6 +1,6 @@
 <tr class="version<%= version %>">
  <td colspan="3">-
-   <%= title %><% if user_version %> (<%= link_to "Public version #{user_version}", user_version_path %>)<% end %>
+   <%= title %><% if user_version %> (<%= current_version? ? user_version_label : link_to(user_version_label, user_version_path) %>)<% end %>
  </td>
 </tr>
 

--- a/app/components/version_milestones_component.rb
+++ b/app/components/version_milestones_component.rb
@@ -14,12 +14,20 @@ class VersionMilestonesComponent < ViewComponent::Base
     @steps ||= milestones_presenter.steps_for(version)
   end
 
+  def current_version?
+    version.to_i == milestones_presenter.current_version
+  end
+
   def user_version
     @user_version ||= milestones_presenter.user_version_for(version)
   end
 
   def user_version_path
     item_user_version_path(item_id: druid, id: user_version)
+  end
+
+  def user_version_label
+    "Public version #{user_version}"
   end
 
   attr_reader :version, :milestones_presenter

--- a/app/presenters/milestones_presenter.rb
+++ b/app/presenters/milestones_presenter.rb
@@ -31,7 +31,11 @@ class MilestonesPresenter
   end
 
   def head_user_version
-    user_versions.max { |user_version1, user_version2| user_version1.userVersion.to_i <=> user_version2.userVersion.to_i }&.userVersion.to_s
+    @head_user_version ||= user_versions.max { |user_version1, user_version2| user_version1.userVersion.to_i <=> user_version2.userVersion.to_i }&.userVersion.to_s
+  end
+
+  def current_version
+    @current_version ||= versions.max_by(&:versionId)&.versionId
   end
 
   attr_reader :druid

--- a/spec/components/version_milestones_component_spec.rb
+++ b/spec/components/version_milestones_component_spec.rb
@@ -15,9 +15,11 @@ RSpec.describe VersionMilestonesComponent, type: :component do
                     steps_for: steps,
                     version_title: '2 (2.0.0) Add collection, set rights to citations',
                     user_version_for: user_version,
+                    current_version:,
                     druid: 'druid:mk420bs7601')
   end
   let(:user_version) { nil }
+  let(:current_version) { 2 }
 
   let(:steps) do
     { 'accessioned' => { display: 'foo',
@@ -49,10 +51,21 @@ RSpec.describe VersionMilestonesComponent, type: :component do
 
   context 'when the accessioned milestone has user version' do
     let(:user_version) { 1 }
+    let(:current_version) { 3 }
 
     it 'renders link to user version' do
       render_inline(instance)
       expect(page).to have_link 'Public version 1', href: '/items/druid:mk420bs7601/user_versions/1'
+    end
+  end
+
+  context 'when the accessioned milestone has user version that is the current object version' do
+    let(:user_version) { 2 }
+
+    it 'renders the user version but not as a link' do
+      render_inline(instance)
+      expect(page).to have_text 'Public version 2'
+      expect(page).to have_no_link 'Public version 2', href: '/items/druid:mk420bs7601/user_versions/2'
     end
   end
 end


### PR DESCRIPTION
closes #4527

# Why was this change made?
User version details page when latest object version isn't helpful to users.

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?
Unit
<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


