### PR TITLE
Do not render lock on user version detail page.

### DIFF
--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -82,15 +82,12 @@
   .open-close {
     width: 2rem;
     float: left;
+    margin-right: 2rem;
 
     .btn {
       font-size: x-large;
       color: $color-cardinal-red;
     }
-  }
-
-  .document-title-heading {
-    margin-left: 2rem;
   }
 
   /* content metadata section */

--- a/app/components/document_title_component.html.erb
+++ b/app/components/document_title_component.html.erb
@@ -5,7 +5,7 @@
     </div>
   <% end %>
   <div class="row">
-    <%= render OpenCloseComponent.new(id: @document.id) if helpers.can?(:update, @presenter.cocina) %>
+    <%= render OpenCloseComponent.new(id: @document.id) if helpers.can?(:update, @presenter.cocina) && !@presenter.user_version_view? %>
 
     <%= content_tag @as, class: @classes do %>
       <%= title -%>

--- a/spec/features/version_view_spec.rb
+++ b/spec/features/version_view_spec.rb
@@ -199,6 +199,7 @@ RSpec.describe 'Version view', :js do
         # And nothing should be editable
         expect(page).to have_no_css('.bi-pencil')
         expect(page).to have_content('Older versions are not released')
+        expect(page).to have_no_css('.open-close') # Lock icon
 
         expect(user_version_client).to have_received(:find).with('2')
         expect(user_version_client).to have_received(:solr).with('2')


### PR DESCRIPTION
closes #4519

# Why was this change made?

The user can't use the lock on a user version.

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?

Unit, QA
<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


