### PR TITLE
Adds Withdraw / Restore buttons.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -450,7 +450,7 @@ Rails/I18nLazyLookup: # new in 2.14
 Rails/I18nLocaleAssignment: # new in 2.11
   Enabled: true
 Rails/I18nLocaleTexts: # new in 2.14
-  Enabled: true
+  Enabled: false
 Rails/IgnoredColumnsAssignment: # new in 2.17
   Enabled: true
 Rails/Inquiry: # new in 2.7

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -236,24 +236,6 @@ Rails/HelperInstanceVariable:
   Exclude:
     - 'app/helpers/items_helper.rb'
 
-# Offense count: 18
-Rails/I18nLocaleTexts:
-  Exclude:
-    - 'app/controllers/agreements_controller.rb'
-    - 'app/controllers/apo_controller.rb'
-    - 'app/controllers/bulk_actions_controller.rb'
-    - 'app/controllers/catalog_controller.rb'
-    - 'app/controllers/content_types_controller.rb'
-    - 'app/controllers/descriptives_controller.rb'
-    - 'app/controllers/embargos_controller.rb'
-    - 'app/controllers/items_controller.rb'
-    - 'app/controllers/publishes_controller.rb'
-    - 'app/controllers/registrations_controller.rb'
-    - 'app/controllers/uploads_controller.rb'
-    - 'app/forms/agreement_form.rb'
-    - 'app/forms/has_view_access.rb'
-    - 'app/forms/registration_form.rb'
-
 # Offense count: 5
 Rails/OutputSafety:
   Exclude:

--- a/app/components/show/controls_component.html.erb
+++ b/app/components/show/controls_component.html.erb
@@ -43,5 +43,6 @@
     <%= apply_apo_defaults %>
     <%= create_embargo %>
     <%= create_text_extraction %>
+    <%= withdraw_or_restore %>
   <% end %>
 </div>

--- a/app/components/show/controls_component.rb
+++ b/app/components/show/controls_component.rb
@@ -25,9 +25,10 @@ module Show
       @manager = manager
       @presenter = presenter
       @doc = presenter.document
+      @user_versions_presenter = presenter.user_versions_presenter
     end
 
-    attr_reader :doc, :presenter
+    attr_reader :doc, :presenter, :user_versions_presenter
 
     def manager?
       @manager
@@ -149,6 +150,25 @@ module Show
         method: 'post',
         disabled: !published? || user_version_view?
       )
+    end
+
+    def withdraw_or_restore
+      return unless item?
+
+      if user_versions_presenter.user_version_withdrawable?
+        render ActionButton.new(
+          url: item_user_version_withdraw_path(doc, user_version),
+          label: 'Withdraw',
+          method: 'post',
+          confirm: 'Once you withdraw this version, the Purl will no longer display it. Are your sure? '
+        )
+      elsif user_versions_presenter.user_version_restorable?
+        render ActionButton.new(
+          url: item_user_version_restore_path(doc, user_version),
+          label: 'Restore',
+          method: 'post'
+        )
+      end
     end
 
     def upload_mods

--- a/app/components/version_milestones_component.rb
+++ b/app/components/version_milestones_component.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class VersionMilestonesComponent < ViewComponent::Base
-  def initialize(version:, milestones_presenter:)
+  def initialize(version:, milestones_presenter:, user_versions_presenter:)
     @version = version
     @milestones_presenter = milestones_presenter
+    @user_versions_presenter = user_versions_presenter
   end
 
   def title
@@ -19,7 +20,7 @@ class VersionMilestonesComponent < ViewComponent::Base
   end
 
   def user_version
-    @user_version ||= milestones_presenter.user_version_for(version)
+    @user_version ||= user_versions_presenter.user_version_for(version)
   end
 
   def user_version_path
@@ -30,7 +31,7 @@ class VersionMilestonesComponent < ViewComponent::Base
     "Public version #{user_version}"
   end
 
-  attr_reader :version, :milestones_presenter
+  attr_reader :version, :milestones_presenter, :user_versions_presenter
 
   delegate :druid, to: :milestones_presenter
 end

--- a/app/controllers/user_versions_controller.rb
+++ b/app/controllers/user_versions_controller.rb
@@ -10,9 +10,34 @@ class UserVersionsController < ApplicationController
     end
   end
 
+  def withdraw
+    update_user_version(withdrawn: true)
+    redirect_to item_user_version_path(druid_param, user_version_param),
+                notice: 'Withdrawn. Purl will no longer display this version.'
+  end
+
+  def restore
+    update_user_version(withdrawn: false)
+    redirect_to item_user_version_path(druid_param, user_version_param),
+                notice: 'Restored. Purl will display this version.'
+  end
+
   private
 
+  def druid_param
+    params[:item_id]
+  end
+
+  def user_version_param
+    params[:id] || params[:user_version_id]
+  end
+
   def find_user_version_cocina
-    @cocina = Repository.find_user_version(params[:item_id], params[:id])
+    @cocina = Repository.find_user_version(druid_param, user_version_param)
+  end
+
+  def update_user_version(withdrawn:)
+    client = Dor::Services::Client.object(druid_param).user_version
+    client.update(user_version: Dor::Services::Client::UserVersion::Version.new(withdrawn:, userVersion: user_version_param))
   end
 end

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -15,8 +15,7 @@ module ItemsHelper
         presenter.cocina = @cocina
         presenter.state_service = StateService.new(@cocina)
         presenter.version_service = VersionService.new(druid: @cocina.externalIdentifier)
-        presenter.user_version = @user_version
-        presenter.head_user_version = @head_user_version
+        presenter.user_versions_presenter = @user_versions_presenter
       end
     end
   end

--- a/app/presenters/argo_show_presenter.rb
+++ b/app/presenters/argo_show_presenter.rb
@@ -18,7 +18,7 @@ class ArgoShowPresenter < Blacklight::ShowPresenter
   end
 
   def user_version_view?
-    user_version.present?
+    user_versions_presenter.present? && user_version.present?
   end
 
   def head_user_version_view?
@@ -27,5 +27,7 @@ class ArgoShowPresenter < Blacklight::ShowPresenter
 
   delegate :open?, :openable?, :open_and_not_assembling?, to: :version_service
 
-  attr_accessor :cocina, :view_token, :state_service, :version_service, :user_version, :head_user_version
+  delegate :user_version, :head_user_version, to: :user_versions_presenter
+
+  attr_accessor :cocina, :view_token, :state_service, :version_service, :user_versions_presenter
 end

--- a/app/presenters/milestones_presenter.rb
+++ b/app/presenters/milestones_presenter.rb
@@ -3,8 +3,10 @@
 # Displays milestones for each of the versions for an object
 class MilestonesPresenter
   # @param [String] druid the druid of the object
-  def initialize(druid:)
+  # @param [Array<Dor::Services::Client::Version::Version>] version_inventory the version inventory
+  def initialize(druid:, version_inventory:)
     @druid = druid
+    @version_inventory = version_inventory
   end
 
   def each_version(&)
@@ -16,45 +18,21 @@ class MilestonesPresenter
   end
 
   def version_title(version)
-    val = versions.find { |this| this.versionId == version.to_i }
+    val = version_inventory.find { |this| this.versionId == version.to_i }
     return version unless val
 
     "#{version} #{val.message}"
   end
 
-  def user_version_for(version)
-    user_versions.find { |user_version| user_version.version == version.to_i }&.userVersion
-  end
-
-  def valid_user_version?(user_version)
-    user_version.nil? || user_versions.any? { |version| version.userVersion.to_s == user_version }
-  end
-
-  def head_user_version
-    @head_user_version ||= user_versions.max { |user_version1, user_version2| user_version1.userVersion.to_i <=> user_version2.userVersion.to_i }&.userVersion.to_s
-  end
-
   def current_version
-    @current_version ||= versions.max_by(&:versionId)&.versionId
+    @current_version ||= version_inventory.max_by(&:versionId)&.versionId
   end
 
-  attr_reader :druid
+  attr_reader :druid, :version_inventory
 
   private
 
   def milestones
     @milestones ||= MilestoneService.milestones_for(druid:)
-  end
-
-  def versions
-    @versions ||= object_client.version.inventory
-  end
-
-  def user_versions
-    @user_versions ||= object_client.user_version.inventory
-  end
-
-  def object_client
-    @object_client ||= Dor::Services::Client.object(druid)
   end
 end

--- a/app/presenters/user_versions_presenter.rb
+++ b/app/presenters/user_versions_presenter.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Displays user versions for an object
+class UserVersionsPresenter
+  # @param [String] user_version the user version of the object
+  # @param [Array<Dor::Services::Client::UserVersion::Version>] user_version_inventory the user version inventory
+  def initialize(user_version:, user_version_inventory:)
+    @user_version = user_version
+    @user_version_inventory = user_version_inventory || []
+  end
+
+  # @param [String] version the object version
+  # @return [String, nil] the user version for the given object version or nil if not found
+  def user_version_for(version)
+    user_version_inventory.find { |user_version_data| user_version_data.version.to_i == version.to_i }&.userVersion
+  end
+
+  # @param [Boolean] true if there is no user version or the user version is found in the inventory
+  def valid_user_version?
+    user_version.nil? || user_version_data_for(user_version).present?
+  end
+
+  # @param [Boolean] true if the current user version is withdrawable
+  def user_version_withdrawable?
+    return false unless user_version_data
+
+    user_version_data.withdrawable?
+  end
+
+  # @param [Boolean] true if the current user version is withdrawable
+  def user_version_restorable?
+    return false unless user_version_data
+
+    user_version_data.restorable?
+  end
+
+  def head_user_version
+    @head_user_version ||= user_version_inventory.max_by { |user_version_data| user_version_data.userVersion.to_i }&.userVersion&.to_s
+  end
+
+  attr_reader :user_version, :user_version_inventory
+
+  private
+
+  def user_version_data
+    @user_version_data ||= user_version_data_for(user_version)
+  end
+
+  def user_version_data_for(user_version)
+    user_version_inventory.find { |user_version_data| user_version_data.userVersion.to_s == user_version.to_s }
+  end
+end

--- a/app/views/catalog/_show_milestones.html.erb
+++ b/app/views/catalog/_show_milestones.html.erb
@@ -4,7 +4,7 @@
   </thead>
   <tbody>
     <% @milestones_presenter.each_version do |version| %>
-      <%= render VersionMilestonesComponent.new(version:, milestones_presenter: @milestones_presenter) %>
+      <%= render VersionMilestonesComponent.new(version:, milestones_presenter: @milestones_presenter, user_versions_presenter: @user_versions_presenter) %>
     <% end %>
   </tbody>
 </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -217,7 +217,10 @@ Rails.application.routes.draw do
     end
 
     resources :user_versions, only: %i[show], constraints: ->(req) { req.format == :json }, as: 'item_user_version_json'
+
     resources :user_versions, controller: 'catalog', only: %i[show] do
+      post 'withdraw', to: 'user_versions#withdraw'
+      post 'restore', to: 'user_versions#restore'
       get 'descriptive', to: 'descriptives#show'
       get 'structure', to: 'structures#show'
       resources 'files', only: %i[index], constraints: { item_id: /.*/ } do

--- a/spec/components/show/controls_component_spec.rb
+++ b/spec/components/show/controls_component_spec.rb
@@ -18,13 +18,17 @@ RSpec.describe Show::ControlsComponent, type: :component do
                     cocina:, openable?: true,
                     open_and_not_assembling?: open_and_not_assembling,
                     user_version:,
-                    user_version_view?: user_version_view)
+                    user_version_view?: user_version_view,
+                    user_versions_presenter:)
   end
+  let(:user_versions_presenter) { instance_double(UserVersionsPresenter, user_version_withdrawable?: user_version_withdrawable, user_version_restorable?: user_version_restorable) }
   let(:cocina) { instance_double(Cocina::Models::DRO, dro?: dro, type: 'https://cocina.sul.stanford.edu/models/book') }
   let(:open) { false }
   let(:open_and_not_assembling) { false }
   let(:user_version_view) { false }
   let(:user_version) { nil }
+  let(:user_version_withdrawable) { false }
+  let(:user_version_restorable) { false }
 
   before do
     rendered
@@ -137,6 +141,24 @@ RSpec.describe Show::ControlsComponent, type: :component do
       it 'the text extraction button exists but is disabled' do
         expect(page).to have_link 'Text extraction', href: '/items/druid:kv840xx0000/text_extraction/new'
         expect(page).to have_css 'a.disabled', text: 'Text extraction'
+      end
+    end
+
+    context 'when the user version can be withdrawn' do
+      let(:user_version) { 2 }
+      let(:user_version_withdrawable) { true }
+
+      it 'the withdraw button is displayed' do
+        expect(page).to have_link 'Withdraw', href: '/items/druid:kv840xx0000/user_versions/2/withdraw'
+      end
+    end
+
+    context 'when the user version can be restorerd' do
+      let(:user_version) { 2 }
+      let(:user_version_restorable) { true }
+
+      it 'the restore button is displayed' do
+        expect(page).to have_link 'Restore', href: '/items/druid:kv840xx0000/user_versions/2/restore'
       end
     end
   end

--- a/spec/components/version_milestones_component_spec.rb
+++ b/spec/components/version_milestones_component_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 RSpec.describe VersionMilestonesComponent, type: :component do
   subject(:instance) do
     described_class.new(version: 2,
-                        milestones_presenter:)
+                        milestones_presenter:,
+                        user_versions_presenter:)
     # title: '2 (2.0.0) Add collection, set rights to citations',
     # steps:)
   end
@@ -14,10 +15,10 @@ RSpec.describe VersionMilestonesComponent, type: :component do
     instance_double(MilestonesPresenter,
                     steps_for: steps,
                     version_title: '2 (2.0.0) Add collection, set rights to citations',
-                    user_version_for: user_version,
                     current_version:,
                     druid: 'druid:mk420bs7601')
   end
+  let(:user_versions_presenter) { instance_double(UserVersionsPresenter, user_version_for: user_version) }
   let(:user_version) { nil }
   let(:current_version) { 2 }
 
@@ -33,7 +34,7 @@ RSpec.describe VersionMilestonesComponent, type: :component do
       expect(page).to have_css 'tr.version2', count: 2
       expect(milestones_presenter).to have_received(:steps_for).with(2)
       expect(milestones_presenter).to have_received(:version_title).with(2)
-      expect(milestones_presenter).to have_received(:user_version_for).with(2)
+      expect(user_versions_presenter).to have_received(:user_version_for).with(2)
     end
   end
 

--- a/spec/presenters/milestones_presenter_spec.rb
+++ b/spec/presenters/milestones_presenter_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe MilestonesPresenter do
   subject(:presenter) do
-    described_class.new(druid: 'druid:mk420bs7601')
+    described_class.new(druid: 'druid:mk420bs7601', version_inventory: versions)
   end
 
   let(:milestone2) do
@@ -34,16 +34,8 @@ RSpec.describe MilestonesPresenter do
     ]
   end
 
-  let(:user_versions) do
-    [
-      Dor::Services::Client::UserVersion::Version.new(version: 2, userVersion: 1)
-    ]
-  end
-
   before do
     allow(MilestoneService).to receive(:milestones_for).and_return(milestones)
-    allow(Dor::Services::Client).to receive_message_chain(:object, :version, :inventory).and_return(versions) # rubocop:disable RSpec/MessageChain
-    allow(Dor::Services::Client).to receive_message_chain(:object, :user_version, :inventory).and_return(user_versions) # rubocop:disable RSpec/MessageChain
   end
 
   describe '#each_version' do
@@ -78,17 +70,5 @@ RSpec.describe MilestonesPresenter do
     subject { presenter.steps_for('2') }
 
     it { is_expected.to eq milestone2 }
-  end
-
-  describe '#user_version_for' do
-    subject { presenter.user_version_for('2') }
-
-    it { is_expected.to eq 1 }
-  end
-
-  describe '#head_user_version' do
-    subject { presenter.head_user_version }
-
-    it { is_expected.to eq '1' }
   end
 end

--- a/spec/presenters/user_versions_presenter_spec.rb
+++ b/spec/presenters/user_versions_presenter_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UserVersionsPresenter do
+  subject(:presenter) do
+    described_class.new(user_version:, user_version_inventory:)
+  end
+
+  let(:user_version) { '1' }
+  let(:user_version_inventory) do
+    [
+      Dor::Services::Client::UserVersion::Version.new(userVersion: '1', version: '3', withdrawable: false, restorable: true),
+      Dor::Services::Client::UserVersion::Version.new(userVersion: '2', version: '4', withdrawable: true, restorable: false)
+    ]
+  end
+
+  describe '#user_version_for' do
+    subject { presenter.user_version_for(version) }
+
+    context 'when the version is found' do
+      let(:version) { '3' }
+
+      it { is_expected.to eq '1' }
+    end
+
+    context 'when the version is not found' do
+      let(:version) { '5' }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#valid_user_version?' do
+    subject { presenter.valid_user_version? }
+
+    context 'when the user version is valid' do
+      let(:user_version) { '1' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the user version is nil' do
+      let(:user_version) { nil }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the user version is invalid' do
+      let(:user_version) { '3' }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#user_version_withdrawable?' do
+    subject { presenter.user_version_withdrawable? }
+
+    context 'when the user version is withdrawable' do
+      let(:user_version) { '1' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when the user version is not withdrawable' do
+      let(:user_version) { '2' }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '#user_version_restorable?' do
+    subject { presenter.user_version_restorable? }
+
+    context 'when the user version is restorable' do
+      let(:user_version) { '2' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when the user version is not restorable' do
+      let(:user_version) { '1' }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '#head_user_version' do
+    subject { presenter.head_user_version }
+
+    it { is_expected.to eq '2' }
+  end
+end


### PR DESCRIPTION
closes #4528

# Why was this change made?
So that users can hide / restore user versions.

# How was this change tested?
Unit, Stage

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


