### PR TITLE
Bump version of erb_lint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem 'sdr-client', '~> 2.0'
 
 group :test, :development do
   gem 'debug'
-  gem 'erb_lint', '~> 0.4.0', require: false
+  gem 'erb_lint', '~> 0.5.0', require: false
   gem 'factory_bot_rails'
   gem 'http_logger', require: false # Change this to `true` to see all http requests logged
   gem 'pry-remote' # allows you to attach remote session to pry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,7 +245,7 @@ GEM
       activesupport (>= 3.0, < 8.0)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
-    erb_lint (0.4.0)
+    erb_lint (0.5.0)
       activesupport
       better_html (>= 2.0.1)
       parser (>= 2.7.1.4)
@@ -692,7 +692,7 @@ DEPENDENCIES
   druid-tools
   dry-monads
   equivalent-xml (>= 0.6.0)
-  erb_lint (~> 0.4.0)
+  erb_lint (~> 0.5.0)
   factory_bot_rails
   faraday
   faraday-multipart


### PR DESCRIPTION
# Why was this change made?
Avoids a bunch of deprecation warnings.

