### PR TITLE
Change to user version links in version history list.

### DIFF
--- a/app/components/version_milestones_component.html.erb
+++ b/app/components/version_milestones_component.html.erb
@@ -1,6 +1,6 @@
 <tr class="version<%= version %>">
  <td colspan="3">-
-   <%= title %><% if user_version %> (<%= current_version? ? user_version_label : link_to(user_version_label, user_version_path) %>)<% end %>
+   <%= title %><% if user_version %> (<%= user_version_link_or_label %>)<% end %>
  </td>
 </tr>
 

--- a/app/components/version_milestones_component.rb
+++ b/app/components/version_milestones_component.rb
@@ -15,12 +15,28 @@ class VersionMilestonesComponent < ViewComponent::Base
     @steps ||= milestones_presenter.steps_for(version)
   end
 
-  def current_version?
-    version.to_i == milestones_presenter.current_version
+  def link_user_version?
+    return false if version.to_i == milestones_presenter.current_version.to_i
+    return false if user_version == user_versions_presenter.user_version.to_i
+
+    true
+  end
+
+  def link_to_document?
+    version.to_i == milestones_presenter.current_version.to_i \
+     && user_version == user_versions_presenter.head_user_version&.to_i \
+     && user_versions_presenter.user_version.present?
+  end
+
+  def user_version_link_or_label
+    return link_to(user_version_label, user_version_path) if link_user_version?
+    return link_to(user_version_label, solr_document_path(milestones_presenter.druid)) if link_to_document?
+
+    user_version_label
   end
 
   def user_version
-    @user_version ||= user_versions_presenter.user_version_for(version)
+    @user_version ||= user_versions_presenter.user_version_for(version)&.to_i
   end
 
   def user_version_path

--- a/spec/components/version_milestones_component_spec.rb
+++ b/spec/components/version_milestones_component_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe VersionMilestonesComponent, type: :component do
     described_class.new(version: 2,
                         milestones_presenter:,
                         user_versions_presenter:)
-    # title: '2 (2.0.0) Add collection, set rights to citations',
-    # steps:)
   end
 
   let(:milestones_presenter) do
@@ -18,7 +16,7 @@ RSpec.describe VersionMilestonesComponent, type: :component do
                     current_version:,
                     druid: 'druid:mk420bs7601')
   end
-  let(:user_versions_presenter) { instance_double(UserVersionsPresenter, user_version_for: user_version) }
+  let(:user_versions_presenter) { instance_double(UserVersionsPresenter, user_version_for: user_version, user_version: 1, head_user_version: 3) }
   let(:user_version) { nil }
   let(:current_version) { 2 }
 
@@ -51,12 +49,23 @@ RSpec.describe VersionMilestonesComponent, type: :component do
   end
 
   context 'when the accessioned milestone has user version' do
-    let(:user_version) { 1 }
+    let(:user_version) { 2 }
     let(:current_version) { 3 }
 
     it 'renders link to user version' do
       render_inline(instance)
-      expect(page).to have_link 'Public version 1', href: '/items/druid:mk420bs7601/user_versions/1'
+      expect(page).to have_link 'Public version 2', href: '/items/druid:mk420bs7601/user_versions/2'
+    end
+  end
+
+  context 'when the accessioned milestone has user version and that is the current version being displayed' do
+    let(:user_version) { 1 }
+    let(:current_version) { 3 }
+
+    it 'renders the user version but not as a link' do
+      render_inline(instance)
+      expect(page).to have_text 'Public version 1'
+      expect(page).to have_no_link 'Public version 1', href: '/items/druid:mk420bs7601/user_versions/1'
     end
   end
 
@@ -67,6 +76,16 @@ RSpec.describe VersionMilestonesComponent, type: :component do
       render_inline(instance)
       expect(page).to have_text 'Public version 2'
       expect(page).to have_no_link 'Public version 2', href: '/items/druid:mk420bs7601/user_versions/2'
+    end
+  end
+
+  context 'when the accessioned milestone has user version that is head version' do
+    let(:user_version) { 3 }
+
+    it 'renders the user version as a link to document path' do
+      render_inline(instance)
+      expect(page).to have_text 'Public version 3'
+      expect(page).to have_no_link 'Public version 3', href: '/items/druid:mk420bs7601'
     end
   end
 end


### PR DESCRIPTION
closes #4548

# Why was this change made?
Per @andrewjbtw 
<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?
Unit, Andrew
<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


