### PR TITLE
Remove unecessary table style

### DIFF
--- a/app/assets/stylesheets/argo.scss
+++ b/app/assets/stylesheets/argo.scss
@@ -24,11 +24,6 @@
   }
 }
 
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
-}
-
 legend {
   border: 0;
 }


### PR DESCRIPTION


# Why was this change made?

Bootstrap already provides collapse.  border-spacing is only relevant when border-collapse is separate



