### PR TITLE
Use the bootstrap way to border tables

### DIFF
--- a/app/assets/stylesheets/bootstrap-overrides.scss
+++ b/app/assets/stylesheets/bootstrap-overrides.scss
@@ -15,4 +15,5 @@
 
 :root {
   --bs-primary-rgb: 140, 21, 21; /* Stanford cardinal; for the header */
+  --bs-table-border-color: var(--stanford-30-black);
 }

--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -147,10 +147,6 @@
     }
   }
 
-  .table {
-    border: 1px solid $silver-sand;
-  }
-
   .header {
     font-weight: 700;
     font-size: x-large;
@@ -166,7 +162,7 @@
   .caption-header > caption {
     caption-side: top;
     @extend .header;
-    background-color: $silver-sand;
+    background-color: var(--bs-table-border-color);
     color: $body-color;
   }
 

--- a/app/assets/stylesheets/sul_variables.scss
+++ b/app/assets/stylesheets/sul_variables.scss
@@ -4,7 +4,6 @@ $color-cardinal-red: #8c1515;
 
 $blue: #00548f; // Digital blue dark in Stanford brand identity
 $bright-blue: #006cb8; // Digital blue in Stanford brand identity
-$silver-sand: #c0c0bf; // "30% black" in Stanford brand identity
 $sonic-silver: #767674; // "60% black" in Stanford brand identity
 $illuminating-light: #ffe781;
 $sky-light: #67afd2;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -16,6 +16,3 @@ $accordion-button-active-color: $white;
 $accordion-button-active-bg: $sonic-silver;
 $accordion-button-focus-box-shadow: 0 0 0.25rem 0.25rem
   rgba($sonic-silver, 0.25);
-
-// Table
-$table-border-color: $silver-sand;

--- a/app/components/show/agreement/details_component.html.erb
+++ b/app/components/show/agreement/details_component.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-sm mb-5 caption-header">
+<table class="table table-sm mb-5 caption-header border">
     <caption>Details</caption>
     <tbody>
       <tr>

--- a/app/components/show/agreement/overview_component.html.erb
+++ b/app/components/show/agreement/overview_component.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-sm mb-5 caption-header">
+<table class="table table-sm mb-5 caption-header border">
     <caption>Overview</caption>
     <tbody>
       <tr>

--- a/app/components/show/apo/default_object_rights_component.html.erb
+++ b/app/components/show/apo/default_object_rights_component.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-sm mb-5 caption-header">
+<table class="table table-sm mb-5 caption-header border">
     <caption>Default object rights</caption>
     <tbody>
       <tr>

--- a/app/components/show/apo/details_component.html.erb
+++ b/app/components/show/apo/details_component.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-sm mb-5 caption-header">
+<table class="table table-sm mb-5 caption-header border">
     <caption>Details</caption>
     <tbody>
       <tr>

--- a/app/components/show/apo/overview_component.html.erb
+++ b/app/components/show/apo/overview_component.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-sm mb-5 caption-header">
+<table class="table table-sm mb-5 caption-header border">
     <caption>Overview</caption>
     <tbody>
       <tr>

--- a/app/components/show/apo/roles_component.html.erb
+++ b/app/components/show/apo/roles_component.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-sm mb-5">
+<table class="table table-sm mb-5 border">
     <thead class="table-light">
       <tr>
         <th>Group name</th>

--- a/app/components/show/collection/details_component.html.erb
+++ b/app/components/show/collection/details_component.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-sm mb-5 caption-header">
+<table class="table table-sm mb-5 caption-header border">
     <caption>Details</caption>
     <tbody>
       <tr>

--- a/app/components/show/collection/overview_component.html.erb
+++ b/app/components/show/collection/overview_component.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-sm mb-5 caption-header">
+<table class="table table-sm mb-5 caption-header border">
     <caption>Overview</caption>
     <tbody>
       <tr>

--- a/app/components/show/item/details_component.html.erb
+++ b/app/components/show/item/details_component.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-sm mb-5 caption-header">
+<table class="table table-sm mb-5 caption-header border">
     <caption>Details</caption>
     <tbody>
       <tr>

--- a/app/components/show/item/overview_component.html.erb
+++ b/app/components/show/item/overview_component.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-sm mb-5 caption-header">
+<table class="table table-sm mb-5 caption-header border">
     <caption>Overview</caption>
     <tbody>
       <tr>


### PR DESCRIPTION
# Why was this change made?

We move away from using SASS and toward the way bootstrap styles tables.

