### PR TITLE
Remove unnecessary style

### DIFF
--- a/app/assets/stylesheets/bulk-actions.scss
+++ b/app/assets/stylesheets/bulk-actions.scss
@@ -1,9 +1,4 @@
 .new_bulk_action {
-  .tab-pane {
-    @extend .mt-3;
-    @extend .mb-3;
-  }
-
   .help-block {
     font-weight: bold;
   }


### PR DESCRIPTION


# Why was this change made?

the .tab_pane contains the .new_bulk_action, not the other way around

