### PR TITLE
We no longer have the .small class within .argo-show-btn-group

### DIFF
--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -44,10 +44,6 @@
       min-width: $button-width;
       margin-right: 0.5rem;
       margin-bottom: 0.5rem;
-
-      &.small {
-        @extend .small;
-      }
     }
   }
 


### PR DESCRIPTION
# Why was this change made?
cleanup.
