### PR TITLE
Explicitly write bootstrap 5 error classes rather than using sass

### DIFF
--- a/app/assets/stylesheets/errors.scss
+++ b/app/assets/stylesheets/errors.scss
@@ -1,7 +1,3 @@
-.field_with_errors > input {
-  @extend .is-invalid;
-}
-
 #error_explanation {
   border: 2px solid $danger;
   padding: 7px 7px 0;


### PR DESCRIPTION


# Why was this change made?

Sass makes it harder to know where this css is being used. We can decouple from sass.

