### PR TITLE
Discard empty stylesheet partial

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,7 +19,6 @@
 @import "show";
 @import "impersonate_groups";
 @import "workflow_grid";
-@import "throbber";
 @import "tags-autocomplete";
 @import "registration";
 @import "text-extraction";

--- a/app/assets/stylesheets/throbber.scss
+++ b/app/assets/stylesheets/throbber.scss
@@ -1,1 +1,0 @@
-// this is a throbber for the workflow grid


### PR DESCRIPTION
# Why was this change made?

No need to include an empty file.



