### PR TITLE
Remove unnecessary css rule

### DIFF
--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -122,7 +122,6 @@
       }
 
       .resource-files {
-        background-color: $body-bg;
         margin-left: 0.5rem;
         margin-right: 0.5rem;
 


### PR DESCRIPTION


# Why was this change made?

Bootstrap already sets the table background to white, we don't need to do it again


