### PR TITLE
Use the bootstrap is-invalid class directly

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,5 +19,4 @@
 @import "impersonate_groups";
 @import "workflow_grid";
 @import "tags-autocomplete";
-@import "registration";
 @import "text-extraction";

--- a/app/assets/stylesheets/registration.scss
+++ b/app/assets/stylesheets/registration.scss
@@ -1,3 +1,0 @@
-.invalid {
-  @extend .is-invalid;
-}

--- a/app/javascript/controllers/registration_controller.js
+++ b/app/javascript/controllers/registration_controller.js
@@ -4,6 +4,6 @@ export default class extends Controller {
   // If the field is marked as invalid, then show the invalid (bootstrap) style.
   displayValidation (event) {
     const field = event.target
-    field.classList.toggle('invalid', !field.validity.valid)
+    field.classList.toggle('is-invalid', !field.validity.valid)
   }
 }

--- a/app/javascript/controllers/registration_item_row_controller.js
+++ b/app/javascript/controllers/registration_item_row_controller.js
@@ -23,10 +23,10 @@ export default class extends Controller {
     if (currentSourceId === '') { return }
 
     if (field.validity.patternMismatch) {
-      field.classList.toggle('invalid', !field.validity.valid)
+      field.classList.toggle('is-invalid', !field.validity.valid)
     } else if (this.isDuplicateSourceId(currentSourceId)) {
       this.setValidation(field, 'Duplicate source ID on this form')
-      field.classList.add('invalid')
+      field.classList.add('is-invalid')
     } else {
       this.clearValidation(field) // all other checks passed
 
@@ -39,7 +39,7 @@ export default class extends Controller {
           } else {
             this.clearValidation(field)
           }
-          field.classList.toggle('invalid', !field.validity.valid)
+          field.classList.toggle('is-invalid', !field.validity.valid)
         })
     }
   }
@@ -47,7 +47,7 @@ export default class extends Controller {
   validateBarcode () {
     const field = this.barcodeTarget
     if (field.validity.patternMismatch) {
-      field.classList.toggle('invalid', !field.validity.valid)
+      field.classList.toggle('is-invalid', !field.validity.valid)
     } else {
       this.clearValidation(field)
     }
@@ -60,7 +60,7 @@ export default class extends Controller {
     if (currentCatalogRecordId === '') { return }
 
     if (field.validity.patternMismatch) {
-      field.classList.toggle('invalid', !field.validity.valid)
+      field.classList.toggle('is-invalid', !field.validity.valid)
     } else {
       // Only check if the format is valid
       this.clearValidation(field)
@@ -77,7 +77,7 @@ export default class extends Controller {
           if (!data) {
             this.setValidation(field, 'Not found in catalog')
           }
-          field.classList.toggle('invalid', !field.validity.valid)
+          field.classList.toggle('is-invalid', !field.validity.valid)
         })
         .catch((error) => {
           this.setValidation(field, error.message)
@@ -91,7 +91,7 @@ export default class extends Controller {
       field.required = true
     } else {
       field.required = false
-      field.classList.toggle('invalid', false)
+      field.classList.toggle('is-invalid', false)
     }
   }
 

--- a/app/javascript/controllers/tag_validation_controller.js
+++ b/app/javascript/controllers/tag_validation_controller.js
@@ -10,7 +10,7 @@ export default class extends Controller {
   validate () {
     const parts = this.element.value.trim().split(/\s*:\s*/)
     this.element.value = parts.join(' : ')
-    this.element.classList.toggle('invalid', this.is_invalid(parts))
+    this.element.classList.toggle('is-invalid', this.is_invalid(parts))
   }
 
   is_invalid (parts) {

--- a/spec/features/item_registration_spec.rb
+++ b/spec/features/item_registration_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe 'Item registration page', :js do
 
       click_button 'Register'
 
-      expect(page).to have_css('.invalid')
+      expect(page).to have_css('.is-invalid')
       expect(page).to have_no_content 'Items successfully registered.'
     end
   end
@@ -201,7 +201,7 @@ RSpec.describe 'Item registration page', :js do
 
       click_button 'Register'
 
-      expect(page).to have_css('.invalid')
+      expect(page).to have_css('.is-invalid')
       expect(page).to have_no_content 'Items successfully registered.'
     end
   end


### PR DESCRIPTION


# Why was this change made?

This avoids sass indirection that does the same thing



