### PR TITLE
Stop setting --bs-primary-rgb

### DIFF
--- a/app/assets/stylesheets/bootstrap-overrides.scss
+++ b/app/assets/stylesheets/bootstrap-overrides.scss
@@ -15,6 +15,5 @@
 }
 
 :root {
-  --bs-primary-rgb: 140, 21, 21; /* Stanford cardinal; for the header */
   --bs-table-border-color: var(--stanford-30-black);
 }

--- a/app/assets/stylesheets/text-extraction.scss
+++ b/app/assets/stylesheets/text-extraction.scss
@@ -6,7 +6,8 @@
   padding-right: 0.45rem;
 
   .language-label {
-    border-inline-end: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color);
+    border-inline-end: var(--bs-border-width) var(--bs-border-style)
+      var(--bs-border-color);
     font-size: 0.875em;
     line-height: 1.45em;
     padding-block: 0.1rem;
@@ -15,7 +16,7 @@
   }
 
   .pill-close {
-    font-size: .6rem;
+    font-size: 0.6rem;
   }
 }
 
@@ -34,11 +35,12 @@
 }
 
 .text-cardinal {
-  color: var(--bs-primary);
+  color: var(--stanford-cardinal);
 }
 
 .text-extraction-search-bar {
-  input, input:focus {
+  input,
+  input:focus {
     border: none;
     outline: none;
   }


### PR DESCRIPTION


# Why was this change made?

We no longer set the header this way.  Ensure that .text-cardinal still works

