### PR TITLE
Use components from the component-library

### DIFF
--- a/app/assets/stylesheets/text-extraction.scss
+++ b/app/assets/stylesheets/text-extraction.scss
@@ -1,25 +1,3 @@
-.language-pill {
-  gap: 0.35rem;
-  display: inline-flex;
-  align-items: center;
-  padding-left: 0.55rem;
-  padding-right: 0.45rem;
-
-  .language-label {
-    border-inline-end: var(--bs-border-width) var(--bs-border-style)
-      var(--bs-border-color);
-    font-size: 0.875em;
-    line-height: 1.45em;
-    padding-block: 0.1rem;
-    padding-inline-end: 0.45rem;
-    text-wrap: nowrap;
-  }
-
-  .pill-close {
-    font-size: 0.6rem;
-  }
-}
-
 .dropdown-content {
   background-color: #f1f1f1;
   overflow-y: auto;

--- a/app/javascript/controllers/text_extraction_controller.js
+++ b/app/javascript/controllers/text_extraction_controller.js
@@ -80,11 +80,14 @@ export default class extends Controller {
     return this.languagesValue.map((language) => {
       return `
         <li class="d-inline-flex gap-2 align-items-center my-2">
-          <span class="bg-light rounded-pill border language-pill">
-            <span class="language-label">
-              ${language.textExtractionLabel}
-            </span>
-            <button data-action="${this.identifier}#deselect" id="${language.textExtractionValue}" type="button" class="btn-close py-0 pill-close" aria-label="Remove ${language.textExtractionLabel}"></button>
+          <span class="bg-light badge rounded-pill border selected-item">
+            <span class="selected-item-label">${language.textExtractionLabel}</span>
+            <button
+              type="button"
+              data-action="${this.identifier}#deselect" id="${language.textExtractionValue}"
+              class="btn-close"
+              aria-label="Remove ${language.textExtractionLabel}"
+            ></button>
           </span>
         </li>
       `

--- a/app/views/bulk_actions/text_extraction_jobs/_new.html.erb
+++ b/app/views/bulk_actions/text_extraction_jobs/_new.html.erb
@@ -3,9 +3,12 @@
     <%= render 'bulk_actions/errors' %>
 
     <span class='help-block'>Start text extraction workflow for the selected items.</span>
-    <div class="mt-2 alert alert-warning">
-      <p>Auto-generating OCR files will not overwrite any existing OCR files that have been corrected to comply with accessibility standards. <strong>Any uncorrected OCR files will be overwritten.</strong> The originally-deposited contents will not be overwritten.</p>
-      <p>Warning: Avoid auto-generating OCR files for contents that do not contain any text, as it may have adverse effects.</p>
+    <div class="mt-2 alert alert-warning d-flex shadow-sm align-items-center">
+      <i class="bi bi-exclamation-triangle-fill fs-3 me-3"></i>
+      <div class="text-body">
+        <p>Auto-generating OCR files will not overwrite any existing OCR files that have been corrected to comply with accessibility standards. <strong>Any uncorrected OCR files will be overwritten.</strong> The originally-deposited contents will not be overwritten.</p>
+        <p>Warning: Avoid auto-generating OCR files for contents that do not contain any text, as it may have adverse effects.</p>
+      </div>
     </div>
 
     <span class='form-text'>

--- a/spec/requests/text_extraction_spec.rb
+++ b/spec/requests/text_extraction_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe 'TextExtractions', :js do
       find('[data-text-extraction-label="Adyghe"]').click
 
       expect(page).to have_css 'div', text: 'Selected language(s)'
-      expect(page.all('.language-label').count).to eq 1
+      expect(page.all('.selected-item-label').count).to eq 1
 
       find('[data-text-extraction-label="English"]').click
-      expect(page.all('.language-label').count).to eq 2
+      expect(page.all('.selected-item-label').count).to eq 2
     end
   end
 


### PR DESCRIPTION
# Why was this change made?

So we don't need duplicate stylesheets.