### PR TITLE
Upgrade Rspec-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ group :test, :development do
   gem 'factory_bot_rails'
   gem 'http_logger', require: false # Change this to `true` to see all http requests logged
   gem 'pry-remote' # allows you to attach remote session to pry
-  gem 'rspec-rails', '~> 5.0'
+  gem 'rspec-rails', '~> 6.1'
   gem 'rubocop-capybara'
   gem 'rubocop-factory_bot'
   gem 'rubocop-performance'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -524,14 +524,14 @@ GEM
     rspec-mocks (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-rails (5.1.2)
-      actionpack (>= 5.2)
-      activesupport (>= 5.2)
-      railties (>= 5.2)
-      rspec-core (~> 3.10)
-      rspec-expectations (~> 3.10)
-      rspec-mocks (~> 3.10)
-      rspec-support (~> 3.10)
+    rspec-rails (6.1.3)
+      actionpack (>= 6.1)
+      activesupport (>= 6.1)
+      railties (>= 6.1)
+      rspec-core (~> 3.13)
+      rspec-expectations (~> 3.13)
+      rspec-mocks (~> 3.13)
+      rspec-support (~> 3.13)
     rspec-support (3.13.1)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
@@ -721,7 +721,7 @@ DEPENDENCIES
   roo (~> 2.9.0)
   roo-xls
   rsolr
-  rspec-rails (~> 5.0)
+  rspec-rails (~> 6.1)
   rspec_junit_formatter
   rubocop-capybara
   rubocop-factory_bot


### PR DESCRIPTION
# Why was this change made?

Required before upgrading to Rails 7.1

