### PR TITLE
Update cocina-models

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GEM
       capybara (>= 1.0, < 4)
       launchy
     childprocess (5.0.0)
-    cocina-models (0.98.1)
+    cocina-models (0.99.0)
       activesupport
       deprecation
       dry-struct (~> 1.0)
@@ -157,10 +157,10 @@ GEM
       thor
       zeitwerk (~> 2.1)
     coderay (1.1.3)
-    commonmarker (1.1.4)
+    commonmarker (1.1.5)
       rb_sys (~> 0.9)
-    commonmarker (1.1.4-x86_64-darwin)
-    commonmarker (1.1.4-x86_64-linux)
+    commonmarker (1.1.5-x86_64-darwin)
+    commonmarker (1.1.5-x86_64-linux)
     concurrent-ruby (1.3.3)
     config (5.5.1)
       deep_merge (~> 1.2, >= 1.2.1)
@@ -201,9 +201,9 @@ GEM
       ed25519
     docile (1.4.1)
     domain_name (0.6.20240107)
-    dor-services-client (14.19.0)
+    dor-services-client (14.20.0)
       activesupport (>= 4.2, < 8)
-      cocina-models (~> 0.98.0)
+      cocina-models (~> 0.99.0)
       deprecation
       faraday (~> 2.0)
       faraday-retry
@@ -438,7 +438,7 @@ GEM
     purl_fetcher-client (1.5.4)
       activesupport
       faraday (~> 2.1)
-    racc (1.8.0)
+    racc (1.8.1)
     rack (2.2.9)
     rack-test (2.1.0)
       rack (>= 1.3)
@@ -479,7 +479,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rb_sys (0.9.99)
+    rb_sys (0.9.100)
     rdoc (6.7.0)
       psych (>= 4.0.0)
     redis-client (0.22.2)
@@ -569,9 +569,9 @@ GEM
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
     scrub_rb (1.0.1)
-    sdr-client (2.16.0)
+    sdr-client (2.17.0)
       activesupport
-      cocina-models (~> 0.98.0)
+      cocina-models (~> 0.99.0)
       config
       dry-monads
       faraday (>= 0.16)
@@ -658,7 +658,7 @@ GEM
       rubyzip (>= 1.0.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.16)
+    zeitwerk (2.6.17)
     zip_tricks (5.6.0)
 
 PLATFORMS


### PR DESCRIPTION
# Why was this change made?

Fixes the argo build. DSA expects this version.

