### PR TITLE
Add missing method mocks

### DIFF
--- a/spec/features/item_source_id_change_spec.rb
+++ b/spec/features/item_source_id_change_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Item source id change' do
   describe 'when modification is not allowed' do
     let(:item) { FactoryBot.create_for_repository(:persisted_item) }
     let(:druid) { item.externalIdentifier }
-    let(:version_service) { instance_double(VersionService, open_and_not_assembling?: false, open?: false) }
+    let(:version_service) { instance_double(VersionService, open_and_not_assembling?: false, closed?: true, open?: false) }
 
     before do
       allow(WorkflowService).to receive(:accessioned?).and_return(false)
@@ -33,7 +33,7 @@ RSpec.describe 'Item source id change' do
     let(:cocina_model) do
       build(:dro_with_metadata, id: druid)
     end
-    let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true, open?: true) }
+    let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true, closed?: false, open?: true) }
     let(:events_client) { instance_double(Dor::Services::Client::Events, list: []) }
     let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
     let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: []) }

--- a/spec/features/item_view_spec.rb
+++ b/spec/features/item_view_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Item view', :js do
                                             release: true)
     ]
   end
-  let(:version_service) { instance_double(VersionService, open?: true, openable?: false, open_and_not_assembling?: true) }
+  let(:version_service) { instance_double(VersionService, open?: true, openable?: false, closeable?: true, open_and_not_assembling?: true) }
 
   context 'when navigating to an object' do
     before do

--- a/spec/features/update_serials_metadata_spec.rb
+++ b/spec/features/update_serials_metadata_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Update serials metadata', :js do
   let(:item) do
     FactoryBot.create_for_repository(:persisted_item)
   end
-  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true, open?: true) }
+  let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true, open?: true, closeable?: true) }
 
   before do
     allow(VersionService).to receive(:new).and_return(version_service)


### PR DESCRIPTION
# Why was this change made?

There are errors in the test suite like:
```
       #<InstanceDouble(VersionService) (anonymous)> received unexpected message :closeable? with (no args)
```

but `spec/support/feature_errors.rb` is masking them.

# How was this change tested?

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


