### PR TITLE
Enable newly available rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -550,3 +550,9 @@ RSpec/EmptyOutput: # new in 2.29
   Enabled: true
 RSpec/UndescriptiveLiteralsDescription: # new in 2.29
   Enabled: true
+Gemspec/AddRuntimeDependency: # new in 1.65
+  Enabled: true
+Style/SendWithLiteralMethodName: # new in 1.64
+  Enabled: true
+Style/SuperArguments: # new in 1.64
+  Enabled: true


### PR DESCRIPTION
# Why was this change made?
Remove warnings.