### PR TITLE
Update version banner with link to latest

### DIFF
--- a/app/components/document_title_component.html.erb
+++ b/app/components/document_title_component.html.erb
@@ -1,7 +1,15 @@
 <header class="document-header mb-5 pb-3">
   <% if version_banner %>
-    <div class="alert alert-warning" role="alert">
-      <%= version_banner %>
+    <div class="alert alert-warning d-flex shadow-sm align-items-center" role="alert">
+      <i class="bi bi-exclamation-triangle-fill fs-3 me-3"></i>
+      <div class="text-body">
+        <%= version_banner %>
+        <% if show_latest_link? %>
+          <div class="text-body">
+              <%= link_to('View latest version', solr_document_path(@document.id)) %>
+          </div>
+        <% end %>
+      </div>
     </div>
   <% end %>
   <div class="row">
@@ -15,9 +23,4 @@
       <%= object_type_label %>
     </div>
   </div>
-  <% if version_or_user_version_view? %>
-    <p>
-      <%= link_to('Back to current', solr_document_path(@document.id)) %>
-    </p>
-  <% end %>
 </header>

--- a/app/components/document_title_component.rb
+++ b/app/components/document_title_component.rb
@@ -15,8 +15,20 @@ class DocumentTitleComponent < Blacklight::DocumentTitleComponent
   def version_banner
     return 'You are viewing the latest version.' if @presenter.head_user_version_view? || @presenter.current_version_view?
 
-    'You are viewing an older version.' if version_or_user_version_view?
+    "You are viewing an older #{version_type} version." if version_or_user_version_view?
   end
 
-  delegate :version_or_user_version_view?, to: :@presenter
+  def show_latest_link?
+    return previous_user_version_view? if @presenter.user_version_view?
+
+    !current_version_view?
+  end
+
+  def version_type
+    return 'public' if @presenter.user_version_view?
+
+    'system' if @presenter.version_view?
+  end
+
+  delegate :version_or_user_version_view?, :previous_user_version_view?, :current_version_view?, to: :@presenter
 end

--- a/spec/components/document_title_component_spec.rb
+++ b/spec/components/document_title_component_spec.rb
@@ -21,6 +21,9 @@ RSpec.describe DocumentTitleComponent, type: :component do
                                        head_user_version:,
                                        head_user_version_view?: user_version.present? && user_version == head_user_version,
                                        version_view: version,
+                                       version_view?: version.present?,
+                                       user_version_view?: user_versions_presenter.present? && user_version_view.present?,
+                                       previous_user_version_view?: user_version.present? && user_version_view != head_user_version,
                                        current_version:,
                                        current_version_view?: version.present? && version == current_version,
                                        version_or_user_version_view?: version.present? || user_version.present?)
@@ -29,6 +32,8 @@ RSpec.describe DocumentTitleComponent, type: :component do
   let(:head_user_version) { nil }
   let(:version) { nil }
   let(:current_version) { nil }
+  let(:user_versions_presenter) { nil }
+  let(:user_version_view) { nil }
   let(:rendered) { render_inline(component) }
 
   before do
@@ -90,30 +95,37 @@ RSpec.describe DocumentTitleComponent, type: :component do
       expect(rendered.css('div.object-type').first.classes).to include('object-type-item')
     end
 
-    context 'with a user version' do
+    context 'with a previous user version' do
       let(:user_version) { '2' }
       let(:head_user_version) { '3' }
+      let(:user_version_view) { '2' }
+      let(:user_versions_presenter) { instance_double(UserVersionsPresenter, present?: true) }
 
       it 'renders the expected user version label' do
-        expect(rendered.content).to include('You are viewing an older version.')
+        expect(rendered.content).to include('You are viewing an older public version.')
+        expect(rendered.content).to include('View latest version')
       end
     end
 
     context 'with a head user version' do
       let(:user_version) { '2' }
       let(:head_user_version) { '2' }
+      let(:user_version_view) { '2' }
+      let(:user_versions_presenter) { instance_double(UserVersionsPresenter, present?: true) }
 
       it 'renders the expected user version label' do
         expect(rendered.content).to include('You are viewing the latest version.')
+        expect(rendered.content).not_to include('View latest version')
       end
     end
 
-    context 'with a version' do
+    context 'with a previous version' do
       let(:version) { '2' }
       let(:current_version) { '3' }
 
       it 'renders the expected version label' do
-        expect(rendered.content).to include('You are viewing an older version.')
+        expect(rendered.content).to include('You are viewing an older system version.')
+        expect(rendered.content).to include('View latest version')
       end
     end
 
@@ -123,6 +135,7 @@ RSpec.describe DocumentTitleComponent, type: :component do
 
       it 'renders the expected version label' do
         expect(rendered.content).to include('You are viewing the latest version.')
+        expect(rendered.content).not_to include('View latest version')
       end
     end
   end

--- a/spec/features/user_version_view_spec.rb
+++ b/spec/features/user_version_view_spec.rb
@@ -190,13 +190,13 @@ RSpec.describe 'User version view', :js do
       }
     end
 
-    context 'when viewing the version' do
+    context 'when viewing the head user version' do
       it 'shows the user version' do
         visit item_user_version_path(item_id: druid, user_version_id: 2)
 
         expect(page).to have_content(title)
         expect(page).to have_content('You are viewing the latest version.')
-        expect(page).to have_link('Back to current', href: "/view/#{druid}")
+        expect(page).to have_no_content('View latest version')
         expect(page).to have_no_content('Technical metadata')
         # And nothing should be editable
         expect(page).to have_no_css('.bi-pencil')
@@ -208,6 +208,27 @@ RSpec.describe 'User version view', :js do
 
         expect(user_version_client).to have_received(:find).with('2').at_least(:once)
         expect(user_version_client).to have_received(:solr).with('2')
+      end
+    end
+
+    context 'when viewing an older user version' do
+      it 'shows the older version' do
+        visit item_user_version_path(item_id: druid, user_version_id: 1)
+
+        expect(page).to have_content(title)
+        expect(page).to have_content('You are viewing an older public version.')
+        expect(page).to have_link('View latest version', href: "/view/#{druid}")
+        expect(page).to have_no_content('Technical metadata')
+        # And nothing should be editable
+        expect(page).to have_no_css('.bi-pencil')
+        expect(page).to have_content('Older versions are not released')
+        expect(page).to have_no_css('.open-close') # Lock icon
+        expect(page).to have_no_link('Withdraw')
+        expect(page).to have_no_link('Restore')
+        expect(page).to have_link('image.jpg')
+
+        expect(user_version_client).to have_received(:find).with('1').at_least(:once)
+        expect(user_version_client).to have_received(:solr).with('1')
       end
     end
 

--- a/spec/features/version_view_spec.rb
+++ b/spec/features/version_view_spec.rb
@@ -195,12 +195,12 @@ RSpec.describe 'Version view', :js do
     end
 
     context 'when viewing the version' do
-      it 'shows the user version' do
+      it 'shows the current version' do
         visit item_version_path(item_id: druid, version_id: 2)
 
         expect(page).to have_content(title)
         expect(page).to have_content('You are viewing the latest version.')
-        expect(page).to have_link('Back to current', href: "/view/#{druid}")
+        expect(page).to have_no_content('View latest version')
         expect(page).to have_no_content('Technical metadata')
         # And nothing should be editable
         expect(page).to have_no_css('.bi-pencil')
@@ -213,6 +213,28 @@ RSpec.describe 'Version view', :js do
 
         expect(version_client).to have_received(:find).with('2').at_least(:once)
         expect(version_client).to have_received(:solr).with('2')
+      end
+    end
+
+    context 'when viewing an older version' do
+      it 'shows the older system version banner' do
+        visit item_version_path(item_id: druid, version_id: 1)
+
+        expect(page).to have_content(title)
+        expect(page).to have_content('You are viewing an older system version.')
+        expect(page).to have_link('View latest version', href: "/view/#{druid}")
+        expect(page).to have_no_content('Technical metadata')
+        # And nothing should be editable
+        expect(page).to have_no_css('.bi-pencil')
+        expect(page).to have_content('Older versions are not released')
+        expect(page).to have_no_css('.open-close') # Lock icon
+        expect(page).to have_no_link('Withdraw')
+        expect(page).to have_no_link('Restore')
+        expect(page).to have_text('image.jpg')
+        expect(page).to have_no_link('image.jpg')
+
+        expect(version_client).to have_received(:find).with('1').at_least(:once)
+        expect(version_client).to have_received(:solr).with('1')
       end
     end
 


### PR DESCRIPTION
# Why was this change made?
Resolves #4608. 

![Screenshot 2024-08-09 at 4 13 13 PM](https://github.com/user-attachments/assets/0e23dd42-41ff-4e55-8967-9a00a077dd44)

![Screenshot 2024-08-09 at 4 13 29 PM](https://github.com/user-attachments/assets/2ff7bbdb-0cc3-4181-9010-99ad16848749)


# How was this change tested?
Unit and deploy to QA.

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


