### PR TITLE
[HOLD] Link version to user version path when version has user version.

### DIFF
--- a/app/components/version_milestones_component.rb
+++ b/app/components/version_milestones_component.rb
@@ -32,6 +32,7 @@ class VersionMilestonesComponent < ViewComponent::Base
   end
 
   def version_link_or_label
+    return link_to(title, user_version_path) if user_version && link_user_version?
     return link_to(title, version_path) if link_version?
     return link_to(title, solr_document_path(druid)) if version_link_to_document?
 

--- a/spec/components/version_milestones_component_spec.rb
+++ b/spec/components/version_milestones_component_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe VersionMilestonesComponent, type: :component do
       expect(page).to have_css 'tr.version2', count: 2
       expect(milestones_presenter).to have_received(:steps_for).with(2)
       expect(milestones_presenter).to have_received(:version_title).with(2)
-      expect(user_versions_presenter).to have_received(:user_version_for).with(2)
+      expect(user_versions_presenter).to have_received(:user_version_for).with(2).twice
     end
   end
 
@@ -70,6 +70,7 @@ RSpec.describe VersionMilestonesComponent, type: :component do
 
     it 'renders link to user version' do
       render_inline(instance)
+      expect(page).to have_link '2 (2.0.0) Add collection, set rights to citations', href: '/items/druid:mk420bs7601/public_version/2'
       expect(page).to have_link 'Public version 2', href: '/items/druid:mk420bs7601/public_version/2'
     end
   end


### PR DESCRIPTION
closes #4631

# Why was this change made?
So that the user is linked to the more useful user version page instead of the less useful version page.
<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?
Unit, Andrew

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


