### PR TITLE
Make reports buttons blue

### DIFF
--- a/app/views/report/_document_list.html.erb
+++ b/app/views/report/_document_list.html.erb
@@ -6,8 +6,8 @@
      data-object-reporter-column-model-value='<%= Report::COLUMN_MODEL.to_json.html_safe %>'>
 
   <div class="mt-1 mb-1">
-    <button class="btn btn-outline-secondary" data-action="click->object-reporter#openColumnSelectorModal">Columns</button>
-    <a class="btn btn-outline-secondary" href="" target="_blank" data-action="click->object-reporter#downloadCSV">Download CSV</a>
+    <button class="btn btn-outline-primary" data-action="click->object-reporter#openColumnSelectorModal">Columns</button>
+    <a class="btn btn-outline-primary" href="" target="_blank" data-action="click->object-reporter#downloadCSV">Download CSV</a>
   </div>
 
   <div id="objectsTable"></div>


### PR DESCRIPTION
# Why was this change made?
Fixes #4630.

<img width="399" alt="Screenshot 2024-08-15 at 8 41 06 AM" src="https://github.com/user-attachments/assets/428db2d1-8a02-47ea-88a9-5aad90d44d5b">

These were the only buttons in Argo that were of style `btn-outline-secondary`. 

# How was this change tested?
Local/QA deploy
