### PR TITLE
Make reset message red

### DIFF
--- a/app/components/workflow_table_process_component.rb
+++ b/app/components/workflow_table_process_component.rb
@@ -74,7 +74,7 @@ class WorkflowTableProcessComponent < ApplicationComponent
                                reset_step: process
                              )
 
-    raw " | #{button_to('reset', report_reset_path(new_params), class: 'btn btn-link p-0')}"
+    raw " | #{button_to('reset', report_reset_path(new_params), class: 'btn btn-link p-0 text-danger')}"
   end
 
   delegate :blacklight_config, to: :search_state


### PR DESCRIPTION
# Why was this change made?
Reverts https://github.com/sul-dlss/argo/pull/4600/files and makes reset link red. 

<img width="74" alt="Screenshot 2024-08-15 at 8 52 00 AM" src="https://github.com/user-attachments/assets/d0c582af-bb2f-4186-990d-4fd8032827b6">

# How was this change tested?
QA deploy.