### PR TITLE
do not need to set runOCR workflow variable

### DIFF
--- a/app/services/text_extraction.rb
+++ b/app/services/text_extraction.rb
@@ -53,6 +53,6 @@ class TextExtraction
 
   # the workflow context to set
   def context
-    { runOCR: true, manuallyCorrectedOCR: false, ocrLanguages: languages }
+    { manuallyCorrectedOCR: false, ocrLanguages: languages }
   end
 end

--- a/spec/requests/text_extraction_spec.rb
+++ b/spec/requests/text_extraction_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'TextExtractions', :js do
 
     it 'adds ocrWF' do
       post "/items/#{druid}/text_extraction", params: { text_extraction_languages: ['English'] }
-      expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'ocrWF', context: { runOCR: true, manuallyCorrectedOCR: false, ocrLanguages: ['English'] }, version: 2)
+      expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'ocrWF', context: { manuallyCorrectedOCR: false, ocrLanguages: ['English'] }, version: 2)
       expect(object_client).to have_received(:reindex)
       expect(response).to redirect_to(solr_document_path(druid))
     end

--- a/spec/services/text_extraction_spec.rb
+++ b/spec/services/text_extraction_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe TextExtraction do
 
   describe '#start' do
     let(:client) { instance_double(Dor::Workflow::Client, create_workflow_by_name: true, lifecycle: Time.zone.now) }
-    let(:context) { { manuallyCorrectedOCR: false, ocrLanguages: languages, runOCR: true } }
+    let(:context) { { manuallyCorrectedOCR: false, ocrLanguages: languages } }
 
     before do
       allow(WorkflowClientFactory).to receive(:build).and_return(client)


### PR DESCRIPTION
# Why was this change made?

We do not need to set the `runocrWF` variable in Argo.  This is only used in the end-accession robot to decide if the ocrWF is to be created, but in Argo, we are creating the workflow on demand.  Adding the variable is incorrectly causing ocrWF to be run twice.

~~HOLD pending test on stage~~

# How was this change tested?

Stage