### PR TITLE
do not allow registration without a workflow

### DIFF
--- a/app/forms/registration_form.rb
+++ b/app/forms/registration_form.rb
@@ -24,6 +24,7 @@ class RegistrationForm < Reform::Form
   property :content_type, virtual: true
   property :viewing_direction, virtual: true
   property :project, virtual: true
+  validates :workflow_id, presence: true
 
   collection :tags, populate_if_empty: VirtualModel, virtual: true, save: false, skip_if: :all_blank,
                     prepopulator: ->(*) { (6 - tags.count).times { tags << VirtualModel.new } } do

--- a/spec/requests/create_new_item_spec.rb
+++ b/spec/requests/create_new_item_spec.rb
@@ -56,6 +56,34 @@ RSpec.describe 'Create a new item' do
     end
   end
 
+  context 'when workflow_id is missing' do
+    before do
+      allow(AdminPolicyOptions).to receive(:for).and_return(['APO 1', 'APO 2', 'APO 3'])
+    end
+
+    it 'shows an error' do
+      post '/registration', params: {
+        registration: {
+          admin_policy: 'druid:hv992ry2431',
+          view_access: 'world',
+          download_access: 'world',
+          controlled_digital_lending: 'false',
+          workflow_id: nil,
+          content_type: 'https://cocina.sul.stanford.edu/models/book',
+          items: [
+            {
+              source_id: 'foo:bar',
+              label: 'This things'
+            }
+          ],
+          tag: ['Registered By : jcoyne85']
+        }
+      }
+      expect(response).to have_http_status :bad_request
+      expect(response.body).to include 'Workflow can&#39;t be blank'
+    end
+  end
+
   context 'when barcode_id is provided' do
     let(:source_id) { "sul:#{SecureRandom.uuid}" }
     let(:submitted) do
@@ -447,6 +475,7 @@ RSpec.describe 'Create a new item' do
           view_access: 'world',
           download_access: 'world',
           controlled_digital_lending: 'false',
+          workflow_id: 'registrationWF',
           content_type: 'https://cocina.sul.stanford.edu/models/book',
           items: [
             {


### PR DESCRIPTION
# Why was this change made?

It may be possible to submit the Argo registration form without a workflow selected, likely because the user has selected a new APO, which forces turbo to update options, but those options (which include the workflow drop down menu) are not rendered yet.  It can also happen if you have javascript turned off in your browser.  

This will trigger this HB alert: https://app.honeybadger.io/projects/49894/faults/96948859 and leaves the object in a state where it needs to have the initial workflow (most often `registrationWF`) added to it manually.

This code change will prevent registration from continuing unless there is a workflow option sent.  You will instead get this error message after trying to register (with javascript on or off, since it is done server side):

![Screenshot 2024-10-23 at 2 02 16 PM](https://github.com/user-attachments/assets/78668b11-7797-45db-afef-68b09eeae3d3)

# How was this change tested?

New spec

Also localhost, by manually deleting the workflow element in the form and trying to submit.  And also turning off javascript and trying to submit.