### PR TITLE
start speechToTextWF for media objects and in bulk jobs

### DIFF
--- a/app/components/show/controls_component.rb
+++ b/app/components/show/controls_component.rb
@@ -92,7 +92,7 @@ module Show
     end
 
     def create_text_extraction
-      return unless Settings.features.ocr_workflow
+      return unless Settings.features.ocr_workflow || Settings.features.speech_to_text_workflow
       return unless TextExtraction.new(presenter.cocina).possible? && !registered_only?
 
       render ActionButton.new url: new_item_text_extraction_path(druid),

--- a/app/services/text_extraction.rb
+++ b/app/services/text_extraction.rb
@@ -44,15 +44,23 @@ class TextExtraction
 
   # mapping of cocina resource types to workflow names
   def resource_type_mapping
-    {
-      'https://cocina.sul.stanford.edu/models/book' => 'ocrWF',
-      'https://cocina.sul.stanford.edu/models/document' => 'ocrWF',
-      'https://cocina.sul.stanford.edu/models/image' => 'ocrWF'
-    }
+    {}.tap do |mapping|
+      if Settings.features.ocr_workflow
+        mapping['https://cocina.sul.stanford.edu/models/book'] = 'ocrWF'
+        mapping['https://cocina.sul.stanford.edu/models/document'] = 'ocrWF'
+        mapping['https://cocina.sul.stanford.edu/models/image'] = 'ocrWF'
+      end
+      mapping['https://cocina.sul.stanford.edu/models/media'] = 'speechToTextWF' if Settings.features.speech_to_text_workflow
+    end
   end
 
   # the workflow context to set
   def context
-    { manuallyCorrectedOCR: false, ocrLanguages: languages }
+    case wf_name
+    when 'ocrWF'
+      { manuallyCorrectedOCR: false, ocrLanguages: languages }
+    when 'speechToTextWF'
+      {}
+    end
   end
 end

--- a/app/views/bulk_actions/text_extraction_jobs/_new.html.erb
+++ b/app/views/bulk_actions/text_extraction_jobs/_new.html.erb
@@ -6,13 +6,22 @@
     <div class="mt-2 alert alert-warning d-flex shadow-sm align-items-center">
       <i class="bi bi-exclamation-triangle-fill fs-3 me-3"></i>
       <div class="text-body">
-        <p>Auto-generating OCR files will not overwrite any existing OCR files that have been corrected to comply with accessibility standards. <strong>Any uncorrected OCR files will be overwritten.</strong> The originally-deposited contents will not be overwritten.</p>
-        <p>Warning: Avoid auto-generating OCR files for contents that do not contain any text, as it may have adverse effects.</p>
+        <% content_types = [] %>
+        <% if Settings.features.ocr_workflow %>
+          <% content_types << %w[Image Book Document/PDF] %>
+          <p>Auto-generating OCR files will not overwrite any existing OCR files that have been corrected to comply with accessibility standards. <strong>Any uncorrected OCR files will be overwritten.</strong> The originally-deposited contents will not be overwritten.</p>
+          <p>Warning: Avoid auto-generating OCR files for contents that do not contain any text, as it may have adverse effects.</p>
+        <% end %>
+        <% if Settings.features.speech_to_text_workflow %>
+          <% content_types << %w[Media] %>
+          <p>Auto-generating caption/transcript files will not overwrite any existing caption/transcript files that have been corrected to comply with accessibility standards. <strong>Any uncorrected caption/transcript files will be overwritten.</strong> The originally-deposited media will not be overwritten.</p>
+          <p>Avoid auto-generating caption/transcript files for media that do not contain any speech or lyrics, as it may have adverse effects.</p>
+        <% end %>
       </div>
     </div>
 
     <span class='form-text'>
-      Warning: Text extraction should only be performed on content types Image, Book, or Document/PDF.
+      Warning: Text extraction should only be performed on content types <%= content_types.join(', ') %>.
     </span>
     <%= render LanguageSelectorComponent.new(form: f) %>
     <%= render 'bulk_actions/druids', f: %>

--- a/app/views/bulk_actions/text_extraction_jobs/new.html.erb
+++ b/app/views/bulk_actions/text_extraction_jobs/new.html.erb
@@ -1,5 +1,5 @@
 <turbo-frame id="bulk-action-form">
-  <% if Settings.features.ocr_workflow %>
+  <% if Settings.features.ocr_workflow || Settings.speech_to_text_workflow %>
     <%= render 'new' %>
   <% else %>
     <p>Text extraction job currently not available.</p>

--- a/app/views/text_extraction/_form.html.erb
+++ b/app/views/text_extraction/_form.html.erb
@@ -4,13 +4,16 @@
     <% if @cocina_object.type == 'https://cocina.sul.stanford.edu/models/document' %>
        <p>Auto-generating OCR files will not overwrite any existing OCR files that have been corrected to comply with accessibility standards. <strong>Any uncorrected OCR files will be overwritten.</strong> The originally-deposited PDF documents will not be overwritten.</p>
        <p>Avoid auto-generating OCR files for PDF documents that do not contain any text, as it may have adverse effects.</p>
+    <% elsif @cocina_object.type == 'https://cocina.sul.stanford.edu/models/media' %>
+       <p>Auto-generating caption/transcript files will not overwrite any existing caption/transcript files that have been corrected to comply with accessibility standards. <strong>Any uncorrected caption/transcript files will be overwritten.</strong> The originally-deposited media will not be overwritten.</p>
+       <p>Avoid auto-generating caption/transcript files for media that do not contain any speech or lyrics, as it may have adverse effects.</p>
     <% else %>
        <p>Auto-generating OCR files will not overwrite any existing OCR files that have been corrected to comply with accessibility standards. <strong>Any uncorrected OCR files will be overwritten.</strong> The originally-deposited images will not be overwritten.</p>
        <p>Avoid auto-generating OCR files for images that do not contain any text, as it may have adverse effects.</p>
     <% end %>
   </div>
   <%= form_with url: item_text_extraction_path, class: 'col-md-4' do |f| %>
-    <%= render LanguageSelectorComponent.new(form: f) %>
+    <%= render LanguageSelectorComponent.new(form: f) unless @cocina_object.type == 'https://cocina.sul.stanford.edu/models/media' %>
     <%= f.submit 'Start text extraction', class: 'btn btn-primary' %>
   <% end %>
 </div>

--- a/app/views/text_extraction/_form.html.erb
+++ b/app/views/text_extraction/_form.html.erb
@@ -9,7 +9,7 @@
        <p>Avoid auto-generating caption/transcript files for media that do not contain any speech or lyrics, as it may have adverse effects.</p>
     <% else %>
        <p>Auto-generating OCR files will not overwrite any existing OCR files that have been corrected to comply with accessibility standards. <strong>Any uncorrected OCR files will be overwritten.</strong> The originally-deposited images will not be overwritten.</p>
-       <p>Avoid auto-generating OCR files for images that do not contain any text, as it may have adverse effects.</p>
+       <p>Avoid auto-generating OCR files for images that do not contain any text, as it may impact the quality of the resulting caption/transcript.</p>
     <% end %>
   </div>
   <%= form_with url: item_text_extraction_path, class: 'col-md-4' do |f| %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -97,3 +97,4 @@ google_analytics: false
 
 features:
   ocr_workflow: false
+  speech_to_text_workflow: false

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -7,3 +7,4 @@ dor_indexing_url: http://localhost:3004/dor
 
 features:
   ocr_workflow: true
+  speech_to_text_workflow: true

--- a/spec/requests/text_extraction_spec.rb
+++ b/spec/requests/text_extraction_spec.rb
@@ -5,50 +5,76 @@ require 'rails_helper'
 RSpec.describe 'TextExtractions', :js do
   let(:current_user) { create(:user) }
   let(:druid) { 'druid:bc123df4567' }
-  let(:cocina_model) { build(:dro_with_metadata, id: druid, version: 2, type: 'https://cocina.sul.stanford.edu/models/document') }
+  let(:cocina_model) { build(:dro_with_metadata, id: druid, version: 2, type: object_type) }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, reindex: true) }
+  let(:workflow_client) { instance_double(Dor::Workflow::Client, workflow:, create_workflow_by_name: nil, lifecycle: Time.zone.now) }
+  let(:workflow) { instance_double(Dor::Workflow::Response::Workflow, active_for?: false) }
+  let(:version_service) { instance_double(VersionService, open?: true) }
 
   before do
     allow(Repository).to receive(:find).with(druid).and_return(cocina_model)
     sign_in current_user, groups: ['sdr:administrator-role']
+    allow(VersionService).to receive(:new).and_return(version_service)
+    allow(WorkflowClientFactory).to receive(:build).and_return(workflow_client)
+    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
   end
 
-  describe '#new' do
-    it 'shows text extraction form with languages' do
-      visit "/items/#{druid}/text_extraction/new"
+  context 'when item is a document' do
+    before { allow(Settings.features).to receive(:ocr_workflow).and_return(true) }
 
-      expect(page).to have_css 'h3', text: 'Text extraction'
-      expect(page).to have_content 'Avoid auto-generating OCR files for PDF documents'
-      expect(page).to have_css 'div', text: 'Content language'
+    let(:object_type) { 'https://cocina.sul.stanford.edu/models/document' }
 
-      first('button[aria-label="toggle dropdown"]').click
+    describe '#new' do
+      it 'shows text extraction form with languages' do
+        visit "/items/#{druid}/text_extraction/new"
 
-      find('[data-text-extraction-label="Adyghe"]').click
+        expect(page).to have_css 'h3', text: 'Text extraction'
+        expect(page).to have_content 'Avoid auto-generating OCR files for PDF documents'
+        expect(page).to have_css 'div', text: 'Content language'
 
-      expect(page).to have_css 'div', text: 'Selected language(s)'
-      expect(page.all('.selected-item-label').count).to eq 1
+        first('button[aria-label="toggle dropdown"]').click
 
-      find('[data-text-extraction-label="English"]').click
-      expect(page.all('.selected-item-label').count).to eq 2
+        find('[data-text-extraction-label="Adyghe"]').click
+
+        expect(page).to have_css 'div', text: 'Selected language(s)'
+        expect(page.all('.selected-item-label').count).to eq 1
+
+        find('[data-text-extraction-label="English"]').click
+        expect(page.all('.selected-item-label').count).to eq 2
+      end
+    end
+
+    describe '#create' do
+      it 'adds ocrWF' do
+        post "/items/#{druid}/text_extraction", params: { text_extraction_languages: ['English'] }
+        expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'ocrWF', context: { manuallyCorrectedOCR: false, ocrLanguages: ['English'] }, version: 2)
+        expect(object_client).to have_received(:reindex)
+        expect(response).to redirect_to(solr_document_path(druid))
+      end
     end
   end
 
-  describe '#create' do
-    let(:object_client) { instance_double(Dor::Services::Client::Object, reindex: true) }
-    let(:workflow_client) { instance_double(Dor::Workflow::Client, workflow:, create_workflow_by_name: nil, lifecycle: Time.zone.now) }
-    let(:workflow) { instance_double(Dor::Workflow::Response::Workflow, active_for?: false) }
-    let(:version_service) { instance_double(VersionService, open?: true) }
+  context 'when item is media' do
+    let(:object_type) { 'https://cocina.sul.stanford.edu/models/media' }
 
-    before do
-      allow(VersionService).to receive(:new).and_return(version_service)
-      allow(WorkflowClientFactory).to receive(:build).and_return(workflow_client)
-      allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+    before { allow(Settings.features).to receive(:speech_to_text_workflow).and_return(true) }
+
+    describe '#new' do
+      it 'shows text extraction form' do
+        visit "/items/#{druid}/text_extraction/new"
+
+        expect(page).to have_css 'h3', text: 'Text extraction'
+        expect(page).to have_content 'Avoid auto-generating caption/transcript files for media that do not contain any speech or lyrics'
+      end
     end
 
-    it 'adds ocrWF' do
-      post "/items/#{druid}/text_extraction", params: { text_extraction_languages: ['English'] }
-      expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'ocrWF', context: { manuallyCorrectedOCR: false, ocrLanguages: ['English'] }, version: 2)
-      expect(object_client).to have_received(:reindex)
-      expect(response).to redirect_to(solr_document_path(druid))
+    describe '#create' do
+      it 'adds speechToTextWF' do
+        post "/items/#{druid}/text_extraction", params: {}
+        expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'speechToTextWF', context: {}, version: 2)
+        expect(object_client).to have_received(:reindex)
+        expect(response).to redirect_to(solr_document_path(druid))
+      end
     end
   end
 end


### PR DESCRIPTION
# Why was this change made?

Fixes #4655 and fixes #4656:

1. Enable the Text Extraction button for media objects
2. Add a new feature setting that allows us to turn speechToTextWF for media on/off independently of ocrWF
3. Enable text extraction bulk job to be run on media objects
~~4. Fix some erb_lint deprecations~~ moved to #4674

**Media Object Modal when using "Text Extraction" button:**

![Screenshot 2024-10-24 at 12 56 40 PM](https://github.com/user-attachments/assets/a8602471-0766-448f-8dd1-07276ae248e6)

**Bulk Action:**

![Screenshot 2024-10-24 at 12 56 55 PM](https://github.com/user-attachments/assets/7c528176-98ac-4198-8c7c-ffa5486ccde6)


# How was this change tested?

Localhost and new spec