### PR TITLE
do not allow sdr-ingest steps to be set to skip or complete

### DIFF
--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -7,4 +7,8 @@ class ApplicationComponent < ViewComponent::Base
   def inspect
     "#<#{self.class.name}:#{object_id}>"
   end
+
+  def allow_skip_or_complete?(workflow_step)
+    %w[sdr-ingest-transfer sdr-ingest-received].exclude?(workflow_step)
+  end
 end

--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -8,6 +8,10 @@ class ApplicationComponent < ViewComponent::Base
     "#<#{self.class.name}:#{object_id}>"
   end
 
+  # this is used by the WorkFlowUpdateButton and the WorklowStepStatusSelect components
+  # to determine if the user is allowed to skip or complete a particular workflow step
+  # (because we do not want to allow the user to manually skip or complete some steps)
+  # see https://github.com/sul-dlss/argo/issues/4670
   def allow_skip_or_complete?(workflow_step)
     %w[sdr-ingest-transfer sdr-ingest-received].exclude?(workflow_step)
   end

--- a/app/components/workflow_step_status_selector.html.erb
+++ b/app/components/workflow_step_status_selector.html.erb
@@ -5,7 +5,7 @@
   <%= hidden_field_tag('process', name) %>
   <div class="input-group">
     <%= select_tag('status',
-                   options_for_select([%w[Rerun waiting], %w[Skip skipped], %w[Complete completed]]),
+                   options_for_select(workflow_step_status_options),
                    prompt: 'Select',
                    class: 'form-select') %>
     <span class="input-group-append">

--- a/app/components/workflow_step_status_selector.rb
+++ b/app/components/workflow_step_status_selector.rb
@@ -17,6 +17,12 @@ class WorkflowStepStatusSelector < ApplicationComponent
     CONFIRM_MESSAGE
   end
 
+  def workflow_step_status_options
+    options = [%w[Rerun waiting]]
+    options.push(%w[Skip skipped], %w[Complete completed]) if allow_skip_or_complete?(name)
+    options
+  end
+
   private
 
   def druid

--- a/app/components/workflow_update_button.html.erb
+++ b/app/components/workflow_update_button.html.erb
@@ -1,8 +1,6 @@
 <%# workflow update requires id, workflow, process, and status parameters %>
-<% unless completed? %>
-  <%= form_tag item_workflow_path(druid, workflow_name), method: 'put' do %>
-    <%= hidden_field_tag('process', name) %>
-    <%= hidden_field_tag('status', next_status) %>
-    <%= button_tag(label, id: "workflow-status-set-#{name}-#{next_status}", type: 'submit', class: 'btn btn-primary') %>
-  <% end %>
+<%= form_tag item_workflow_path(druid, workflow_name), method: 'put' do %>
+  <%= hidden_field_tag('process', name) %>
+  <%= hidden_field_tag('status', next_status) %>
+  <%= button_tag(label, id: "workflow-status-set-#{name}-#{next_status}", type: 'submit', class: 'btn btn-primary') %>
 <% end %>

--- a/app/components/workflow_update_button.rb
+++ b/app/components/workflow_update_button.rb
@@ -9,6 +9,10 @@ class WorkflowUpdateButton < ApplicationComponent
 
   delegate :workflow_name, :name, to: :process
 
+  def render?
+    !completed? && allow_skip_or_complete?(name)
+  end
+
   def label
     "Set to #{next_status}"
   end

--- a/spec/components/workflow_step_status_selector_spec.rb
+++ b/spec/components/workflow_step_status_selector_spec.rb
@@ -10,12 +10,36 @@ RSpec.describe WorkflowStepStatusSelector, type: :component do
                     status: 'error',
                     pid: 'druid:132',
                     workflow_name: 'accessionWF',
-                    name: 'technical-metadata')
+                    name:)
   end
 
-  it 'has a form' do
-    expect(body.css('select[name="status"] > option').map(&:text)).to eq %w[Select Rerun Skip Complete]
-    expect(body.css('input[name="_method"][value="put"]')).to be_present
-    expect(body.css('input[name="process"]').first['value']).to eq 'technical-metadata'
+  context 'when a step allows all updates' do
+    let(:name) { 'technical-metadata' }
+
+    it 'has a form with all options' do
+      expect(body.css('select[name="status"] > option').map(&:text)).to eq %w[Select Rerun Skip Complete]
+      expect(body.css('input[name="_method"][value="put"]')).to be_present
+      expect(body.css('input[name="process"]').first['value']).to eq 'technical-metadata'
+    end
+  end
+
+  context 'when sdr-ingest-received' do
+    let(:name) { 'sdr-ingest-received' }
+
+    it 'has a form without skip or complete' do
+      expect(body.css('select[name="status"] > option').map(&:text)).to eq %w[Select Rerun]
+      expect(body.css('input[name="_method"][value="put"]')).to be_present
+      expect(body.css('input[name="process"]').first['value']).to eq 'sdr-ingest-received'
+    end
+  end
+
+  context 'when sdr-ingest-transfer' do
+    let(:name) { 'sdr-ingest-transfer' }
+
+    it 'has a form without skip or complete' do
+      expect(body.css('select[name="status"] > option').map(&:text)).to eq %w[Select Rerun]
+      expect(body.css('input[name="_method"][value="put"]')).to be_present
+      expect(body.css('input[name="process"]').first['value']).to eq 'sdr-ingest-transfer'
+    end
   end
 end

--- a/spec/components/workflow_update_button_spec.rb
+++ b/spec/components/workflow_update_button_spec.rb
@@ -10,8 +10,10 @@ RSpec.describe WorkflowUpdateButton, type: :component do
                     status:,
                     pid: 'druid:132',
                     workflow_name: 'accessionWF',
-                    name: 'technical-metadata')
+                    name:)
   end
+
+  let(:name) { 'technical-metadata' }
 
   context 'when the state is error' do
     let(:status) { 'error' }
@@ -20,6 +22,22 @@ RSpec.describe WorkflowUpdateButton, type: :component do
       expect(body.css('input[name="process"]').first['value']).to eq 'technical-metadata'
       expect(body.css('button').to_html).to eq \
         '<button name="button" type="submit" id="workflow-status-set-technical-metadata-waiting" class="btn btn-primary">Set to waiting</button>'
+    end
+
+    context 'when the step is sdr-ingest-received' do
+      let(:name) { 'sdr-ingest-received' }
+
+      it 'renders nothing' do
+        expect(body.css('*').to_html).to eq ''
+      end
+    end
+
+    context 'when the step is sdr-ingest-transfer' do
+      let(:name) { 'sdr-ingest-transfer' }
+
+      it 'renders nothing' do
+        expect(body.css('*').to_html).to eq ''
+      end
     end
   end
 


### PR DESCRIPTION
# Why was this change made?

Fixes #4670 - do not show the skip/complete options for workflow steps sdr-ingest-transfer or sdr-ingest-received.  Other steps remain unchanged.

Set to complete button is also hidden for those steps if they are in waiting state.  See screenshots below for examples

![Screenshot 2024-11-18 at 10 57 29 AM](https://github.com/user-attachments/assets/e9545b66-fcff-4def-b7ff-c2c5e10a28ee)

![Screenshot 2024-11-18 at 10 57 35 AM](https://github.com/user-attachments/assets/0b010acf-6f6f-4cf0-8f7d-7ca3ec09c6d2)


# How was this change tested?

Localhost and specs