### PR TITLE
Bump Ruby to 3.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
   node: circleci/node@5.1.0
 
 references:
-  default_ruby_version: &default_ruby_version 3.3.1-browsers
+  default_ruby_version: &default_ruby_version 3.4.1-browsers
   default_postgres_version: &default_postgres_version '12.9'
   ruby_envs: &ruby_envs
     environment:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ require:
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 3.3
+  TargetRubyVersion: 3.4
   DisplayCopNames: true
   SuggestExtensions: false
   Exclude:
@@ -561,4 +561,40 @@ Gemspec/AddRuntimeDependency: # new in 1.65
 Style/SendWithLiteralMethodName: # new in 1.64
   Enabled: true
 Style/SuperArguments: # new in 1.64
+  Enabled: true
+Lint/DuplicateSetElement: # new in 1.67
+  Enabled: true
+Lint/HashNewWithKeywordArgumentsAsDefault: # new in 1.69
+  Enabled: true
+Lint/NumericOperationWithConstantResult: # new in 1.69
+  Enabled: true
+Lint/UnescapedBracketInRegexp: # new in 1.68
+  Enabled: true
+Lint/UselessDefined: # new in 1.69
+  Enabled: true
+Lint/UselessNumericOperation: # new in 1.66
+  Enabled: true
+Style/AmbiguousEndlessMethodDefinition: # new in 1.68
+  Enabled: true
+Style/BitwisePredicate: # new in 1.68
+  Enabled: true
+Style/CombinableDefined: # new in 1.68
+  Enabled: true
+Style/DigChain: # new in 1.69
+  Enabled: true
+Style/FileNull: # new in 1.69
+  Enabled: true
+Style/FileTouch: # new in 1.69
+  Enabled: true
+Style/KeywordArgumentsMerging: # new in 1.68
+  Enabled: true
+Style/RedundantInterpolationUnfreeze: # new in 1.66
+  Enabled: true
+Style/SafeNavigationChainLength: # new in 1.68
+  Enabled: true
+Performance/StringBytesize: # new in 1.23
+  Enabled: true
+Rails/EnumSyntax: # new in 2.26
+  Enabled: true
+RSpec/StringAsInstanceDoubleConstant: # new in 3.1
   Enabled: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.3.1-bookworm
+FROM ruby:3.4.1-bookworm
 
 RUN curl -fsSL https://deb.nodesource.com/setup_current.x | bash -
 

--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ group :test, :development do
   gem 'rubocop-rails'
   gem 'rubocop-rspec'
   gem 'rubocop-rspec_rails'
-  gem 'sqlite3', '~> 1.4'
+  gem 'sqlite3', '~> 2.0'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -611,10 +611,10 @@ GEM
     spreadsheet (1.3.3)
       bigdecimal
       ruby-ole
-    sqlite3 (1.7.3)
+    sqlite3 (2.5.0)
       mini_portile2 (~> 2.8.0)
-    sqlite3 (1.7.3-x86_64-darwin)
-    sqlite3 (1.7.3-x86_64-linux)
+    sqlite3 (2.5.0-x86_64-darwin)
+    sqlite3 (2.5.0-x86_64-linux-gnu)
     sshkit (1.23.2)
       base64
       net-scp (>= 1.1.2)
@@ -746,7 +746,7 @@ DEPENDENCIES
   selenium-webdriver
   sidekiq (~> 7.1)
   simplecov
-  sqlite3 (~> 1.4)
+  sqlite3 (~> 2.0)
   turbo-rails (~> 1.0)
   view_component
   web-console

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Argo is the administrative interface to the Stanford Digital Repository.
 ### System Requirements
 
 1. Install Docker
-2. Install Ruby 3.3.1
+2. Install Ruby 3.4.1
 
 ### Check Out the Code
 


### PR DESCRIPTION
# Why was this change made?

To keep pace with Ruby versions.

# How was this change tested?

- [x] CI
- [x] stage
