### PR TITLE
Bump cocina-models to put commonmarker problems in the past

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,9 +147,8 @@ GEM
       xpath (~> 3.2)
     childprocess (5.1.0)
       logger (~> 1.5)
-    cocina-models (0.99.2)
+    cocina-models (0.99.3)
       activesupport
-      commonmarker (= 2.0.1)
       deprecation
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -158,21 +157,16 @@ GEM
       i18n
       jsonpath
       nokogiri
-      openapi3_parser
       openapi_parser (~> 1.0)
       super_diff
       thor
       zeitwerk (~> 2.1)
     coderay (1.1.3)
-    commonmarker (2.0.1)
-      rb_sys (~> 0.9)
-    commonmarker (2.0.1-x86_64-darwin)
-    commonmarker (2.0.1-x86_64-linux)
     concurrent-ruby (1.3.4)
     config (5.5.2)
       deep_merge (~> 1.2, >= 1.2.1)
       ostruct
-    connection_pool (2.4.1)
+    connection_pool (2.5.0)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -239,12 +233,12 @@ GEM
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.0, < 2)
       zeitwerk (~> 2.6)
-    dry-struct (1.6.0)
-      dry-core (~> 1.0, < 2)
-      dry-types (>= 1.7, < 2)
+    dry-struct (1.7.0)
+      dry-core (~> 1.1)
+      dry-types (~> 1.8)
       ice_nine (~> 0.11)
       zeitwerk (~> 2.6)
-    dry-types (1.7.2)
+    dry-types (1.8.0)
       bigdecimal (~> 3.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.0)
@@ -411,8 +405,6 @@ GEM
       i18n
       nokogiri
     okcomputer (1.18.5)
-    openapi3_parser (0.10.0)
-      commonmarker (>= 1.0)
     openapi_parser (1.0.0)
     optimist (3.2.0)
     orm_adapter (0.5.0)
@@ -501,7 +493,6 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rb_sys (0.9.105)
     rdoc (6.10.0)
       psych (>= 4.0.0)
     redis-client (0.23.0)
@@ -622,8 +613,6 @@ GEM
       ruby-ole
     sqlite3 (1.7.3)
       mini_portile2 (~> 2.8.0)
-    sqlite3 (1.7.3-x86_64-darwin)
-    sqlite3 (1.7.3-x86_64-linux)
     sshkit (1.23.2)
       base64
       net-scp (>= 1.1.2)
@@ -634,7 +623,7 @@ GEM
       activesupport
       mods (~> 3.0, >= 3.0.4)
     stringio (3.1.2)
-    super_diff (0.14.0)
+    super_diff (0.15.0)
       attr_extras (>= 6.2.4)
       diff-lcs
       patience_diff


### PR DESCRIPTION
# Why was this change made?

To set up the Ruby 3.4.1 upgrade, we needed to be able to install the *current* set of dependencies atop the new Ruby version. That is not possible due to commonmarker being pegged to specific Ruby versions.

# How was this change tested?

CI
