### PR TITLE
Update Stanford Libraries logos to 2025 versions

### DIFF
--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -25,7 +25,7 @@
     <%= javascript_include_tag 'application', 'data-turbo-track': 'reload', defer: true %>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbo-track': 'reload' %>
     <%= stylesheet_link_tag 'https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css' %>
-    <%= stylesheet_link_tag 'https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2024-09-04/styles/sul.css' %>
+    <%= stylesheet_link_tag 'https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-01-10/styles/sul.css' %>
     <%= csrf_meta_tags %>
     <%= content_for(:head) %>
   </head>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,3 @@
-
 <footer role="contentinfo">
   <section id="pre-footer" class="pt-3 pb-2">
     <div class="container">
@@ -6,12 +5,7 @@
         <div
           id="sul-footer-img"
           class="col-sm-12 col-md-5 col-lg-4 col-xl-3 d-flex justify-content-center justify-content-md-start">
-          <a href="https://library.stanford.edu">
-            <img
-              alt="Stanford Libraries"
-              height="45"
-              src="https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2024-09-04/styles/StanfordLibraries-logo-whitetext.svg">
-          </a>
+          <a href="https://library.stanford.edu" class="prefooter-logo"></a>
         </div>
         <div
           class="col d-flex justify-content-md-start justify-content-center">


### PR DESCRIPTION
# Why was this change made?

Update Stanford Libraries logos per 2025 brand identity guidelines.

# How was this change tested?

CI, QA
