### PR TITLE
Use an earlier component library release

### DIFF
--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -25,7 +25,7 @@
     <%= javascript_include_tag 'application', 'data-turbo-track': 'reload', defer: true %>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbo-track': 'reload' %>
     <%= stylesheet_link_tag 'https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css' %>
-    <%= stylesheet_link_tag 'https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-01-10/styles/sul.css' %>
+    <%= stylesheet_link_tag 'https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2024-11-21/styles/sul.css' %>
     <%= csrf_meta_tags %>
     <%= content_for(:head) %>
   </head>


### PR DESCRIPTION
# Why was this change made?

This release has the updated SUL logo but none of the pagination and facet changes.

# How was this change tested?

CI, QA
