### PR TITLE
Filter out bulk action form params

### DIFF
--- a/app/components/new_bulk_action_button_component.html.erb
+++ b/app/components/new_bulk_action_button_component.html.erb
@@ -1,0 +1,1 @@
+<%= link_to 'New Bulk Action', link_path, class: 'btn btn-primary' %>

--- a/app/components/new_bulk_action_button_component.rb
+++ b/app/components/new_bulk_action_button_component.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class NewBulkActionButtonComponent < ApplicationComponent
+  def link_path
+    new_bulk_action_path(search_state.reset_search.to_h.except(*bulk_action_params))
+  end
+
+  def bulk_action_params
+    %i[tag
+       who
+       what
+       workflow
+       to
+       version_description
+       new_apo_id
+       download_access
+       view_access
+       copyright_statement
+       copyright_statement_option
+       license
+       license_option
+       use_statement
+       use_statement_option
+       barcodes
+       use_barcodes_option
+       catalog_record_ids
+       use_catalog_record_ids_option
+       current_resource_type
+       new_resource_type
+       new_content_type
+       new_collection_id]
+  end
+end

--- a/app/components/new_bulk_action_button_component.rb
+++ b/app/components/new_bulk_action_button_component.rb
@@ -2,6 +2,8 @@
 
 class NewBulkActionButtonComponent < ApplicationComponent
   def link_path
+    # Since reset_search does not remove all the bulk action form params from the search state,
+    # remove them as specified
     new_bulk_action_path(search_state.reset_search.to_h.except(*bulk_action_params))
   end
 

--- a/app/views/bulk_actions/index.html.erb
+++ b/app/views/bulk_actions/index.html.erb
@@ -3,7 +3,7 @@
   <h1>Bulk Actions</h1>
   <div class="row">
     <div class="col-md-10">
-      <%= link_to 'New Bulk Action', new_bulk_action_path(search_state.reset_search.to_h), class: 'btn btn-primary' %>
+      <%= render NewBulkActionButtonComponent.new %>
     </div>
     <div class="col-md-2">
       <%= link_back_to_catalog label: 'Back to search', class: 'btn btn-primary' %>

--- a/spec/requests/bulk_action_spec.rb
+++ b/spec/requests/bulk_action_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe 'BulkActionsController' do
       url = '/bulk_actions/new?f%5Bcurrent_version_isi%5D%5B%5D=3&f%5Bis_governed_by_ssim%5D%5B%5D=info%3Afedora%2Fdruid%3Azw306xn5593&f%5BobjectType_ssim%5D%5B%5D=item'
       expect(rendered).to have_link 'New Bulk Action', href: url
     end
+
+    it 'shows a button without bulk action form params' do
+      get '/bulk_actions?action=index&controller=catalog&f[current_version_isi][]=3&f[is_governed_by_ssim][]=info%3Afedora%2Fdruid%3Azw306xn5593&f[objectType_ssim][]=item&page=3&download_access=world&view_access=stanford'
+      # this tests that form params for download_access and view_access, in addition to page, action and controller are stripped out of the parameters
+      url = '/bulk_actions/new?f%5Bcurrent_version_isi%5D%5B%5D=3&f%5Bis_governed_by_ssim%5D%5B%5D=info%3Afedora%2Fdruid%3Azw306xn5593&f%5BobjectType_ssim%5D%5B%5D=item'
+      expect(rendered).to have_link 'New Bulk Action', href: url
+    end
   end
 
   describe 'GET new' do


### PR DESCRIPTION
# Why was this change made?
Resolves #4710 to strip bulk action form params from future bulk actions.

# How was this change tested?
Request spec; tested by PO

