### PR TITLE
show workflow name on modal

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,6 @@ GEM
     base64 (0.2.0)
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
-    bcrypt_pbkdf (1.1.1-x86_64-darwin)
     benchmark (0.4.0)
     better_html (2.1.1)
       actionview (>= 6.0)
@@ -206,7 +205,7 @@ GEM
       ed25519
     docile (1.4.1)
     domain_name (0.6.20240107)
-    dor-services-client (15.3.0)
+    dor-services-client (15.4.0)
       activesupport (>= 7.0.0)
       cocina-models (~> 0.99.0)
       deprecation
@@ -313,7 +312,7 @@ GEM
       activesupport (>= 5.0.0)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.9.1)
+    json (2.10.1)
     jsonpath (1.1.5)
       multi_json
     kaminari (1.2.2)

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -92,6 +92,7 @@ class WorkflowsController < ApplicationController
     status = WorkflowStatus.new(workflow:,
                                 workflow_steps: workflow_processes(params[:id]))
     WorkflowPresenter.new(view: view_context,
+                          workflow_name: params[:id],
                           workflow_status: status,
                           cocina_object: Repository.find(params[:item_id]))
   end

--- a/app/presenters/workflow_presenter.rb
+++ b/app/presenters/workflow_presenter.rb
@@ -4,10 +4,11 @@ class WorkflowPresenter
   # @param [Object] view the rails view context
   # @param [WorkflowStatus] workflow_status
   # @param [Cocina::Models::DRO,Cocina::Models::Collection] cocina_object the repository object that the workflow is about
-  def initialize(view:, workflow_status:, cocina_object:)
+  def initialize(view:, workflow_status:, cocina_object:, workflow_name:)
     @view = view
     @workflow_status = workflow_status
     @cocina_object = cocina_object
+    @workflow_name = workflow_name
   end
 
   delegate :druid, :workflow_name, :workflow_context, to: :workflow_status
@@ -17,7 +18,7 @@ class WorkflowPresenter
     workflow_status.process_statuses
   end
 
-  attr_reader :cocina_object
+  attr_reader :cocina_object, :workflow_name
 
   private
 

--- a/app/views/workflows/_show.html.erb
+++ b/app/views/workflows/_show.html.erb
@@ -1,10 +1,10 @@
 <span class="section-head-link">
+  <h4><%= @presenter.workflow_name %> - <%= @presenter.druid %></h4>
   View:
   <%= link_to 'XML', item_workflow_path(item_id: @presenter.druid, id: @presenter.workflow_name, raw: 'true'),
               title: @presenter.workflow_name,
               data: { blacklight_modal: 'trigger' } %>
 </span>
-<%= @presenter.druid %>
 
 <table class="detail table">
   <thead>

--- a/app/views/workflows/_show.html.erb
+++ b/app/views/workflows/_show.html.erb
@@ -1,5 +1,5 @@
 <span class="section-head-link">
-  <h4><%= @presenter.workflow_name %> - <%= @presenter.druid %></h4>
+  <div class="h4"><%= @presenter.workflow_name %> - <%= @presenter.druid %></div>
   View:
   <%= link_to 'XML', item_workflow_path(item_id: @presenter.druid, id: @presenter.workflow_name, raw: 'true'),
               title: @presenter.workflow_name,

--- a/spec/presenters/workflow_presenter_spec.rb
+++ b/spec/presenters/workflow_presenter_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe WorkflowPresenter do
   subject(:presenter) do
-    described_class.new(view: stub_view, workflow_status:, cocina_object: item)
+    described_class.new(view: stub_view, workflow_status:, cocina_object: item, workflow_name:)
   end
 
   let(:stub_view) { double('view') }


### PR DESCRIPTION
# Why was this change made?

I noticed the workflow name itself was not showing in the modal that shows workflow details.  I think this is an improvement.

**Current**

![Screenshot 2025-02-14 at 10 29 32 AM](https://github.com/user-attachments/assets/69bb265f-5a56-4002-bbb1-2e441618d00c)


**Updated**

![Screenshot 2025-02-14 at 10 28 59 AM](https://github.com/user-attachments/assets/ad65df09-ec26-4ac1-a9dd-d74ae5808d41)


# How was this change tested?

Localhost/CI