### PR TITLE
bootstrap item/apo/agreement creation to better link together

### DIFF
--- a/lib/tasks/argo.rake
+++ b/lib/tasks/argo.rake
@@ -45,12 +45,7 @@ namespace :argo do
     $stdout.puts 'This will clear the Solr repo. Are you sure? [y/n]:'
     if $stdin.gets.chomp == 'y'
       ResetSolr.reset_solr
-      FactoryBot.create_for_repository(:agreement)
       FactoryBot.create_for_repository(:persisted_item)
-      FactoryBot.create_for_repository(:persisted_apo,
-                                       roles: [{ name: 'dor-apo-manager',
-                                                 members: [{ identifier: 'sdr:administrator-role',
-                                                             type: 'workgroup' }] }])
     else
       $stdout.puts 'stopping'
     end

--- a/spec/factories/apos.rb
+++ b/spec/factories/apos.rb
@@ -25,7 +25,7 @@ FactoryBot.define do
     end
 
     admin_policy_id { 'druid:hv992ry2431' }
-    agreement_id { 'druid:hp308wm0436' }
+    agreement_id { FactoryBot.create_for_repository(:agreement).externalIdentifier }
     label { 'test apo' }
     type { Cocina::Models::ObjectType.admin_policy }
   end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -25,7 +25,12 @@ FactoryBot.define do
       Dor::Services::Client.objects.register(params: builder.cocina_model)
     end
 
-    admin_policy_id { 'druid:hv992ry2431' }
+    admin_policy_id do
+      FactoryBot.create_for_repository(:persisted_apo,
+                                       roles: [{ name: 'dor-apo-manager',
+                                                 members: [{ identifier: 'sdr:administrator-role',
+                                                             type: 'workgroup' }] }]).externalIdentifier
+    end
     label { 'test object' }
     type { Cocina::Models::ObjectType.object }
     source_id { "sul:#{SecureRandom.uuid}" }
@@ -38,6 +43,7 @@ FactoryBot.define do
     factory :agreement do
       type { Cocina::Models::ObjectType.agreement }
       label { 'Test Agreement' }
+      admin_policy_id { 'druid:hv992ry2431' }
     end
   end
 end

--- a/spec/requests/apo_count_spec.rb
+++ b/spec/requests/apo_count_spec.rb
@@ -40,22 +40,20 @@ RSpec.describe 'Count the members of an apo' do
   end
 
   describe 'counting the item members' do
-    before do
-      FactoryBot.create_for_repository(:persisted_item)
-      FactoryBot.create_for_repository(:persisted_item)
-    end
+    let(:item) { FactoryBot.create_for_repository(:persisted_item) }
+    let(:admin_policy_id) { item.administrative.hasAdminPolicy }
 
     it 'returns the count' do
-      get "/apo/#{ur_apo_id}/count_items"
+      get "/apo/#{admin_policy_id}/count_items"
 
       expect(rendered.find_css('turbo-frame#apo-item-count')).to be_present
-      expect(rendered).to have_link '2', href: search_catalog_path(
+      expect(rendered).to have_link '1', href: search_catalog_path(
         f: {
-          is_governed_by_ssim: ["info:fedora/#{ur_apo_id}"],
+          is_governed_by_ssim: ["info:fedora/#{admin_policy_id}"],
           objectType_ssim: ['item']
         }
       )
-      expect(rendered.find_link('2')[:target]).to eq '_top'
+      expect(rendered.find_link('1')[:target]).to eq '_top'
     end
   end
 end


### PR DESCRIPTION
# Why was this change made?

Allows you to work on localhost without hitting errors where the fixture APO is not connected to an actual agreeement.  Instead create each object as it is needed, so it can be properly wired together.


# How was this change tested?

Localhost