### PR TITLE
Validate HRID in APO create collection form

### DIFF
--- a/app/javascript/controllers/collection_editor.js
+++ b/app/javascript/controllers/collection_editor.js
@@ -1,7 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
-  static targets = ['titleWarning', 'catalogRecordIdWarning', 'createCollectionFields', 'catalogRecordIdFields']
+  static targets = ['titleWarning', 'catalogRecordId', 'catalogRecordIdWarning', 'catalogRecordIdFormatError', 'createCollectionFields', 'catalogRecordIdFields']
 
   revealCreateCollection () {
     this.createCollectionFieldsTarget.hidden = false
@@ -22,6 +22,7 @@ export default class extends Controller {
   }
 
   checkCatalogRecordId (event) {
+    this.catalogRecordIdFormatErrorTarget.hidden = !this.catalogRecordIdTarget.validity.patternMismatch
     fetch(`/collections/exists?catalog_record_id=${event.target.value}`)
       .then(resp => resp.json())
       .then(data => {

--- a/app/views/collections/new.html.erb
+++ b/app/views/collections/new.html.erb
@@ -51,8 +51,11 @@
             <label for="collection_catalog_record_id">
               Collection <%= CatalogRecordId.label %>
             </label>
-            <%= text_field_tag 'collection_catalog_record_id', nil, class: 'form-control', data: { action: 'collection-editor#checkCatalogRecordId' }, autocomplete: 'off' %>
-            <span data-collection-editor-target="catalogRecordIdWarning" class="mt-2 alert alert-warning" hidden>Collection with this <%= CatalogRecordId.label %> already exists.</span>
+            <%= text_field_tag 'collection_catalog_record_id', nil, class: 'form-control',
+                                                                    pattern: CatalogRecordId.html_pattern_string,
+                                                                    data: { action: 'collection-editor#checkCatalogRecordId', collection_editor_target: 'catalogRecordId' }, autocomplete: 'off' %>
+            <div data-collection-editor-target="catalogRecordIdFormatError" class="mt-2 alert alert-danger" role="alert" hidden>Collection Folio Instance HRID must be in an allowed format.</div>
+            <div data-collection-editor-target="catalogRecordIdWarning" class="mt-2 alert alert-warning" role="alert" hidden>Collection with this <%= CatalogRecordId.label %> already exists.</div>
           </div>
           <div class="mb-3">
             <label for="collection_rights_catalog_record_id">

--- a/spec/system/create_collection_spec.rb
+++ b/spec/system/create_collection_spec.rb
@@ -29,6 +29,20 @@ RSpec.describe 'Add collection' do
     end
   end
 
+  describe 'when invalid FOLIO Collection HRID is provided', :js do
+    let(:result) { { 'response' => { 'numFound' => 0 } } }
+
+    it 'warns that catalog id is not formatted correctly' do
+      visit new_apo_collection_path apo_id
+      choose "Create a Collection from #{CatalogRecordId.type.capitalize}"
+      expect(page).to have_text("Collection #{CatalogRecordId.label}")
+      fill_in 'collection_catalog_record_id', with: '123'
+      expect(page).to have_text('Collection Folio Instance HRID must be in an allowed format.')
+      fill_in 'collection_catalog_record_id', with: 'a123'
+      expect(page).to have_no_text('Collection Folio Instance HRID must be in an allowed format.')
+    end
+  end
+
   describe 'when collection title is provided', :js do
     it 'warns if title exists' do
       visit new_apo_collection_path apo_id


### PR DESCRIPTION
# Why was this change made?
Resolves #4733 to validate Folio HRIDs in new collection form on APO. 

https://github.com/user-attachments/assets/6e07020e-d48e-4e6e-8778-844cec73e183

![Screenshot 2025-03-21 at 3 44 06 PM](https://github.com/user-attachments/assets/3c698637-c20c-4a7d-bd70-9ec142762929)

# How was this change tested?
System test and deploy to QA
