### PR TITLE
Remove redundant purge actions.

### DIFF
--- a/app/services/purge_service.rb
+++ b/app/services/purge_service.rb
@@ -1,15 +1,10 @@
 # frozen_string_literal: true
 
-# Removes an object from dor-services-app, the workflow service and solr.
+# Removes an object from SDR.
 class PurgeService
   # @param [String] druid
   # @param [String] user_name
   def self.purge(druid:, user_name:)
     Dor::Services::Client.object(druid).destroy(user_name:)
-    WorkflowClientFactory.build.delete_all_workflows(pid: druid)
-    blacklight_config = CatalogController.blacklight_config
-    solr_conn = blacklight_config.repository_class.new(blacklight_config).connection
-    solr_conn.delete_by_id(druid)
-    solr_conn.commit
   end
 end

--- a/spec/services/purge_service_spec.rb
+++ b/spec/services/purge_service_spec.rb
@@ -7,22 +7,14 @@ RSpec.describe PurgeService do
     subject(:purge) { described_class.purge(druid: 'druid:ab123cd4567', user_name: 'dijkstra') }
 
     let(:object_client) { instance_double(Dor::Services::Client::Object, destroy: true) }
-    let(:workflow_client) { instance_double(Dor::Workflow::Client, delete_all_workflows: true) }
-    let(:solr_client) { instance_double(RSolr::Client, delete_by_id: true, commit: true) }
-    let(:repo) { instance_double(Blacklight::Solr::Repository, connection: solr_client) }
 
     before do
       allow(Dor::Services::Client).to receive(:object).and_return(object_client)
-      allow(WorkflowClientFactory).to receive(:build).and_return(workflow_client)
-      allow(Blacklight::Solr::Repository).to receive(:new).and_return(repo)
     end
 
     it 'removes the object' do
       purge
       expect(object_client).to have_received(:destroy)
-      expect(workflow_client).to have_received(:delete_all_workflows)
-      expect(solr_client).to have_received(:delete_by_id)
-      expect(solr_client).to have_received(:commit)
     end
   end
 end


### PR DESCRIPTION
# Why was this change made?
The actions are handled by calling destroy on the object in DSA. See https://github.com/sul-dlss/dor-services-app/blob/main/app/services/delete_service.rb

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


