### PR TITLE
Switch default database from MySQL to Postgres

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,11 @@ jobs:
   test:
     environment:
       TZ: 'America/Los_Angeles'
+      DATABASE_NAME: argo_test
+      DATABASE_USERNAME: postgres
+      DATABASE_PASSWORD: sekret
+      DATABASE_HOSTNAME: db
+      DATABASE_PORT: 5432
       # To generate the token: docker-compose run dor-services-app rake generate_token
       SETTINGS__DOR_SERVICES__TOKEN: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJGb28ifQ.-BVfLTW9Q1_ZQEsGv4tuzGLs5rESN7LgdtEwUltnKv4
       SETTINGS__DOR_SERVICES__URL: http://dor-services-app:3000

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'jsbundling-rails', '~> 1.0'
 gem 'lograge'
 gem 'nokogiri', '~> 1.18'
 gem 'okcomputer' # monitors application and its dependencies
+gem 'pg'
 gem 'prawn', '~> 1' # Prawn is used to create "tracksheets"
 gem 'prawn-table'
 gem 'propshaft'
@@ -64,7 +65,6 @@ group :test, :development do
   gem 'rubocop-rails'
   gem 'rubocop-rspec'
   gem 'rubocop-rspec_rails'
-  gem 'sqlite3', '~> 2.0'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -422,6 +422,7 @@ GEM
     patience_diff (1.2.0)
       optimist (~> 3.0)
     pdf-core (0.4.0)
+    pg (1.5.9)
     pp (0.6.2)
       prettyprint
     prawn (1.3.0)
@@ -630,10 +631,6 @@ GEM
       bigdecimal
       logger
       ruby-ole
-    sqlite3 (2.6.0)
-      mini_portile2 (~> 2.8.0)
-    sqlite3 (2.6.0-x86_64-darwin)
-    sqlite3 (2.6.0-x86_64-linux-gnu)
     sshkit (1.24.0)
       base64
       logger
@@ -739,6 +736,7 @@ DEPENDENCIES
   mysql2 (~> 0.5)
   nokogiri (~> 1.18)
   okcomputer
+  pg
   prawn (~> 1)
   prawn-table
   preservation-client (~> 7.0)
@@ -766,7 +764,6 @@ DEPENDENCIES
   selenium-webdriver
   sidekiq (~> 7.1)
   simplecov
-  sqlite3 (~> 2.0)
   turbo-rails (~> 1.0)
   view_component
   web-console

--- a/README.md
+++ b/README.md
@@ -26,14 +26,6 @@ cd argo
 bundle install
 ```
 
-Note that `bundle install` may complain if MySQL isn't installed.  You can either comment out the `mysql2` inclusion in `Gemfile` and come back to it later (you can develop using `sqlite3`), or you can install MySQL.
-
-Install foreman for local development (foreman is not supposed to be in the Gemfile, See this [wiki article](https://github.com/ddollar/foreman/wiki/Don't-Bundle-Foreman)):
-
-```bash
-gem install foreman
-```
-
 ## Local Development TL;DR
 
 Brings up app at localhost:3000 with some test data:
@@ -43,6 +35,7 @@ gem install foreman
 yarn install
 docker compose up -d
 docker compose stop web
+bin/rails db:prepare
 bin/dev
 bin/rake argo:seed_data # run in separate terminal window
 rdbg -A # run in separate terminal window
@@ -79,7 +72,7 @@ CI runs a series of steps;  this the sequence to do it locally, along with some 
 4. **Prepare rails for testing**
 
     ```
-    bin/rails test:prepare
+    bin/rails db:prepare test:prepare
     ```
 
 5. **Run the linters and the tests**
@@ -124,6 +117,12 @@ Be sure all of the docker containers for dependent services are running in the b
 ```
 docker compose up -d
 docker compose stop web
+```
+
+Create/prepare the dev/test databases:
+
+```
+bin/rails db:prepare
 ```
 
 Start the development server - this should give you the Argo app on port 3000 mocking an admin login:

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,6 +10,11 @@ services:
     ports:
       - 3000:3000
     environment:
+      DATABASE_NAME: argo
+      DATABASE_USERNAME: postgres
+      DATABASE_PASSWORD: sekret
+      DATABASE_HOSTNAME: db
+      DATABASE_PORT: 5432
       NODE_ENV: development
       RAILS_LOG_TO_STDOUT: 'true'
       REMOTE_USER: blalbrit@stanford.edu
@@ -30,6 +35,8 @@ services:
       PID_FILE: /dev/null
     # To allow yarn --watch from Procfile.dev to continue after stdin is closed
     tty: true
+    depends_on:
+      - db
 
   dor-services-app:
     image: suldlss/dor-services-app:latest
@@ -104,6 +111,8 @@ services:
 
   db:
     image: postgres:11 # aligns the pg version with what is supported by dor-services-app
+    ports:
+      - 5432:5432
     environment:
       - POSTGRES_PASSWORD=sekret
     volumes:

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,24 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
-  adapter: sqlite3
-  pool: 10
+  adapter: postgresql
+  encoding: unicode
+  username: "<%= ENV.fetch('DATABASE_USERNAME', 'postgres') %>"
+  password: "<%= ENV.fetch('DATABASE_PASSWORD', 'sekret') %>"
+  host: "<%= ENV.fetch('DATABASE_HOSTNAME', 'localhost') %>"
+  port: "<%= ENV.fetch('DATABASE_PORT', 5432) %>"
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 10 } %>
   timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: "<%= ENV.fetch('DATABASE_NAME', 'argo_development') %>"
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: "<%= ENV.fetch('DATABASE_NAME', 'argo_test') %>"
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: "<%= ENV.fetch('DATABASE_NAME', 'argo') %>"

--- a/db/migrate/20160318203331_increase_delayed_job_column.rb
+++ b/db/migrate/20160318203331_increase_delayed_job_column.rb
@@ -1,8 +1,11 @@
 class IncreaseDelayedJobColumn < ActiveRecord::Migration[4.2]
   def change
-    # Ensure that the handler column in the delayed_job table is MySQL longtext
-    # so that we can pass in lots of druids in the params when a new Delayed
-    # Job is created.
-    change_column :delayed_jobs, :handler, :text, limit: 4_294_967_295
+    # Only run this migration if MySQL is the database. The :text datatype in Postgres is unlimited.
+    if ActiveRecord::Base.connection.adapter_name.match?(/mysql/i)
+      # Ensure that the handler column in the delayed_job table is MySQL longtext
+      # so that we can pass in lots of druids in the params when a new Delayed
+      # Job is created.
+      change_column :delayed_jobs, :handler, :text, limit: 4_294_967_295
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_01_155124) do
-  create_table "bookmarks", force: :cascade do |t|
+ActiveRecord::Schema[7.2].define(version: 2024_08_01_155124) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "bookmarks", id: :serial, force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "document_id"
     t.string "title"
@@ -22,7 +25,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_01_155124) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "bulk_actions", force: :cascade do |t|
+  create_table "bulk_actions", id: :serial, force: :cascade do |t|
     t.string "action_type"
     t.string "status"
     t.string "log_name"
@@ -36,7 +39,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_01_155124) do
     t.index ["user_id"], name: "index_bulk_actions_on_user_id"
   end
 
-  create_table "indexing_exceptions", force: :cascade do |t|
+  create_table "indexing_exceptions", id: :serial, force: :cascade do |t|
     t.string "pid"
     t.text "solr_document"
     t.string "dor_services_version"
@@ -46,7 +49,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_01_155124) do
     t.index ["pid"], name: "index_indexing_exceptions_on_pid"
   end
 
-  create_table "searches", force: :cascade do |t|
+  create_table "searches", id: :serial, force: :cascade do |t|
     t.text "query_params"
     t.integer "user_id"
     t.datetime "created_at", precision: nil
@@ -55,10 +58,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_01_155124) do
     t.index ["user_id"], name: "index_searches_on_user_id"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", id: :serial, force: :cascade do |t|
     t.string "sunetid"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
   end
-
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,19 +3,18 @@
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
 
-unless Rails.env.production?
+# Prevent executing this code in the production Rails env, which is what we use in deployed environments.
+if Rails.env.local?
   require_relative '../spec/support/create_strategy_repository_pattern'
   require_relative '../spec/support/item_method_sender'
   require_relative '../spec/support/apo_method_sender'
   require_relative '../spec/support/reset_solr'
 
-  $stdout.puts 'This will clear the Solr repo. Are you sure? [y/n]:'
-  if gets.chomp == 'y'
-    ResetSolr.reset_solr
-    FactoryBot.create_for_repository(:agreement)
-    FactoryBot.create_for_repository(:persisted_apo,
-                                     roles: [{ name: 'dor-apo-manager',
-                                               members: [{ identifier: 'sdr:administrator-role',
-                                                           type: 'workgroup' }] }])
-  end
+  $stdout.puts 'Clearing the Solr repo.'
+  ResetSolr.reset_solr
+  FactoryBot.create_for_repository(:agreement)
+  FactoryBot.create_for_repository(:persisted_apo,
+                                   roles: [{ name: 'dor-apo-manager',
+                                             members: [{ identifier: 'sdr:administrator-role',
+                                                         type: 'workgroup' }] }])
 end


### PR DESCRIPTION
# Why was this change made?

Connects to #4743

Includes:

* Change DB config to use Postgres for all envs
* Remove MySQL-ism from DB migration and allow db:migrate to function with Postgres underneath
* Change DB seeding so db:prepare functions like it does everywhere else
* Make web container depend on Postgres in docker compose
* Reflect above changes in README

# How was this change tested?

CI
