### PR TITLE
Allow serials form to handle new and old digital serials structures

### DIFF
--- a/app/forms/serials_form.rb
+++ b/app/forms/serials_form.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 class SerialsForm < ApplicationChangeSet
-  property :part_number, virtual: true
-  property :part_name, virtual: true
-  property :part_number2, virtual: true
-  property :sort_field, virtual: true
+  property :part_label, virtual: true
+  property :sort_key, virtual: true
 
   PART_NAME = 'part name'
   PART_NUMBER = 'part number'
@@ -13,45 +11,50 @@ class SerialsForm < ApplicationChangeSet
   NOTE_TYPE = 'date/sequential designation'
 
   # When the object is initialized, copy the properties from the cocina model to the form:
-  def setup_properties!(_options)
-    titles = model.description.title
-    title_to_change = titles.find { |title| title.status == PRIMARY }
-    title_to_change ||= titles.first
-
-    structured_value = structured_value_for_setup(title_to_change)
-    setup_from_structured_value(structured_value) if structured_value
-    self.sort_field = model.description.note.find { |note| note.type == NOTE_TYPE }&.value
+  def setup_properties!(_options) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    self.part_label = model.identification&.catalogLinks&.find { |link| link.catalog == 'folio' }&.partLabel ||
+                      part_label_from_titles
+    self.sort_key = model.identification&.catalogLinks&.find { |link| link.catalog == 'folio' }&.sortKey ||
+                    model.description.note.find { |note| note.type == NOTE_TYPE }&.value
   end
 
-  def structured_value_for_setup(title)
+  def part_label_from_titles # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    title_to_change = model.description.title.find { |title| title.status == PRIMARY } ||
+                      model.description.title.first
+
+    return unless (structured_title = structured_title_for_setup(title_to_change))
+
+    part_name = structured_title.find { |element| element.type == PART_NAME }&.value
+    part_parts = [part_name]
+    part_number, part_number_position = setup_part_number(structured_title)
+
+    if part_number_position == :before
+      part_parts.prepend(part_number)
+    elsif part_number_position == :after
+      part_parts.append(part_number)
+    end
+
+    part_parts.compact.join(', ')
+  end
+
+  def structured_title_for_setup(title)
     return title.structuredValue if title.structuredValue.present?
     return title.parallelValue.first.structuredValue if title.parallelValue.first&.structuredValue
 
     nil
   end
 
-  def setup_from_structured_value(structured_value)
-    setup_part_name(structured_value)
-    setup_part_number(structured_value)
-  end
+  def setup_part_number(structured_title)
+    part_number_value = structured_title.find { |element| element.type == PART_NUMBER }&.value
 
-  def setup_part_name(structured_value)
-    self.part_name = structured_value.find { |element| element.type == PART_NAME }&.value
-  end
+    return [nil, nil] if part_number_value.nil?
 
-  def setup_part_number(structured_value)
-    part_number_value = structured_value.find { |element| element.type == PART_NUMBER }&.value
+    part_number_index = structured_title.index { |element| element.type == PART_NUMBER }
+    part_name_index = structured_title.index { |element| element.type == PART_NAME }
 
-    return if part_number_value.nil?
+    position = part_name_index && part_number_index > part_name_index ? :after : :before
 
-    part_number_index = structured_value.index { |element| element.type == PART_NUMBER }
-    part_name_index = structured_value.index { |element| element.type == PART_NAME }
-
-    if part_name_index && part_number_index > part_name_index
-      self.part_number2 = part_number_value
-    else
-      self.part_number = part_number_value
-    end
+    [part_number_value, position]
   end
 
   def save_model
@@ -66,8 +69,7 @@ class SerialsForm < ApplicationChangeSet
   def updated_title
     # Convert to hash so we can mutate.
     model.description.title.map(&:to_h).tap do |titles|
-      title_to_change = titles.find { |title| title[:status] == PRIMARY }
-      title_to_change ||= titles.first
+      title_to_change = titles.find { |title| title[:status] == PRIMARY } || titles.first
       if title_to_change[:parallelValue].present?
         title_to_change[:parallelValue].first[:structuredValue] =
           update_or_create_structured_value(title_to_change[:parallelValue].first)
@@ -81,7 +83,7 @@ class SerialsForm < ApplicationChangeSet
     # Convert to hash so we can mutate.
     model.description.note.map(&:to_h).tap do |notes|
       notes.delete_if { |note| note[:type] == NOTE_TYPE }
-      notes << { type: NOTE_TYPE, value: sort_field } if sort_field.present?
+      notes << { type: NOTE_TYPE, value: sort_key } if sort_key.present?
     end
   end
 
@@ -99,17 +101,13 @@ class SerialsForm < ApplicationChangeSet
 
   def update_structured_value(structured_value)
     structured_value.delete_if { |element| [PART_NAME, PART_NUMBER].include?(element[:type]) }
-    structured_value << { value: part_number, type: PART_NUMBER } if part_number.present?
-    structured_value << { value: part_name, type: PART_NAME } if part_name.present?
-    structured_value << { value: part_number2, type: PART_NUMBER } if part_number2.present?
+    structured_value << { value: part_label, type: PART_NAME } if part_label.present?
     structured_value
   end
 
   def create_structured_value_from_unstructured(unstructured)
     [{ value: unstructured.delete(:value), type: MAIN_TITLE }].tap do |structured_value|
-      structured_value << { value: part_number, type: PART_NUMBER } if part_number.present?
-      structured_value << { value: part_name, type: PART_NAME } if part_name.present?
-      structured_value << { value: part_number2, type: PART_NUMBER } if part_number2.present?
+      structured_value << { value: part_label, type: PART_NAME } if part_label.present?
     end
   end
 
@@ -119,7 +117,14 @@ class SerialsForm < ApplicationChangeSet
 
   def updated_catalog_links
     model.identification.catalogLinks.map do |catalog_link|
-      catalog_link.to_h.merge(refresh: false)
+      catalog_link_hash = catalog_link.to_h
+
+      if catalog_link_hash[:catalog] == 'folio'
+        catalog_link_hash[:partLabel] = part_label
+        catalog_link_hash[:sortKey] = sort_key
+      end
+
+      catalog_link_hash.merge(refresh: false)
     end
   end
 end

--- a/app/views/serials/_form.html.erb
+++ b/app/views/serials/_form.html.erb
@@ -1,27 +1,12 @@
 <%= form_with model: @form, url: item_serials_path(@form.to_param), target: '_top' do |f| %>
-  <p>Enter part number in the order it will appear next to the part name. If it appears before
-  part name, enter it in the first 'Part number' field and leave 'Part number 2' blank.
-  If it appears after part name, enter it in the 'Part number 2' field and leave the
-  'Part number' blank.</p>
-
   <div class="row">
     <div class="col">
-      <%= f.label :part_number, class: 'form-label' %>
-      <%= f.text_field :part_number, class: 'form-control' %>
+      <%= f.label :part_label, class: 'form-label' %>
+      <%= f.text_field :part_label, class: 'form-control' %>
     </div>
     <div class="col">
-      <%= f.label :part_name, class: 'form-label' %>
-      <%= f.text_field :part_name, class: 'form-control' %>
-    </div>
-    <div class="col">
-      <%= f.label :part_number2, class: 'form-label' %>
-      <%= f.text_field :part_number2, class: 'form-control' %>
-    </div>
-  </div>
-  <div class="row mt-4">
-    <div class="col-md-4">
-      <%= f.label :sort_field, class: 'form-label' %>
-      <%= f.text_field :sort_field, class: 'form-control' %>
+      <%= f.label :sort_key, class: 'form-label' %>
+      <%= f.text_field :sort_key, class: 'form-control' %>
     </div>
   </div>
   <%= f.button 'Update', class: 'btn btn-primary mt-4' %>

--- a/spec/requests/serials_spec.rb
+++ b/spec/requests/serials_spec.rb
@@ -29,12 +29,11 @@ RSpec.describe 'Serials' do
     describe 'update the form' do
       let(:expected) do
         cocina_model.new(description: {
-                           :title => [
+                           title: [
                              {
                                structuredValue: [
                                  { value: 'My Serial', type: 'main title' },
-                                 { value: '7', type: 'part number' },
-                                 { value: 'samurai', type: 'part name' }
+                                 { value: '7 samurai', type: 'part name' }
                                ]
                              }
                            ],
@@ -43,7 +42,7 @@ RSpec.describe 'Serials' do
       end
 
       it 'updates the form' do
-        put '/items/druid:kv840xx0000/serials', params: { serials: { part_number: '7', part_name: 'samurai' } }
+        put '/items/druid:kv840xx0000/serials', params: { serials: { part_label: '7 samurai' } }
         expect(object_client).to have_received(:update).with(params: expected)
         expect(object_client).to have_received(:reindex)
 

--- a/spec/system/update_serials_metadata_spec.rb
+++ b/spec/system/update_serials_metadata_spec.rb
@@ -32,9 +32,8 @@ RSpec.describe 'Update serials metadata', :js do
     click_button 'Manage description'
     click_link 'Manage serials'
 
-    fill_in 'Part number', with: 'part 17'
-    fill_in 'Part name', with: 'supplement'
-    fill_in 'Sort field', with: '17'
+    fill_in 'Part label', with: 'part 17, supplement'
+    fill_in 'Sort key', with: '17'
     click_button 'Update'
 
     expect(page).to have_content 'test object. part 17, supplement'


### PR DESCRIPTION
**HOLD** until:

- [x] Tested in stage
- [x] ~~Postgres migration done in `prod`~~, or **PR rebased on `main` without postgres commits**

# Why was this change made?

Fixes #4745

# How was this change tested?

- [x] CI
- [x] stage
