### PR TITLE
Bulk action for exporting catalogLinks and barcodes

### DIFF
--- a/app/components/bulk_actions_form_component.rb
+++ b/app/components/bulk_actions_form_component.rb
@@ -52,7 +52,8 @@ class BulkActionsFormComponent < ApplicationComponent
         ['Download descriptive metadata (as MODS)', new_download_mods_job_path(search_of_druids)],
         ['Validate Cocina descriptive metadata spreadsheet', new_validate_cocina_descriptive_job_path],
         ['Download tracking sheet', new_tracking_sheet_report_job_path(search_of_druids)],
-        ['Download full Cocina JSON', new_export_cocina_json_job_path(search_of_druids)]
+        ['Download full Cocina JSON', new_export_cocina_json_job_path(search_of_druids)],
+        ['Download Folio Instance HRIDs and barcodes', new_export_catalog_links_job_path(search_of_druids)]
       ]]
     ]
   end

--- a/app/controllers/bulk_actions/export_catalog_links_controller.rb
+++ b/app/controllers/bulk_actions/export_catalog_links_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module BulkActions
+  class ExportCatalogLinksController < ApplicationController
+    include CreatesBulkActions
+    self.action_type = 'ExportCatalogLinksJob'
+  end
+end

--- a/app/controllers/bulk_actions/export_catalog_links_jobs_controller.rb
+++ b/app/controllers/bulk_actions/export_catalog_links_jobs_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module BulkActions
-  class ExportCatalogLinksController < ApplicationController
+  class ExportCatalogLinksJobsController < ApplicationController
     include CreatesBulkActions
     self.action_type = 'ExportCatalogLinksJob'
   end

--- a/app/jobs/export_catalog_links_job.rb
+++ b/app/jobs/export_catalog_links_job.rb
@@ -13,11 +13,11 @@ class ExportCatalogLinksJob < GenericJob
       headers = %w[druid folio_instance_hrid refresh part_label sort_key barcode]
       CSV.open(csv_download_path, 'w', write_headers: true, headers: headers) do |csv|
         druids.each do |druid|
-          log_buffer.puts("#{Time.current} #{self.class}: Exporting catalogLinks for #{druid} (bulk_action.id=#{bulk_action_id})")
+          log_buffer.puts("#{Time.current} #{self.class}: Exporting FOLIO instance HRIDs and barcodes for #{druid} (bulk_action.id=#{bulk_action_id})")
           csv << [druid, *export_catalog_links(druid)]
           bulk_action.increment(:druid_count_success).save
         rescue StandardError => e
-          log_buffer.puts("#{Time.current} #{self.class}: Unexpected error exporting catalogLinks for #{druid} (bulk_action.id=#{bulk_action.id}): #{e}")
+          log_buffer.puts("#{Time.current} #{self.class}: Unexpected error exporting FOLIO instance HRIDs and barcodes for #{druid} (bulk_action.id=#{bulk_action.id}): #{e}")
           bulk_action.increment(:druid_count_fail).save
         end
       end

--- a/app/jobs/export_catalog_links_job.rb
+++ b/app/jobs/export_catalog_links_job.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+##
+# A job that exports catalog_links to CSV for one or more objects
+# @param [Integer] bulk_action_id GlobalID for a BulkAction object
+# @param [Hash] _params additional parameters that an Argo job may need
+class ExportCatalogLinksJob < GenericJob
+  def perform(bulk_action_id, _params)
+    super
+
+    with_bulk_action_log do |log_buffer|
+      update_druid_count
+      headers = %w[druid folio_instance_hrid refresh part_label sort_key barcode]
+      CSV.open(csv_download_path, 'w', write_headers: true, headers: headers) do |csv|
+        druids.each do |druid|
+          log_buffer.puts("#{Time.current} #{self.class}: Exporting catalogLinks for #{druid} (bulk_action.id=#{bulk_action_id})")
+          csv << [druid, *export_catalog_links(druid)]
+          bulk_action.increment(:druid_count_success).save
+        rescue StandardError => e
+          log_buffer.puts("#{Time.current} #{self.class}: Unexpected error exporting catalogLinks for #{druid} (bulk_action.id=#{bulk_action.id}): #{e}")
+          bulk_action.increment(:druid_count_fail).save
+        end
+      end
+    end
+  end
+
+  private
+
+  def export_catalog_links(druid)
+    object_client = Dor::Services::Client.object(druid)
+    identification = object_client.find_lite.identification
+    link = identification.catalogLinks.find { |catalog_link| catalog_link.catalog == 'folio' }
+
+    [link&.catalogRecordId, link&.refresh, link&.partLabel, link&.sortKey, identification.barcode]
+  end
+
+  def csv_download_path
+    FileUtils.mkdir_p(bulk_action.output_directory)
+    File.join(bulk_action.output_directory, Settings.export_catalog_links_job.csv_filename)
+  end
+end

--- a/app/models/bulk_action.rb
+++ b/app/models/bulk_action.rb
@@ -36,7 +36,8 @@ class BulkAction < ApplicationRecord
                      ValidateCocinaDescriptiveJob
                      TrackingSheetReportJob
                      ExportCocinaJsonJob
-                     TextExtractionJob]
+                     TextExtractionJob
+                     ExportCatalogLinksJob]
             }
 
   after_create :create_output_directory, :create_log_file

--- a/app/views/bulk_actions/_export_catalog_links_job.html.erb
+++ b/app/views/bulk_actions/_export_catalog_links_job.html.erb
@@ -1,0 +1,3 @@
+<% if bulk_action.has_report?(Settings.export_catalog_links_job.csv_filename) %>
+  <%= link_to('Download FOLIO Instance HRIDs and Barcodes CSV', file_bulk_action_path(bulk_action.id, filename: Settings.export_catalog_links_job.csv_filename), download: true) %>
+<% end %>

--- a/app/views/bulk_actions/export_catalog_links_jobs/_new.html.erb
+++ b/app/views/bulk_actions/export_catalog_links_jobs/_new.html.erb
@@ -2,8 +2,7 @@
   <%= render 'bulk_actions/errors' %>
 
   <span class='help-block'>
-    Export FOLIO Instance HRIDs and barcodes for objects.
-  </span>
+    Download FOLIO Instance HRIDs and barcodes as CSV (comma-separated values) for druids specified below.
 
   <%= render 'bulk_actions/druids', f: %>
   <%= render 'bulk_actions/common_fields', f: %>

--- a/app/views/bulk_actions/export_catalog_links_jobs/_new.html.erb
+++ b/app/views/bulk_actions/export_catalog_links_jobs/_new.html.erb
@@ -1,0 +1,10 @@
+<%= form_with url: export_catalog_links_job_path, class: 'new_bulk_action', data: { turbo_frame: '_top' } do |f| %>
+  <%= render 'bulk_actions/errors' %>
+
+  <span class='help-block'>
+    Export FOLIO Instance HRIDs and barcodes for objects.
+  </span>
+
+  <%= render 'bulk_actions/druids', f: %>
+  <%= render 'bulk_actions/common_fields', f: %>
+<% end %>

--- a/app/views/bulk_actions/export_catalog_links_jobs/new.html.erb
+++ b/app/views/bulk_actions/export_catalog_links_jobs/new.html.erb
@@ -1,0 +1,3 @@
+<turbo-frame id="bulk-action-form">
+  <%= render 'new' %>
+</turbo-frame>

--- a/app/views/bulk_actions/export_catalog_links_jobs/new.turbo_stream.erb
+++ b/app/views/bulk_actions/export_catalog_links_jobs/new.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.replace("bulk-action-form", partial: 'new') %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
         resource :validate_cocina_descriptive_job, only: %i[new create]
         resource :tracking_sheet_report_job, only: %i[new create]
         resource :export_cocina_json_job, only: %i[new create]
+        resource :export_catalog_links_job, only: %i[new create]
       end
     end
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,6 +14,8 @@ checksum_report_job:
   csv_filename: "checksum_report.csv"
 descriptive_metadata_export_job:
   csv_filename: "descriptive.csv"
+export_catalog_links_job:
+  csv_filename: "catalog_links.csv"
 export_tags_job:
   csv_filename: "tags.csv"
 export_structural_job:

--- a/spec/jobs/export_catalog_links_job_spec.rb
+++ b/spec/jobs/export_catalog_links_job_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ExportCatalogLinksJob do
+  subject(:job) { described_class.new }
+
+  let(:bulk_action) { create(:bulk_action, action_type: 'ExportCatalogLinksJob') }
+  let(:csv_path) { File.join(bulk_action.output_directory, Settings.export_catalog_links_job.csv_filename) }
+  let(:log_buffer) { StringIO.new }
+  let(:object_client1) { instance_double(Dor::Services::Client::Object, find_lite: cocina_object1) }
+  let(:object_client2) { instance_double(Dor::Services::Client::Object, find_lite: cocina_object2) }
+  let(:object_client3) { instance_double(Dor::Services::Client::Object, find_lite: cocina_object3) }
+  let(:druid1) { 'druid:hj185xx2222' }
+  let(:druid2) { 'druid:kv840xx0000' }
+  let(:druid3) { 'druid:cd123cc1111' }
+  let(:cocina_object1) { build(:dro, id: druid1).new(identification: ident1) }
+  let(:cocina_object2) { build(:dro, id: druid2).new(identification: ident2) }
+  let(:cocina_object3) { build(:dro, id: druid3).new(identification: ident3) }
+  let(:ident1) { Cocina::Models::Identification.new(catalogLinks: [link1], barcode: '36105010101010', sourceId: 'sul:123') }
+  let(:ident2) { Cocina::Models::Identification.new(catalogLinks: [link2], sourceId: 'sul:234') }
+  let(:ident3) { Cocina::Models::Identification.new(barcode: '36105010101011', sourceId: 'sul:345') }
+  let(:link1) do
+    Cocina::Models::FolioCatalogLink.new(catalog: 'folio',
+                                         catalogRecordId: 'in1234',
+                                         refresh: true,
+                                         partLabel: 'Part 1',
+                                         sortKey: '1')
+  end
+  let(:link2) do
+    Cocina::Models::FolioCatalogLink.new(catalog: 'folio',
+                                         catalogRecordId: 'in5678',
+                                         refresh: false,
+                                         partLabel: 'Part 2')
+  end
+
+  before do
+    allow(job).to receive(:bulk_action).and_return(bulk_action)
+    allow(BulkJobLog).to receive(:open).and_yield(log_buffer)
+    allow(Dor::Services::Client).to receive(:object).with(druid1).and_return(object_client1)
+    allow(Dor::Services::Client).to receive(:object).with(druid2).and_return(object_client2)
+    allow(Dor::Services::Client).to receive(:object).with(druid3).and_return(object_client3)
+  end
+
+  after do
+    FileUtils.rm_f(csv_path)
+  end
+
+  describe '#perform_now' do
+    let(:groups) { [] }
+    let(:user) { instance_double(User, to_s: 'a_user') }
+
+    context 'when happy path' do
+      before do
+        job.perform(bulk_action.id,
+                    druids: [druid1, druid2, druid3],
+                    groups:,
+                    user:)
+      end
+
+      it 'records zero failures and all successes' do
+        expect(bulk_action.druid_count_total).to eq(3)
+        expect(bulk_action.druid_count_success).to eq(3)
+        expect(bulk_action.druid_count_fail).to eq(0)
+      end
+
+      it 'logs messages for each druid in the list' do
+        expect(log_buffer.string).to include "Exporting catalogLinks for #{druid1} (bulk_action.id=#{bulk_action.id})"
+        expect(log_buffer.string).to include "Exporting catalogLinks for #{druid2} (bulk_action.id=#{bulk_action.id})"
+        expect(log_buffer.string).to include "Exporting catalogLinks for #{druid3} (bulk_action.id=#{bulk_action.id})"
+        expect(log_buffer.string).not_to include 'Unexpected error'
+      end
+
+      it 'writes a CSV file' do
+        expect(File).to exist(csv_path)
+
+        csv = CSV.read(csv_path, headers: true)
+        expect(csv.headers).to eq %w[druid folio_instance_hrid refresh part_label sort_key barcode]
+        expect(csv[0].to_h.values).to eq [druid1, 'in1234', 'true', 'Part 1', '1', '36105010101010']
+        expect(csv[1].to_h.values).to eq [druid2, 'in5678', 'false', 'Part 2', nil, nil]
+        expect(csv[2].to_h.values).to eq [druid3, nil, nil, nil, nil, '36105010101011']
+      end
+    end
+
+    context 'when an exception is raised' do
+      before do
+        allow(object_client1).to receive(:find_lite).and_raise(StandardError, 'ruh roh')
+        job.perform(bulk_action.id,
+                    druids: [druid1],
+                    groups:,
+                    user:)
+      end
+
+      it 'records all failures and zero successes' do
+        expect(bulk_action.druid_count_total).to eq(1)
+        expect(bulk_action.druid_count_success).to eq(0)
+        expect(bulk_action.druid_count_fail).to eq(1)
+      end
+
+      it 'logs messages for each druid in the list' do
+        expect(log_buffer.string).to include "Unexpected error exporting catalogLinks for #{druid1} (bulk_action.id=#{bulk_action.id}): ruh roh"
+      end
+
+      it 'writes a CSV file' do
+        expect(File).to exist(csv_path)
+        csv = CSV.read(csv_path, headers: true)
+        expect(csv.headers).to eq %w[druid folio_instance_hrid refresh part_label sort_key barcode]
+      end
+    end
+  end
+end

--- a/spec/jobs/export_catalog_links_job_spec.rb
+++ b/spec/jobs/export_catalog_links_job_spec.rb
@@ -65,9 +65,9 @@ RSpec.describe ExportCatalogLinksJob do
       end
 
       it 'logs messages for each druid in the list' do
-        expect(log_buffer.string).to include "Exporting catalogLinks for #{druid1} (bulk_action.id=#{bulk_action.id})"
-        expect(log_buffer.string).to include "Exporting catalogLinks for #{druid2} (bulk_action.id=#{bulk_action.id})"
-        expect(log_buffer.string).to include "Exporting catalogLinks for #{druid3} (bulk_action.id=#{bulk_action.id})"
+        expect(log_buffer.string).to include "Exporting FOLIO instance HRIDs and barcodes for #{druid1} (bulk_action.id=#{bulk_action.id})"
+        expect(log_buffer.string).to include "Exporting FOLIO instance HRIDs and barcodes for #{druid2} (bulk_action.id=#{bulk_action.id})"
+        expect(log_buffer.string).to include "Exporting FOLIO instance HRIDs and barcodes for #{druid3} (bulk_action.id=#{bulk_action.id})"
         expect(log_buffer.string).not_to include 'Unexpected error'
       end
 
@@ -98,7 +98,7 @@ RSpec.describe ExportCatalogLinksJob do
       end
 
       it 'logs messages for each druid in the list' do
-        expect(log_buffer.string).to include "Unexpected error exporting catalogLinks for #{druid1} (bulk_action.id=#{bulk_action.id}): ruh roh"
+        expect(log_buffer.string).to include "Unexpected error exporting FOLIO instance HRIDs and barcodes for #{druid1} (bulk_action.id=#{bulk_action.id}): ruh roh"
       end
 
       it 'writes a CSV file' do


### PR DESCRIPTION
# Why was this change made?

Resolves #4748 to create bulk action for exporting folio HRIDs and barcodes.

# How was this change tested?
Unit. Reviewed by Andrew on stage.


