### PR TITLE
Remove explicit one-time key setup

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -2,5 +2,3 @@
 
 server 'argo-prod-01.stanford.edu', user: 'lyberadmin', roles: %w[web db app worker]
 server 'argo-prod-02.stanford.edu', user: 'lyberadmin', roles: %w[web db app worker]
-
-Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -2,5 +2,3 @@
 
 server 'argo-qa-a.stanford.edu', user: 'lyberadmin', roles: %w[web db app worker]
 server 'argo-qa-b.stanford.edu', user: 'lyberadmin', roles: %w[web db app worker]
-
-Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -2,5 +2,3 @@
 
 server 'argo-stage-a.stanford.edu', user: 'lyberadmin', roles: %w[web db app worker]
 server 'argo-stage-b.stanford.edu', user: 'lyberadmin', roles: %w[web db app worker]
-
-Capistrano::OneTimeKey.generate_one_time_key!


### PR DESCRIPTION
This line has been a no-op since dlss-capistrano 5.2.0. Setting up the one-time key is done automatically in dlss-capistrano now.