### PR TITLE
Serials form should only write to catalogLinks

### DIFF
--- a/app/forms/serials_form.rb
+++ b/app/forms/serials_form.rb
@@ -6,111 +6,15 @@ class SerialsForm < ApplicationChangeSet
 
   validates :part_label, presence: true, if: -> { sort_key.present? }
 
-  PART_NAME = 'part name'
-  PART_NUMBER = 'part number'
-  MAIN_TITLE = 'main title'
-  PRIMARY = 'primary'
-  NOTE_TYPE = 'date/sequential designation'
-
   # When the object is initialized, copy the properties from the cocina model to the form:
   def setup_properties!(_options) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-    self.part_label = model.identification&.catalogLinks&.find { |link| link.catalog == 'folio' }&.partLabel ||
-                      part_label_from_titles
-    self.sort_key = model.identification&.catalogLinks&.find { |link| link.catalog == 'folio' }&.sortKey ||
-                    model.description.note.find { |note| note.type == NOTE_TYPE }&.value
-  end
-
-  def part_label_from_titles # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-    title_to_change = model.description.title.find { |title| title.status == PRIMARY } ||
-                      model.description.title.first
-
-    return unless (structured_title = structured_title_for_setup(title_to_change))
-
-    part_name = structured_title.find { |element| element.type == PART_NAME }&.value
-    part_parts = [part_name]
-    part_number, part_number_position = setup_part_number(structured_title)
-
-    if part_number_position == :before
-      part_parts.prepend(part_number)
-    elsif part_number_position == :after
-      part_parts.append(part_number)
-    end
-
-    part_parts.compact.join(', ')
-  end
-
-  def structured_title_for_setup(title)
-    return title.structuredValue if title.structuredValue.present?
-    return title.parallelValue.first.structuredValue if title.parallelValue.first&.structuredValue
-
-    nil
-  end
-
-  def setup_part_number(structured_title)
-    part_number_value = structured_title.find { |element| element.type == PART_NUMBER }&.value
-
-    return [nil, nil] if part_number_value.nil?
-
-    part_number_index = structured_title.index { |element| element.type == PART_NUMBER }
-    part_name_index = structured_title.index { |element| element.type == PART_NAME }
-
-    position = part_name_index && part_number_index > part_name_index ? :after : :before
-
-    [part_number_value, position]
+    self.part_label = model.identification&.catalogLinks&.find { |link| link.catalog == 'folio' }&.partLabel
+    self.sort_key = model.identification&.catalogLinks&.find { |link| link.catalog == 'folio' }&.sortKey
   end
 
   def save_model
-    updated_model = model.new(description: updated_description, identification: updated_identification)
+    updated_model = model.new(identification: updated_identification)
     Repository.store(updated_model)
-  end
-
-  def updated_description
-    model.description.new(title: updated_title, note: updated_note)
-  end
-
-  def updated_title
-    # Convert to hash so we can mutate.
-    model.description.title.map(&:to_h).tap do |titles|
-      title_to_change = titles.find { |title| title[:status] == PRIMARY } || titles.first
-      if title_to_change[:parallelValue].present?
-        title_to_change[:parallelValue].first[:structuredValue] =
-          update_or_create_structured_value(title_to_change[:parallelValue].first)
-      else
-        title_to_change[:structuredValue] = update_or_create_structured_value(title_to_change)
-      end
-    end
-  end
-
-  def updated_note
-    # Convert to hash so we can mutate.
-    model.description.note.map(&:to_h).tap do |notes|
-      notes.delete_if { |note| note[:type] == NOTE_TYPE }
-      notes << { type: NOTE_TYPE, value: sort_key } if sort_key.present?
-    end
-  end
-
-  def update_or_create_structured_value(title_to_change)
-    # If the existing title value is a structuredValue:
-    #   Remove any values in the structured value with type “part name” or “part number”.
-    #   Add the new part name/number values to the structuredValue with the appropriate type in the order in which they were entered.
-    return update_structured_value(title_to_change[:structuredValue]) if title_to_change[:structuredValue].present?
-
-    # If the existing title value is an unstructured value:
-    #   1. Change the title entry to a structuredValue with the existing title value as the first element, with type “main title”.
-    #   2. Add the new part name/number values to the structuredValue with the appropriate type in the order in which they were entered.
-    create_structured_value_from_unstructured(title_to_change)
-  end
-
-  def update_structured_value(structured_value)
-    structured_value.delete_if { |element| [PART_NAME, PART_NUMBER].include?(element[:type]) }
-    structured_value << { value: part_label, type: PART_NAME } if part_label.present?
-    structured_value
-  end
-
-  def create_structured_value_from_unstructured(unstructured)
-    [{ value: unstructured.delete(:value), type: MAIN_TITLE }].tap do |structured_value|
-      structured_value << { value: part_label, type: PART_NAME } if part_label.present?
-    end
   end
 
   def updated_identification
@@ -121,12 +25,9 @@ class SerialsForm < ApplicationChangeSet
     model.identification.catalogLinks.map do |catalog_link|
       catalog_link_hash = catalog_link.to_h
 
-      if catalog_link_hash[:catalog] == 'folio'
-        catalog_link_hash[:partLabel] = part_label
-        catalog_link_hash[:sortKey] = sort_key
-      end
+      next catalog_link_hash.merge(partLabel: part_label, sortKey: sort_key) if catalog_link.catalog == 'folio'
 
-      catalog_link_hash.merge(refresh: false)
+      catalog_link_hash
     end
   end
 end

--- a/spec/forms/serials_form_spec.rb
+++ b/spec/forms/serials_form_spec.rb
@@ -6,34 +6,9 @@ RSpec.describe SerialsForm do
   let(:instance) { described_class.new(cocina_item) }
   let(:druid) { 'druid:bc123df4567' }
   let(:purl) { 'https://purl.stanford.edu/bc123df4567' }
-  let(:cocina_item) { build(:dro_with_metadata, id: druid).new(description:) }
+  let(:cocina_item) { build(:dro_with_metadata, id: druid).new(description:, identification:) }
 
   describe 'loading from cocina' do
-    context 'when the number is before the part name' do
-      let(:description) do
-        {
-          title: [
-            {
-              structuredValue: [
-                { value: 'My Serial', type: 'main title' },
-                { value: '7', type: 'part number' },
-                { value: 'samurai', type: 'part name' }
-              ]
-            }
-          ],
-          note: [
-            { value: '1990', type: 'date/sequential designation' }
-          ],
-          purl:
-        }
-      end
-
-      it 'loads the part label from the title' do
-        expect(instance.part_label).to eq '7, samurai'
-        expect(instance.sort_key).to eq '1990'
-      end
-    end
-
     context 'when catalog link contains part label' do
       let(:cocina_item) { build(:dro_with_metadata, id: druid).new(description:, identification:) }
       let(:description) do
@@ -56,310 +31,147 @@ RSpec.describe SerialsForm do
       let(:identification) do
         {
           catalogLinks: [
-            { catalog: 'folio', refresh: false, catalogRecordId: 'a6671606', partLabel: '11 ninjas', sortKey: 'something else' }
+            { catalog: 'folio', refresh: true, catalogRecordId: 'a6671606', partLabel: '11 ninjas', sortKey: 'something else' }
           ],
           sourceId: 'sul:1234'
         }
       end
 
-      it 'loads the part label from the title' do
+      it 'loads the part label from the catalog link' do
         expect(instance.part_label).to eq '11 ninjas'
         expect(instance.sort_key).to eq 'something else'
       end
     end
 
-    context 'when the number is after the part name' do
+    context 'when the catalog link does not contain a part label' do
+      let(:cocina_item) { build(:dro_with_metadata, id: druid).new(description:, identification:) }
       let(:description) do
         {
           title: [
             {
               structuredValue: [
                 { value: 'My Serial', type: 'main title' },
-                { value: 'samurai', type: 'part name' },
-                { value: '7', type: 'part number' }
-              ]
-            }
-          ],
-          purl:
-        }
-      end
-
-      it 'loads the part label from the title' do
-        expect(instance.part_label).to eq 'samurai, 7'
-        expect(instance.sort_key).to be_nil
-      end
-    end
-
-    context 'when parallel title' do
-      let(:description) do
-        {
-          title: [
-            parallelValue: [
-              {
-                structuredValue: [
-                  { value: 'My Serial', type: 'main title' },
-                  { value: '7', type: 'part number' },
-                  { value: 'samurai', type: 'part name' }
-                ]
-              },
-              {
-                value: 'parallel title'
-              }
-            ]
-          ],
-          note: [
-            { value: '1990', type: 'date/sequential designation' }
-          ],
-          purl:
-        }
-      end
-
-      it 'loads the part label from the first parallel title' do
-        expect(instance.part_label).to eq '7, samurai'
-        expect(instance.sort_key).to eq '1990'
-      end
-    end
-
-    context 'when there is no part name' do
-      let(:description) do
-        {
-          title: [
-            {
-              structuredValue: [
-                { value: 'My Serial', type: 'main title' },
-                { value: '7', type: 'part number' }
+                { value: 'May 2025', type: 'part number' }
               ]
             }
           ],
           note: [
             { value: '1990', type: 'date/sequential designation' }
           ],
-          purl:
-        }
-      end
-
-      it 'loads the part label, just the number' do
-        expect(instance.part_label).to eq '7'
-        expect(instance.sort_key).to eq '1990'
-      end
-    end
-  end
-
-  describe 'validate and save' do
-    before { allow(Repository).to receive(:store) }
-
-    context 'when the initial title is unstructured' do
-      let(:description) do
-        {
-          title: [{ value: 'My Serial' }],
           purl:
         }
       end
       let(:identification) do
         {
           catalogLinks: [
-            { catalog: 'folio', refresh: false, catalogRecordId: 'a6671606', partLabel: '7 samurai', sortKey: 'something' }
+            { catalog: 'folio', refresh: true, catalogRecordId: 'a6671606' }
           ],
           sourceId: 'sul:1234'
         }
       end
 
-      context 'when part_number is set' do
-        let(:cocina_item) do
-          build(:dro_with_metadata, id: druid).new(description:, identification:)
-        end
-        let(:expected) do
-          build(:dro_with_metadata, id: druid).new(
-            description: {
-              title: [
-                {
-                  structuredValue: [
-                    { value: 'My Serial', type: 'main title' },
-                    { value: '7 samurai', type: 'part name' }
-                  ]
-                }
-              ],
-              note: [{ value: 'something', type: 'date/sequential designation' }],
-              purl:
-            },
-            identification:
-          )
-        end
+      it 'the form is blank' do
+        expect(instance.part_label).to be_nil
+        expect(instance.sort_key).to be_nil
+      end
+    end
+  end
 
-        before do
-          instance.validate({ part_label: '7 samurai', sort_key: 'something' })
-          instance.save
-        end
+  describe 'validate and save' do
+    let(:description) do
+      {
+        title: [{ value: 'My Serial' }],
+        purl:
+      }
+    end
+    let(:identification) do
+      {
+        catalogLinks: [
+          { catalog: 'folio', refresh: true, catalogRecordId: 'a6671606', partLabel: '7 samurai', sortKey: '2' }
+        ],
+        sourceId: 'sul:1234'
+      }
+    end
 
-        it 'serializes correctly' do
-          expect(Repository).to have_received(:store).with(expected)
-        end
+    before { allow(Repository).to receive(:store) }
+
+    context 'when editing fields' do
+      let(:cocina_item) do
+        build(:dro_with_metadata, id: druid).new(description:, identification:)
       end
 
-      context 'when sort_key is set and part_label is not' do
-        let(:cocina_item) do
-          build(:dro_with_metadata, id: druid).new(description:, identification:)
-        end
-
-        it 'does not validate' do
-          expect(instance.validate({ part_label: '', sort_key: 'something' })).to be false
-        end
-      end
-
-      context 'when part_number2 is set' do
-        let(:expected) do
-          build(:dro_with_metadata, id: druid).new(description: {
-                                                     title: [
-                                                       {
-                                                         structuredValue: [
-                                                           { value: 'My Serial', type: 'main title' },
-                                                           { value: 'samurai 7', type: 'part name' }
-                                                         ]
-                                                       }
-                                                     ],
-                                                     note: [{ value: 'something',
-                                                              type: 'date/sequential designation' }],
-                                                     purl:
-                                                   })
-        end
-
-        before do
-          instance.validate({ part_label: 'samurai 7', sort_key: 'something' })
-          instance.save
-        end
-
-        it 'serialized correctly' do
-          expect(Repository).to have_received(:store).with(expected)
-        end
+      it 'does validate' do
+        expect(instance.validate({ part_label: '7 samurai', sort_key: '2' }))
       end
     end
 
-    context 'when the initial title is structured' do
-      let(:description) do
-        {
-          title: [{
-            structuredValue: [
-              { type: 'subtitle', value: '99' },
-              { type: 'main title', value: 'Frog' }
-            ]
-          }],
-          purl:
-        }
+    context 'when sort_key is set and part_label is not' do
+      let(:cocina_item) do
+        build(:dro_with_metadata, id: druid).new(description:, identification:)
       end
 
+      it 'does not validate' do
+        expect(instance.validate({ part_label: '', sort_key: 'something' })).to be false
+      end
+    end
+
+    context 'when refresh is false' do
+      let(:cocina_item) do
+        build(:dro_with_metadata, id: druid).new(identification:, description:)
+      end
+      let(:identification) do
+        {
+          catalogLinks: [
+            { catalog: 'folio', catalogRecordId: 'a6671606', refresh: false, partLabel: 'a part', sortKey: '1' }
+          ],
+          sourceId: 'sul:1234'
+        }
+      end
       let(:expected) do
-        build(:dro_with_metadata, id: druid).new(description: {
-                                                   title: [
-                                                     {
-                                                       structuredValue: [
-                                                         { type: 'subtitle', value: '99' },
-                                                         { type: 'main title', value: 'Frog' },
-                                                         { value: '7 samurai', type: 'part name' }
-                                                       ]
-                                                     }
-                                                   ],
-                                                   note: [{ value: 'something',
-                                                            type: 'date/sequential designation' }],
-                                                   purl:
-                                                 })
+        build(:dro_with_metadata, id: druid).new(
+          description: description,
+          identification: {
+            catalogLinks: [
+              { catalog: 'folio', refresh: false, catalogRecordId: 'a6671606', partLabel: 'a new part', sortKey: '1' }
+            ],
+            sourceId: 'sul:1234'
+          }
+        )
       end
 
       before do
-        instance.validate({ part_label: '7 samurai', sort_key: 'something' })
+        instance.validate({ part_label: 'a new part', sort_key: '1' })
         instance.save
       end
 
-      it 'serializes correctly' do
+      it 'keeps refresh as false' do
         expect(Repository).to have_received(:store).with(expected)
       end
     end
 
-    context 'when parallel title' do
-      let(:description) do
-        {
-          title: [
-            {
-              parallelValue: [
-                {
-                  value: 'My Serial'
-                },
-                {
-                  value: 'My Parallel Serial'
-                }
-              ]
-            }
-          ],
-          purl:
-        }
+    context 'when blank form submitted' do
+      let(:cocina_item) do
+        build(:dro_with_metadata, id: druid, folio_instance_hrids: ['a6671606']).new(description: description)
+      end
+      let(:expected) do
+        build(:dro_with_metadata, id: druid).new(
+          description: description,
+          identification: {
+            catalogLinks: [
+              { catalog: 'folio', partLabel: '', sortKey: '', refresh: true, catalogRecordId: 'a6671606' }
+            ],
+            sourceId: 'sul:1234'
+          }
+        )
       end
 
-      context 'when part_number is set' do
-        let(:expected) do
-          build(:dro_with_metadata, id: druid).new(description:
-                                                     {
-                                                       title: [
-                                                         {
-                                                           parallelValue: [
-                                                             {
-                                                               structuredValue: [
-                                                                 { value: 'My Serial', type: 'main title' },
-                                                                 { value: '7 samurai', type: 'part name' }
-                                                               ]
-                                                             },
-                                                             {
-                                                               value: 'My Parallel Serial'
-                                                             }
-                                                           ]
-                                                         }
-                                                       ],
-                                                       note: [{ value: 'something', type: 'date/sequential designation' }],
-                                                       purl:
-                                                     })
-        end
-
-        before do
-          instance.validate({ part_label: '7 samurai', sort_key: 'something' })
-          instance.save
-        end
-
-        it 'serializes correctly to first parallel title' do
-          expect(Repository).to have_received(:store).with(expected)
-        end
+      before do
+        instance.validate({ part_label: '', sort_key: '' })
+        instance.save
       end
 
-      context 'when catalog links present' do
-        let(:cocina_item) do
-          build(:dro_with_metadata, id: druid, folio_instance_hrids: ['a6671606'])
-        end
-        let(:expected) do
-          build(:dro_with_metadata, id: druid).new(
-            description: {
-              title: [
-                {
-                  structuredValue: [
-                    { value: 'factory DRO title', type: 'main title' }
-                  ]
-                }
-              ],
-              purl: 'https://purl.stanford.edu/bc123df4567'
-            },
-            identification: {
-              catalogLinks: [
-                { catalog: 'folio', refresh: false, catalogRecordId: 'a6671606', partLabel: '', sortKey: '' }
-              ],
-              sourceId: 'sul:1234'
-            }
-          )
-        end
-
-        before do
-          instance.validate({ part_label: '', sort_key: '' })
-          instance.save
-        end
-
-        it 'sets refresh to false' do
-          expect(Repository).to have_received(:store).with(expected)
-        end
+      it 'retains the existing refresh and removes the labels' do
+        expect(Repository).to have_received(:store).with(expected)
       end
     end
   end

--- a/spec/forms/serials_form_spec.rb
+++ b/spec/forms/serials_form_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe SerialsForm do
       end
 
       it 'does validate' do
-        expect(instance.validate({ part_label: '7 samurai', sort_key: '2' }))
+        expect(instance.validate({ part_label: '7 samurai', sort_key: '2' })).to be true
       end
     end
 

--- a/spec/forms/serials_form_spec.rb
+++ b/spec/forms/serials_form_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe SerialsForm do
             {
               structuredValue: [
                 { value: 'My Serial', type: 'main title' },
-                { value: '7', type: 'part number' },
-                { value: 'samurai', type: 'part name' }
+                { value: 'Non-serial part', type: 'part number' },
+                { value: 'Non-serial number', type: 'part name' }
               ]
             }
           ],
@@ -171,6 +171,41 @@ RSpec.describe SerialsForm do
       end
 
       it 'retains the existing refresh and removes the labels' do
+        expect(Repository).to have_received(:store).with(expected)
+      end
+    end
+
+    context 'with more than one catalogLink' do
+      let(:cocina_item) do
+        build(:dro_with_metadata, id: druid).new(description:, identification:)
+      end
+      let(:identification) do
+        {
+          catalogLinks: [
+            { catalog: 'folio', refresh: true, catalogRecordId: 'a6671606', partLabel: '7 samurai', sortKey: '1' },
+            { catalog: 'symphony', refresh: false, catalogRecordId: '6671606' }
+          ],
+          sourceId: 'sul:1234'
+        }
+      end
+      let(:expected) do
+        build(:dro_with_metadata, id: druid).new(
+          description:,
+          identification: {
+            catalogLinks: [
+              { catalog: 'folio', partLabel: '11 ninjas', sortKey: '2', refresh: true, catalogRecordId: 'a6671606' },
+              { catalog: 'symphony', refresh: false, catalogRecordId: '6671606' }
+            ],
+            sourceId: 'sul:1234'
+          }
+        )
+      end
+
+      it 'validates and saves the folio link' do
+        expect(instance.part_label).to eq '7 samurai'
+        expect(instance.sort_key).to eq '1'
+        instance.validate({ part_label: '11 ninjas', sort_key: '2' })
+        instance.save
         expect(Repository).to have_received(:store).with(expected)
       end
     end

--- a/spec/system/update_serials_metadata_spec.rb
+++ b/spec/system/update_serials_metadata_spec.rb
@@ -36,6 +36,6 @@ RSpec.describe 'Update serials metadata', :js do
     fill_in 'Sort key', with: '17'
     click_button 'Update'
 
-    expect(page).to have_content 'test object. part 17, supplement'
+    expect(page).to have_content 'test object, part 17, supplement'
   end
 end


### PR DESCRIPTION
# Why was this change made?
Resolves #4766 for digital serials. HOLD until digital serials migrator has run on prod and then merge /deploy.

# How was this change tested?
Deploy to QA