### PR TITLE
Fix Argo spreadsheet validation for titles.

### DIFF
--- a/app/services/description_validator.rb
+++ b/app/services/description_validator.rb
@@ -9,12 +9,13 @@ class DescriptionValidator
     @errors = []
   end
 
-  attr_reader :errors
-
   def valid?
     validate_duplicate_headers
     validate_title_headers
-    validate_matching_structured_title_headers
+    validate_title_value_for_type
+    validate_title_value_for_structured_type
+    validate_title_type_for_value
+    validate_title_type_for_structured_value
     validate_structured_title_types
     validate_header_paths
     validate_cell_values
@@ -25,41 +26,85 @@ class DescriptionValidator
     errors.empty?
   end
 
+  def errors
+    @errors.uniq
+  end
+
   def validate_cell_values
     @csv.each.with_index(2) do |row, i|
       @headers.excluding('druid').each do |header|
         location = row['druid'] || "row #{i}"
         cell_value = row[header]&.strip
-        errors << "Value error: #{location} has 0 value in #{header}." if cell_value == '0'
-        errors << "Value error: #{location} has spreadsheet formula error in #{header}." if %w[#NA #REF! #VALUE?
-                                                                                               #NAME?].include? cell_value
+        @errors << "Value error: #{location} has 0 value in #{header}." if cell_value == '0'
+        @errors << "Value error: #{location} has spreadsheet formula error in #{header}." if %w[#NA #REF! #VALUE?
+                                                                                                #NAME?].include? cell_value
       end
     end
   end
 
   def validate_duplicate_headers
     duplicate_headers.each do |header|
-      errors << "Duplicate column headers: The header #{header} should occur only once."
+      @errors << "Duplicate column headers: The header #{header} should occur only once."
     end
   end
 
   def validate_title_headers
     return if title_value_header? || title_structured_value_header? || title_parallel_value_header?
 
-    errors << 'Title column not found.'
+    @errors << 'Title column not found.'
   end
 
-  # verify that each titleX.structuredValueY.type has a corresponding titleX.structuredValueY.value (where X and Y are any integer).
-  def validate_matching_structured_title_headers
+  # verify that each titleX.type has a corresponding titleX.value or titleX.structuredValue1.value
+  def validate_title_value_for_type
     @headers.each do |header|
-      next if header.blank?
+      next unless (match = header&.match(/\Atitle(\d+)\.type\z/))
 
-      next unless header.match?(/\Atitle\d+.structuredValue\d+\.(type|value)\z/)
+      expected_header1 = "title#{match[1]}.value"
+      expected_header2 = "title#{match[1]}.structuredValue1.value"
 
-      expected_corresponding_header = header.ends_with?('type') ? header.sub('type', 'value') : header.sub('value', 'type')
-      next if @headers.include?(expected_corresponding_header)
+      next if @headers.include?(expected_header1) || @headers.include?(expected_header2)
 
-      errors << "Unexpected or missing title structuredValue columns: found #{header} but not #{expected_corresponding_header}"
+      @errors << "Missing title value for #{header}. Expected either #{expected_header1} or #{expected_header2}."
+    end
+  end
+
+  # verify that each titleX.structuredValueY.type has a corresponding titleX.structuredValueY.value
+  def validate_title_value_for_structured_type
+    @headers.each do |header|
+      next unless (match = header&.match(/\Atitle(\d+)\.structuredValue(\d+)\.type\z/))
+
+      expected_header = "title#{match[1]}.structuredValue#{match[2]}.value"
+
+      next if @headers.include?(expected_header)
+
+      @errors << "Missing title structured value for #{header}. Expected #{expected_header}."
+    end
+  end
+
+  # verify that each titleX.value has a corresponding titleX.type
+  def validate_title_type_for_value
+    @headers.each do |header|
+      next unless (match = header&.match(/\Atitle(\d+)\.value\z/))
+
+      expected_header = "title#{match[1]}.type"
+
+      next if @headers.include?(expected_header)
+
+      @errors << "Missing title value for #{header}. Expected #{expected_header}."
+    end
+  end
+
+  # verify that each titleX.structuredValueY.value has a corresponding titleX.type or titleX.structuredValueY.type
+  def validate_title_type_for_structured_value
+    @headers.each do |header|
+      next unless (match = header&.match(/\Atitle(\d+)\.structuredValue(\d+)\.value\z/))
+
+      expected_header1 = "title#{match[1]}.type"
+      expected_header2 = "title#{match[1]}.structuredValue#{match[2]}.type"
+
+      next if @headers.include?(expected_header1) || @headers.include?(expected_header2)
+
+      @errors << "Missing title type for #{header}. Expected either #{expected_header1} or #{expected_header2}."
     end
   end
 
@@ -71,28 +116,28 @@ class DescriptionValidator
       @csv.each do |row|
         next if row[title_value_header].blank? && row[title_type_header].blank?
 
-        errors << "Missing title value for #{title_type_header}." if row[title_value_header].blank?
-        errors << "Missing title type for #{title_value_header}." if row[title_type_header].blank?
+        @errors << "Missing title value for #{title_type_header}." if row[title_value_header].blank?
+        @errors << "Missing title type for #{title_value_header}." if row[title_type_header].blank?
       end
     end
   end
 
   def validate_header_paths
     invalid_headers.each do |invalid_header|
-      errors << "Column header invalid: #{invalid_header}"
+      @errors << "Column header invalid: #{invalid_header}"
     end
   end
 
   def validate_druid_headers
-    errors << 'Druid column not found.' if @headers.exclude?('druid')
+    @errors << 'Druid column not found.' if @headers.exclude?('druid')
   end
 
   def validate_druid_rows
     duplicate_druids.each do |druid|
-      errors << "Duplicate druids: The druid \"#{druid}\" should occur only once."
+      @errors << "Duplicate druids: The druid \"#{druid}\" should occur only once."
     end
     @csv.each.with_index(2) do |row, i|
-      errors << "Missing druid: No druid present in row #{i}." if row['druid'].blank?
+      @errors << "Missing druid: No druid present in row #{i}." if row['druid'].blank?
     end
   end
 
@@ -103,7 +148,7 @@ class DescriptionValidator
   end
 
   def title_structured_value_header?
-    @headers.include?('title1.structuredValue1.type') && @headers.include?('title1.structuredValue1.value')
+    @headers.include?('title1.structuredValue1.value')
   end
 
   def title_parallel_value_header?

--- a/spec/services/description_validator_spec.rb
+++ b/spec/services/description_validator_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe DescriptionValidator do
           expect(instance.valid?).to be false
           expect(instance.errors).to eq [
             'Duplicate column headers: The header title1.value should occur only once.',
-            'Duplicate column headers: The header title2.value should occur only once.'
+            'Duplicate column headers: The header title2.value should occur only once.',
+            'Missing title value for title1.value. Expected title1.type.',
+            'Missing title value for title2.value. Expected title2.type.',
+            'Missing title value for title3.value. Expected title3.type.'
           ]
         end
       end
@@ -25,7 +28,7 @@ RSpec.describe DescriptionValidator do
         it 'finds errors' do
           expect(instance.valid?).to be false
           expect(instance.errors).to eq [
-            'Unexpected or missing title structuredValue columns: found title1.structuredValue2.value but not title1.structuredValue2.type'
+            'Missing title type for title1.structuredValue2.value. Expected either title1.type or title1.structuredValue2.type.'
           ]
         end
       end
@@ -36,8 +39,8 @@ RSpec.describe DescriptionValidator do
         it 'finds errors' do
           expect(instance.valid?).to be false
           expect(instance.errors).to eq [
-            'Unexpected or missing title structuredValue columns: found title2.structuredValue1.type but not title2.structuredValue1.value',
-            'Unexpected or missing title structuredValue columns: found title2.structuredValue2.value but not title2.structuredValue2.type'
+            'Missing title structured value for title2.structuredValue1.type. Expected title2.structuredValue1.value.',
+            'Missing title type for title2.structuredValue2.value. Expected either title2.type or title2.structuredValue2.type.'
           ]
         end
       end
@@ -48,8 +51,8 @@ RSpec.describe DescriptionValidator do
         it 'finds errors' do
           expect(instance.valid?).to be false
           expect(instance.errors).to eq [
-            'Unexpected or missing title structuredValue columns: found title2.structuredValue2.type but not title2.structuredValue2.value',
-            'Unexpected or missing title structuredValue columns: found title3.structuredValue2.value but not title3.structuredValue2.type'
+            'Missing title structured value for title2.structuredValue2.type. Expected title2.structuredValue2.value.',
+            'Missing title type for title3.structuredValue2.value. Expected either title3.type or title3.structuredValue2.type.'
           ]
         end
       end
@@ -68,8 +71,10 @@ RSpec.describe DescriptionValidator do
 
         it 'finds errors' do
           expect(instance.valid?).to be false
-          expect(instance.errors).to eq ['Title column not found.',
-                                         'Unexpected or missing title structuredValue columns: found title1.structuredValue1.type but not title1.structuredValue1.value']
+          expect(instance.errors).to eq [
+            'Title column not found.',
+            'Missing title structured value for title1.structuredValue1.type. Expected title1.structuredValue1.value.'
+          ]
         end
       end
 
@@ -78,8 +83,9 @@ RSpec.describe DescriptionValidator do
 
         it 'finds errors' do
           expect(instance.valid?).to be false
-          expect(instance.errors).to eq ['Title column not found.',
-                                         'Unexpected or missing title structuredValue columns: found title1.structuredValue1.value but not title1.structuredValue1.type']
+          expect(instance.errors).to eq [
+            'Missing title type for title1.structuredValue1.value. Expected either title1.type or title1.structuredValue1.type.'
+          ]
         end
       end
 
@@ -91,11 +97,22 @@ RSpec.describe DescriptionValidator do
         end
       end
 
-      context 'with a title1.value,title2.structuredValue1.value and a title2.structuredValue1.type column' do
-        let(:csv) { 'druid,title1.value,title2.structuredValue1.type,title2.structuredValue1.value' }
+      context 'with a title1.structuredValue1.value and a title1.type column' do
+        let(:csv) { 'druid,title1.type,title1.structuredValue1.value' }
 
         it 'validates' do
           expect(instance.valid?).to be true
+        end
+      end
+
+      context 'with a title1.value,title2.structuredValue1.value and a title2.structuredValue1.type column' do
+        let(:csv) { 'druid,title1.value,title2.structuredValue1.type,title2.structuredValue1.value' }
+
+        it 'finds errors' do
+          expect(instance.valid?).to be false
+          expect(instance.errors).to eq [
+            'Missing title value for title1.value. Expected title1.type.'
+          ]
         end
       end
 
@@ -106,6 +123,8 @@ RSpec.describe DescriptionValidator do
           expect(instance.valid?).to be false
           expect(instance.errors).to eq [
             'Title column not found.',
+            'Missing title value for title2.value. Expected title2.type.',
+            'Missing title value for title3.value. Expected title3.type.',
             'Column header invalid: title1.value.type'
           ]
         end
@@ -138,8 +157,9 @@ RSpec.describe DescriptionValidator do
       context 'with a title1.value column' do
         let(:csv) { 'druid,title1.value' }
 
-        it 'validates' do
-          expect(instance.valid?).to be true
+        it 'finds errors' do
+          expect(instance.valid?).to be false
+          expect(instance.errors).to eq ['Missing title value for title1.value. Expected title1.type.']
         end
       end
 
@@ -161,7 +181,7 @@ RSpec.describe DescriptionValidator do
 
       context 'with headers that do not map to cocina model' do
         let(:csv) do
-          'druid,title1.value,title2.value,title3.value,bogus,event.contributor,event1.contributor,event1.note1.source.value'
+          'druid,title1.value,title1.type,title2.value,title2.type,title3.value,title3.type,bogus,event.contributor,event1.contributor,event1.note1.source.value'
         end
 
         it 'finds errors' do
@@ -174,7 +194,7 @@ RSpec.describe DescriptionValidator do
       end
 
       context 'with missing header for column' do
-        let(:csv) { 'druid,title1.value,,title2.value' }
+        let(:csv) { 'druid,title1.value,title1.type,,title2.value,title2.type' }
 
         it 'finds errors' do
           expect(instance.valid?).to be false
@@ -188,7 +208,7 @@ RSpec.describe DescriptionValidator do
       let(:instance) { described_class.new(CSV.parse(csv, headers: true), bulk_job: true) }
 
       context 'with missing druid header' do
-        let(:csv) { 'title1.value,title2.value,title3.value' }
+        let(:csv) { 'title1.value,title1.type,title2.value,title2.type,title3.value,title3.type' }
 
         it 'finds errors' do
           expect(instance.valid?).to be false
@@ -199,10 +219,10 @@ RSpec.describe DescriptionValidator do
       context 'with missing druid in a row' do
         let(:csv) do
           <<~CSV
-            druid,title1.value,title2.value,title3.value
-            druid:ab123cd4567,cool,stuff,here
-            ,missing,druid,here
-            druid:cd456de5678,value,,
+            druid,title1.value,title1.type,title2.value,title2.type,title3.value,title3.type
+            druid:ab123cd4567,super,cool,stuff,here
+            ,a,missing,druid,here
+            druid:cd456de5678,value,type,
           CSV
         end
 
@@ -215,10 +235,10 @@ RSpec.describe DescriptionValidator do
       context 'with duplicate druids in separate rows' do
         let(:csv) do
           <<~CSV
-            druid,title1.value,title2.value,title3.value
-            druid:ab123cd4567,cool,stuff,here
-            druid:ab123cd4567,cool2,stuff2,here2
-            druid:cd456de5678,value,,
+            druid,title1.value,title1.type,title2.value,title2.type,title3.value,title3.type
+            druid:ab123cd4567,cool,stuff,here,cool2,stuff2,here2
+            druid:ab123cd4567,cool,stuff,here,cool2,stuff2,here2
+            druid:cd456de5678,value,type,
           CSV
         end
 
@@ -231,8 +251,8 @@ RSpec.describe DescriptionValidator do
       context 'with cell values that have a 0' do
         let(:csv) do
           <<~CSV
-            druid,title1.value,title2.value
-            druid:cd456de6677,allgood,stuff
+            druid,title1.value,title1.type,title2.value,title2.type
+            druid:cd456de6677,allgood,stuff,allgood2,stuff2
             druid:cd456de6678,0,stuff
           CSV
         end
@@ -246,7 +266,7 @@ RSpec.describe DescriptionValidator do
       context 'with cell values that look like formulas' do
         let(:csv) do
           <<~CSV
-            druid,title1.value,title2.value
+            druid,title1.value,title1.type
             druid:ab123cd4567,cool,#NA
             druid:cd456de5670,#REF!,stuff
             druid:cd456de8678,what,#VALUE?
@@ -258,9 +278,9 @@ RSpec.describe DescriptionValidator do
         it 'finds errors' do
           expect(instance.valid?).to be false
           expect(instance.errors).to eq [
-            'Value error: druid:ab123cd4567 has spreadsheet formula error in title2.value.',
+            'Value error: druid:ab123cd4567 has spreadsheet formula error in title1.type.',
             'Value error: druid:cd456de5670 has spreadsheet formula error in title1.value.',
-            'Value error: druid:cd456de8678 has spreadsheet formula error in title2.value.',
+            'Value error: druid:cd456de8678 has spreadsheet formula error in title1.type.',
             'Value error: druid:cd456de6678 has spreadsheet formula error in title1.value.'
           ]
         end
@@ -271,7 +291,7 @@ RSpec.describe DescriptionValidator do
       let(:instance) { described_class.new(CSV.parse(csv, headers: true), bulk_job: false) }
 
       context 'with missing druid header' do
-        let(:csv) { 'title1.value,title2.value,title3.value' }
+        let(:csv) { 'title1.value,title1.type,title2.value,title2.type,title3.value,title3.type' }
         let(:bulk_job) { false }
 
         it 'validates' do
@@ -282,8 +302,8 @@ RSpec.describe DescriptionValidator do
       context 'with missing druid in a row' do
         let(:csv) do
           <<~CSV
-            druid,title1.value,title2.value,title3.value
-            ,missing,druid,here
+            druid,title1.value,title1.type
+            ,missing,druid
           CSV
         end
 
@@ -295,7 +315,7 @@ RSpec.describe DescriptionValidator do
       context 'with cell values that have a 0' do
         let(:csv) do
           <<~CSV
-            title1.value,title2.value
+            title1.value,title1.type
             0,stuff
           CSV
         end
@@ -309,7 +329,7 @@ RSpec.describe DescriptionValidator do
       context 'with cell values that look like formulas' do
         let(:csv) do
           <<~CSV
-            title1.value,title2.value
+            title1.value,title1.type
             cool,#NA
           CSV
         end
@@ -317,7 +337,7 @@ RSpec.describe DescriptionValidator do
         it 'finds errors' do
           expect(instance.valid?).to be false
           expect(instance.errors).to eq [
-            'Value error: row 2 has spreadsheet formula error in title2.value.'
+            'Value error: row 2 has spreadsheet formula error in title1.type.'
           ]
         end
       end


### PR DESCRIPTION
closes #4789

# Why was this change made?
Validation was too strict.
<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?
Unit, Andrew
<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


