### PR TITLE
run text extraction jobs in the low priority lane

### DIFF
--- a/app/services/text_extraction.rb
+++ b/app/services/text_extraction.rb
@@ -20,10 +20,11 @@ class TextExtraction
     version = cocina_object.version
     # if the object has already been opened, don't increment the version for the new workflow
     # this is to ensure the new workflow is started with the same version as the existing object
-    # if the object is already open, they are the same; if not, ocrWF will open the object version, incrementing it
+    # if the object is already open, they are the same; if not, ocrWF/speechToTextWF will open the object version, incrementing it
     version += 1 unless @already_opened
     WorkflowClientFactory.build.create_workflow_by_name(cocina_object.externalIdentifier,
                                                         wf_name,
+                                                        lane_id: 'low',
                                                         context:,
                                                         version:)
   end

--- a/spec/requests/text_extraction_spec.rb
+++ b/spec/requests/text_extraction_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'TextExtractions', :js do
     describe '#create' do
       it 'adds ocrWF' do
         post "/items/#{druid}/text_extraction", params: { text_extraction_languages: ['English'] }
-        expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'ocrWF', context: { manuallyCorrectedOCR: false, ocrLanguages: ['English'] }, version: 2)
+        expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'ocrWF', lane_id: 'low', context: { manuallyCorrectedOCR: false, ocrLanguages: ['English'] }, version: 2)
         expect(object_client).to have_received(:reindex)
         expect(response).to redirect_to(solr_document_path(druid))
       end
@@ -42,7 +42,7 @@ RSpec.describe 'TextExtractions', :js do
     describe '#create' do
       it 'adds speechToTextWF' do
         post "/items/#{druid}/text_extraction", params: {}
-        expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'speechToTextWF', context: {}, version: 2)
+        expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'speechToTextWF', lane_id: 'low', context: {}, version: 2)
         expect(object_client).to have_received(:reindex)
         expect(response).to redirect_to(solr_document_path(druid))
       end

--- a/spec/services/text_extraction_spec.rb
+++ b/spec/services/text_extraction_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe TextExtraction do
 
         it 'starts ocrWF and returns true' do
           expect(text_extraction.start).to be true
-          expect(client).to have_received(:create_workflow_by_name).with(druid, ocr_wf, version:, context: ocr_context)
+          expect(client).to have_received(:create_workflow_by_name).with(druid, ocr_wf, lane_id: 'low', version:, context: ocr_context)
         end
       end
 
@@ -163,7 +163,7 @@ RSpec.describe TextExtraction do
 
         it 'starts ocrWF and returns true' do
           expect(text_extraction.start).to be true
-          expect(client).to have_received(:create_workflow_by_name).with(druid, ocr_wf, version:, context: ocr_context)
+          expect(client).to have_received(:create_workflow_by_name).with(druid, ocr_wf, lane_id: 'low', version:, context: ocr_context)
         end
       end
 
@@ -172,7 +172,7 @@ RSpec.describe TextExtraction do
 
         it 'starts ocrWF and returns true' do
           expect(text_extraction.start).to be true
-          expect(client).to have_received(:create_workflow_by_name).with(druid, ocr_wf, version:, context: ocr_context)
+          expect(client).to have_received(:create_workflow_by_name).with(druid, ocr_wf, lane_id: 'low', version:, context: ocr_context)
         end
       end
 
@@ -181,7 +181,7 @@ RSpec.describe TextExtraction do
 
         it 'starts speechToTextWF and returns true' do
           expect(text_extraction.start).to be true
-          expect(client).to have_received(:create_workflow_by_name).with(druid, speech_to_text_wf, version:, context: speech_to_text_context)
+          expect(client).to have_received(:create_workflow_by_name).with(druid, speech_to_text_wf, lane_id: 'low', version:, context: speech_to_text_context)
         end
       end
     end
@@ -194,7 +194,7 @@ RSpec.describe TextExtraction do
 
         it 'starts ocrWF for the next version and returns true' do
           expect(text_extraction.start).to be true
-          expect(client).to have_received(:create_workflow_by_name).with(druid, ocr_wf, version: version + 1, context: ocr_context)
+          expect(client).to have_received(:create_workflow_by_name).with(druid, ocr_wf, lane_id: 'low', version: version + 1, context: ocr_context)
         end
       end
 
@@ -203,7 +203,7 @@ RSpec.describe TextExtraction do
 
         it 'starts ocrWF and returns true' do
           expect(text_extraction.start).to be true
-          expect(client).to have_received(:create_workflow_by_name).with(druid, ocr_wf, version: version + 1, context: ocr_context)
+          expect(client).to have_received(:create_workflow_by_name).with(druid, ocr_wf, lane_id: 'low', version: version + 1, context: ocr_context)
         end
       end
 
@@ -212,7 +212,7 @@ RSpec.describe TextExtraction do
 
         it 'starts ocrWF and returns true' do
           expect(text_extraction.start).to be true
-          expect(client).to have_received(:create_workflow_by_name).with(druid, ocr_wf, version: version + 1, context: ocr_context)
+          expect(client).to have_received(:create_workflow_by_name).with(druid, ocr_wf, lane_id: 'low', version: version + 1, context: ocr_context)
         end
       end
 
@@ -221,7 +221,7 @@ RSpec.describe TextExtraction do
 
         it 'starts speechToTextWF and returns true' do
           expect(text_extraction.start).to be true
-          expect(client).to have_received(:create_workflow_by_name).with(druid, speech_to_text_wf, version: version + 1, context: speech_to_text_context)
+          expect(client).to have_received(:create_workflow_by_name).with(druid, speech_to_text_wf, lane_id: 'low', version: version + 1, context: speech_to_text_context)
         end
       end
     end
@@ -231,7 +231,7 @@ RSpec.describe TextExtraction do
 
       it 'returns false and does nothing' do
         expect(text_extraction.start).to be false
-        expect(client).not_to have_received(:create_workflow_by_name).with(druid, ocr_wf, version:, context: ocr_context)
+        expect(client).not_to have_received(:create_workflow_by_name).with(druid, ocr_wf, lane_id: 'low', version:, context: ocr_context)
       end
     end
 
@@ -240,7 +240,7 @@ RSpec.describe TextExtraction do
 
       it 'returns false and does nothing' do
         expect(text_extraction.start).to be false
-        expect(client).not_to have_received(:create_workflow_by_name).with(druid, ocr_wf, version:, context: ocr_context)
+        expect(client).not_to have_received(:create_workflow_by_name).with(druid, ocr_wf, lane_id: 'low', version:, context: ocr_context)
       end
     end
   end


### PR DESCRIPTION
# Why was this change made?

Fixes https://github.com/sul-dlss/common-accessioning/issues/1511 - run text extraction jobs in the low priority accessioning lane
