### PR TITLE
Pin blacklight-hierarchy to 6.6.0 to avoid a new exception in 6.7.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,8 @@ gem 'zip_tricks'
 
 # Stanford related gems
 gem 'blacklight', '~> 7.41'
-gem 'blacklight-hierarchy', '~> 6.1'
+# pinned because 6.7.0 is effectively coupled to BL >= 8.3.0 and Argo hasn't been updated to BL8 yet
+gem 'blacklight-hierarchy', '~> 6.6.0'
 gem 'dor-services-client', '~> 15.1'
 gem 'dor-workflow-client', '~> 7.0'
 gem 'druid-tools'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
       rails (>= 6.1, < 8.1)
       view_component (>= 2.74, < 4)
       zeitwerk
-    blacklight-hierarchy (6.7.1)
+    blacklight-hierarchy (6.6.0)
       blacklight (>= 7.18, < 9)
       deprecation
       rails (>= 7.1, < 9)
@@ -254,7 +254,7 @@ GEM
       activesupport (>= 3.0, < 9.0)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
-    erb (5.0.1)
+    erb (5.0.2)
     erb_lint (0.9.0)
       activesupport
       better_html (>= 2.0.1)
@@ -303,7 +303,7 @@ GEM
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
-    io-console (0.8.0)
+    io-console (0.8.1)
     irb (1.15.2)
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
@@ -700,7 +700,7 @@ PLATFORMS
 DEPENDENCIES
   barby
   blacklight (~> 7.41)
-  blacklight-hierarchy (~> 6.1)
+  blacklight-hierarchy (~> 6.6.0)
   bootsnap (>= 1.4.2)
   cancancan
   capistrano-maintenance (~> 1.2)


### PR DESCRIPTION
# Why was this change made?

See: https://app.honeybadger.io/projects/49894/faults/122116465

This is a new exception that has been occurring in prod and other envs since the last blacklight-hierarchy bump earlier this week. Since Argo is stuck on BL7 for now and we do not know that need the bleeding edge of the hierarchy gem, pin the dependency for now and documented why it is pinned.

# How was this change tested?

CI
