### PR TITLE
Strip whitespace from druids in uploaded CSVs.

### DIFF
--- a/app/services/csv_upload_normalizer.rb
+++ b/app/services/csv_upload_normalizer.rb
@@ -55,7 +55,7 @@ class CsvUploadNormalizer
 
   def normalize_druids!(table)
     table.each do |row|
-      druid_headers.each { |header| row[header] = Druid.new(row[header]).with_namespace if row[header].present? }
+      druid_headers.each { |header| row[header] = Druid.new(row[header].strip).with_namespace if row[header].present? }
     end
   end
 end

--- a/spec/fixtures/files/catalog_record_id_and_barcode_with_whitespace.csv
+++ b/spec/fixtures/files/catalog_record_id_and_barcode_with_whitespace.csv
@@ -1,0 +1,3 @@
+Druid,Catkey,Barcode
+druid:bb396kf5077  ,13157971,
+  bb631ry3167,13965062,

--- a/spec/services/csv_upload_normalizer_spec.rb
+++ b/spec/services/csv_upload_normalizer_spec.rb
@@ -79,5 +79,13 @@ RSpec.describe CsvUploadNormalizer do
         expect(csv).to eq(expected_csv)
       end
     end
+
+    context 'with whitespace around the druid' do
+      let(:filepath) { file_fixture('catalog_record_id_and_barcode_with_whitespace.csv').to_s }
+
+      it 'reads the CSV' do
+        expect(csv).to eq(expected_csv)
+      end
+    end
   end
 end


### PR DESCRIPTION
closes #4816

# Why was this change made?
Users continue to find creative ways to generate problematic CSVs.

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?
Unit
<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


