### PR TITLE
do not show thumbnails for file types

### DIFF
--- a/app/components/show/item/thumbnail_component.html.erb
+++ b/app/components/show/item/thumbnail_component.html.erb
@@ -1,4 +1,4 @@
-<% if document.thumbnail_url %>
+<% if show_thumbnail? %>
   <%= image_tag document.thumbnail_url, class: 'thumbnail' %>
 <% else %>
   <svg style="text-anchor: middle" width="240" height="240" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Responsive image" focusable="false">

--- a/app/components/show/item/thumbnail_component.rb
+++ b/app/components/show/item/thumbnail_component.rb
@@ -9,6 +9,10 @@ module Show
 
       attr_reader :document
 
+      def show_thumbnail?
+        document.object_type != 'file' && document.thumbnail_url
+      end
+
       def placeholder_text
         truncate(CitationPresenter.new(document, italicize: false).render, length: 246, omission: '…')
       end

--- a/spec/components/show/item/thumbnail_component_spec.rb
+++ b/spec/components/show/item/thumbnail_component_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe Show::Item::ThumbnailComponent, type: :component do
 
   let(:document) do
     SolrDocument.new('id' => 'druid:kv840xx0000',
-                     SolrDocument::FIELD_TITLE => title)
+                     SolrDocument::FIELD_TITLE => title,
+                     SolrDocument::FIELD_OBJECT_TYPE => object_type,
+                     'first_shelved_image_ss' => thumbnail)
   end
 
   context 'without a thumbnail_url and a long title' do
@@ -19,9 +21,34 @@ RSpec.describe Show::Item::ThumbnailComponent, type: :component do
         'gravida sodales, dui ex ullamcorper ante, vestibulum consectetur odio arcu ' \
         'mattis dolor. '
     end
+    let(:thumbnail) { nil }
+    let(:object_type) { 'image' }
 
     it 'truncates the title' do
       expect(rendered.to_html).to include 'gravida sodales, dui ex…'
+    end
+  end
+
+  context 'with a thumbnail_url' do
+    let(:title) { 'a very cool title' }
+    let(:thumbnail) { 'something.jpg' }
+
+    context 'with object_type == file' do
+      let(:object_type) { 'file' }
+
+      it 'does not render the thumbnail' do
+        expect(rendered.to_html).not_to include 'something/full/!400,400/0/default.jpg'
+        expect(rendered.to_html).to include title
+      end
+    end
+
+    context 'with object_type == image' do
+      let(:object_type) { 'image' }
+
+      it 'renders the thumbnail' do
+        expect(rendered.to_html).to include 'something/full/!400,400/0/default.jpg'
+        expect(rendered.to_html).not_to include title
+      end
     end
   end
 end


### PR DESCRIPTION
# Why was this change made?

See https://stanfordlib.slack.com/archives/C09M7P91R/p1755209369834039

Objects with an image that are of type file for which the image is in hierarchical folder will not show a thumbnail correctly in Argo.  This simply causes argo to not bother trying to show a thumbnail when the object type is file (which is the only one that supports hierarchy).


# How was this change tested?

Specs