### PR TITLE
should look for content_type not object_type

### DIFF
--- a/app/components/show/item/thumbnail_component.rb
+++ b/app/components/show/item/thumbnail_component.rb
@@ -10,7 +10,7 @@ module Show
       attr_reader :document
 
       def show_thumbnail?
-        document.object_type != 'file' && document.thumbnail_url
+        document.content_type != 'file' && document.thumbnail_url
       end
 
       def placeholder_text

--- a/spec/components/show/item/thumbnail_component_spec.rb
+++ b/spec/components/show/item/thumbnail_component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Show::Item::ThumbnailComponent, type: :component do
   let(:document) do
     SolrDocument.new('id' => 'druid:kv840xx0000',
                      SolrDocument::FIELD_TITLE => title,
-                     SolrDocument::FIELD_OBJECT_TYPE => object_type,
+                     SolrDocument::FIELD_CONTENT_TYPE => content_type,
                      'first_shelved_image_ss' => thumbnail)
   end
 
@@ -22,7 +22,7 @@ RSpec.describe Show::Item::ThumbnailComponent, type: :component do
         'mattis dolor. '
     end
     let(:thumbnail) { nil }
-    let(:object_type) { 'image' }
+    let(:content_type) { 'image' }
 
     it 'truncates the title' do
       expect(rendered.to_html).to include 'gravida sodales, dui ex…'
@@ -33,8 +33,8 @@ RSpec.describe Show::Item::ThumbnailComponent, type: :component do
     let(:title) { 'a very cool title' }
     let(:thumbnail) { 'something.jpg' }
 
-    context 'with object_type == file' do
-      let(:object_type) { 'file' }
+    context 'with content_type == file' do
+      let(:content_type) { 'file' }
 
       it 'does not render the thumbnail' do
         expect(rendered.to_html).not_to include 'something/full/!400,400/0/default.jpg'
@@ -43,7 +43,7 @@ RSpec.describe Show::Item::ThumbnailComponent, type: :component do
     end
 
     context 'with object_type == image' do
-      let(:object_type) { 'image' }
+      let(:content_type) { 'image' }
 
       it 'renders the thumbnail' do
         expect(rendered.to_html).to include 'something/full/!400,400/0/default.jpg'


### PR DESCRIPTION
# Why was this change made?

Follow on from https://github.com/sul-dlss/argo/pull/4828

I messed up, we need to look at the content_type, not the object_type (which is always `item`)

# How was this change tested?

Stage, see https://argo-stage.stanford.edu/view/druid:mh980pm4136 (no thumbnail anymore) vs https://argo-stage.stanford.edu/view/druid:bb226qd5125 (still has a thumbnail)