### PR TITLE
Exclude etdSubmitWF from workflow grid

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -81,6 +81,7 @@ inactive_workflows:
   - googleScannedBookWF
   - eemsAccessionWF
   - gisDiscoveryWF
+  - etdSubmitWF
 
 tech_md_service:
   url: "http://localhost:3005"


### PR DESCRIPTION
# Why was this change made?
This wf is deprecated.

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


