### PR TITLE
Remove data quality facet field from configuration

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -191,9 +191,6 @@ class CatalogController < ApplicationController
                                                                has_constituents: { label: 'Virtual Objects', fq: "#{SolrDocument::FIELD_CONSTITUENTS}:*" }
                                                              }
 
-    # This will help us find records that need to be fixed before we can move to cocina.
-    config.add_facet_field 'data_quality_ssim', label: 'Data Quality', component: true
-
     config.add_facet_field 'identifiers', label: 'Identifiers',
                                           component: true,
                                           query: {


### PR DESCRIPTION
# Why was this change made?
This field isn't populated by the indexer so it is never rendered. This is just cruft.

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


