### PR TITLE
Use Cocina TitleBuilder for apo list of collections

### DIFF
--- a/app/controllers/apo_controller.rb
+++ b/app/controllers/apo_controller.rb
@@ -35,7 +35,7 @@ class ApoController < ApplicationController
     @access_template = AccessTemplate.new(access_template:, apo_defaults_template: administrative.accessTemplate)
 
     @collections = Dor::Services::Client.objects.find_all(druids: administrative.collectionsForRegistration).map do |collection|
-      ["#{collection.label.truncate(60, separator: /\s/)} (#{collection.externalIdentifier.delete_prefix('druid:')})", collection.externalIdentifier]
+      [collection_title_display(collection), collection.externalIdentifier]
     end
 
     # before returning the list, sort by collection title (case insensitive, dropping brackets)
@@ -130,6 +130,11 @@ class ApoController < ApplicationController
   end
 
   private
+
+  def collection_title_display(cocina_object)
+    title = Cocina::Models::Builders::TitleBuilder.build(cocina_object.description.title, catalog_links: cocina_object.identification.catalogLinks)
+    "#{title.truncate(60, separator: /\s/)} (#{cocina_object.externalIdentifier.delete_prefix('druid:')})"
+  end
 
   def search_service
     @search_service ||= Blacklight::SearchService.new(config: CatalogController.blacklight_config,

--- a/spec/requests/registration_spec.rb
+++ b/spec/requests/registration_spec.rb
@@ -114,14 +114,9 @@ RSpec.describe 'Registration' do
 
     context 'when the collections are in solr' do
       let(:collections) { [collection_druid] }
-      let(:collection) { build(:collection, id: collection_druid, admin_policy_id: apo_id, label:) }
+      let(:collection) { build(:collection, id: collection_druid, admin_policy_id: apo_id) }
       let(:collection_druid) { 'druid:pb873ty1662' }
       let(:apo_id) { 'druid:hv992yv2222' }
-      let(:label) do
-        'Annual report of the State Corporation Commission showing the condition ' \
-          'of the incorporated state banks and other institutions operating in ' \
-          'Virginia at the close of business'
-      end
 
       before do
         allow(Dor::Services::Client.objects).to receive(:find_all).with(druids: collections).and_return([collection])
@@ -132,7 +127,7 @@ RSpec.describe 'Registration' do
         options = rendered.find_css('#registration_collection option')
         expect(options.map { |node| [node.attr('value'), node.text] }).to eq [
           ['', 'None'],
-          ['druid:pb873ty1662', 'Annual report of the State Corporation Commission showing... (pb873ty1662)']
+          ['druid:pb873ty1662', 'factory collection title (pb873ty1662)']
         ]
       end
     end


### PR DESCRIPTION
# Why was this change made?

Follow up to the prior PR, this now gets the title based on the Cocina instead of the label (which is unreliable)


# How was this change tested?

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


