### PR TITLE
Change bulk action description field to text.

### DIFF
--- a/db/migrate/20251007125342_change_bulk_action_description.rb
+++ b/db/migrate/20251007125342_change_bulk_action_description.rb
@@ -1,0 +1,9 @@
+class ChangeBulkActionDescription < ActiveRecord::Migration[8.0]
+  def up
+    change_column :bulk_actions, :description, :text
+  end
+
+  def down
+    change_column :bulk_actions, :description, :string, limit: 255
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_08_01_155124) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_07_125342) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -29,7 +29,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_08_01_155124) do
     t.string "action_type"
     t.string "status"
     t.string "log_name"
-    t.string "description"
+    t.text "description"
     t.integer "druid_count_total", default: 0
     t.integer "druid_count_success", default: 0
     t.integer "druid_count_fail", default: 0


### PR DESCRIPTION
closes #2259

# Why was this change made?
So that user can enter a longer description.

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


