### PR TITLE
[HOLD] Sets remaining bulk actions to open version if needed.

### DIFF
--- a/app/jobs/add_workflow_job.rb
+++ b/app/jobs/add_workflow_job.rb
@@ -20,6 +20,8 @@ class AddWorkflowJob < GenericJob
       next failure.call("#{workflow_name} already exists") if WorkflowService.workflow_active?(druid: cocina_object.externalIdentifier,
                                                                                                wf_name: workflow_name, version: cocina_object.version)
 
+      open_new_version_if_needed(cocina_object, "Running #{workflow_name}")
+
       Dor::Services::Client.object(cocina_object.externalIdentifier).workflow(workflow_name).create(version: cocina_object.version)
       success.call("started #{workflow_name}")
     end

--- a/app/jobs/set_content_type_job.rb
+++ b/app/jobs/set_content_type_job.rb
@@ -35,11 +35,11 @@ class SetContentTypeJob < GenericJob
 
     return failure.call('Not authorized') unless ability.can?(:update, cocina_object)
 
-    return failure.call('Object cannot be modified in its current state.') unless VersionService.open?(druid: cocina_object.externalIdentifier)
+    new_cocina_object = open_new_version_if_needed(cocina_object, 'Updating content type')
 
     # use dor services client to pass a hash for structural metadata and update the cocina object
-    new_model = cocina_object.new(cocina_update_attributes(cocina_object))
-    Repository.store(new_model)
+    new_cocina_object = new_cocina_object.new(cocina_update_attributes(new_cocina_object))
+    Repository.store(new_cocina_object)
     success.call('Successfully updated content type')
   end
 

--- a/spec/jobs/add_workflow_job_spec.rb
+++ b/spec/jobs/add_workflow_job_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe AddWorkflowJob do
     allow(Ability).to receive(:new).and_return(ability)
     allow(Dor::Services::Client).to receive(:object).with(druids[0]).and_return(object_client1)
     allow(Dor::Services::Client).to receive(:object).with(druids[1]).and_return(object_client2)
+    allow(VersionService).to receive(:open?).with(druid: druids[0]).and_return(true)
+    allow(VersionService).to receive(:open?).with(druid: druids[1]).and_return(false)
+    allow(VersionService).to receive(:openable?).with(druid: druids[1]).and_return(true)
+    allow(VersionService).to receive(:open).and_return(cocina2)
     allow(BulkJobLog).to receive(:open).and_yield(logger)
 
     described_class.perform_now(bulk_action.id,
@@ -55,6 +59,8 @@ RSpec.describe AddWorkflowJob do
         expect(logger).to have_received(:puts).with(/started accessionWF for druid:bb111cc2222/)
 
         expect(wf_client).to have_received(:create).twice
+        expect(VersionService).to have_received(:open)
+          .with(druid: druids[1], description: 'Running accessionWF', opening_user_name: bulk_action.user.to_s)
       end
     end
   end

--- a/spec/jobs/import_structural_job_spec.rb
+++ b/spec/jobs/import_structural_job_spec.rb
@@ -16,7 +16,10 @@ RSpec.describe ImportStructuralJob do
     allow(Ability).to receive(:new).and_return(ability)
     allow(Dor::Services::Client).to receive(:object).with(druid1).and_return(object_client1)
     allow(Dor::Services::Client).to receive(:object).with(druid2).and_return(object_client2)
-    allow(VersionService).to receive(:open?).and_return(true)
+    allow(VersionService).to receive(:open?).with(druid: druid1).and_return(true)
+    allow(VersionService).to receive(:open?).with(druid: druid2).and_return(false)
+    allow(VersionService).to receive(:openable?).with(druid: druid2).and_return(true)
+    allow(VersionService).to receive(:open).and_return(cocina2)
   end
 
   describe '#perform' do
@@ -140,6 +143,9 @@ RSpec.describe ImportStructuralJob do
         expect(bulk_action.druid_count_total).to eq 2
         expect(bulk_action.druid_count_success).to eq 2
         expect(bulk_action.druid_count_fail).to eq 0
+        expect(VersionService).to have_received(:open).with(druid: druid2,
+                                                            description: 'Updating content',
+                                                            opening_user_name: bulk_action.user.to_s)
       end
     end
 

--- a/spec/jobs/set_content_type_job_spec.rb
+++ b/spec/jobs/set_content_type_job_spec.rb
@@ -57,7 +57,10 @@ RSpec.describe SetContentTypeJob do
     allow(subject).to receive(:bulk_action).and_return(bulk_action)
     allow(BulkJobLog).to receive(:open).and_yield(buffer)
     allow(subject.ability).to receive(:can?).and_return(true)
-    allow(VersionService).to receive(:open?).and_return(true)
+    allow(VersionService).to receive(:open?).with(druid: druids[0]).and_return(true)
+    allow(VersionService).to receive(:open?).with(druid: druids[1]).and_return(false)
+    allow(VersionService).to receive(:openable?).with(druid: druids[1]).and_return(true)
+    allow(VersionService).to receive(:open).and_return(cocina2)
     allow(Dor::Services::Client).to receive(:object).with(druids[0]).and_return(object_client1)
     allow(Dor::Services::Client).to receive(:object).with(druids[1]).and_return(object_client2)
     allow(Dor::Services::Client).to receive(:object).with(druids[2]).and_return(object_client3)
@@ -76,6 +79,7 @@ RSpec.describe SetContentTypeJob do
           )
         )
       expect(buffer.string).to include "Successfully updated content type for #{druids[0]}"
+      expect(VersionService).not_to have_received(:open)
     end
   end
 
@@ -98,6 +102,24 @@ RSpec.describe SetContentTypeJob do
             resource_types: [Cocina::Models::FileSetType.page, Cocina::Models::FileSetType.image]
           )
         )
+    end
+  end
+
+  context 'when not open' do
+    let(:params) do
+      {
+        druids: [druids[1]],
+        current_resource_type: 'https://cocina.sul.stanford.edu/models/resources/file',
+        new_content_type: 'https://cocina.sul.stanford.edu/models/map',
+        new_resource_type: 'https://cocina.sul.stanford.edu/models/resources/image'
+      }
+    end
+
+    it 'opens a version' do
+      subject.perform(bulk_action.id, params)
+      expect(VersionService).to have_received(:open).with(druid: druids[1],
+                                                          description: 'Updating content type',
+                                                          opening_user_name: bulk_action.user.to_s)
     end
   end
 
@@ -218,18 +240,6 @@ RSpec.describe SetContentTypeJob do
       subject.perform(bulk_action.id, params)
       expect(object_client1).to have_received(:update)
         .with(params: cocina_object_with_types(content_type: Cocina::Models::ObjectType.map))
-    end
-  end
-
-  context 'when modification is not allowed' do
-    before do
-      allow(VersionService).to receive(:open?).and_return(false)
-    end
-
-    it 'does not update and logs an error' do
-      subject.perform(bulk_action.id, params)
-      expect(object_client2).not_to have_received(:update)
-      expect(buffer.string).to include 'Object cannot be modified in its current state.'
     end
   end
 


### PR DESCRIPTION
refs #3683

# Why was this change made?
Bulk action consistency

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?
Unit
<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


