### PR TITLE
Rescue conflict and redirect when sourceid raises a duplicate conflict

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -63,6 +63,9 @@ class ItemsController < ApplicationController
     change_set.save
     reindex
     redirect_to solr_document_path(params[:id]), notice: "Source Id for #{params[:id]} has been updated!"
+  rescue Dor::Services::Client::ConflictResponse => e
+    error_message = "Source ID could not be updated: #{e.message}"
+    redirect_to solr_document_path(params[:id]), flash: { error: error_message }
   end
 
   def purge_object

--- a/app/views/items/_source_id_ui.html.erb
+++ b/app/views/items/_source_id_ui.html.erb
@@ -1,3 +1,9 @@
+<% if flash.now[:alert] %>
+  <div class="alert alert-danger" role="alert">
+    <%= flash.now[:alert] %>
+  </div>
+<% end %>
+
 <%= form_tag source_id_item_path(@cocina.externalIdentifier) do %>
   <div class="mb-3">
     <input class="form-control" name="new_id" id="new_id" type="text" value="<%= @cocina.identification.sourceId %>" autocomplete="off">


### PR DESCRIPTION
# Why was this change made?

Fixes #4822 

<img width="1439" height="360" alt="Screenshot 2025-10-09 at 1 04 46 PM" src="https://github.com/user-attachments/assets/5509b54a-81f7-4d11-8c66-ab20fdf57e9e" />


# How was this change tested?

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


