### PR TITLE
Adds the rosette to the header

### DIFF
--- a/app/components/top_navbar_component.html.erb
+++ b/app/components/top_navbar_component.html.erb
@@ -41,9 +41,12 @@
     <div class="container">
       <div class="row align-items-center">
         <div
-          class="col-md-8 d-flex justify-content-center justify-content-md-start">
-          <div class="h1 my-3">
-            <%= link_to 'Argo', root_path %>
+          class="col-md-8 d-flex gap-2 justify-content-center justify-content-md-start">
+          <span class="rosette-logo my-3 me-1 align-self-start flex-shrink-0" aria-hidden="true"></span>
+          <div class="me-1 flex-grow-1">
+            <div class="h1 my-3">
+              <%= link_to 'Argo', root_path %>
+            </div>
           </div>
         </div>
         <div class="col-md-4">


### PR DESCRIPTION
# Why was this change made?

Fixes #4885 

<img width="935" height="217" alt="Screenshot 2025-10-15 at 4 13 04 PM" src="https://github.com/user-attachments/assets/d7daa52d-6d85-4e8d-82c8-87b8cb8cd916" />



# How was this change tested?

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


