### PR TITLE
Tweak display of virtual object constituents.

### DIFF
--- a/app/components/contents/constituent_component.html.erb
+++ b/app/components/contents/constituent_component.html.erb
@@ -2,9 +2,9 @@
   <ul class="child-list">
     <li class="external-file">
       <span class="label">
-        External File
+        Constituent:
       </span>
-      (from item '<%= link_to druid, solr_document_path(druid), target: '_top' %>')
+      <%= link_to druid, solr_document_path(druid), target: '_top' %>
     </li>
   </ul>
 </li>

--- a/app/components/contents/constituent_component.rb
+++ b/app/components/contents/constituent_component.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Contents
-  # Displays external files for a virtual object
+  # Displays constituents for a virtual object
   # e.g. https://argo.stanford.edu/view/druid:tm280sk2404
-  class ExternalFileComponent < ViewComponent::Base
+  class ConstituentComponent < ViewComponent::Base
     with_collection_parameter :druid
 
     def initialize(druid:)

--- a/app/components/contents/structural_component.html.erb
+++ b/app/components/contents/structural_component.html.erb
@@ -4,5 +4,5 @@
 </div>
 <ul class="resource-list">
   <%= render Contents::ResourceComponent.with_collection(paginatable_array, counter_offset: paginatable_array.offset_value, object_id:, user_version:, viewable: viewable?) %>
-  <%= render Contents::ExternalFileComponent.with_collection(structural.hasMemberOrders.first&.members) %>
+  <%= render Contents::ConstituentComponent.with_collection(structural.hasMemberOrders.first&.members) %>
 </ul>

--- a/spec/components/contents/constituent_component_spec.rb
+++ b/spec/components/contents/constituent_component_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Contents::ExternalFileComponent, type: :component do
+RSpec.describe Contents::ConstituentComponent, type: :component do
   let(:component) { described_class.new(druid: id) }
   let(:rendered) { render_inline(component) }
   let(:id) { 'druid:bf746ns6287' }


### PR DESCRIPTION
closes #4924

# Why was this change made?

Clarity

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?

QA, unit

<img width="1316" height="306" alt="image" src="https://github.com/user-attachments/assets/7601f76b-48e5-42d0-888d-7ffbd9273343" />


<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


