### PR TITLE
Hide upload and download csv links for empty objects and virtual objects

### DIFF
--- a/app/components/contents/structural_component.html.erb
+++ b/app/components/contents/structural_component.html.erb
@@ -1,5 +1,5 @@
 <div class="d-flex justify-content-between">
-  <div><%= pluralize number_of_content_items, label_for_content_items %></div>
+  <div><%= pluralize number_of_content_items, label %></div>
   <%= helpers.paginate paginatable_array, theme: :blacklight %>
 </div>
 <ul class="resource-list">

--- a/app/components/contents/structural_component.rb
+++ b/app/components/contents/structural_component.rb
@@ -15,6 +15,8 @@ module Contents
 
     attr_reader :structural, :object_id, :user_version
 
+    delegate :constituents, :label, :number_of_content_items, :virtual_object?, to: :structural_presenter
+
     def viewable?
       @viewable
     end
@@ -23,24 +25,8 @@ module Contents
       @paginatable_array ||= Kaminari.paginate_array(structural.contains).page(params[:page]).per(50)
     end
 
-    def number_of_content_items
-      return constituents.size if virtual_object?
-
-      structural.contains.size
-    end
-
-    def label_for_content_items
-      return 'Constituent' if virtual_object?
-
-      'Resource'
-    end
-
-    def virtual_object?
-      constituents.present?
-    end
-
-    def constituents
-      @constituents ||= structural.hasMemberOrders.first&.members
+    def structural_presenter
+      @structural_presenter ||= StructuralPresenter.new(structural)
     end
   end
 end

--- a/app/components/contents_component.rb
+++ b/app/components/contents_component.rb
@@ -15,12 +15,18 @@ class ContentsComponent < ApplicationComponent
   delegate :open_and_not_assembling?, :version_or_user_version_view?, :user_version_view?, :version_view?,
            :user_version_view, :version_view, to: :@presenter
 
+  delegate :enable_csv?, to: :structural_presenter
+
   def upload_csv?
-    !version_or_user_version_view? && open_and_not_assembling?
+    return false if version_or_user_version_view? && !open_and_not_assembling?
+
+    enable_csv?
   end
 
   def download_csv?
-    !version_or_user_version_view?
+    return false if version_or_user_version_view?
+
+    enable_csv?
   end
 
   def structural_link_path
@@ -31,5 +37,9 @@ class ContentsComponent < ApplicationComponent
     else
       item_structure_path(@view_token)
     end
+  end
+
+  def structural_presenter
+    @structural_presenter ||= StructuralPresenter.new(@cocina.structural)
   end
 end

--- a/app/presenters/argo_show_presenter.rb
+++ b/app/presenters/argo_show_presenter.rb
@@ -47,5 +47,7 @@ class ArgoShowPresenter < Blacklight::ShowPresenter
 
   delegate :version_view, :current_version, to: :versions_presenter
 
+  delegate :structural, to: :cocina
+
   attr_accessor :cocina, :view_token, :state_service, :version_service, :user_versions_presenter, :versions_presenter
 end

--- a/app/presenters/structural_presenter.rb
+++ b/app/presenters/structural_presenter.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# This presenter is for content based on cocina structural content
+class StructuralPresenter
+  def initialize(structural)
+    @structural = structural
+  end
+
+  attr_reader :structural
+
+  def label
+    return 'Constituent' if virtual_object?
+
+    'Resource'
+  end
+
+  # Determine if the upload/download CSV links should be enabled
+  # Returns true if there are content items and it is not a virtual object
+  def enable_csv?
+    return false if virtual_object? || number_of_content_items.nil?
+
+    number_of_content_items.positive?
+  end
+
+  def number_of_content_items
+    return constituents.size if virtual_object?
+
+    structural&.contains&.size
+  end
+
+  def virtual_object?
+    constituents.present?
+  end
+
+  def constituents
+    return nil unless structural
+    return nil if structural.hasMemberOrders.blank?
+
+    @constituents ||= structural.hasMemberOrders.first&.members
+  end
+end

--- a/spec/components/contents_component_spec.rb
+++ b/spec/components/contents_component_spec.rb
@@ -25,14 +25,63 @@ RSpec.describe ContentsComponent, type: :component do
     let(:solr_doc) do
       SolrDocument.new(id: 'druid:bb000zn0114')
     end
-    let(:cocina) { build(:dro) }
+    let(:cocina) { build(:dro).new(structural:) }
+    let(:structural) { Cocina::Models::DROStructural.new(contains:, hasMemberOrders: member_orders, isMemberOf: []) }
+    let(:member_orders) { [] }
+    let(:contains) { [] }
 
     before do
       allow(vc_test_controller).to receive(:can?).and_return(true)
     end
 
-    context 'with unlocked object' do
+    context 'with unlocked object with no attached resources' do
       let(:open) { true }
+
+      it 'renders a turbo frame' do
+        expect(rendered.css('turbo-frame').first['src']).to eq '/items/skret-t0k3n/structure'
+      end
+
+      it 'shows Upload CSV button' do
+        expect(rendered.css('.bi-upload')).not_to be_present
+      end
+
+      it 'does not show the Download CSV button' do
+        expect(rendered.css('.bi-download')).not_to be_present
+      end
+    end
+
+    context 'with unlocked object with an attached resources' do
+      let(:open) { true }
+      let(:contains) do
+        [
+          Cocina::Models::FileSet.new(
+            type: Cocina::Models::FileSetType.file,
+            externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/bb573tm8486-bc91c072-3b0f-4338-a9b2-0f85e1b98e00',
+            version: 1,
+            label: 'Image 1',
+            structural: {
+              contains: [
+                Cocina::Models::File.new(
+                  type: Cocina::Models::ObjectType.file,
+                  filename: 'example.tif',
+                  label: 'example.tif',
+                  externalIdentifier: 'https://cocina.sul.stanford.edu/file/b7cdfa7a-6e1f-484b-bbb0-f9a46c40dbb4',
+                  hasMimeType: 'image/tiff',
+                  version: 1,
+                  access: {
+                    view: 'dark'
+                  },
+                  administrative: {
+                    publish: true,
+                    sdrPreserve: true,
+                    shelve: false
+                  }
+                )
+              ]
+            }
+          )
+        ]
+      end
 
       it 'renders a turbo frame' do
         expect(rendered.css('turbo-frame').first['src']).to eq '/items/skret-t0k3n/structure'
@@ -77,6 +126,25 @@ RSpec.describe ContentsComponent, type: :component do
       end
 
       it 'hides Download CSV button' do
+        expect(rendered.css('.bi-download')).not_to be_present
+      end
+    end
+
+    context 'with a virtual object' do
+      let(:open) { true }
+      let(:member_orders) do
+        [
+          {
+            members: %w[druid:ry482gj6267 druid:cd655zh4100 druid:bc123df4567]
+          }
+        ]
+      end
+
+      it 'does not show the Upload CSV button' do
+        expect(rendered.css('.bi-upload')).not_to be_present
+      end
+
+      it 'does not shows the download CSV button' do
         expect(rendered.css('.bi-download')).not_to be_present
       end
     end

--- a/spec/presenters/structural_presenter_spec.rb
+++ b/spec/presenters/structural_presenter_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StructuralPresenter do
+  subject(:presenter) { described_class.new(structural) }
+
+  let(:structural) { Cocina::Models::DROStructural.new(contains: contains, hasMemberOrders: member_orders) }
+  let(:contains) do
+    [
+      Cocina::Models::FileSet.new(
+        type: Cocina::Models::FileSetType.file,
+        externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/bb573tm8486-bc91c072-3b0f-4338-a9b2-0f85e1b98e00',
+        version: 1,
+        label: 'Image 1'
+      ),
+      Cocina::Models::FileSet.new(
+        type: Cocina::Models::FileSetType.file,
+        externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/bb573tm8486-bc91c072-3b0f-4338-a9b2-0f85e1b98e11',
+        version: 2,
+        label: 'Image 2'
+      )
+    ]
+  end
+  let(:member_orders) { [] }
+
+  describe '#label' do
+    context 'when a virtual object' do
+      let(:member_orders) do
+        [
+          members: %w[druid:aa111bb2222 druid:cc333dd4444]
+        ]
+      end
+
+      it 'returns Constituent' do
+        expect(presenter.label).to eq 'Constituent'
+      end
+    end
+
+    context 'when not a virtual object' do
+      it 'returns Resource' do
+        expect(presenter.label).to eq 'Resource'
+      end
+    end
+  end
+
+  describe '#number_of_content_items' do
+    context 'when a virtual object' do
+      let(:member_orders) do
+        [
+          members: %w[druid:aa111bb2222 druid:cc333dd4444]
+        ]
+      end
+
+      it 'returns the number of constituents' do
+        expect(presenter.number_of_content_items).to eq 2
+      end
+    end
+
+    context 'when not a virtual object' do
+      it 'returns the number of contains' do
+        expect(presenter.number_of_content_items).to eq 2
+      end
+
+      context 'when contains is nil' do
+        let(:contains) { [] }
+
+        it 'returns 0' do
+          expect(presenter.number_of_content_items).to eq 0
+        end
+      end
+    end
+  end
+
+  describe '#enable_csv?' do
+    context 'when a virtual object' do
+      let(:member_orders) do
+        [
+          members: %w[druid:aa111bb2222 druid:cc333dd4444]
+        ]
+      end
+
+      it 'returns false' do
+        expect(presenter.enable_csv?).to be false
+      end
+    end
+
+    context 'when not a virtual object' do
+      it 'returns true' do
+        expect(presenter.enable_csv?).to be true
+      end
+    end
+  end
+
+  describe '#virtual_object?' do
+    context 'when a virtual object' do
+      let(:member_orders) do
+        [
+          members: %w[druid:aa111bb2222 druid:cc333dd4444]
+        ]
+      end
+
+      it 'returns true' do
+        expect(presenter.virtual_object?).to be true
+      end
+    end
+
+    context 'when not a virtual object' do
+      it 'returns false' do
+        expect(presenter.virtual_object?).to be false
+      end
+    end
+  end
+
+  describe '#constituents' do
+    context 'when a virtual object' do
+      let(:member_orders) do
+        [
+          members: %w[druid:aa111bb2222 druid:cc333dd4444]
+        ]
+      end
+
+      it 'returns the member orders' do
+        expect(presenter.constituents).to eq ['druid:aa111bb2222', 'druid:cc333dd4444']
+      end
+    end
+
+    context 'when not a virtual object' do
+      it 'returns an empty array' do
+        expect(presenter.constituents).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Why was this change made?

Fixes #4881

Note: most of this PR is moving the code that is used in the StructuralComponent for determining if an object is a virtual object into a presenter so that it can be reused in the ContentsComponent to determine if the upload and download csv links should be displayed.

# How was this change tested?

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


