### PR TITLE
Truncate long facet values on show page

### DIFF
--- a/app/assets/stylesheets/argo.css
+++ b/app/assets/stylesheets/argo.css
@@ -10,11 +10,36 @@
 
 /* Overriding blacklight to keep the border-color */
 .applied-filter {
-  .constraint-value {
+  display: flex;
+
+  &:hover,
+  &:active {
+    border-color: var(--bs-body-color);
+  }
+
+  .btn-close {
+    align-self: center;
+    font-size: 0.6rem;
+    padding: 0.35em 0.65em;
+
     &:hover,
     &:active {
-      border-color: var(--bs-body-color);
+      --bs-btn-close-color: var(--stanford-digital-red);
+      mask-position: center;
+      mask-repeat: no-repeat;
+      mask-size: 65%;
+      mask-image: var(--bs-btn-close-bg);
     }
+  }
+
+  .constraint-value {
+    display: inline-block;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    padding-inline: 0.75rem 0.25rem;
+    white-space: nowrap;
+    max-width: clamp(288px, calc(30vw), 500px);
+    border-inline-end: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color);
   }
 }
 

--- a/app/components/constraint_layout_component.html.erb
+++ b/app/components/constraint_layout_component.html.erb
@@ -1,6 +1,6 @@
-<li class="d-inline-flex gap-2 align-items-center applied-filter constraint <%= classes %>">
-    <span class="bg-light badge rounded-pill border selected-item constraint-value">
-        <span class="selected-item-label">
+<li class="d-inline-flex gap-2 align-items-center <%= classes %>">
+    <span class="bg-light rounded-pill border applied-filter constraint">
+        <span class="constraint-value">
             <% if label.present? %>
                 <span class="filter-name"><%= label %></span>
             <% end %>

--- a/spec/factories/apos.rb
+++ b/spec/factories/apos.rb
@@ -26,7 +26,7 @@ FactoryBot.define do
 
     admin_policy_id { 'druid:hv992ry2431' }
     agreement_id { FactoryBot.create_for_repository(:agreement).externalIdentifier }
-    label { 'test apo' }
+    label { 'this is a really long test APO label to test truncation of facet labels on show page' }
     type { Cocina::Models::ObjectType.admin_policy }
   end
 end


### PR DESCRIPTION
# Why was this change made?

Fixes #4773

![Peek 2025-10-21 16-58](https://github.com/user-attachments/assets/259e093d-dae9-44bf-b442-28119ed9f865)

# How was this change tested?

- [x] CI
- [x] QA

