### PR TITLE
Fix the logic for showing the download link

### DIFF
--- a/app/components/contents_component.rb
+++ b/app/components/contents_component.rb
@@ -18,15 +18,15 @@ class ContentsComponent < ApplicationComponent
   delegate :enable_csv?, to: :structural_presenter
 
   def upload_csv?
-    return false if version_or_user_version_view? && !open_and_not_assembling?
+    return enable_csv? if !version_or_user_version_view? && open_and_not_assembling?
 
-    enable_csv?
+    false
   end
 
   def download_csv?
-    return false if version_or_user_version_view?
+    return enable_csv? unless version_or_user_version_view?
 
-    enable_csv?
+    false
   end
 
   def structural_link_path


### PR DESCRIPTION
# Why was this change made?

Restores the original `upload_csv?` and `download_csv?` logic and returns `enable_csv?` instead of swapping the logic for a guard clause fixing an inadvertent but.


# How was this change tested?

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


