### PR TITLE
Stop creating releaseWF when creating a tag.

### DIFF
--- a/app/controllers/manage_releases_controller.rb
+++ b/app/controllers/manage_releases_controller.rb
@@ -16,9 +16,7 @@ class ManageReleasesController < ApplicationController
   def update
     authorize! :update, @cocina
 
-    object_client = Dor::Services::Client.object(@cocina.externalIdentifier)
-    object_client.release_tags.create(tag: new_tag)
-    object_client.workflow('releaseWF').create(version: @cocina.version)
+    Dor::Services::Client.object(@cocina.externalIdentifier).release_tags.create(tag: new_tag)
 
     redirect_to solr_document_path(@cocina.externalIdentifier), notice: "Updated release for #{@cocina.externalIdentifier}"
   end

--- a/app/jobs/release_object_job.rb
+++ b/app/jobs/release_object_job.rb
@@ -16,7 +16,6 @@ class ReleaseObjectJob < BulkActionJob
       return failure!(message: 'Object has never been published and cannot be released') unless WorkflowService.published?(druid:)
 
       object_client.release_tags.create(tag: new_tag)
-      object_client.workflow('releaseWF').create(version: cocina_object.version)
 
       success!(message: 'Workflow creation successful')
     end

--- a/spec/jobs/release_object_job_spec.rb
+++ b/spec/jobs/release_object_job_spec.rb
@@ -26,9 +26,7 @@ RSpec.describe ReleaseObjectJob do
       allow(job_item).to receive_messages(check_update_ability?: true, cocina_object: cocina_object)
     end
   end
-  let(:object_client) { instance_double(Dor::Services::Client::Object, workflow: workflow_client, release_tags: release_tags_client) }
-  let(:workflow_client) { instance_double(Dor::Services::Client::ObjectWorkflow, create: true) }
-
+  let(:object_client) { instance_double(Dor::Services::Client::Object, release_tags: release_tags_client) }
   let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, create: true) }
 
   before do
@@ -44,8 +42,6 @@ RSpec.describe ReleaseObjectJob do
     expect(job_item).to have_received(:check_update_ability?)
     expect(WorkflowService).to have_received(:published?).with(druid: druid)
     expect(release_tags_client).to have_received(:create).with(tag: an_instance_of(Dor::Services::Client::ReleaseTag))
-    expect(object_client).to have_received(:workflow).with('releaseWF')
-    expect(workflow_client).to have_received(:create).with(version: version)
 
     expect(bulk_action.reload.druid_count_total).to eq(1)
     expect(bulk_action.druid_count_fail).to eq(0)
@@ -62,7 +58,6 @@ RSpec.describe ReleaseObjectJob do
 
       expect(WorkflowService).not_to have_received(:published?)
       expect(release_tags_client).not_to have_received(:create)
-      expect(workflow_client).not_to have_received(:create)
     end
   end
 
@@ -75,7 +70,6 @@ RSpec.describe ReleaseObjectJob do
       job.perform_now
 
       expect(release_tags_client).not_to have_received(:create)
-      expect(workflow_client).not_to have_received(:create)
 
       expect(bulk_action.reload.druid_count_total).to eq(1)
       expect(bulk_action.druid_count_fail).to eq(1)

--- a/spec/system/collection_manage_release_spec.rb
+++ b/spec/system/collection_manage_release_spec.rb
@@ -18,10 +18,8 @@ RSpec.describe 'Collection manage release' do
                     events: events_client,
                     version: version_client,
                     user_version: user_version_client,
-                    release_tags: release_tags_client,
-                    workflow: workflow_client)
+                    release_tags: release_tags_client)
   end
-  let(:workflow_client) { instance_double(Dor::Services::Client::ObjectWorkflow, create: true) }
   let(:cocina_model) do
     build(:collection_with_metadata, id: collection_id)
   end
@@ -45,7 +43,7 @@ RSpec.describe 'Collection manage release' do
     expect(page).to have_css 'a', text: 'Manage release'
   end
 
-  it 'sets a tag and starts releaseWF' do
+  it 'sets a tag' do
     visit edit_item_manage_release_path(collection_id)
 
     expect(page).to have_css 'label', text: "Manage release to discovery applications for collection #{collection_id}"
@@ -62,7 +60,5 @@ RSpec.describe 'Collection manage release' do
       expect(tag.release).to be true
       expect(tag.date).to be_a DateTime
     end
-    expect(object_client).to have_received(:workflow).with('releaseWF')
-    expect(workflow_client).to have_received(:create).with(version: cocina_model.version)
   end
 end

--- a/spec/system/item_manage_release_spec.rb
+++ b/spec/system/item_manage_release_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe 'Item manage release' do
                     events: events_client,
                     version: version_client,
                     user_version: user_version_client,
-                    release_tags: release_tags_client,
-                    workflow: workflow_client)
+                    release_tags: release_tags_client)
   end
   let(:item) do
     FactoryBot.create_for_repository(:persisted_item)
@@ -37,7 +36,7 @@ RSpec.describe 'Item manage release' do
     expect(page).to have_css 'a', text: 'Manage release'
   end
 
-  it 'sets a tag and starts releaseWF' do
+  it 'sets a tag' do
     visit edit_item_manage_release_path(item.externalIdentifier)
     expect(page).to have_css 'label',
                              text: "Manage release to discovery applications for item #{item.externalIdentifier}"
@@ -52,7 +51,5 @@ RSpec.describe 'Item manage release' do
       expect(tag.release).to be true
       expect(tag.date).to be_a DateTime
     end
-    expect(object_client).to have_received(:workflow).with('releaseWF')
-    expect(workflow_client).to have_received(:create).with(version: item.version)
   end
 end


### PR DESCRIPTION
refs https://github.com/sul-dlss/dor-services-app/issues/5586

# Why was this change made?
This should be the responsibility of DSA, not Argo.

# How was this change tested?
Unit
<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


