### PR TITLE
Disable hide csv upload/download logic until it can be fixed

### DIFF
--- a/app/components/contents_component.rb
+++ b/app/components/contents_component.rb
@@ -18,15 +18,11 @@ class ContentsComponent < ApplicationComponent
   delegate :enable_csv?, to: :structural_presenter
 
   def upload_csv?
-    return enable_csv? if !version_or_user_version_view? && open_and_not_assembling?
-
-    false
+    !version_or_user_version_view? && open_and_not_assembling?
   end
 
   def download_csv?
-    return enable_csv? unless version_or_user_version_view?
-
-    false
+    !version_or_user_version_view?
   end
 
   def structural_link_path

--- a/spec/components/contents_component_spec.rb
+++ b/spec/components/contents_component_spec.rb
@@ -41,11 +41,13 @@ RSpec.describe ContentsComponent, type: :component do
         expect(rendered.css('turbo-frame').first['src']).to eq '/items/skret-t0k3n/structure'
       end
 
-      it 'shows Upload CSV button' do
+      # This test is expected to fail until CSV upload/download hide logic is fixed
+      it 'shows Upload CSV button', pending: 'CSV upload button visibility logic needs to be fixed' do
         expect(rendered.css('.bi-upload')).not_to be_present
       end
 
-      it 'does not show the Download CSV button' do
+      # This test is expected to fail until CSV upload/download hide logic is fixed
+      it 'does not show the Download CSV button', pending: 'CSV download button visibility logic needs to be fixed' do
         expect(rendered.css('.bi-download')).not_to be_present
       end
     end
@@ -130,7 +132,8 @@ RSpec.describe ContentsComponent, type: :component do
       end
     end
 
-    context 'with a virtual object' do
+    # These test is expected to fail until CSV upload/download hide logic is fixed
+    context 'with a virtual object', pending: 'CSV upload button visibility logic needs to be fixed' do
       let(:open) { true }
       let(:member_orders) do
         [
@@ -140,12 +143,12 @@ RSpec.describe ContentsComponent, type: :component do
         ]
       end
 
-      it 'does not show the Upload CSV button' do
-        expect(rendered.css('.bi-upload')).not_to be_present
+      xit 'does not show the Upload CSV button' do # rubocop:disable RSpec/PendingWithoutReason
+        expect(rendered.css('.bi-upload')).to be_present
       end
 
-      it 'does not shows the download CSV button' do
-        expect(rendered.css('.bi-download')).not_to be_present
+      xit 'does not shows the download CSV button' do # rubocop:disable RSpec/PendingWithoutReason
+        expect(rendered.css('.bi-download')).to be_present
       end
     end
   end


### PR DESCRIPTION
# Why was this change made?

This restores the original logic for showing the upload and download CSV buttons until the logic around vitrual objects can be debugged.


# How was this change tested?

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


