### PR TITLE
Fix show page when object type is virtual object.

### DIFF
--- a/app/components/document_component.rb
+++ b/app/components/document_component.rb
@@ -6,7 +6,19 @@ class DocumentComponent < Blacklight::DocumentComponent
   end
 
   def child_component
-    type = @document.object_type
-    "Show::#{type.classify}Component".constantize.new(presenter: @presenter)
+    component_class.new(presenter: @presenter)
+  end
+
+  def component_class
+    case @document.object_type
+    when 'collection'
+      Show::CollectionComponent
+    when 'agreement'
+      Show::AgreementComponent
+    when 'adminPolicy'
+      Show::AdminPolicyComponent
+    else
+      Show::ItemComponent
+    end
   end
 end

--- a/spec/system/item_view_spec.rb
+++ b/spec/system/item_view_spec.rb
@@ -200,6 +200,25 @@ RSpec.describe 'Item view', :js do
           }
         end
 
+        context 'when item is a virtual object' do
+          let(:solr_doc) do
+            {
+              id: 'druid:hj185xx2222',
+              SolrDocument::FIELD_OBJECT_TYPE => 'virtual object',
+              display_title_ss: title
+            }
+          end
+
+          let(:title) { 'Slides, IA 11, Geodesic Domes, Double Skin "Growth" House, N.C. State, 1953' }
+
+          it 'renders the page' do
+            visit solr_document_path item_id
+
+            expect(page).to have_css 'h1', text: title
+            expect(page).to have_css '.object-type-virtual-object'
+          end
+        end
+
         context 'when the file is on stacks' do
           let(:solr_doc) do
             {


### PR DESCRIPTION
closes #4944

# Why was this change made?
Virtual object show pages were not rendering.

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?
Unit, stage
<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


