### PR TITLE
Drop virtual objects facet.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -188,11 +188,6 @@ class CatalogController < ApplicationController
     # common method since search results and reports all do the same configuration
     add_common_date_facet_fields_to_config! config
 
-    config.add_facet_field SolrDocument::FIELD_CONSTITUENTS, label: 'Virtual Objects', component: true,
-                                                             query: {
-                                                               has_constituents: { label: 'Virtual Objects', fq: "#{SolrDocument::FIELD_CONSTITUENTS}:*" }
-                                                             }
-
     config.add_facet_field 'identifiers', label: 'Identifiers',
                                           component: true,
                                           query: {


### PR DESCRIPTION
closes #4929

# Why was this change made?
It is now an object type:
<img width="431" height="247" alt="image" src="https://github.com/user-attachments/assets/ed7322b5-d1d1-45ee-ac89-87a802a4501a" />


<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?
Local

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


