### PR TITLE
Adds support for tickets to csv registration

### DIFF
--- a/spec/system/item_registration_csv_spec.rb
+++ b/spec/system/item_registration_csv_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'Item registration page', :js do
 
       fill_in 'Project Name', with: 'X-Files'
       fill_in 'Tags', with: 'i : believe'
+      fill_in 'Tickets', with: 'DIGREQ-1234'
 
       click_button 'Upload CSV'
 
@@ -50,7 +51,7 @@ RSpec.describe 'Item registration page', :js do
           reading_order: 'left-to-right',
           rights_download: 'stanford',
           rights_view: 'stanford',
-          tags: ['i : believe', "Registered By : #{user.login}"]
+          tags: ['i : believe', 'Ticket : DIGREQ-1234', "Registered By : #{user.login}"]
         }
       )
     end


### PR DESCRIPTION
closes #4957

# Why was this change made?
So that registration via CSV works correctly.

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?
Unit
<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


