### PR TITLE
Log instead of alert on Turbo fetch error

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -27,7 +27,7 @@ document.addEventListener('turbo:before-fetch-response', async (event) => {
 })
 
 document.addEventListener('turbo:fetch-request-error', async (event) => {
+  console.log("refreshing page after turbo:fetch-request-error")
   console.dir(event.detail)
-  alert('A network error occurred, possibly because your session has expired. The page will be refreshed.')
   window.location.reload()
 })

--- a/spec/system/open_and_close_a_version_spec.rb
+++ b/spec/system/open_and_close_a_version_spec.rb
@@ -28,9 +28,7 @@ RSpec.describe 'Open and close a version' do
 
     sleep 0.5 until VersionService.openable?(druid: item.externalIdentifier)
 
-    accept_alert do # For an unknown reason, sometimes a network error occurs here which triggers the refresh alert.
-      visit solr_document_path item.externalIdentifier
-    end
+    visit solr_document_path item.externalIdentifier
     click_link 'Unlock to make changes to this object'
     fill_in 'Version description', with: 'Test a change'
 


### PR DESCRIPTION
# Why was this change made?

These alerts were causing problems for integration tests that needed to handle them when the speed at which the tests were operating caused the `turbo:fetch-request-error` to be triggered. Removing the alert also made a workaround in one of the Argo unit tests no longer necessary.

The alternative is peppering multiple `sleep` calls into 7 different feature tests. There may be some way to instrument rspec's `visit` to do something to avoid the alerts, since it seems most of the `sleep` calls needed to be added before those...

# How was this change tested?

Unit tests & integration tests.
