### PR TITLE
[DRAFT] Add initial decommission service

### DIFF
--- a/app/services/decommission_service.rb
+++ b/app/services/decommission_service.rb
@@ -20,7 +20,10 @@ class DecommissionService
                          description: "Decommissioned: #{reason}",
                          opening_user_name: sunetid)
 
-    release_tags.each do |release_tag|
+    released_to.each do |release_target|
+      release_tag = latest_release_tag_for(to: release_target)
+      next unless release_tag.release
+
       object_client.release_tags.create(tag: release_tag.new(release: false))
     end
 
@@ -55,5 +58,13 @@ class DecommissionService
 
   def release_tags
     object_client.release_tags.list
+  end
+
+  def released_to
+    release_tags.pluck(:to).uniq
+  end
+
+  def latest_release_tag_for(to:)
+    release_tags.select { |tag| tag.to == to }.max_by(&:date)
   end
 end

--- a/lib/tasks/decommission.rake
+++ b/lib/tasks/decommission.rake
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-def version_service(druid:)
-  VersionService.new(druid: druid)
-end
-
 namespace :decommission do
   desc 'Decommission items by druid'
   task :item, %i[druid sunetid reason] => :environment do |_t, args|
@@ -16,5 +12,23 @@ namespace :decommission do
     DecommissionService.new(druid:, reason:, sunetid:).decommission
   rescue Dor::Services::Client::UnprocessableContentError => e
     puts "Failed to decommission #{args[:druid]}: #{e.message}"
+  end
+
+  task :items, %i[file sunetid reason] => :environment do |_t, args|
+    raise '*** file is a required argument' if args[:file].nil?
+
+    file = args[:file]
+    CSV.open("log/decommission_items_#{Time.now.strftime('%Y%m%d%H%M%S')}.csv", 'w', write_headers: true, headers: %w[druid status message]) do |log|
+      CSV.read(file, headers: true).each do |row|
+        druid = row['druid']
+        sunetid = row['sunetid'] || args[:sunetid]
+        reason = row['reason'] || args[:reason]
+
+        DecommissionService.new(druid:, reason:, sunetid:).decommission
+        log << [druid, 'SUCCESS', 'Decommissioned successfully']
+      rescue Error => e
+        log << [druid, 'FAILURE', e.message]
+      end
+    end
   end
 end


### PR DESCRIPTION
# Why was this change made?

Fixes #5599

DRAFT notes:

- I'm working through adding an un-release endpoint to DSA in order to be able to add all `release: false` tags before reindexing and running the `releaseWF` in order to avoid triggering those more than once at a time for the same object.
- I need to add the bulk option here. My intention is to allow a csv file with individual reasons/tickets to allow bulk decommissioning of multiple tickets at once that can be overridden on the command line


# How was this change tested?

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


