### PR TITLE
Fix releasing collection.

### DIFF
--- a/app/controllers/manage_releases_controller.rb
+++ b/app/controllers/manage_releases_controller.rb
@@ -25,7 +25,7 @@ class ManageReleasesController < ApplicationController
     Dor::Services::Client::ReleaseTag.new(
       to: params[:to],
       who: current_user.sunetid,
-      what: 'self',
+      what: params[:what] || 'self',
       release: params[:tag] == 'true',
       date: DateTime.now.utc.iso8601
     )

--- a/spec/system/collection_manage_release_spec.rb
+++ b/spec/system/collection_manage_release_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'Collection manage release' do
       tag = args[:tag]
       expect(tag.to).to eq 'Searchworks'
       expect(tag.who).to eq 'esnowden'
-      expect(tag.what).to eq 'self'
+      expect(tag.what).to eq 'collection'
       expect(tag.release).to be true
       expect(tag.date).to be_a DateTime
     end


### PR DESCRIPTION
closes #4973

# Why was this change made?
Releases were being set to self even when collection was selected.

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?
Unit

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


