### PR TITLE
Disable manage release button when item is dark.

### DIFF
--- a/app/components/show/controls_component.rb
+++ b/app/components/show/controls_component.rb
@@ -46,7 +46,7 @@ module Show
 
     delegate :admin_policy?, :agreement?, :item?, :collection?, :embargoed?, to: :doc
     delegate :open?, :openable?, :open_and_not_assembling?, :user_version_view, :version_or_user_version_view?,
-             :user_version_view?, :version_view?, :version_view, to: :presenter
+             :user_version_view?, :version_view?, :version_view, :dark?, to: :presenter
 
     def button_disabled?
       !open_and_not_assembling? || version_or_user_version_view?
@@ -67,7 +67,7 @@ module Show
         url: edit_item_manage_release_path(druid),
         label: 'Manage release',
         open_modal: true,
-        disabled: version_or_user_version_view?
+        disabled: version_or_user_version_view? || dark?
       )
     end
 

--- a/app/presenters/argo_show_presenter.rb
+++ b/app/presenters/argo_show_presenter.rb
@@ -41,6 +41,10 @@ class ArgoShowPresenter < Blacklight::ShowPresenter
     version_view? || user_version_view?
   end
 
+  def dark?
+    cocina.access.view == 'dark'
+  end
+
   delegate :open?, :openable?, :open_and_not_assembling?, to: :version_service
 
   delegate :user_version_view, :head_user_version, to: :user_versions_presenter

--- a/spec/components/show/controls_component_spec.rb
+++ b/spec/components/show/controls_component_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe Show::ControlsComponent, type: :component do
                     version_view: version,
                     version_view?: version.present?,
                     version_or_user_version_view?: version.present? || user_version.present?,
-                    user_versions_presenter:)
+                    user_versions_presenter:,
+                    dark?: dark)
   end
   let(:user_versions_presenter) { instance_double(UserVersionsPresenter, user_version_withdrawable?: user_version_withdrawable, user_version_restorable?: user_version_restorable) }
   let(:cocina) { instance_double(Cocina::Models::DRO, dro?: dro, type: 'https://cocina.sul.stanford.edu/models/book') }
@@ -32,6 +33,7 @@ RSpec.describe Show::ControlsComponent, type: :component do
   let(:version) { nil }
   let(:user_version_withdrawable) { false }
   let(:user_version_restorable) { false }
+  let(:dark) { false }
 
   before do
     rendered
@@ -79,6 +81,14 @@ RSpec.describe Show::ControlsComponent, type: :component do
 
         it 'does not generate errors given an object that has no associated APO' do
           expect(rendered.css('a').to_html).to eq ''
+        end
+      end
+
+      context 'when the item is dark' do
+        let(:dark) { true }
+
+        it 'disables the manage release button' do
+          expect(page).to have_link 'Manage release', href: '/items/druid:kv840xx0000/manage_release/edit', class: 'disabled'
         end
       end
 


### PR DESCRIPTION
closes #4972

# Why was this change made?
Per Andrew.
<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


