### PR TITLE
Check folio hrid when creating collections.

### DIFF
--- a/app/javascript/controllers/apo_form_controller.js
+++ b/app/javascript/controllers/apo_form_controller.js
@@ -35,4 +35,17 @@ export default class extends Controller {
     this.hideCollection()
     this.selectCollectionFieldsTarget.hidden = false
   }
+
+  async validateCatalogRecordId (event) {
+    event.target.setCustomValidity('')
+    if (event.target.validity.patternMismatch) return
+
+    await fetch(`/registration/catalog_record_id?catalog_record_id=${event.target.value}`)
+      .then(resp => resp.json())
+      .then(data => {
+        if (!data) {
+          event.target.setCustomValidity('Record not found')
+        }
+      })
+  }
 }

--- a/app/javascript/controllers/collection_editor.js
+++ b/app/javascript/controllers/collection_editor.js
@@ -1,7 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
-  static targets = ['titleWarning', 'catalogRecordId', 'catalogRecordIdWarning', 'catalogRecordIdFormatError', 'createCollectionFields', 'catalogRecordIdFields']
+  static targets = ['titleWarning', 'catalogRecordId', 'catalogRecordIdWarning', 'catalogRecordIdFormatError', 'createCollectionFields', 'catalogRecordIdFields', 'catalogRecordDoesNotExistWarning']
 
   revealCreateCollection () {
     this.createCollectionFieldsTarget.hidden = false
@@ -21,12 +21,23 @@ export default class extends Controller {
       })
   }
 
-  checkCatalogRecordId (event) {
-    this.catalogRecordIdFormatErrorTarget.hidden = !this.catalogRecordIdTarget.validity.patternMismatch
-    fetch(`/collections/exists?catalog_record_id=${event.target.value}`)
+  async checkCatalogRecordId (event) {
+    if (this.catalogRecordIdTarget.validity.patternMismatch) {
+      this.catalogRecordIdFormatErrorTarget.hidden = false
+      return
+    }
+
+    this.catalogRecordIdFormatErrorTarget.hidden = true
+    await fetch(`/collections/exists?catalog_record_id=${event.target.value}`)
       .then(resp => resp.json())
       .then(data => {
         this.catalogRecordIdWarningTarget.hidden = !data
+      })
+
+    await fetch(`/registration/catalog_record_id?catalog_record_id=${event.target.value}`)
+      .then(resp => resp.json())
+      .then(data => {
+        this.catalogRecordDoesNotExistWarningTarget.hidden = data
       })
   }
 }

--- a/app/views/apo/_form.html.erb
+++ b/app/views/apo/_form.html.erb
@@ -86,7 +86,7 @@
       <div class="mb-3">
         <%= collection.label :collection_catalog_record_id, "Collection #{CatalogRecordId.label}", class: 'col-sm-4 control-label' %>
         <div class="col-sm-8">
-          <%= collection.text_field :collection_catalog_record_id, class: 'form-control', pattern: CatalogRecordId.html_pattern_string %>
+          <%= collection.text_field :collection_catalog_record_id, class: 'form-control', pattern: CatalogRecordId.html_pattern_string, data: { action: 'apo-form#validateCatalogRecordId' } %>
         </div>
       </div>
       <div class="mb-3">

--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -51,6 +51,7 @@
                                                               data: { action: 'collection-editor#checkCatalogRecordId', collection_editor_target: 'catalogRecordId' }, autocomplete: 'off' %>
       <div data-collection-editor-target="catalogRecordIdFormatError" class="mt-2 alert alert-danger" role="alert" hidden>Collection Folio Instance HRID must be in an allowed format.</div>
       <div data-collection-editor-target="catalogRecordIdWarning" class="mt-2 alert alert-warning" role="alert" hidden>Collection with this <%= CatalogRecordId.label %> already exists.</div>
+      <div data-collection-editor-target="catalogRecordDoesNotExistWarning" class="mt-2 alert alert-warning" role="alert" hidden><%= CatalogRecordId.label %> does not exist.</div>
     </div>
     <div class="mb-3">
       <label for="collection_rights_catalog_record_id">


### PR DESCRIPTION
closes #4962

# Why was this change made?
Per Andrew.

This implementation isn't pretty -- I stayed consistent with the validation approaches in the existing forms.

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?
Stage
<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


