### PR TITLE
Update event time format to include seconds

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,7 +29,7 @@ en:
       am: am
       formats:
         default: "%Y-%m-%d %I:%M%p"
-        event: "%Y-%m-%d"
+        event: "%Y-%m-%d %I:%M%S %p"
   argo:
     search:
       catalog_view: 'Results View'


### PR DESCRIPTION
# Why was this change made?

This supports easier identification of events in the event log when there are multiple similar ones in a short timeframe.

# How was this change tested?

No changes to logic or templates, just text on the page.


