### PR TITLE
Set the Solr URL in one place and use it everywhere

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,7 @@ jobs:
       SETTINGS__DOR_SERVICES__URL: http://dor-services-app:3000
       SETTINGS__REDIS_URL: redis://redis:6379/
       SETTINGS__SDR_API__URL: http://sdr-api:3000
-      SETTINGS__SOLRIZER_URL: http://solr:8983/solr/argo
+      SETTINGS__SOLR__URL: http://solr:8983/solr/argo
       SETTINGS__TECH_MD_SERVICE__URL: http://techmd:3000
       TT: 1 # track templates
     executor: ruby_with_all_deps

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -1,6 +1,12 @@
+default: &default
+  adapter: solr
+  url: <%= Settings.solr.url %>
+
 development:
-  adapter: solr
-  url: <%= Settings.solrizer_url %>
-test: &test
-  adapter: solr
-  url: <%= Settings.solrizer_url %>
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -25,7 +25,7 @@ set :bundle_without, %w[deployment test development].join(' ')
 # set :pty, true
 
 # Default value for :linked_files is []
-set :linked_files, %w[config/database.yml config/secrets.yml config/blacklight.yml config/honeybadger.yml]
+set :linked_files, %w[config/database.yml config/secrets.yml config/honeybadger.yml]
 
 # Default value for linked_dirs is []
 set :linked_dirs, %w[log config/settings tmp/pids tmp/cache tmp/sockets vendor/bundle public/system]

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -48,11 +48,13 @@ normalizer_url: "https://modsulator-app-stage.stanford.edu/v1/normalizer"
 purl_url: "https://sul-purl-stage.stanford.edu"
 searchworks_url: "http://searchworks.stanford.edu/view/%{id}"
 robot_status_url: "https://robot-console-stage.stanford.edu"
-solrizer_url: "http://solr:8983/solr/argo"
 spreadsheet_url: "https://modsulator-app-stage.stanford.edu/v1/spreadsheet"
 stacks_file_url: "https://stacks-test.stanford.edu/file"
 stacks_version_file_url: "https://stacks-test.stanford.edu/v2/file"
 stacks_url: "https://stacks-test.stanford.edu/image"
+
+solr:
+  url: "http://solr:8983/solr/argo"
 
 apo:
   default_workflow_option: "registrationWF"

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,2 +1,2 @@
-# URLs
-solrizer_url: 'http://localhost:8983/solr/argo'
+solr:
+  url: 'http://localhost:8983/solr/argo'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,8 +1,8 @@
 bulk_metadata:
   directory: 'spec/fixtures/bulk_upload/workspace/'
 
-# URLs
-solrizer_url: 'http://localhost:8983/solr/argo'
+solr:
+  url: 'http://localhost:8983/solr/argo'
 
 features:
   ocr_workflow: true


### PR DESCRIPTION
# Why was this change made?

This will reduce the number of steps when performing maintenance such as Solr cluster upgrades and will increase clarity about where changes need to be made.

# How was this change tested?

CI and will be tested in stage

