### PR TITLE
Add search builder that allows the expected behavior for druid searches

### DIFF
--- a/app/search_builders/argo/custom_search.rb
+++ b/app/search_builders/argo/custom_search.rb
@@ -14,5 +14,14 @@ module Argo
       solr_parameters[:rows] = 99_999_999
       solr_parameters[:facet] = false
     end
+
+    # When a user issues a query containing just a druid, strip off the 'druid:'
+    # prefix if it exists, lest we return results that match the word 'druid' in
+    # e.g. the label.
+    def strip_qualified_druids(solr_parameters)
+      return unless DruidTools::Druid.valid?(solr_parameters[:q])
+
+      solr_parameters[:q] = Druid.new(solr_parameters[:q]).without_namespace
+    end
   end
 end

--- a/app/search_builders/search_builder.rb
+++ b/app/search_builders/search_builder.rb
@@ -12,6 +12,7 @@ class SearchBuilder < Blacklight::SearchBuilder
     druids_only
     add_date_field_queries
     add_profile_queries
+    strip_qualified_druids
   ]
 
   # Override blacklight in order to customize facet paging behavior.

--- a/spec/search_builders/argo/custom_search_spec.rb
+++ b/spec/search_builders/argo/custom_search_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+##
+# Fake class for testing module
+class TestClass
+  include Argo::CustomSearch
+end
+
+RSpec.describe Argo::CustomSearch do
+  subject { TestClass.new }
+
+  describe '#strip_qualified_druids' do
+    let(:solr_params) { { q: query } }
+
+    context 'when the query is not a single druid' do
+      let(:query) { 'Infinite Jest' }
+
+      it 'does not alter the query' do
+        subject.strip_qualified_druids(solr_params)
+        expect(solr_params).to eq(q: 'Infinite Jest')
+      end
+    end
+
+    context 'when the query is a single, unprefixed druid' do
+      let(:query) { 'bc123df4567' }
+
+      it 'does not alter the query' do
+        subject.strip_qualified_druids(solr_params)
+        expect(solr_params).to eq(q: 'bc123df4567')
+      end
+    end
+
+    context 'when the query is a single, prefixed druid' do
+      let(:query) { 'druid:bc123df4567' }
+
+      it 'removes the druid prefix from the query' do
+        subject.strip_qualified_druids(solr_params)
+        expect(solr_params).to eq(q: 'bc123df4567')
+      end
+    end
+  end
+end

--- a/spec/search_builders/argo/date_field_queries_spec.rb
+++ b/spec/search_builders/argo/date_field_queries_spec.rb
@@ -11,10 +11,6 @@ end
 RSpec.describe Argo::DateFieldQueries do
   subject { TestClass.new }
 
-  let(:user) do
-    double('user', manager?: false, admin?: false, viewer?: false)
-  end
-
   describe 'add_date_field_queries' do
     describe 'when a date field is faceted' do
       it 'removes the raw fq query in favor of default range query' do

--- a/spec/search_builders/search_builder_spec.rb
+++ b/spec/search_builders/search_builder_spec.rb
@@ -59,6 +59,18 @@ RSpec.describe SearchBuilder do
       expect(subject.processor_chain
         .count { |x| x == :add_profile_queries }).to eq 1
     end
+
+    it 'has strip_qualified_druids in chain once' do
+      expect(subject.processor_chain)
+        .to include :strip_qualified_druids
+      expect(subject.processor_chain
+               .count { |x| x == :strip_qualified_druids }).to eq 1
+      new_search = described_class.new(subject.processor_chain, context)
+      expect(new_search.processor_chain)
+        .to include :strip_qualified_druids
+      expect(subject.processor_chain
+               .count { |x| x == :strip_qualified_druids }).to eq 1
+    end
   end
 
   describe '#add_facet_paging_to_solr' do


### PR DESCRIPTION
# Why was this change made?

To fix single druid searches against Solr >= 9.7.0 collections, where ICU tokenization has changed, resulting in single druid searches returning also any objects that have the token `druid` in their labels, titles, etc. This is a cheaper solution with fewer potential side effects than changing the Argo Solr configs, field types, etc.

# How was this change tested?

CI, Stage

