### PR TITLE
Properly notify user when a version cannot be opened.

### DIFF
--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -28,17 +28,16 @@ class VersionsController < ApplicationController
   end
 
   def open
-    VersionService.open(druid: @cocina_object.externalIdentifier,
-                        description: params[:description],
-                        opening_user_name: current_user.to_s)
+    begin
+      VersionService.open(druid: @cocina_object.externalIdentifier,
+                          description: params[:description],
+                          opening_user_name: current_user.to_s)
+    rescue Dor::Services::Client::UnexpectedResponse => e
+      return redirect_to solr_document_path(params[:item_id]), alert: e.message
+    end
     msg = "#{@cocina_object.externalIdentifier} is open for modification!"
     redirect_to solr_document_path(params[:item_id]), notice: msg
     Dor::Services::Client.object(@cocina_object.externalIdentifier).reindex
-  rescue StandardError => e
-    raise e unless e.to_s == 'Object net yet accessioned'
-
-    render status: :internal_server_error, plain: 'Object net yet accessioned'
-    nil
   end
 
   # as long as this isn't a bulk operation, and we get description

--- a/spec/requests/open_version_spec.rb
+++ b/spec/requests/open_version_spec.rb
@@ -5,8 +5,10 @@ require 'rails_helper'
 RSpec.describe 'Open a version' do
   let(:druid) { 'druid:bc123df4567' }
   let(:user) { create(:user) }
-  let(:object_service) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
   let(:cocina_model) { build(:dro_with_metadata, id: druid) }
+
+  let(:object_service) { instance_double(Dor::Services::Client::Object, version: version_client, find: cocina_model, reindex: true) }
+  let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, open: true) }
 
   before do
     allow(Dor::Services::Client).to receive(:object).and_return(object_service)
@@ -17,15 +19,35 @@ RSpec.describe 'Open a version' do
       sign_in user, groups: ['sdr:administrator-role']
     end
 
-    let(:object_service) { instance_double(Dor::Services::Client::Object, version: version_client, find: cocina_model, reindex: true) }
-    let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, open: true) }
-
     it 'calls dor-services to open a new version' do
       post "/items/#{druid}/version/open", params: { description: 'something' }
 
       expect(version_client).to have_received(:open).with(description: 'something',
                                                           opening_user_name: user.to_s)
       expect(object_service).to have_received(:reindex)
+
+      expect(response).to redirect_to(solr_document_path(druid))
+      expect(flash[:notice]).to eq("#{druid} is open for modification!")
+    end
+  end
+
+  context 'when cannot be opened' do
+    let(:response) { instance_double(Faraday::Response, status: 422, body: '', reason_phrase: 'Cannot open version') }
+
+    before do
+      allow(version_client).to receive(:open).and_raise(Dor::Services::Client::UnexpectedResponse.new(response:))
+      sign_in user, groups: ['sdr:administrator-role']
+    end
+
+    it 'calls dor-services to open a new version' do
+      post "/items/#{druid}/version/open", params: { description: 'something' }
+
+      expect(version_client).to have_received(:open).with(description: 'something',
+                                                          opening_user_name: user.to_s)
+      expect(object_service).not_to have_received(:reindex)
+
+      expect(response).to redirect_to(solr_document_path(druid))
+      expect(flash[:alert]).to include('Cannot open version')
     end
   end
 


### PR DESCRIPTION
refs https://github.com/sul-dlss/dor-services-app/issues/5662

# Why was this change made?
DSA doesn't check that an object is in an openable state in Pres until actually attempting to open the object. When this causes opening to fail, the user should be properly notified.

# How was this change tested?
QA
<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


