### PR TITLE
Avoid using object_id as a method name

### DIFF
--- a/app/components/contents/file_component.rb
+++ b/app/components/contents/file_component.rb
@@ -2,15 +2,15 @@
 
 module Contents
   class FileComponent < ViewComponent::Base
-    def initialize(file:, object_id:, user_version:, viewable:, image:)
+    def initialize(file:, item_id:, user_version:, viewable:, image:)
       @file = file
-      @object_id = object_id
+      @item_id = item_id
       @user_version = user_version
       @viewable = viewable
       @image = image
     end
 
-    attr_reader :file, :object_id, :user_version
+    attr_reader :file, :item_id, :user_version
 
     def viewable?
       @viewable
@@ -59,7 +59,7 @@ module Contents
     end
 
     def files_link
-      attrs = { item_id: object_id, user_version_id: user_version, id: filename }.compact
+      attrs = { item_id:, user_version_id: user_version, id: filename }.compact
       user_version ? item_public_version_files_path(**attrs) : item_files_path(**attrs)
     end
   end

--- a/app/components/contents/resource_component.html.erb
+++ b/app/components/contents/resource_component.html.erb
@@ -25,6 +25,6 @@
         <th>Download</th>
       </tr>
 
-    <%= render Contents::FileComponent.with_collection(files, object_id:, user_version:, viewable: viewable?, image: image?) %>
+    <%= render Contents::FileComponent.with_collection(files, item_id:, user_version:, viewable: viewable?, image: image?) %>
   </table>
 </li>

--- a/app/components/contents/resource_component.rb
+++ b/app/components/contents/resource_component.rb
@@ -2,15 +2,15 @@
 
 module Contents
   class ResourceComponent < ViewComponent::Base
-    def initialize(resource:, resource_counter:, counter_offset:, object_id:, user_version:, viewable:) # rubocop:disable Metrics/ParameterLists
+    def initialize(resource:, resource_counter:, counter_offset:, item_id:, user_version:, viewable:) # rubocop:disable Metrics/ParameterLists
       @resource = resource
       @resource_counter = resource_counter + counter_offset
-      @object_id = object_id
+      @item_id = item_id
       @user_version = user_version
       @viewable = viewable
     end
 
-    attr_reader :resource, :resource_counter, :object_id, :user_version
+    attr_reader :resource, :resource_counter, :item_id, :user_version
 
     def viewable?
       @viewable

--- a/app/components/contents/structural_component.html.erb
+++ b/app/components/contents/structural_component.html.erb
@@ -3,6 +3,6 @@
   <%= helpers.paginate paginatable_array, theme: :blacklight, outer_window: 2 %>
 </div>
 <ul class="resource-list">
-  <%= render Contents::ResourceComponent.with_collection(paginatable_array, counter_offset: paginatable_array.offset_value, object_id:, user_version:, viewable: viewable?) %>
+  <%= render Contents::ResourceComponent.with_collection(paginatable_array, counter_offset: paginatable_array.offset_value, item_id:, user_version:, viewable: viewable?) %>
   <%= render Contents::ConstituentComponent.with_collection(structural.hasMemberOrders.first&.members) %>
 </ul>

--- a/app/components/contents/structural_component.rb
+++ b/app/components/contents/structural_component.rb
@@ -3,17 +3,17 @@
 module Contents
   class StructuralComponent < ViewComponent::Base
     # @param [Cocina::Models::DroStructural] structural
-    # @param [String] object_id the identifier of the object
+    # @param [String] item_id the identifier of the object
     # @param [String] user_version the user version of the object
     # @param [Bool] viewable if true the user will be presented with a link to download files
-    def initialize(structural:, object_id:, user_version:, viewable:)
+    def initialize(structural:, item_id:, user_version:, viewable:)
       @structural = structural
       @viewable = viewable
-      @object_id = object_id
+      @item_id = item_id
       @user_version = user_version
     end
 
-    attr_reader :structural, :object_id, :user_version
+    attr_reader :structural, :item_id, :user_version
 
     delegate :constituents, :label, :number_of_content_items, :virtual_object?, to: :structural_presenter
 

--- a/app/views/structures/show.html.erb
+++ b/app/views/structures/show.html.erb
@@ -1,3 +1,3 @@
 <turbo-frame id="structure">
-  <%= render Contents::StructuralComponent.new(structural: @cocina_item.structural, object_id: @cocina_item.externalIdentifier, viewable: @viewable, user_version: @user_version) %>
+  <%= render Contents::StructuralComponent.new(structural: @cocina_item.structural, item_id: @cocina_item.externalIdentifier, viewable: @viewable, user_version: @user_version) %>
 </turbo-frame>

--- a/spec/components/contents/file_component_spec.rb
+++ b/spec/components/contents/file_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Contents::FileComponent, type: :component do
-  let(:component) { described_class.new(file:, object_id: 'druid:kb487gt5106', viewable: true, image: true, user_version:) }
+  let(:component) { described_class.new(file:, item_id: 'druid:kb487gt5106', viewable: true, image: true, user_version:) }
   let(:rendered) { render_inline(component) }
   let(:file) do
     instance_double(Cocina::Models::File,
@@ -60,7 +60,7 @@ RSpec.describe Contents::FileComponent, type: :component do
   end
 
   context 'with a fileset that is not an image' do
-    let(:component) { described_class.new(file:, object_id: 'druid:kb487gt5106', viewable: true, image: false, user_version:) }
+    let(:component) { described_class.new(file:, item_id: 'druid:kb487gt5106', viewable: true, image: false, user_version:) }
 
     it 'renders the component without height' do
       expect(rendered.to_html).to include 'World'

--- a/spec/components/contents/resource_component_spec.rb
+++ b/spec/components/contents/resource_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Contents::ResourceComponent, type: :component do
     described_class.new(resource:,
                         resource_counter: 1,
                         counter_offset: 50,
-                        object_id: 'druid:kb487gt5106',
+                        item_id: 'druid:kb487gt5106',
                         viewable: true,
                         user_version: nil)
   end

--- a/spec/components/contents/structural_component_spec.rb
+++ b/spec/components/contents/structural_component_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Contents::StructuralComponent, type: :component do
   let(:component) do
     described_class.new(structural: Cocina::Models::DROStructural.new(contains:, hasMemberOrders: member_orders),
                         viewable: true,
-                        object_id: 'druid:kb487gt5106',
+                        item_id: 'druid:kb487gt5106',
                         user_version: nil)
   end
   let(:rendered) { render_inline(component) }


### PR DESCRIPTION


# Why was this change made?

It is used as the Ruby object identifier and shouldn't be overwritten. Fixes #5030


# How was this change tested?
CI

