### PR TITLE
Remove folio client legacy_auth param

### DIFF
--- a/config/initializers/folio_client.rb
+++ b/config/initializers/folio_client.rb
@@ -5,8 +5,7 @@ FolioClient.configure(
   url: Settings.catalog.folio.okapi.url,
   login_params: {
     username: Settings.catalog.folio.okapi.username,
-    password: Settings.catalog.folio.okapi.password,
-    legacy_auth: Settings.catalog.folio.okapi.legacy_auth
+    password: Settings.catalog.folio.okapi.password
   },
   okapi_headers: {
     'X-Okapi-Tenant': Settings.catalog.folio.tenant_id,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -65,7 +65,6 @@ catalog:
       url: "https://okapi-dev.example.com"
       username: "app"
       password: "supersecret"
-      legacy_auth: true
     tenant_id: "example_tenant"
 
 sdr_api:


### PR DESCRIPTION
# Why was this change made?
Remove deprecated param / endpoint. 
