### PR TITLE
Enable Blacklight-hierarchy for SW Format

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -230,6 +230,7 @@ class CatalogController < ApplicationController
 
     config.facet_display = {
       hierarchy: {
+        'sw_format' => [['ssimdv'], ':'],
         'wf_wps' => [['ssimdv'], ':'],
         'wf_wsp' => [['ssimdv'], ':'],
         'wf_swp' => [['ssimdv'], ':'],


### PR DESCRIPTION
# Why was this change made?
Display the SW format facet as a hierarchy (as it is in Searchworks)

# How was this change tested?
ci