### PR TITLE
Allow display of user versions with valid *and* invalid cocina

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
       ed25519
     docile (1.4.1)
     domain_name (0.6.20240107)
-    dor-services-client (15.34.0)
+    dor-services-client (15.35.0)
       activesupport (>= 7.0.0)
       cocina-models (~> 0.114.0)
       deprecation

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -352,7 +352,8 @@ class CatalogController < ApplicationController
   def show
     if user_version_param
       @cocina = Repository.find_user_version(druid_param, user_version_param)
-      @document = SolrDocument.new(object_client.user_version.solr(user_version_param))
+      # Skip validating the Cocina underlying the Solr representation
+      @document = SolrDocument.new(object_client.user_version.solr(user_version_param, validate: false))
     elsif version_param
       @cocina = Repository.find_version(druid_param, version_param)
       # Skip validating the Cocina underlying the Solr representation

--- a/app/controllers/user_versions_controller.rb
+++ b/app/controllers/user_versions_controller.rb
@@ -1,45 +1,35 @@
 # frozen_string_literal: true
 
 class UserVersionsController < ApplicationController
-  before_action :find_user_version_cocina
-  load_and_authorize_resource :cocina, parent: false, except: %i[show]
+  before_action :load_cocina_object_user_version
+  authorize_resource :cocina_object, parent: false, id_param: 'item_id'
 
   def show
-    authorize! :read, @cocina
-
     respond_to do |format|
-      format.json { render json: CocinaHashPresenter.new(cocina_object: @cocina).render }
+      format.json { render json: CocinaHashPresenter.new(cocina_object: @cocina_object).render }
     end
   end
 
   def withdraw
     update_user_version(withdrawn: true)
-    redirect_to item_public_version_path(druid_param, user_version_param),
+    redirect_to item_public_version_path(params[:item_id], params[:user_version_id]),
                 notice: 'Withdrawn. Purl will no longer display this version.'
   end
 
   def restore
     update_user_version(withdrawn: false)
-    redirect_to item_public_version_path(druid_param, user_version_param),
+    redirect_to item_public_version_path(params[:item_id], params[:user_version_id]),
                 notice: 'Restored. Purl will display this version.'
   end
 
   private
 
-  def druid_param
-    params[:item_id]
-  end
-
-  def user_version_param
-    params[:user_version_id]
-  end
-
-  def find_user_version_cocina
-    @cocina = Repository.find_user_version(druid_param, user_version_param)
+  def load_cocina_object_user_version
+    @cocina_object = Repository.find_user_version(params[:item_id], params[:user_version_id])
   end
 
   def update_user_version(withdrawn:)
-    client = Dor::Services::Client.object(druid_param).user_version
-    client.update(user_version: Dor::Services::Client::UserVersion::Version.new(withdrawn:, userVersion: user_version_param))
+    client = Dor::Services::Client.object(params[:item_id]).user_version
+    client.update(user_version: Dor::Services::Client::UserVersion::Version.new(withdrawn:, userVersion: params[:user_version_id]))
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -33,7 +33,7 @@ class Ability
     cannot :create, :token
     can :create, :token if current_user.sdr_api_authorized?
 
-    alias_action :open, :close, :open_ui, :close_ui, to: :update
+    alias_action :open, :close, :open_ui, :close_ui, :withdraw, :restore, to: :update
 
     if current_user.manager?
       can %i[update manage_governing_apo view_content read],

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -24,7 +24,8 @@ class Repository
 
   # @param [String] id the identifier for the item to be found
   # @param [String] user_version the user version to be found
-  # @return [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy] cocina model instance corresponding to the given druid
+  # @return [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy] cocina model instance corresponding
+  #   to the given druid & user version
   # @raise [Dor::Services::Client::NotFoundResponse] when dor-services-app cannot find the requested user version
   def self.find_user_version(id, user_version)
     raise ArgumentError, 'Missing identifier' unless id

--- a/spec/components/document_title_component_spec.rb
+++ b/spec/components/document_title_component_spec.rb
@@ -107,6 +107,15 @@ RSpec.describe DocumentTitleComponent, type: :component do
         expect(rendered.content).to include('You are viewing an older public version.')
         expect(rendered.content).to include('View latest version')
       end
+
+      context 'when it has invalid cocina' do
+        let(:invalid_cocina) { true }
+
+        it 'renders the expected version label' do
+          expect(rendered.content).to include('You are viewing an older public version that is no longer valid. You can view the JSON below.')
+          expect(rendered.content).to include('View latest version')
+        end
+      end
     end
 
     context 'with a head user version' do

--- a/spec/requests/view_cocina_model_for_user_version_spec.rb
+++ b/spec/requests/view_cocina_model_for_user_version_spec.rb
@@ -3,37 +3,53 @@
 require 'rails_helper'
 
 RSpec.describe 'View Cocina model for user version' do
-  let(:user) { create(:user) }
+  let(:groups) { ['sdr:viewer-role'] }
+  let(:item) { FactoryBot.create_for_repository(:persisted_item) }
 
-  let(:object_client) { instance_double(Dor::Services::Client::Object, user_version: user_version_client) }
-  let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, find: item) }
-  let(:item) do
-    FactoryBot.create_for_repository(:persisted_item)
-  end
+  # let(:user) { create(:user) }
+
+  # let(:object_client) { instance_double(Dor::Services::Client::Object, user_version: user_version_client) }
+  # let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, find: item) }
+  # let(:item) do
+  #   FactoryBot.create_for_repository(:persisted_item)
+  # end
 
   before do
-    allow(Dor::Services::Client).to receive(:object).with(item.externalIdentifier).and_return(object_client)
+    # allow(Dor::Services::Client).to receive(:object).with(item.externalIdentifier).and_return(object_client)
+    sign_in create(:user), groups: groups
+    allow(Repository).to receive(:find_user_version).and_return(item)
   end
 
-  context 'when user is authorized' do
-    before do
-      sign_in user, groups: ['sdr:viewer-role']
+  it 'returns json' do
+    get "/items/#{item.externalIdentifier}/public_version/2.json"
+    expect(response).to be_successful
+    expect(response.parsed_body).to include(type: Cocina::Models::ObjectType.object)
+  end
+
+  context 'with an invalid cocina object' do
+    let(:item) { Dor::Services::Client::InvalidCocina.new(invalid_item_hash.merge(error_message: 'Foo!')) }
+    let(:invalid_item_hash) do
+      FactoryBot.create_for_repository(:persisted_item).to_h.tap do |hash|
+        hash[:description][:title] = [
+          {
+            parallelValue: [{ value: 'first parallel' }, { value: 'second parallel' }],
+            value: 'test object'
+          }
+        ]
+      end
     end
 
-    it 'return json' do
-      get "/items/#{item.externalIdentifier}/public_version/2.json"
+    it 'returns json' do
+      get "/items/#{item.externalIdentifier}/public_version/1.json"
       expect(response).to be_successful
-      expect(response.body).to include "\"type\":\"#{Cocina::Models::ObjectType.object}\","
-      expect(user_version_client).to have_received(:find).with('2')
+      expect(response.parsed_body).to include(type: Cocina::Models::ObjectType.object, error_message: 'Foo!')
     end
   end
 
   context 'when user is not authorized' do
-    before do
-      sign_in user
-    end
+    let(:groups) { [] }
 
-    it 'return unauthorized' do
+    it 'returns unauthorized' do
       get "/items/#{item.externalIdentifier}/public_version/2.json"
       expect(response).to be_forbidden
     end

--- a/spec/system/user_version_view_spec.rb
+++ b/spec/system/user_version_view_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe 'User version view', :js do
         expect(page).to have_link('image.jpg')
 
         expect(user_version_client).to have_received(:find).with('2').at_least(:once)
-        expect(user_version_client).to have_received(:solr).with('2')
+        expect(user_version_client).to have_received(:solr).with('2', validate: false)
       end
     end
 
@@ -219,7 +219,7 @@ RSpec.describe 'User version view', :js do
         expect(page).to have_link('image.jpg')
 
         expect(user_version_client).to have_received(:find).with('1').at_least(:once)
-        expect(user_version_client).to have_received(:solr).with('1')
+        expect(user_version_client).to have_received(:solr).with('1', validate: false)
       end
     end
 


### PR DESCRIPTION
~~This PR is on hold until https://github.com/sul-dlss/dor-services-client/pull/608 is merged and a new release of DSC is bumped here~~

# Why was this change made?

Connects to sul-dlss/dor-services-app#5850

This commit applies the approach used in #5063 to user versions

# How was this change tested?

CI
