### PR TITLE
Generalize arm platform to avoid version conflicts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -679,7 +679,7 @@ GEM
     zip_tricks (5.6.0)
 
 PLATFORMS
-  arm64-darwin-25
+  arm64-darwin
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Minor update to the lockfile to avoid unexpected changes to Gemfile.lock based on new platform numbers.

