### PR TITLE
Colorize JSON (e.g., Cocina), shift disclosure controls, and make all links non-selectable

### DIFF
--- a/app/assets/stylesheets/renderjson.css
+++ b/app/assets/stylesheets/renderjson.css
@@ -1,12 +1,60 @@
 .renderjson {
-  /* Hide top level disclosure */
-   > span > .object > .disclosure:first-of-type {
+  /* Bump up the font size slightly to make the JSON more readable. The default
+   font size is 0.875em. */
+  font-size: 0.95em;
+
+  /* Allow elements to be positioned absolutely within the container. This has the
+   effect of shifting the expand/collapse controls so that their positioning is
+   consistent. */
+  position: relative;
+
+  /* Hide the top-level disclosure so that the Cocina is not fully collapsible */
+  > span > .object > .disclosure:first-of-type {
     display: none;
   }
 
+  /* Prevent text selection of links within the entire container. Without this, it
+   is possible to copy/paste elements that make the JSON invalid, such as the
+   expand/collapse controls and the collapsed message text (e.g., "3 items") */
+  a {
+    user-select: none;
+  }
+
   .disclosure {
+    color: var(--stanford-60-black);
     font-family: bootstrap-icons;
-    margin-right: 5px;
-    font-size: 14px;
+    font-size: x-large;
+
+    /* Position the expand/collapse controls so that they are left-aligned within
+     the container and vertically centered with the text. */
+    position: absolute;
+    inset-inline-start: 0;
+    transform: translateY(-20%);
+  }
+
+  /* Colorize the JSON elements. The colors are chosen to be visually distinct and
+   to provide contrast against the default background color. */
+  .syntax, .keyword {
+    color: var(--stanford-80-black);
+  }
+
+  .string {
+    color: var(--stanford-poppy-darker);
+  }
+
+  .number {
+    color: var(--stanford-spirited-dark);
+  }
+
+  .boolean {
+    color: var(--stanford-palo-verde-dark);
+  }
+
+  .key {
+    color: var(--stanford-plum-light);
+  }
+
+  .object.syntax, .array.syntax {
+    color: var(--stanford-archway-light);
   }
 }

--- a/app/assets/stylesheets/variables.css
+++ b/app/assets/stylesheets/variables.css
@@ -1,14 +1,19 @@
 :root {
-  /* Stanford colors that are not defined in the component library */
-  --stanford-illuminating-light: #ffe781;
-  --stanford-sky-light: #67afd2;
-  --stanford-bay-light: #8ab8a7;
+  /* Stanford colors that are not defined in the component library version used by
+   Argo */
   --stanford-60-black: #767674;
-  --stanford-stone-dark-rgb: 84, 73, 72;
-  --stanford-poppy-light: #f9a44a;
+  --stanford-archway-light: #766253;
+  --stanford-bay-light: #8ab8a7;
+  --stanford-illuminating-light: #ffe781;
+  --stanford-palo-verde-dark: #017e7c;
   --stanford-palo-verde-light: #59b3a9;
+  --stanford-plum-light: #734675;
+  --stanford-poppy-light: #f9a44a;
+  --stanford-sky-light: #67afd2;
+  --stanford-spirited-dark: #c74632;
 
-  /* non-standard colors (not part of Stanford's palette) */
+  /* Non-standard colors (not part of Stanford's palette) */
   --argo-floral-white: #f9f6ef;
   --argo-tahuna-sands: #d2c295;
+  --stanford-poppy-darker: #c15600;
 }

--- a/app/javascript/controllers/json_renderer.js
+++ b/app/javascript/controllers/json_renderer.js
@@ -8,7 +8,7 @@ export default class extends Controller {
   }
 
   connect () {
-    renderjson.set_icons('\uF4FC', '\uF2E8') // Bootstrap icons
+    renderjson.set_icons('\uF231', '\uF229') // Bootstrap icons
     this.collapse()
   }
 


### PR DESCRIPTION
Here's a little spike that re-styles the Cocina JSON (and the event JSON) making the following tweaks:

* Bump the JSON font size up slightly (<1em)
* Colorize the JSON using the Stanford palette
* Move expand/collapse controls to a fixed location (left-most within the containing div)
* Make sure expand/collapse controls and collapse text (e.g., `3 items`) are not user-selectable, which keeps them out of copy/pastes (ensuring the copied JSON is still valid JSON)
* Tweak the style of the expand/collapse controls (from +/- icons to caret right/down icons)

Happy to get your impressions on these changes, @andrewjbtw and @astridu. Of course any/all of this is subject to change. We could even dump the whole thing. Only a spike.

# Before

![argo_cocina_before](https://github.com/user-attachments/assets/24318db7-203d-475f-bdb5-6b3cbdbd6885)

# After

![argo_cocina_after](https://github.com/user-attachments/assets/bb2db5d9-0e0b-4887-841c-a67f991448a2)
