### PR TITLE
Add CSV header validation case

### DIFF
--- a/app/services/description_validator.rb
+++ b/app/services/description_validator.rb
@@ -203,8 +203,8 @@ class DescriptionValidator
 
     return true if rest.empty?
 
-    # error if not a Cocina model class
-    return false if type.is_a?(Dry::Types::AnyClass)
+    # Catch CSV headers such as `note1.type1` that have a number at the end of the header
+    return false unless type.respond_to?(:schema)
 
     resolve_address(type, rest)
   end

--- a/spec/services/description_validator_spec.rb
+++ b/spec/services/description_validator_spec.rb
@@ -3,378 +3,386 @@
 require 'rails_helper'
 
 RSpec.describe DescriptionValidator do
-  describe '#valid?' do
-    let(:instance) { described_class.new(CSV.parse(csv, headers: true)) }
+  let(:instance) { described_class.new(CSV.parse(csv, headers: true)) }
 
-    context 'for all jobs' do
-      context 'with duplicate columns' do
-        let(:csv) { 'druid,title1.value,title2.value,title1.value,title2.value,title3.value' }
+  context 'when leaf-node values are enumerated' do
+    let(:csv) { 'druid,title1.value,title2.value1,title2.type1' }
 
-        it 'finds errors' do
-          expect(instance.valid?).to be false
-          expect(instance.errors).to eq [
-            'Duplicate column headers: The header title1.value should occur only once.',
-            'Duplicate column headers: The header title2.value should occur only once.'
-          ]
-        end
-      end
+    it 'finds errors' do
+      expect(instance).not_to be_valid
+      expect(instance.errors).to eq [
+        'Column header invalid: title2.value1',
+        'Column header invalid: title2.type1'
+      ]
+    end
+  end
 
-      context 'with mismatched structured title1.structuredValue columns' do
-        let(:csv) { 'druid,title1.structuredValue1.type,title1.structuredValue1.value,title1.structuredValue12type,title1.structuredValue2.value' }
+  context 'with duplicate columns' do
+    let(:csv) { 'druid,title1.value,title2.value,title1.value,title2.value,title3.value' }
 
-        it 'finds errors' do
-          expect(instance.valid?).to be false
-          expect(instance.errors).to eq [
-            'Missing title type for title1.structuredValue2.value. Expected title1.structuredValue2.type.'
-          ]
-        end
-      end
+    it 'finds errors' do
+      expect(instance).not_to be_valid
+      expect(instance.errors).to eq [
+        'Duplicate column headers: The header title1.value should occur only once.',
+        'Duplicate column headers: The header title2.value should occur only once.'
+      ]
+    end
+  end
 
-      context 'with mismatched structured title2.structuredValue columns' do
-        let(:csv) { 'druid,title1.structuredValue1.type,title1.structuredValue1.value,title2.structuredValue1.type,title2.structuredValue2.value' }
+  context 'with mismatched structured title1.structuredValue columns' do
+    let(:csv) { 'druid,title1.structuredValue1.type,title1.structuredValue1.value,title1.structuredValue12type,title1.structuredValue2.value' }
 
-        it 'finds errors' do
-          expect(instance.valid?).to be false
-          expect(instance.errors).to eq [
-            'Missing title structured value for title2.structuredValue1.type. Expected title2.structuredValue1.value.',
-            'Missing title type for title2.structuredValue2.value. Expected title2.structuredValue2.type.'
-          ]
-        end
-      end
+    it 'finds errors' do
+      expect(instance).not_to be_valid
+      expect(instance.errors).to eq [
+        'Missing title type for title1.structuredValue2.value. Expected title1.structuredValue2.type.'
+      ]
+    end
+  end
 
-      context 'with another form of mismatched structured title2.structuredValue columns' do
-        let(:csv) { 'druid,title1.structuredValue1.type,title1.structuredValue1.value,title2.structuredValue2.type,title3.structuredValue2.value' }
+  context 'with mismatched structured title2.structuredValue columns' do
+    let(:csv) { 'druid,title1.structuredValue1.type,title1.structuredValue1.value,title2.structuredValue1.type,title2.structuredValue2.value' }
 
-        it 'finds errors' do
-          expect(instance.valid?).to be false
-          expect(instance.errors).to eq [
-            'Missing title structured value for title2.structuredValue2.type. Expected title2.structuredValue2.value.',
-            'Missing title type for title3.structuredValue2.value. Expected title3.structuredValue2.type.'
-          ]
-        end
-      end
+    it 'finds errors' do
+      expect(instance).not_to be_valid
+      expect(instance.errors).to eq [
+        'Missing title structured value for title2.structuredValue1.type. Expected title2.structuredValue1.value.',
+        'Missing title type for title2.structuredValue2.value. Expected title2.structuredValue2.type.'
+      ]
+    end
+  end
 
-      context 'with missing title1.value column' do
-        let(:csv) { 'druid,event1.note1.source.value' }
+  context 'with another form of mismatched structured title2.structuredValue columns' do
+    let(:csv) { 'druid,title1.structuredValue1.type,title1.structuredValue1.value,title2.structuredValue2.type,title3.structuredValue2.value' }
 
-        it 'finds errors' do
-          expect(instance.valid?).to be false
-          expect(instance.errors).to eq ['Title column not found.']
-        end
-      end
+    it 'finds errors' do
+      expect(instance).not_to be_valid
+      expect(instance.errors).to eq [
+        'Missing title structured value for title2.structuredValue2.type. Expected title2.structuredValue2.value.',
+        'Missing title type for title3.structuredValue2.value. Expected title3.structuredValue2.type.'
+      ]
+    end
+  end
 
-      context 'with missing title1.structuredValue1.value column' do
-        let(:csv) { 'druid,title1.structuredValue1.type' }
+  context 'with missing title1.value column' do
+    let(:csv) { 'druid,event1.note1.source.value' }
 
-        it 'finds errors' do
-          expect(instance.valid?).to be false
-          expect(instance.errors).to eq [
-            'Title column not found.',
-            'Missing title structured value for title1.structuredValue1.type. Expected title1.structuredValue1.value.'
-          ]
-        end
-      end
+    it 'finds errors' do
+      expect(instance).not_to be_valid
+      expect(instance.errors).to eq ['Title column not found.']
+    end
+  end
 
-      context 'with missing title1.structuredValue1.type column' do
-        let(:csv) { 'druid,title1.structuredValue1.value' }
+  context 'with missing title1.structuredValue1.value column' do
+    let(:csv) { 'druid,title1.structuredValue1.type' }
 
-        it 'finds errors' do
-          expect(instance.valid?).to be false
-          expect(instance.errors).to eq [
-            'Missing title type for title1.structuredValue1.value. Expected title1.structuredValue1.type.'
-          ]
-        end
-      end
+    it 'finds errors' do
+      expect(instance).not_to be_valid
+      expect(instance.errors).to eq [
+        'Title column not found.',
+        'Missing title structured value for title1.structuredValue1.type. Expected title1.structuredValue1.value.'
+      ]
+    end
+  end
 
-      context 'with a title1.structuredValue1.value and a title1.structuredValue1.type column' do
-        let(:csv) { 'druid,title1.structuredValue1.type,title1.structuredValue1.value' }
+  context 'with missing title1.structuredValue1.type column' do
+    let(:csv) { 'druid,title1.structuredValue1.value' }
 
-        it 'validates' do
-          expect(instance.valid?).to be true
-        end
-      end
+    it 'finds errors' do
+      expect(instance).not_to be_valid
+      expect(instance.errors).to eq [
+        'Missing title type for title1.structuredValue1.value. Expected title1.structuredValue1.type.'
+      ]
+    end
+  end
 
-      context 'with a title1.structuredValue1.value and a title1.type column' do
-        let(:csv) { 'druid,title1.type,title1.structuredValue1.value' }
+  context 'with a title1.structuredValue1.value and a title1.structuredValue1.type column' do
+    let(:csv) { 'druid,title1.structuredValue1.type,title1.structuredValue1.value' }
 
-        it 'finds errors' do
-          expect(instance.valid?).to be false
-          expect(instance.errors).to eq [
-            'Missing title type for title1.structuredValue1.value. Expected title1.structuredValue1.type.'
-          ]
-        end
-      end
+    it 'validates' do
+      expect(instance).to be_valid
+    end
+  end
 
-      context 'with a title1.value,title2.structuredValue1.value and a title2.structuredValue1.type column' do
-        let(:csv) { 'druid,title1.value,title2.structuredValue1.type,title2.structuredValue1.value' }
+  context 'with a title1.structuredValue1.value and a title1.type column' do
+    let(:csv) { 'druid,title1.type,title1.structuredValue1.value' }
 
-        it 'validates' do
-          expect(instance.valid?).to be true
-        end
-      end
+    it 'finds errors' do
+      expect(instance).not_to be_valid
+      expect(instance.errors).to eq [
+        'Missing title type for title1.structuredValue1.value. Expected title1.structuredValue1.type.'
+      ]
+    end
+  end
 
-      context 'with a title1.type,title1.structuredValue1.value and a title1.structuredValue1.type column' do
-        let(:csv) { 'druid,title1.value,title2.structuredValue1.type,title2.structuredValue1.value,title2.type' }
+  context 'with a title1.value,title2.structuredValue1.value and a title2.structuredValue1.type column' do
+    let(:csv) { 'druid,title1.value,title2.structuredValue1.type,title2.structuredValue1.value' }
 
-        it 'validates' do
-          expect(instance.valid?).to be true
-        end
-      end
+    it 'validates' do
+      expect(instance).to be_valid
+    end
+  end
 
-      context 'with invalid title headers in druid,title1.value.type,title2.value,title3.value' do
-        let(:csv) { 'druid,title1.value.type,title2.value,title3.value' }
+  context 'with a title1.type,title1.structuredValue1.value and a title1.structuredValue1.type column' do
+    let(:csv) { 'druid,title1.value,title2.structuredValue1.type,title2.structuredValue1.value,title2.type' }
 
-        it 'finds errors' do
-          expect(instance.valid?).to be false
-          expect(instance.errors).to eq [
-            'Title column not found.',
-            'Column header invalid: title1.value.type'
-          ]
-        end
-      end
+    it 'validates' do
+      expect(instance).to be_valid
+    end
+  end
 
-      context 'with the bulk_upload_descriptive fixture file' do
-        let(:csv) { File.read('spec/fixtures/files/bulk_upload_descriptive.csv') }
+  context 'with invalid title headers in druid,title1.value.type,title2.value,title3.value' do
+    let(:csv) { 'druid,title1.value.type,title2.value,title3.value' }
 
-        it 'validates' do
-          expect(instance.valid?).to be true
-        end
-      end
+    it 'finds errors' do
+      expect(instance).not_to be_valid
+      expect(instance.errors).to eq [
+        'Title column not found.',
+        'Column header invalid: title1.value.type'
+      ]
+    end
+  end
 
-      context 'when the csv file has a missing title2.structuredValue2.value' do
-        let(:csv) { File.read('spec/fixtures/files/bulk_upload_descriptive_bad.csv') }
+  context 'with the bulk_upload_descriptive fixture file' do
+    let(:csv) { File.read('spec/fixtures/files/bulk_upload_descriptive.csv') }
 
-        it 'validates' do
-          expect(instance.valid?).to be false
-          expect(instance.errors).to eq [
-            'Missing title value for title2.structuredValue2.type.'
-          ]
-        end
-      end
+    it 'validates' do
+      expect(instance).to be_valid
+    end
+  end
 
-      context 'with title1.value and title2 structured value with type' do
-        let(:csv) do
-          <<~CSV
-            druid,title1.value,title2.type,title2.structuredValue1.value,title2.structuredValue1.type
-            druid:ab123cd4567,title1,title2_type,title2_value1,title2_type1
-          CSV
-        end
+  context 'when the csv file has a missing title2.structuredValue2.value' do
+    let(:csv) { File.read('spec/fixtures/files/bulk_upload_descriptive_bad.csv') }
 
-        it 'validates' do
-          expect(instance.valid?).to be true
-        end
-      end
+    it 'validates' do
+      expect(instance).not_to be_valid
+      expect(instance.errors).to eq [
+        'Missing title value for title2.structuredValue2.type.'
+      ]
+    end
+  end
 
-      context 'with title1.value and title1.type' do
-        let(:csv) do
-          <<~CSV
-            druid,title1.value,title1.type
-            druid:ab123cd4567,title with type,type
-            druid:cd456de5678,title without type,
-          CSV
-        end
+  context 'with title1.value and title2 structured value with type' do
+    let(:csv) do
+      <<~CSV
+        druid,title1.value,title2.type,title2.structuredValue1.value,title2.structuredValue1.type
+        druid:ab123cd4567,title1,title2_type,title2_value1,title2_type1
+      CSV
+    end
 
-        it 'validates' do
-          expect(instance.valid?).to be true
-        end
-      end
+    it 'validates' do
+      expect(instance).to be_valid
+    end
+  end
 
-      context 'with a title1.value column' do
-        let(:csv) { 'druid,title1.value' }
+  context 'with title1.value and title1.type' do
+    let(:csv) do
+      <<~CSV
+        druid,title1.value,title1.type
+        druid:ab123cd4567,title with type,type
+        druid:cd456de5678,title without type,
+      CSV
+    end
 
-        it 'validates' do
-          expect(instance.valid?).to be true
-        end
-      end
+    it 'validates' do
+      expect(instance).to be_valid
+    end
+  end
 
-      context 'with a title2.type column but no value column' do
-        let(:csv) { 'druid,title1.value,title2.type' }
+  context 'with a title1.value column' do
+    let(:csv) { 'druid,title1.value' }
 
-        it 'finds errors' do
-          expect(instance.valid?).to be false
-          expect(instance.errors).to eq [
-            'Missing title value for title2.type. Expected either title2.value or title2.structuredValue1.value.'
-          ]
-        end
-      end
+    it 'validates' do
+      expect(instance).to be_valid
+    end
+  end
 
-      context 'with title1.parallelValue1.value column' do
-        let(:csv) { 'druid,title1.parallelValue1.value' }
+  context 'with a title2.type column but no value column' do
+    let(:csv) { 'druid,title1.value,title2.type' }
 
-        it 'validates' do
-          expect(instance.valid?).to be true
-        end
-      end
+    it 'finds errors' do
+      expect(instance).not_to be_valid
+      expect(instance.errors).to eq [
+        'Missing title value for title2.type. Expected either title2.value or title2.structuredValue1.value.'
+      ]
+    end
+  end
 
-      context 'with title1.parallelValue1.structuredValue1.value column' do
-        let(:csv) { 'druid,title1.parallelValue1.structuredValue1.value' }
+  context 'with title1.parallelValue1.value column' do
+    let(:csv) { 'druid,title1.parallelValue1.value' }
 
-        it 'validates' do
-          expect(instance.valid?).to be true
-        end
-      end
+    it 'validates' do
+      expect(instance).to be_valid
+    end
+  end
 
-      context 'with headers that do not map to cocina model' do
-        let(:csv) do
-          'druid,title1.value,title1.type,title2.value,title2.type,title3.value,title3.type,bogus,event.contributor,event1.contributor,event1.note1.source.value'
-        end
+  context 'with title1.parallelValue1.structuredValue1.value column' do
+    let(:csv) { 'druid,title1.parallelValue1.structuredValue1.value' }
 
-        it 'finds errors' do
-          expect(instance.valid?).to be false
-          # "bogus" is not a valid cocina attribute, and "event" must be an array (so needs to include a number)
-          expect(instance.errors).to eq ['Column header invalid: bogus',
-                                         'Column header invalid: event.contributor',
-                                         'Column header invalid: event1.contributor']
-        end
-      end
+    it 'validates' do
+      expect(instance).to be_valid
+    end
+  end
 
-      context 'with missing header for column' do
-        let(:csv) { 'druid,title1.value,title1.type,,title2.value,title2.type' }
+  context 'with headers that do not map to cocina model' do
+    let(:csv) do
+      'druid,title1.value,title1.type,title2.value,title2.type,title3.value,title3.type,bogus,event.contributor,event1.contributor,event1.note1.source.value'
+    end
 
-        it 'finds errors' do
-          expect(instance.valid?).to be false
-          # missing header value is not a valid cocina attribute
-          expect(instance.errors).to eq ['Column header invalid: (empty string)']
-        end
+    it 'finds errors' do
+      expect(instance).not_to be_valid
+      # "bogus" is not a valid cocina attribute, and "event" must be an array (so needs to include a number)
+      expect(instance.errors).to eq ['Column header invalid: bogus',
+                                     'Column header invalid: event.contributor',
+                                     'Column header invalid: event1.contributor']
+    end
+  end
+
+  context 'with missing header for column' do
+    let(:csv) { 'druid,title1.value,title1.type,,title2.value,title2.type' }
+
+    it 'finds errors' do
+      expect(instance).not_to be_valid
+      # missing header value is not a valid cocina attribute
+      expect(instance.errors).to eq ['Column header invalid: (empty string)']
+    end
+  end
+
+  context 'when bulk_job flag is set to true' do
+    let(:instance) { described_class.new(CSV.parse(csv, headers: true), bulk_job: true) }
+
+    context 'with missing druid header' do
+      let(:csv) { 'title1.value,title2.value,title3.value' }
+
+      it 'finds errors' do
+        expect(instance).not_to be_valid
+        expect(instance.errors).to eq ['Druid column not found.']
       end
     end
 
-    context 'for bulk jobs' do
-      let(:instance) { described_class.new(CSV.parse(csv, headers: true), bulk_job: true) }
-
-      context 'with missing druid header' do
-        let(:csv) { 'title1.value,title2.value,title3.value' }
-
-        it 'finds errors' do
-          expect(instance.valid?).to be false
-          expect(instance.errors).to eq ['Druid column not found.']
-        end
+    context 'with missing druid in a row' do
+      let(:csv) do
+        <<~CSV
+          druid,title1.value,title2.value,title3.value
+          druid:ab123cd4567,cool,stuff,here
+          ,missing,druid,here
+          druid:cd456de5678,value,,
+        CSV
       end
 
-      context 'with missing druid in a row' do
-        let(:csv) do
-          <<~CSV
-            druid,title1.value,title2.value,title3.value
-            druid:ab123cd4567,cool,stuff,here
-            ,missing,druid,here
-            druid:cd456de5678,value,,
-          CSV
-        end
-
-        it 'finds errors' do
-          expect(instance.valid?).to be false
-          expect(instance.errors).to eq ['Missing druid: No druid present in row 3.']
-        end
-      end
-
-      context 'with duplicate druids in separate rows' do
-        let(:csv) do
-          <<~CSV
-            druid,title1.value,title2.value,title3.value
-            druid:ab123cd4567,cool,stuff,here
-            druid:ab123cd4567,cool2,stuff2,here2
-            druid:cd456de5678,value,,
-          CSV
-        end
-
-        it 'finds errors' do
-          expect(instance.valid?).to be false
-          expect(instance.errors).to eq ['Duplicate druids: The druid "druid:ab123cd4567" should occur only once.']
-        end
-      end
-
-      context 'with cell values that have a 0' do
-        let(:csv) do
-          <<~CSV
-            druid,title1.value,title2.value
-            druid:cd456de6677,allgood,stuff
-            druid:cd456de6678,0,stuff
-          CSV
-        end
-
-        it 'finds errors' do
-          expect(instance.valid?).to be false
-          expect(instance.errors).to eq ['Value error: druid:cd456de6678 has 0 value in title1.value.']
-        end
-      end
-
-      context 'with cell values that look like formulas' do
-        let(:csv) do
-          <<~CSV
-            druid,title1.value,title2.value
-            druid:ab123cd4567,cool,#NA
-            druid:cd456de5670,#REF!,stuff
-            druid:cd456de8678,what,#VALUE?
-            druid:cd456de6677,allgood,stuff
-            druid:cd456de6678,#NAME?,stuff
-          CSV
-        end
-
-        it 'finds errors' do
-          expect(instance.valid?).to be false
-          expect(instance.errors).to eq [
-            'Value error: druid:ab123cd4567 has spreadsheet formula error in title2.value.',
-            'Value error: druid:cd456de5670 has spreadsheet formula error in title1.value.',
-            'Value error: druid:cd456de8678 has spreadsheet formula error in title2.value.',
-            'Value error: druid:cd456de6678 has spreadsheet formula error in title1.value.'
-          ]
-        end
+      it 'finds errors' do
+        expect(instance).not_to be_valid
+        expect(instance.errors).to eq ['Missing druid: No druid present in row 3.']
       end
     end
 
-    context 'for non bulk jobs' do
-      let(:instance) { described_class.new(CSV.parse(csv, headers: true), bulk_job: false) }
-
-      context 'with missing druid header' do
-        let(:csv) { 'title1.value,title2.value,title3.value' }
-        let(:bulk_job) { false }
-
-        it 'validates' do
-          expect(instance.valid?).to be true
-        end
+    context 'with duplicate druids in separate rows' do
+      let(:csv) do
+        <<~CSV
+          druid,title1.value,title2.value,title3.value
+          druid:ab123cd4567,cool,stuff,here
+          druid:ab123cd4567,cool2,stuff2,here2
+          druid:cd456de5678,value,,
+        CSV
       end
 
-      context 'with missing druid in a row' do
-        let(:csv) do
-          <<~CSV
-            druid,title1.value,title2.value,title3.value
-            ,missing,druid,here
-          CSV
-        end
+      it 'finds errors' do
+        expect(instance).not_to be_valid
+        expect(instance.errors).to eq ['Duplicate druids: The druid "druid:ab123cd4567" should occur only once.']
+      end
+    end
 
-        it 'validates' do
-          expect(instance.valid?).to be true
-        end
+    context 'with cell values that have a 0' do
+      let(:csv) do
+        <<~CSV
+          druid,title1.value,title2.value
+          druid:cd456de6677,allgood,stuff
+          druid:cd456de6678,0,stuff
+        CSV
       end
 
-      context 'with cell values that have a 0' do
-        let(:csv) do
-          <<~CSV
-            title1.value,title2.value
-            0,stuff
-          CSV
-        end
+      it 'finds errors' do
+        expect(instance).not_to be_valid
+        expect(instance.errors).to eq ['Value error: druid:cd456de6678 has 0 value in title1.value.']
+      end
+    end
 
-        it 'finds errors' do
-          expect(instance.valid?).to be false
-          expect(instance.errors).to eq ['Value error: row 2 has 0 value in title1.value.']
-        end
+    context 'with cell values that look like formulas' do
+      let(:csv) do
+        <<~CSV
+          druid,title1.value,title2.value
+          druid:ab123cd4567,cool,#NA
+          druid:cd456de5670,#REF!,stuff
+          druid:cd456de8678,what,#VALUE?
+          druid:cd456de6677,allgood,stuff
+          druid:cd456de6678,#NAME?,stuff
+        CSV
       end
 
-      context 'with cell values that look like formulas' do
-        let(:csv) do
-          <<~CSV
-            title1.value,title2.value
-            cool,#NA
-          CSV
-        end
+      it 'finds errors' do
+        expect(instance).not_to be_valid
+        expect(instance.errors).to eq [
+          'Value error: druid:ab123cd4567 has spreadsheet formula error in title2.value.',
+          'Value error: druid:cd456de5670 has spreadsheet formula error in title1.value.',
+          'Value error: druid:cd456de8678 has spreadsheet formula error in title2.value.',
+          'Value error: druid:cd456de6678 has spreadsheet formula error in title1.value.'
+        ]
+      end
+    end
+  end
 
-        it 'finds errors' do
-          expect(instance.valid?).to be false
-          expect(instance.errors).to eq [
-            'Value error: row 2 has spreadsheet formula error in title2.value.'
-          ]
-        end
+  context 'when bulk_job flag is set to false' do
+    let(:instance) { described_class.new(CSV.parse(csv, headers: true), bulk_job: false) }
+
+    context 'with missing druid header' do
+      let(:csv) { 'title1.value,title2.value,title3.value' }
+      let(:bulk_job) { false }
+
+      it 'validates' do
+        expect(instance).to be_valid
+      end
+    end
+
+    context 'with missing druid in a row' do
+      let(:csv) do
+        <<~CSV
+          druid,title1.value,title2.value,title3.value
+          ,missing,druid,here
+        CSV
+      end
+
+      it 'validates' do
+        expect(instance).to be_valid
+      end
+    end
+
+    context 'with cell values that have a 0' do
+      let(:csv) do
+        <<~CSV
+          title1.value,title2.value
+          0,stuff
+        CSV
+      end
+
+      it 'finds errors' do
+        expect(instance).not_to be_valid
+        expect(instance.errors).to eq ['Value error: row 2 has 0 value in title1.value.']
+      end
+    end
+
+    context 'with cell values that look like formulas' do
+      let(:csv) do
+        <<~CSV
+          title1.value,title2.value
+          cool,#NA
+        CSV
+      end
+
+      it 'finds errors' do
+        expect(instance).not_to be_valid
+        expect(instance.errors).to eq [
+          'Value error: row 2 has spreadsheet formula error in title2.value.'
+        ]
       end
     end
   end


### PR DESCRIPTION
# Why was this change made?

Fixes #5095

Including CSV headers such as note1.type1 currently breaks validation in a way that raises an exception and displays the 500 error page to users. Instead, the validator should be able to handle these cases and flag to the user what CSV header mistakes they have.

# How was this change tested?

CI

