### PR TITLE
[HOLD] Add a BulkAction report for missing technical metadata

### DIFF
--- a/app/components/bulk_actions_form_component.rb
+++ b/app/components/bulk_actions_form_component.rb
@@ -57,6 +57,7 @@ class BulkActionsFormComponent < ApplicationComponent
         ['Import tags', new_import_tag_job_path],
         ['Download tracking sheets', new_tracking_sheet_report_job_path(search_of_druids)],
         ['Download checksum report', new_checksum_report_job_path(search_of_druids)],
+        ['Download missing technical metadata report', new_missing_techmd_report_job_path(search_of_druids)],
         ['Download full Cocina JSON', new_export_cocina_json_job_path(search_of_druids)]
       ]]
     ]

--- a/app/controllers/bulk_actions/missing_techmd_report_jobs_controller.rb
+++ b/app/controllers/bulk_actions/missing_techmd_report_jobs_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module BulkActions
+  class MissingTechmdReportJobsController < ApplicationController
+    include CreatesBulkActions
+
+    self.action_type = 'MissingTechmdReportJob'
+  end
+end

--- a/app/jobs/missing_techmd_report_job.rb
+++ b/app/jobs/missing_techmd_report_job.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# A job that, given a list of druids, checks the technical metadata service for each object
+# and generates a CSV report of those with files in Cocina and stored in preservation but
+# with no technical metadata results.
+class MissingTechmdReportJob < BulkActionJob
+  HEADERS = %w[druid].freeze
+
+  def perform_bulk_action
+    return unless check_view_ability?
+
+    super
+  end
+
+  def export_file
+    @export_file ||= CSV.open(report_filename, 'w', write_headers: true, headers: HEADERS)
+  end
+
+  class MissingTechmdReportJobItem < BulkActionJobItem
+    def perform
+      return success! if preserved_cocina_files.empty?
+      return success! if Preservation::Client.objects.checksum(druid:).empty?
+
+      result = TechmdService.techmd_for(druid:)
+
+      if result.failure?
+        failure!(message: result.failure)
+        return
+      end
+
+      export_file << [druid] if result.value!.empty?
+      success!
+    rescue Preservation::Client::NotFoundError
+      success!
+    end
+
+    delegate :export_file, to: :job
+
+    private
+
+    def preserved_cocina_files
+      return [] unless cocina_object.dro?
+
+      Array(cocina_object.structural&.contains).flat_map do |resource|
+        resource.structural.contains.select { |file| file.administrative.sdrPreserve }
+      end
+    end
+  end
+
+  private
+
+  def report_filename
+    File.join(bulk_action.output_directory, Settings.missing_techmd_report_job.csv_filename)
+  end
+end

--- a/app/models/bulk_action.rb
+++ b/app/models/bulk_action.rb
@@ -37,7 +37,8 @@ class BulkAction < ApplicationRecord
                      TrackingSheetReportJob
                      ExportCocinaJsonJob
                      TextExtractionJob
-                     ExportCatalogLinksJob]
+                     ExportCatalogLinksJob
+                     MissingTechmdReportJob]
             }
 
   after_create :create_output_directory, :create_log_file

--- a/app/views/bulk_actions/_missing_techmd_report_job.html.erb
+++ b/app/views/bulk_actions/_missing_techmd_report_job.html.erb
@@ -1,0 +1,3 @@
+<% if bulk_action.has_report?(Settings.missing_techmd_report_job.csv_filename) %>
+  <%= link_to('Download Missing Technical Metadata Report', file_bulk_action_path(bulk_action.id, filename: Settings.missing_techmd_report_job.csv_filename), download: true) %>
+<% end %>

--- a/app/views/bulk_actions/missing_techmd_report_jobs/_new.html.erb
+++ b/app/views/bulk_actions/missing_techmd_report_jobs/_new.html.erb
@@ -1,0 +1,10 @@
+<%= form_with url: missing_techmd_report_job_path, class: 'new_bulk_action', data: { turbo_frame: '_top' } do |f| %>
+  <%= render 'bulk_actions/errors' %>
+
+  <span class='help-block'>
+    Check the technical metadata service for each object and download a CSV of druids with no technical metadata results.
+  </span>
+
+  <%= render 'bulk_actions/druids', f: %>
+  <%= render 'bulk_actions/common_fields', f: %>
+<% end %>

--- a/app/views/bulk_actions/missing_techmd_report_jobs/new.html.erb
+++ b/app/views/bulk_actions/missing_techmd_report_jobs/new.html.erb
@@ -1,0 +1,3 @@
+<turbo-frame id="bulk-action-form">
+  <%= render 'new' %>
+</turbo-frame>

--- a/app/views/bulk_actions/missing_techmd_report_jobs/new.turbo_stream.erb
+++ b/app/views/bulk_actions/missing_techmd_report_jobs/new.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.replace("bulk-action-form", partial: 'new') %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do
         resource :descriptive_metadata_import_job, only: %i[new create]
         resource :download_mods_job, only: %i[new create]
         resource :checksum_report_job, only: %i[new create]
+        resource :missing_techmd_report_job, only: %i[new create]
         resource :validate_cocina_descriptive_job, only: %i[new create]
         resource :tracking_sheet_report_job, only: %i[new create]
         resource :export_cocina_json_job, only: %i[new create]

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,6 +13,8 @@ bulk_metadata:
 
 checksum_report_job:
   csv_filename: "checksum_report.csv"
+missing_techmd_report_job:
+  csv_filename: "missing_techmd_report.csv"
 descriptive_metadata_export_job:
   csv_filename: "descriptive.csv"
 export_catalog_links_job:

--- a/spec/jobs/missing_techmd_report_job_spec.rb
+++ b/spec/jobs/missing_techmd_report_job_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MissingTechmdReportJob do
+  include Dry::Monads[:result]
+
+  subject(:job) { described_class.new(bulk_action.id, druids: [druid_missing, druid_present]) }
+
+  let(:druid_missing) { 'druid:bb111cc2222' }
+  let(:druid_present) { 'druid:ff333gg4444' }
+
+  let(:output_directory) { bulk_action.output_directory }
+  let(:bulk_action) do
+    create(
+      :bulk_action,
+      action_type: 'MissingTechmdReportJob',
+      log_name: 'tmp/missing_techmd_report_job_log.txt'
+    )
+  end
+  let(:csv_filename) { File.join(output_directory, Settings.missing_techmd_report_job.csv_filename) }
+
+  let(:structural) do
+    {
+      contains: [
+        {
+          type: Cocina::Models::FileSetType.image.to_s,
+          externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/abc123',
+          label: 'Image 1',
+          version: 1,
+          structural: {
+            contains: [
+              {
+                type: Cocina::Models::ObjectType.file.to_s,
+                externalIdentifier: 'https://cocina.sul.stanford.edu/file/def456',
+                label: 'image.tif',
+                filename: 'image.tif',
+                size: 1_000_000,
+                version: 1,
+                hasMimeType: 'image/tiff',
+                hasMessageDigests: [],
+                access: { view: 'world', download: 'world' },
+                administrative: { publish: false, sdrPreserve: true, shelve: false }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  end
+
+  let(:cocina_object_missing) { build(:dro, id: druid_missing).new(structural:, access: { view: 'world', download: 'world' }) }
+  let(:cocina_object_present) { build(:dro, id: druid_present).new(structural:, access: { view: 'world', download: 'world' }) }
+
+  let(:checksum_response) do
+    [{ 'filename' => 'image.tif', 'md5' => 'abc', 'sha1' => 'def', 'sha256' => 'ghi', 'filesize' => '1000000' }]
+  end
+
+  after do
+    FileUtils.rm_rf(output_directory)
+  end
+
+  before do
+    allow(Repository).to receive(:find).with(druid_missing).and_return(cocina_object_missing)
+    allow(Repository).to receive(:find).with(druid_present).and_return(cocina_object_present)
+    allow(Preservation::Client.objects).to receive(:checksum).with(druid: druid_missing).and_return(checksum_response)
+    allow(Preservation::Client.objects).to receive(:checksum).with(druid: druid_present).and_return(checksum_response)
+    allow(TechmdService).to receive(:techmd_for).with(druid: druid_missing).and_return(Success([]))
+    allow(TechmdService).to receive(:techmd_for).with(druid: druid_present).and_return(Success([{ 'filename' => 'image.tif' }]))
+    allow(job).to receive(:check_view_ability?).and_return(true)
+  end
+
+  it 'writes only druids missing techmd to the CSV' do
+    job.perform_now
+
+    expect(File.read(csv_filename)).to eq(
+      <<~CSV
+        druid
+        #{druid_missing}
+      CSV
+    )
+    expect(bulk_action.reload.druid_count_total).to eq(2)
+    expect(bulk_action.druid_count_success).to eq(2)
+    expect(bulk_action.druid_count_fail).to eq(0)
+  end
+
+  context 'when not authorized to view' do
+    before do
+      allow(job).to receive(:check_view_ability?).and_return(false)
+    end
+
+    it 'does not call the techmd service' do
+      job.perform_now
+
+      expect(TechmdService).not_to have_received(:techmd_for)
+    end
+  end
+
+  context 'when the techmd service returns a failure' do
+    before do
+      allow(TechmdService).to receive(:techmd_for).with(druid: druid_missing)
+                                                  .and_return(Failure('unexpected 500'))
+    end
+
+    it 'records the failure and does not write to the CSV' do
+      job.perform_now
+
+      expect(File.read(csv_filename)).to eq("druid\n")
+      expect(bulk_action.reload.druid_count_fail).to eq(1)
+      expect(bulk_action.druid_count_success).to eq(1)
+    end
+  end
+
+  context 'when the object has no preserved files in Cocina' do
+    let(:structural) { { contains: [] } }
+
+    it 'skips the object and does not check techmd' do
+      job.perform_now
+
+      expect(TechmdService).not_to have_received(:techmd_for)
+      expect(File.read(csv_filename)).to eq("druid\n")
+      expect(bulk_action.reload.druid_count_success).to eq(2)
+      expect(bulk_action.druid_count_fail).to eq(0)
+    end
+  end
+
+  context 'when the object is not found in preservation' do
+    before do
+      allow(Preservation::Client.objects).to receive(:checksum).with(druid: druid_missing)
+                                                               .and_raise(Preservation::Client::NotFoundError)
+    end
+
+    it 'skips the object and does not check techmd' do
+      job.perform_now
+
+      expect(TechmdService).not_to have_received(:techmd_for).with(druid: druid_missing)
+      expect(File.read(csv_filename)).to eq("druid\n")
+      expect(bulk_action.reload.druid_count_success).to eq(2)
+      expect(bulk_action.druid_count_fail).to eq(0)
+    end
+  end
+
+  context 'when preservation returns an empty checksum list' do
+    before do
+      allow(Preservation::Client.objects).to receive(:checksum).with(druid: druid_missing).and_return([])
+    end
+
+    it 'skips the object and does not check techmd' do
+      job.perform_now
+
+      expect(TechmdService).not_to have_received(:techmd_for).with(druid: druid_missing)
+      expect(File.read(csv_filename)).to eq("druid\n")
+      expect(bulk_action.reload.druid_count_success).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
# Why was this change made?

Fixes: [hungry-hungry-hippo#1836](https://github.com/sul-dlss/hungry-hungry-hippo/issues/1836)

HOLD until tested in stage and verified

Adds a new "Download missing technical metadata report" bulk action that generates a CSV of druids whose files are present in Cocina and stored in preservation but lack technical metadata records. 

What changed:

Job logic — The report now applies three-stage filtering before flagging a druid:                                                                                                        
1. Checks that the Cocina object is a DRO with at least one sdrPreserve: true file in its structural metadata                                                                          
2. Verifies those files exist in preservation via Preservation::Client.objects.checksum                                                                                                  
3. Only then queries TechmdService — druids with an empty response are written to the CSV                                                                                              

Testing                                                                                                                                                                                

- Happy path: only druids with preserved Cocina files, confirmed in preservation, and missing techmd are written to the CSV
- Objects with no preserved files in Cocina are skipped without calling the techmd service
- Objects not found in preservation (NotFoundError or empty checksum response) are skipped without calling the techmd service                                                            
- TechmdService failures are recorded as job failures