### PR TITLE
Provide low lane id when adding release tags in bulk.

### DIFF
--- a/app/controllers/manage_releases_controller.rb
+++ b/app/controllers/manage_releases_controller.rb
@@ -16,7 +16,7 @@ class ManageReleasesController < ApplicationController
   def update
     authorize! :update, @cocina
 
-    Dor::Services::Client.object(@cocina.externalIdentifier).release_tags.create(tag: new_tag)
+    Dor::Services::Client.object(@cocina.externalIdentifier).release_tags.create(tag: new_tag, lane_id: 'low')
 
     redirect_to solr_document_path(@cocina.externalIdentifier), notice: "Updated release for #{@cocina.externalIdentifier}"
   end

--- a/app/jobs/release_object_job.rb
+++ b/app/jobs/release_object_job.rb
@@ -15,7 +15,7 @@ class ReleaseObjectJob < BulkActionJob
 
       return failure!(message: 'Object has never been published and cannot be released') unless WorkflowService.published?(druid:)
 
-      object_client.release_tags.create(tag: new_tag)
+      object_client.release_tags.create(tag: new_tag, lane_id: 'low')
 
       success!(message: 'Workflow creation successful')
     end

--- a/spec/jobs/release_object_job_spec.rb
+++ b/spec/jobs/release_object_job_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe ReleaseObjectJob do
 
     expect(job_item).to have_received(:check_update_ability?)
     expect(WorkflowService).to have_received(:published?).with(druid: druid)
-    expect(release_tags_client).to have_received(:create).with(tag: an_instance_of(Dor::Services::Client::ReleaseTag))
+    expect(release_tags_client).to have_received(:create)
+      .with(tag: an_instance_of(Dor::Services::Client::ReleaseTag), lane_id: 'low')
 
     expect(bulk_action.reload.druid_count_total).to eq(1)
     expect(bulk_action.druid_count_fail).to eq(0)

--- a/spec/system/item_manage_release_spec.rb
+++ b/spec/system/item_manage_release_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe 'Item manage release' do
       expect(tag.what).to eq 'self'
       expect(tag.release).to be true
       expect(tag.date).to be_a DateTime
+      expect(args[:lane_id]).to eq 'low'
     end
   end
 end


### PR DESCRIPTION
refs https://github.com/sul-dlss/dor-services-app/issues/5959

# Why was this change made?
So that the bulk action doesn't interfere with accessioning.

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


