### PR TITLE
Add instructions for version audits and add to bin/rake

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ CI runs a series of steps;  this the sequence to do it locally, along with some 
     bin/rails db:prepare test:prepare
     ```
 
-5. **Run the linters and the tests**
+5. **Run the linters, audits and the tests**
 
     ```
     bin/rake
@@ -74,7 +74,7 @@ CI runs a series of steps;  this the sequence to do it locally, along with some 
 
 To run just the linters, run `bin/rake lint`. To run the linters individually, run `bundle exec erb_lint --lint-all`, `bundle exec rubocop`, and `bundle exec rake jslint`
 
-To run just the security audit, run `bin/brakeman`, or bundler-audit `bin/bundler-audit`
+To run just the security audits, run `bin/rake audit`. To run the audits individually, run `bin/brakeman`, `bin/bundler-audit`, `bun/bundle outdated`, and `yarn outdated`.
 
 ## Recommended Local Development
 

--- a/lib/tasks/argo_testing.rake
+++ b/lib/tasks/argo_testing.rake
@@ -48,5 +48,20 @@ task security_audit: :environment do
   system('bin/brakeman -i config/brakeman.ignore')
 end
 
-desc 'run linters and tests (for CI)'
-task default: %i[lint bundle_audit security_audit spec]
+desc 'run bundle outdated'
+task bundle_outdated: :environment do
+  puts 'Running bundle outdated...'
+  system('bin/bundle outdated')
+end
+
+desc 'run yarn outdated'
+task yarn_outdated: :environment do
+  puts 'Running yarn outdated...'
+  system('yarn outdated')
+end
+
+desc 'run linters, audits and tests (for CI)'
+task default: %i[lint bundle_audit security_audit bundle_outdated yarn_outdated spec]
+
+desc 'Run all configured security and version audits'
+task audit: %i[bundle_audit bundle_outdated yarn_outdated security_audit]


### PR DESCRIPTION
# Why was this change made?

Add gem and yarn version and security audits and instructions