### PR TITLE
Prevent shelve=yes publish=no preserve=no

### DIFF
--- a/app/services/structure_updater.rb
+++ b/app/services/structure_updater.rb
@@ -30,6 +30,7 @@ class StructureUpdater
         next
       end
       errors << "On row #{index} found #{row['filename']}, which changed preserve from no to yes, which is not supported" if invalid_preservation_change?(row)
+      errors << "On row #{index} found #{row['filename']}, which has shelve=yes with publish=no and preserve=no, which would cause the file to be deleted from all systems" if shelve_without_publish_or_preserve?(row)
       errors << "On row #{index} found #{row['filename']}, which set view or download rights to location-based but did not specify a location" if invalid_location_rights?(row)
     end
     csv.rewind
@@ -44,6 +45,12 @@ class StructureUpdater
   # Ensure no existing files change preserve from no to yes
   def invalid_preservation_change?(row)
     existing_files_by_filename[row['filename']].administrative.sdrPreserve == false && row['preserve'] == 'yes'
+  end
+
+  # Ensure no files are set to shelve=yes with both publish and preserve disabled,
+  # which would cause the file to be deleted from all systems at end of accessioning
+  def shelve_without_publish_or_preserve?(row)
+    row['shelve'] == 'yes' && row['publish'] == 'no' && row['preserve'] == 'no'
   end
 
   # Ensure no existing files set location-based access without specifying a location

--- a/spec/services/structure_updater_spec.rb
+++ b/spec/services/structure_updater_spec.rb
@@ -369,6 +369,24 @@ RSpec.describe StructureUpdater do
     end
   end
 
+  context 'when setting shelve=yes with publish=no and preserve=no for a file' do
+    let(:csv) do
+      <<~CSV
+        druid,resource_label,resource_type,sequence,filename,file_label,publish,shelve,preserve,rights_view,rights_download,rights_location,mimetype,role,file_language,sdr_generated_text,corrected_for_accessibility
+        #{bare_druid},Image 1,image,1,bb045jk9908_0001.tiff,bb045jk9908_0001.tiff,no,yes,no,world,world,,image/tiff,
+        #{bare_druid},Image 1,image,1,bb045jk9908_0001.jp2,bb045jk9908_0001.jp2,yes,yes,no,world,world,,image/jp2,
+        #{bare_druid},Image 2,image,2,bb045jk9908_0002.tiff,bb045jk9908_0002.tiff,no,no,yes,world,world,,image/tiff,
+        #{bare_druid},Image 2,image,2,CCTV新闻联播文本数据-20060615-20220630-Stanford University.xlsx,CCTV新闻联播文本数据-20060615-20220630-Stanford University.xlsx,yes,yes,no,world,world,,image/jp2,
+      CSV
+    end
+
+    it 'returns an error' do
+      expect(result.failure).to include(
+        'On row 2 found bb045jk9908_0001.tiff, which has shelve=yes with publish=no and preserve=no, which would cause the file to be deleted from all systems'
+      )
+    end
+  end
+
   context 'with specify location-based rights and no location' do
     let(:csv) do
       <<~CSV


### PR DESCRIPTION
# Why was this change made?

We want to prevent files from being accessioned with shelve=yes publish=no and preserve=no because it results in the file being deleted from all systems at the end of accessioning.

See https://github.com/sul-dlss/cocina-models/issues/1067 for context on why this is a bad idea.

# How was this change tested?

Tested by @andrewjbtw in stage. Also there is a new unit test.
