### PR TITLE
use different folioclient method to check for instance record

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,6 +180,9 @@ jobs:
           key: gems-v2
       - node/install-packages:
           pkg-manager: yarn
+      - run:
+          name: Build JS assets
+          command: yarn build
       # Check DB status
       - run:
           name: Wait for DB

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -59,7 +59,7 @@ class RegistrationsController < ApplicationController
   # Allow the front end to check if a catalog record ID exists
   def catalog_record_id
     resp = begin
-      FolioClient.fetch_marc_hash(instance_hrid: params[:catalog_record_id])
+      FolioClient.fetch_instance_info(hrid: params[:catalog_record_id])
       true
     rescue FolioClient::ResourceNotFound, FolioClient::MultipleResourcesFound
       false

--- a/spec/requests/registration_catalog_record_id_spec.rb
+++ b/spec/requests/registration_catalog_record_id_spec.rb
@@ -11,20 +11,20 @@ RSpec.describe 'Registration catalog_record_id check' do
 
   context 'when catalog_record_id found' do
     before do
-      allow(FolioClient).to receive(:fetch_marc_hash).and_return(true)
+      allow(FolioClient).to receive(:fetch_instance_info).and_return(true)
     end
 
     it 'returns true' do
       get '/registration/catalog_record_id?catalog_record_id=123'
 
       expect(response.body).to eq('true')
-      expect(FolioClient).to have_received(:fetch_marc_hash).with(instance_hrid: '123')
+      expect(FolioClient).to have_received(:fetch_instance_info).with(hrid: '123')
     end
   end
 
   context 'when catalog_record_id not found' do
     before do
-      allow(FolioClient).to receive(:fetch_marc_hash).and_raise(FolioClient::ResourceNotFound)
+      allow(FolioClient).to receive(:fetch_instance_info).and_raise(FolioClient::ResourceNotFound)
     end
 
     it 'returns false' do
@@ -36,7 +36,7 @@ RSpec.describe 'Registration catalog_record_id check' do
 
   context 'when other error' do
     before do
-      allow(FolioClient).to receive(:fetch_marc_hash).and_raise(FolioClient::Error)
+      allow(FolioClient).to receive(:fetch_instance_info).and_raise(FolioClient::Error)
     end
 
     it 'returns true' do
@@ -49,7 +49,7 @@ RSpec.describe 'Registration catalog_record_id check' do
   context 'when other error and production' do
     before do
       allow(Rails.env).to receive(:production?).and_return(true)
-      allow(FolioClient).to receive(:fetch_marc_hash).and_raise(FolioClient::Error)
+      allow(FolioClient).to receive(:fetch_instance_info).and_raise(FolioClient::Error)
     end
 
     it 'returns 500' do

--- a/spec/system/create_collection_from_apo_spec.rb
+++ b/spec/system/create_collection_from_apo_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Add collection from APO show page' do
   before do
     allow(Blacklight::Solr::Repository).to receive(:new).and_return(repo)
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
-    allow(FolioClient).to receive(:fetch_marc_hash).with(instance_hrid: 'a123')
+    allow(FolioClient).to receive(:fetch_instance_info).with(hrid: 'a123')
 
     sign_in create(:user), groups: ['sdr:administrator-role']
   end
@@ -47,7 +47,7 @@ RSpec.describe 'Add collection from APO show page' do
 
   describe 'when non-existent FOLIO Collection HRID is provided', :js do
     before do
-      allow(FolioClient).to receive(:fetch_marc_hash).with(instance_hrid: 'a1234').and_raise(FolioClient::ResourceNotFound)
+      allow(FolioClient).to receive(:fetch_instance_info).with(hrid: 'a1234').and_raise(FolioClient::ResourceNotFound)
     end
 
     it 'warns that catalog id does not exist' do

--- a/spec/system/create_collection_spec.rb
+++ b/spec/system/create_collection_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Add collection' do
   before do
     allow(Blacklight::Solr::Repository).to receive(:new).and_return(repo)
     allow(AdminPolicyOptions).to receive(:for).and_return([['An APO', 'druid:vt333hq2222']])
-    allow(FolioClient).to receive(:fetch_marc_hash).with(instance_hrid: 'a123')
+    allow(FolioClient).to receive(:fetch_instance_info).with(hrid: 'a123')
 
     sign_in create(:user), groups: ['sdr:administrator-role']
   end
@@ -44,7 +44,7 @@ RSpec.describe 'Add collection' do
 
   describe 'when non-existent FOLIO Collection HRID is provided', :js do
     before do
-      allow(FolioClient).to receive(:fetch_marc_hash).with(instance_hrid: 'a1234').and_raise(FolioClient::ResourceNotFound)
+      allow(FolioClient).to receive(:fetch_instance_info).with(hrid: 'a1234').and_raise(FolioClient::ResourceNotFound)
     end
 
     it 'warns that catalog id does not exist' do

--- a/spec/system/item_registration_spec.rb
+++ b/spec/system/item_registration_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe 'Item registration page', :js do
     before do
       allow(Dor::Services::Client::Objects).to receive(:find).with(source_id:).and_return(true)
       allow(Dor::Services::Client::Objects).to receive(:register).and_raise(Dor::Services::Client::UnexpectedResponse, 'FOLIO error')
-      allow(FolioClient).to receive(:fetch_marc_hash).and_return(true)
+      allow(FolioClient).to receive(:fetch_instance_info).and_return(true)
     end
 
     it 'displays an error message with the HRID' do


### PR DESCRIPTION
# Why was this change made?

Fixes #5149 

~~HOLD until verify that /spec/features/accessioning/item_creation_with_folio_hrid_spec.rb test passes~~
Integration tests passed

# How was this change tested?

- Updated spec
- Integration test