### PR TITLE
Adds fallback when invalid cocina head version.

### DIFF
--- a/app/components/document_component.html.erb
+++ b/app/components/document_component.html.erb
@@ -9,5 +9,7 @@
                 class: 'document document-component' do %>
   <%= with_title(component: DocumentTitleComponent) %>
 
-  <%= render child_component %>
+  <% unless @presenter.head_invalid_cocina? %>
+    <%= render child_component %>
+  <% end %>
 <% end %>

--- a/app/components/document_title_component.html.erb
+++ b/app/components/document_title_component.html.erb
@@ -13,7 +13,7 @@
     </div>
   <% end %>
   <div class="row">
-    <%= render OpenCloseComponent.new(id: @document.id) if helpers.can?(:update, @presenter.cocina) && !version_or_user_version_view? %>
+    <%= render OpenCloseComponent.new(id: @document.id) if !head_invalid_cocina? && helpers.can?(:update, @presenter.cocina) && !version_or_user_version_view? %>
 
     <%= content_tag @as, class: @classes do %>
       <%= title -%>

--- a/app/components/document_title_component.rb
+++ b/app/components/document_title_component.rb
@@ -12,7 +12,9 @@ class DocumentTitleComponent < Blacklight::DocumentTitleComponent
   end
 
   def version_banner
-    if head_user_version_view? || current_version_view?
+    if head_invalid_cocina?
+      'This item is currently not available, likely because it is part of an ongoing cocina migration. Please check back later.'
+    elsif head_user_version_view? || current_version_view?
       'You are viewing the latest version.'
     elsif invalid_cocina?
       "You are viewing an older #{version_type} version that is no longer valid. You can view the JSON below."
@@ -22,6 +24,7 @@ class DocumentTitleComponent < Blacklight::DocumentTitleComponent
   end
 
   def show_latest_link?
+    return false if head_invalid_cocina?
     return previous_user_version_view? if @presenter.user_version_view?
 
     !current_version_view?
@@ -34,5 +37,5 @@ class DocumentTitleComponent < Blacklight::DocumentTitleComponent
   end
 
   delegate :version_or_user_version_view?, :head_user_version_view?, :previous_user_version_view?, :current_version_view?,
-           :invalid_cocina?, to: :@presenter
+           :invalid_cocina?, :head_invalid_cocina?, to: :@presenter
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -360,22 +360,32 @@ class CatalogController < ApplicationController
       @document = SolrDocument.new(object_client.version.solr(version_param, validate: false))
     else
       _deprecated_response, @document = search_service.fetch(druid_param)
-      @cocina = Repository.find_lite(druid_param, structural: false)
+      begin
+        @cocina = Repository.find_lite(druid_param, structural: false)
+      rescue Cocina::Models::Error => e
+        Honeybadger.notify(e, context: { druid: druid_param })
+        @cocina = Dor::Services::Client::InvalidCocina.new('externalIdentifier' => druid_param,
+                                                           'error_message' => e.message,
+                                                           'administrative' => { 'hasAdminPolicy' => @document.apo_id })
+      end
     end
 
     authorize! :read, @cocina
 
-    @workflows = WorkflowService.workflows_for(druid: druid_param)
+    unless @cocina.is_a?(Dor::Services::Client::InvalidCocina)
 
-    @user_versions_presenter = UserVersionsPresenter.new(user_version_view: user_version_param, user_version_inventory: object_client.user_version.inventory)
-    @versions_presenter = VersionsPresenter.new(version_view: version_param, version_inventory:)
-    @milestones_presenter = MilestonesPresenter.new(druid: druid_param, version_inventory:)
+      @workflows = WorkflowService.workflows_for(druid: druid_param)
 
-    @head_user_version = @user_versions_presenter.head_user_version
-    @release_tags = @cocina.admin_policy? ? [] : object_client.release_tags.list
+      @user_versions_presenter = UserVersionsPresenter.new(user_version_view: user_version_param, user_version_inventory: object_client.user_version.inventory)
+      @versions_presenter = VersionsPresenter.new(version_view: version_param, version_inventory:)
+      @milestones_presenter = MilestonesPresenter.new(druid: druid_param, version_inventory:)
 
-    # If you have this token, it indicates you have read access to the object
-    @verified_token_with_expiration = generate_token
+      @head_user_version = @user_versions_presenter.head_user_version
+      @release_tags = @cocina.admin_policy? ? [] : object_client.release_tags.list
+
+      # If you have this token, it indicates you have read access to the object
+      @verified_token_with_expiration = generate_token
+    end
 
     respond_to do |format|
       format.html { @search_context = setup_next_and_previous_documents }

--- a/app/presenters/argo_show_presenter.rb
+++ b/app/presenters/argo_show_presenter.rb
@@ -45,6 +45,10 @@ class ArgoShowPresenter < Blacklight::ShowPresenter
     cocina.respond_to?(:error_message)
   end
 
+  def head_invalid_cocina?
+    invalid_cocina? && !version_or_user_version_view?
+  end
+
   def dark?
     cocina.access.view == 'dark'
   end

--- a/spec/components/document_title_component_spec.rb
+++ b/spec/components/document_title_component_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe DocumentTitleComponent, type: :component do
                                        previous_user_version_view?: user_version.present? && user_version_view != head_user_version,
                                        current_version:,
                                        invalid_cocina?: invalid_cocina,
+                                       head_invalid_cocina?: invalid_cocina && !(version.present? || user_version.present?),
                                        current_version_view?: version.present? && version == current_version,
                                        version_or_user_version_view?: version.present? || user_version.present?)
   end
@@ -95,6 +96,18 @@ RSpec.describe DocumentTitleComponent, type: :component do
 
     it 'renders the expected object type class' do
       expect(rendered.css('div.object-type').first.classes).to include('object-type-item')
+    end
+
+    context 'when head_invalid_cocina? is true' do
+      let(:invalid_cocina) { true }
+
+      it 'renders the cocina migration banner' do
+        expect(rendered.content).to include('This item is currently not available')
+      end
+
+      it 'does not render the View latest version link' do
+        expect(rendered.content).not_to include('View latest version')
+      end
     end
 
     context 'with a previous user version' do

--- a/spec/requests/catalog_show_invalid_cocina_spec.rb
+++ b/spec/requests/catalog_show_invalid_cocina_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Catalog show with invalid HEAD cocina' do
+  let(:blacklight_config) { CatalogController.blacklight_config }
+  let(:solr_conn) { blacklight_config.repository_class.new(blacklight_config).connection }
+
+  let(:druid) { 'druid:hj185xx2222' }
+  let(:title) { 'Some Object With a Title' }
+  let(:apo_druid) { 'druid:hv992ry2431' }
+  let(:solr_doc) do
+    {
+      id: druid,
+      SolrDocument::FIELD_OBJECT_TYPE => 'item',
+      ApoConcern::FIELD_APO_ID => [apo_druid],
+      display_title_ss: title
+    }
+  end
+
+  let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: [], current: 1) }
+  let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: []) }
+  let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: []) }
+  let(:object_client) do
+    instance_double(Dor::Services::Client::Object,
+                    version: version_client,
+                    user_version: user_version_client,
+                    release_tags: release_tags_client)
+  end
+
+  let(:version_service) do
+    instance_double(VersionService, open?: false, openable?: false, closeable?: false, open_and_not_assembling?: false)
+  end
+  let(:state_service) { instance_double(StateService) }
+
+  before do
+    solr_conn.add(solr_doc)
+    solr_conn.commit
+
+    allow(Repository).to receive(:find_lite).and_raise(Cocina::Models::ValidationError, 'bad cocina')
+    allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
+    allow(WorkflowService).to receive(:workflows_for).and_return([])
+    allow(VersionService).to receive(:new).and_return(version_service)
+    allow(StateService).to receive(:new).and_return(state_service)
+    allow(Honeybadger).to receive(:notify)
+
+    sign_in create(:user), groups: ['sdr:viewer-role']
+  end
+
+  after do
+    solr_conn.delete_by_id(druid)
+    solr_conn.commit
+  end
+
+  it 'returns 200 instead of 500' do
+    get "/view/#{druid}"
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'renders the warning banner' do
+    get "/view/#{druid}"
+    expect(response.body).to include('This item is currently not available')
+  end
+
+  it 'renders the object title' do
+    get "/view/#{druid}"
+    expect(response.body).to include(title)
+  end
+
+  it 'does not render a "View latest version" link' do
+    get "/view/#{druid}"
+    expect(response.body).not_to include('View latest version')
+  end
+
+  it 'notifies Honeybadger with the druid context' do
+    get "/view/#{druid}"
+    expect(Honeybadger).to have_received(:notify).with(instance_of(Cocina::Models::ValidationError),
+                                                       context: { druid: })
+  end
+end


### PR DESCRIPTION
closes #5157

# Why was this change made?

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?
QA

<img width="3302" height="1850" alt="image" src="https://github.com/user-attachments/assets/521ebd40-2471-4f24-9c9b-5135166171cb" />


<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


