### PR TITLE
Fix CSV upload normalizer

### DIFF
--- a/app/controllers/concerns/creates_bulk_actions.rb
+++ b/app/controllers/concerns/creates_bulk_actions.rb
@@ -13,8 +13,12 @@ module CreatesBulkActions
   def create
     begin
       bulk_action_job_params = job_params
-    rescue StandardError => e
       # if job_params calls CsvUploadNormalizer, CSV::MalformedCSVError may be raised
+    rescue CSV::MalformedCSVError => e
+      @errors = ["Error starting bulk action: #{e.message}"]
+      return render :new, status: :unprocessable_content
+    rescue StandardError => e
+      Honeybadger.notify(e)
       @errors = ["Error starting bulk action: #{e.message}"]
       return render :new, status: :unprocessable_content
     end

--- a/app/services/csv_upload_normalizer.rb
+++ b/app/services/csv_upload_normalizer.rb
@@ -64,7 +64,7 @@ class CsvUploadNormalizer
     raw = normalized_csv_file
 
     # Find the first row that starts with DRUID_HEADER
-    druid_index = raw.index { |line| line.first.casecmp?(DRUID_HEADER) }
+    druid_index = raw.index { |line| line.first&.casecmp?(DRUID_HEADER) }
 
     # DROP all preamble rows leading up to the proper header row
     csv_string = CSV.generate do |csv|

--- a/spec/fixtures/files/catalog_record_id_and_barcode_preamble.csv
+++ b/spec/fixtures/files/catalog_record_id_and_barcode_preamble.csv
@@ -1,4 +1,5 @@
 Explanatory text that will be ignored.
+,Explanatory column header
 
 Druid,Catkey,Barcode
 druid:bb396kf5077,13157971,


### PR DESCRIPTION
# Why was this change made?
Recent changes to CSV upload normalizer did not correctly handle blank columns in the preamble.

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?
Unit, stage

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


