### PR TITLE
Escape query when searching solr for collection.

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -96,7 +96,7 @@ class CollectionsController < ApplicationController
     return false unless title || catalog_record_id
 
     query = "_query_:\"{!raw f=#{SolrDocument::FIELD_OBJECT_TYPE}}collection\""
-    query += " AND #{SolrDocument::FIELD_LABEL}:\"#{title}\"" if title
+    query += " AND #{SolrDocument::FIELD_LABEL}:\"#{title.gsub('"', '\\"')}\"" if title
     if catalog_record_id
       query += " AND identifier_ssim:\"#{CatalogRecordId.indexing_prefix}:#{params[:catalog_record_id]}\""
     end

--- a/spec/requests/create_collections_spec.rb
+++ b/spec/requests/create_collections_spec.rb
@@ -89,6 +89,19 @@ RSpec.describe 'Create collections' do
       end
     end
 
+    context 'when the title contains embedded double quotes' do
+      let(:title) { 'Scrapbook from "Cruise Bravo"' }
+      let(:result) { { 'response' => { 'numFound' => 1 } } }
+
+      it 'escapes the quotes in the Solr query' do
+        get '/collections/exists', params: { title: }
+        expect(response.body).to eq('true')
+        expect(solr_client).to have_received(:get).with('select', params: a_hash_including(
+          q: "_query_:\"{!raw f=#{SolrDocument::FIELD_OBJECT_TYPE}}collection\" AND obj_label_tesim:\"Scrapbook from \\\"Cruise Bravo\\\"\""
+        ))
+      end
+    end
+
     context 'when the catalog_record_id is provided and the collection exists' do
       let(:result) { { 'response' => { 'numFound' => 1 } } }
 


### PR DESCRIPTION
closes #5167

# Why was this change made?

<!-- `Fixes #1234` is fine if the PR is closely tied to an issue; a few words about WHY if not. -->


# How was this change tested?
Unit

<!-- Run infrastructure integration test(s) if change has cross-service impact.-->

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


