### PR TITLE
Switch registration from label to title, update Solr field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -303,7 +303,7 @@ class CatalogController < ApplicationController
           id
           druid_bare_ssi
           druid_prefixed_ssi
-          obj_label_tesim
+          main_title_tenim
           identifier_ssim
           identifier_tesim
           barcode_id_ssimdv

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -96,7 +96,7 @@ class CollectionsController < ApplicationController
     return false unless title || catalog_record_id
 
     query = "_query_:\"{!raw f=#{SolrDocument::FIELD_OBJECT_TYPE}}collection\""
-    query += " AND #{SolrDocument::FIELD_LABEL}:\"#{title.gsub('"', '\\"')}\"" if title
+    query += " AND #{SolrDocument::FIELD_MAIN_TITLE}:\"#{title.gsub('"', '\\"')}\"" if title
     if catalog_record_id
       query += " AND identifier_ssim:\"#{CatalogRecordId.indexing_prefix}:#{params[:catalog_record_id]}\""
     end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -104,7 +104,7 @@ class RegistrationsController < ApplicationController
     respond_to do |format|
       format.csv do
         csv_template = CSV.generate do |csv|
-          csv << ['barcode', CatalogRecordId.csv_header, 'source_id', 'label']
+          csv << ['barcode', CatalogRecordId.csv_header, 'source_id', 'title']
         end
         send_data csv_template, filename: 'registration.csv'
       end

--- a/app/forms/apo_form.rb
+++ b/app/forms/apo_form.rb
@@ -74,7 +74,7 @@ class ApoForm < ApplicationChangeSet
       .fetch(default_collections, rows: default_collections.size)
       .last
       .sort_by do |solr_doc|
-        solr_doc.title_display.downcase || solr_doc.label.downcase
+        solr_doc.title_display.downcase
       end
   end
 

--- a/app/forms/csv_registration_form.rb
+++ b/app/forms/csv_registration_form.rb
@@ -109,6 +109,6 @@ It's legal to have more than one colon in a hierarchy, but at least one colon is
   end
 
   def one_of_data_headers
-    @one_of_data_headers ||= ['label', CatalogRecordId.csv_header]
+    @one_of_data_headers ||= ['title', CatalogRecordId.csv_header]
   end
 end

--- a/app/forms/registration_form.rb
+++ b/app/forms/registration_form.rb
@@ -45,7 +45,7 @@ It's legal to have more than one colon in a hierarchy, but at least one colon is
                      prepopulator: ->(*) { (1 - items.count).times { items << VirtualModel.new } } do
     property :source_id, virtual: true
     property :catalog_record_id, virtual: true
-    property :label, virtual: true
+    property :title, virtual: true
     property :barcode, virtual: true
     validates :source_id, format: { with: /\A.+:.+\z/, message: 'ID is invalid' }
     validates :barcode, allow_blank: true, format: { with: VALID_BARCODE_REGEX, message: 'is invalid' }
@@ -106,10 +106,10 @@ It's legal to have more than one colon in a hierarchy, but at least one colon is
   def cocina_model(item)
     model_params = {
       type: content_type,
-      label: item.label,
       version: 1,
       administrative:,
       identification: identification(item),
+      description: { title: [{ value: item.title }] },
       structural:,
       access:
     }

--- a/app/helpers/blacklight_config_helper.rb
+++ b/app/helpers/blacklight_config_helper.rb
@@ -43,7 +43,7 @@ module BlacklightConfigHelper
         id
         druid_bare_ssi
         druid_prefixed_ssi
-        obj_label_tesim
+        main_title_tenim
         identifier_ssim
         identifier_tesim
         barcode_id_ssimdv

--- a/app/javascript/controllers/registration_item_row_controller.js
+++ b/app/javascript/controllers/registration_item_row_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
-  static targets = ['barcode', 'catalogRecordId', 'sourceId', 'label']
+  static targets = ['barcode', 'catalogRecordId', 'sourceId', 'title']
   static values = {
     csv: Boolean
   }
@@ -12,7 +12,7 @@ export default class extends Controller {
       this.validateCatalogRecordId()
       this.validateSourceId()
       this.validateBarcode()
-      this.validateLabel()
+      this.validateTitle()
     }
   }
 
@@ -89,8 +89,8 @@ export default class extends Controller {
     }
   }
 
-  validateLabel () {
-    const field = this.labelTarget
+  validateTitle () {
+    const field = this.titleTarget
     if (this.catalogRecordIdTarget.value === '') {
       field.required = true
     } else {

--- a/app/jobs/register_druids_job.rb
+++ b/app/jobs/register_druids_job.rb
@@ -3,7 +3,7 @@
 ##
 # job to register a list of druids
 class RegisterDruidsJob < BulkActionJob
-  HEADERS = ['Druid', 'Barcode', CatalogRecordId.label, 'Source Id', 'Label'].freeze
+  HEADERS = ['Druid', 'Barcode', CatalogRecordId.label, 'Source Id', 'Title'].freeze
 
   def perform_bulk_action
     convert_results.each.with_index do |convert_result, index|
@@ -58,7 +58,7 @@ class RegisterDruidsJob < BulkActionJob
         cocina_object.identification.barcode,
         cocina_object.identification.catalogLinks.first&.catalogRecordId,
         cocina_object.identification.sourceId,
-        cocina_object.label
+        Cocina::Models::Builders::TitleBuilder.build(cocina_object.description.title)
       ]
     end
   end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -3,8 +3,7 @@
 # Runs a query against solr and returns the results.
 # Does exactly what blacklight does, paginates the solr requests until all results
 # have been received
-# rubocop:disable Metrics/ClassLength
-class Report
+class Report # rubocop:disable Metrics/ClassLength
   include Blacklight::Configurable
   include DateFacetConfigurations
   include Blacklight::Searchable
@@ -347,4 +346,3 @@ class Report
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -32,7 +32,6 @@ class SolrDocument
   FIELD_FORMATTED_REGISTERED_EARLIEST = 'formatted_registered_earliest_ss'
   FIELD_HUMAN_PRESERVED_SIZE = 'human_preserved_size_ss'
   FIELD_GENRE = 'genre_ssimdv'
-  FIELD_LABEL = 'obj_label_tesim'
   FIELD_LAST_ACCESSIONED_DATE = 'accessioned_latest_dtpsidv'
   FIELD_LAST_OPENED_DATE = 'opened_latest_dtpsidv'
   FIELD_LAST_PUBLISHED_DATE = 'published_latest_dtpsidv'
@@ -41,6 +40,7 @@ class SolrDocument
   FIELD_MODS_TYPE_OF_RESOURCE = 'mods_typeOfResource_ssimdv'
   FIELD_OBJECT_TYPE = 'objectType_ssimdv'
   FIELD_ORCIDS = 'contributor_orcids_ssimdv'
+  FIELD_MAIN_TITLE = 'main_title_tenim'
   FIELD_PROCESSING_STATUS = 'processing_status_text_ssidv'
   FIELD_MODS_CREATED_DATE = 'originInfo_date_created_tesim'
   FIELD_PLACE = 'originInfo_place_placeTerm_tesim'
@@ -85,7 +85,6 @@ class SolrDocument
   attribute :preservation_size, Blacklight::Types::Value, FIELD_PRESERVATION_SIZE
   attribute :released_to, Blacklight::Types::Array, FIELD_RELEASED_TO
 
-  attribute :label, Blacklight::Types::String, FIELD_LABEL
   attribute :title_display, Blacklight::Types::String, FIELD_TITLE
   attribute :author, Blacklight::Types::String, FIELD_AUTHOR
   attribute :place, Blacklight::Types::String, FIELD_PLACE

--- a/app/models/track_sheet.rb
+++ b/app/models/track_sheet.rb
@@ -93,8 +93,8 @@ class TrackSheet
   # @return [Array<Array<String>>] Complex array suitable for pdf.table()
   def doc_to_table(solr_doc)
     table_data = []
-    label = solr_doc.title_display.truncate(110)
-    table_data.push(['Object Label:', label])
+    title = solr_doc.title_display.truncate(110)
+    table_data.push(['Object Title:', title])
     table_data.push(['Project Name:', solr_doc.project_tag]) if solr_doc.project_tag
 
     tags = solr_doc.tags.filter_map do |tag|

--- a/app/search_builders/argo/custom_search.rb
+++ b/app/search_builders/argo/custom_search.rb
@@ -17,7 +17,7 @@ module Argo
 
     # When a user issues a query containing just a druid, strip off the 'druid:'
     # prefix if it exists, lest we return results that match the word 'druid' in
-    # e.g. the label.
+    # e.g. titles.
     def strip_qualified_druids(solr_parameters)
       return unless DruidTools::Druid.valid?(solr_parameters[:q])
 

--- a/app/services/admin_policy_persister.rb
+++ b/app/services/admin_policy_persister.rb
@@ -22,9 +22,11 @@ class AdminPolicyPersister
 
   def model_for_registration
     Cocina::Models::RequestAdminPolicy.new(
-      label: title,
       version: 1,
       type: Cocina::Models::ObjectType.admin_policy,
+      description: {
+        title: [{ value: title }]
+      },
       administrative: {
         hasAdminPolicy: SolrDocument::UBER_APO_ID,
         hasAgreement: agreement_object_id,
@@ -65,7 +67,6 @@ class AdminPolicyPersister
     form.access_location = nil if clear_location?
 
     updated = model
-    updated = updated.new(label: title)
     updated = updated_administrative(updated)
     updated_description(updated)
   end
@@ -100,8 +101,7 @@ class AdminPolicyPersister
 
   def updated_description(updated)
     description = { title: [{ value: title }], purl: model.description.purl }
-    updated_description = updated.description.new(description)
-    updated.new(description: updated_description)
+    updated.new(description: updated.description.new(description))
   end
 
   def updated_administrative(updated)

--- a/app/services/apply_mods_metadata.rb
+++ b/app/services/apply_mods_metadata.rb
@@ -98,8 +98,7 @@ class ApplyModsMetadata
   end
 
   def cocina_description
-    @cocina_description ||= Cocina::Models::Description.new(Cocina::Models::Mapping::FromMods::Description.props(mods: mods_ng, druid: cocina.externalIdentifier,
-                                                                                                                 label: cocina.label))
+    @cocina_description ||= Cocina::Models::Description.new(Cocina::Models::Mapping::FromMods::Description.props(mods: mods_ng, druid: cocina.externalIdentifier, label: ''))
   end
 
   def mods_ng

--- a/app/services/registration_csv_converter.rb
+++ b/app/services/registration_csv_converter.rb
@@ -40,7 +40,7 @@ class RegistrationCsvConverter
   #   5: source_id (required)
   #   6: folio_id (optional)
   #   7: barcode (optional)
-  #   8: label (required unless a folio_id has been entered)
+  #   8: title (required unless a folio_id has been entered)
   #   9: rights_view (required)
   #  10: rights_download (required)
   #  11: rights_location (required if "view" or "download" uses "location-based")
@@ -66,7 +66,6 @@ class RegistrationCsvConverter
     model_params = {
       type: dro_type(params[:content_type] || row.fetch('content_type')),
       version: 1,
-      label: row[catalog_record_id_column] ? row['label'] : row.fetch('label'),
       administrative: {
         hasAdminPolicy: params[:administrative_policy_object] || row.fetch('administrative_policy_object')
       },
@@ -77,6 +76,7 @@ class RegistrationCsvConverter
       }.compact
     }
 
+    model_params[:description] = description(row)
     model_params[:structural] = structural(row)
     model_params[:access] = access(row)
     project_name = params[:project_name] || row['project_name']
@@ -149,6 +149,13 @@ class RegistrationCsvConverter
       structural[:isMemberOf] = [collection] if collection
       reading_order = params[:reading_order] || row['reading_order']
       structural[:hasMemberOrders] = [{ viewingDirection: reading_order }] if reading_order.present?
+    end
+  end
+
+  def description(row)
+    {}.tap do |description|
+      title = row[catalog_record_id_column] ? row['title'] : row.fetch('title')
+      description[:title] = [{ value: title }]
     end
   end
 

--- a/app/views/apo/_form.html.erb
+++ b/app/views/apo/_form.html.erb
@@ -18,7 +18,7 @@
       <legend>Default Collections</legend>
       <% @form.default_collection_objects.each_with_index do |solr_doc, index| %>
         <%= hidden_field_tag "apo[collections_for_registration][#{index}][id]", solr_doc.id %>
-        <% title_shown = solr_doc.title_display.presence || solr_doc.label %>
+        <% title_shown = solr_doc.title_display %>
         <%= link_to title_shown, solr_doc %> <%= link_to('(remove)', delete_collection_apo_path(collection: solr_doc.id, id: @form), data: { turbo_confirm: 'You are about to leave the page, are you sure?' }) %><br>
       <% end %>
     </fieldset>

--- a/app/views/bulk_actions/register_druid_jobs/_new.html.erb
+++ b/app/views/bulk_actions/register_druid_jobs/_new.html.erb
@@ -18,7 +18,7 @@
               <li>source_id (required)</li>
               <li><%= CatalogRecordId.csv_header %> (optional)</li>
               <li>barcode (optional)</li>
-              <li>label (required unless a <%= CatalogRecordId.csv_header %> has been entered)</li>
+              <li>title (required unless a <%= CatalogRecordId.csv_header %> has been entered)</li>
               <li>rights_view (required)</li>
               <li>rights_download (required)</li>
               <li>rights_location (required if "view" or "download" uses "location-based")</li>

--- a/app/views/collections/new_modal.html.erb
+++ b/app/views/collections/new_modal.html.erb
@@ -1,7 +1,7 @@
 <%= render EditModalComponent.new do |component| %>
   <% component.with_header { 'Create Collection' } %>
   <% component.with_body do %>
-    <h4>APO &mdash; <%= @cocina_admin_policy.label %></h4>
+    <h4>APO &mdash; <%= Cocina::Models::Builders::TitleBuilder.build(@cocina_admin_policy.description.title) %></h4>
     <%= form_tag collections_path(@cocina_admin_policy.externalIdentifier) do %>
       <%= hidden_field_tag :apo_druid, @cocina_admin_policy.externalIdentifier %>
       <%= hidden_field_tag :modal, true %>

--- a/app/views/items/_collection_ui.html.erb
+++ b/app/views/items/_collection_ui.html.erb
@@ -11,7 +11,7 @@
       <div class='panel-body'>
         <ul class='list-group'>
           <% @collection_list.each do |collection| %>
-            <%= render 'collection_ui_line_item', collection_label: collection.label,
+            <%= render 'collection_ui_line_item', collection_label: Cocina::Models::Builders::TitleBuilder.build(collection.description.title),
                                                   collection_id: collection.externalIdentifier,
                                                   item_id: @cocina.externalIdentifier %>
           <% end %>

--- a/app/views/registrations/_item_row.html.erb
+++ b/app/views/registrations/_item_row.html.erb
@@ -16,7 +16,7 @@
     <%= item_form.text_field :catalog_record_id, class: 'form-control',
                                                  pattern: CatalogRecordId.html_pattern_string,
                                                  data: {
-                                                   action: 'change->registration-item-row#validateCatalogRecordId change->registration-item-row#validateLabel invalid->registration#displayValidation',
+                                                   action: 'change->registration-item-row#validateCatalogRecordId change->registration-item-row#validateTitle invalid->registration#displayValidation',
                                                    registration_item_row_target: 'catalogRecordId'
                                                  } %>
   </div>
@@ -37,13 +37,13 @@
 </div>
 
 <div class="row mb-3">
-  <%= item_form.label :label, class: 'col-sm-2 col-form-label' %>
+  <%= item_form.label :title, class: 'col-sm-2 col-form-label' %>
   <div class="col-sm-10">
-    <%= item_form.text_field :label, class: 'form-control',
+    <%= item_form.text_field :title, class: 'form-control',
                                      data: {
-                                       registration_item_row_target: 'label',
+                                       registration_item_row_target: 'title',
                                        registration_tabs_target: 'requiredFormField',
-                                       action: 'change->registration-item-row#validateLabel invalid->registration#displayValidation'
+                                       action: 'change->registration-item-row#validateTitle invalid->registration#displayValidation'
                                      } %>
   </div>
 </div>

--- a/app/views/registrations/create_status.html.erb
+++ b/app/views/registrations/create_status.html.erb
@@ -17,7 +17,7 @@
           <th>Barcode</th>
           <th><%= CatalogRecordId.label %></th>
           <th>Source ID</th>
-          <th>Label</th>
+          <th>Title</th>
         </tr>
       </thead>
       <tbody>
@@ -27,7 +27,7 @@
           <td><%= dro.identification.barcode %></td>
           <td><%= dro.identification.catalogLinks.first&.catalogRecordId %></td>
           <td><%= dro.identification.sourceId %></td>
-          <td><%= dro.label %></td>
+          <td><%= Cocina::Models::Builders::TitleBuilder.build(dro.description.title) %></td>
         </tr>
       <% end %>
       </tbody>

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -74,7 +74,7 @@
         id
         druid_bare_ssi
         druid_prefixed_ssi
-        obj_label_tesim
+        main_title_tenim
         identifier_ssim
         identifier_tesim
         barcode_id_ssim
@@ -105,7 +105,7 @@
 
         collection_title_tesim^5
 
-        obj_label_tesim^5
+        main_title_tenim^5
         identifier_tesim^5
         source_id_text_nostem_i^5
       </str>
@@ -129,7 +129,7 @@
 
         collection_title_tesim^3
 
-        obj_label_tesim^3
+        main_title_tenim^3
         identifier_tesim^3
         source_id_text_nostem_i^3
       </str>
@@ -153,7 +153,7 @@
 
         collection_title_tesim^2
 
-        obj_label_tesim^2
+        main_title_tenim^2
         identifier_tesim^2
         source_id_text_nostem_i^2
       </str>
@@ -217,7 +217,7 @@
         id
         druid_bare_ssi
         druid_prefixed_ssi
-        obj_label_tesim
+        main_title_tenim
         identifier_ssim
         identifier_tesim
         barcode_id_ssim
@@ -248,7 +248,7 @@
 
         collection_title_tesim^5
 
-        obj_label_tesim^5
+        main_title_tenim^5
         identifier_tesim^5
         source_id_text_nostem_i^5
       </str>
@@ -272,7 +272,7 @@
 
         collection_title_tesim^3
 
-        obj_label_tesim^3
+        main_title_tenim^3
         identifier_tesim^3
         source_id_text_nostem_i^3
       </str>
@@ -296,7 +296,7 @@
 
         collection_title_tesim^2
 
-        obj_label_tesim^2
+        main_title_tenim^2
         identifier_tesim^2
         source_id_text_nostem_i^2
       </str>

--- a/spec/factories/apos.rb
+++ b/spec/factories/apos.rb
@@ -6,7 +6,6 @@ FactoryBot.define do
       ApoMethodSender.new(
         Cocina::Models.build_request({
                                        'type' => type,
-                                       'label' => label,
                                        'version' => 1,
                                        'administrative' => {
                                          'hasAdminPolicy' => admin_policy_id,
@@ -15,6 +14,9 @@ FactoryBot.define do
                                            'view' => 'world',
                                            'download' => 'world'
                                          }
+                                       },
+                                       'description' => {
+                                         'title' => [{ value: title }]
                                        }
                                      })
       )
@@ -26,7 +28,7 @@ FactoryBot.define do
 
     admin_policy_id { 'druid:hv992ry2431' }
     agreement_id { FactoryBot.create_for_repository(:agreement).externalIdentifier }
-    label { 'this is a really long test APO label to test truncation of facet labels on show page' }
+    title { 'this is a really long test APO title to test truncation of facet labels on show page' }
     type { Cocina::Models::ObjectType.admin_policy }
   end
 end

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
                                        'administrative' => {
                                          'hasAdminPolicy' => admin_policy_id
                                        },
-                                       :identification => { sourceId: "sul:#{SecureRandom.uuid}" },
+                                       'identification' => { 'sourceId' => "sul:#{SecureRandom.uuid}" },
                                        'access' => {}
                                      })
       )

--- a/spec/fixtures/files/character-test.csv
+++ b/spec/fixtures/files/character-test.csv
@@ -1,2 +1,2 @@
-source_id,catkey,barcode,label
+source_id,catkey,barcode,title
 sul:M1835_B1_F4_024,,,Mademoiselle Sylvain en Belgique by André Scohy

--- a/spec/fixtures/files/item_registration.csv
+++ b/spec/fixtures/files/item_registration.csv
@@ -1,2 +1,2 @@
-source_id,catkey,barcode,label
+source_id,catkey,barcode,title
 foo:123,,,My new object

--- a/spec/fixtures/files/item_registration_incomplete.csv
+++ b/spec/fixtures/files/item_registration_incomplete.csv
@@ -1,3 +1,3 @@
-source_id,folio_instance_id,barcode,label
+source_id,folio_instance_id,barcode,title
 foo:123,in12319237,,My new object
 bar:345,,,

--- a/spec/forms/csv_registration_form_spec.rb
+++ b/spec/forms/csv_registration_form_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CsvRegistrationForm do
 
       it 'returns errors' do
         expect(form.errors.full_messages).to include(
-          /missing header\. One of these must be provided: label, folio_instance_hrid/
+          /missing header\. One of these must be provided: title, folio_instance_hrid/
         )
       end
     end
@@ -35,7 +35,7 @@ RSpec.describe CsvRegistrationForm do
 
       it 'returns errors' do
         expect(form.errors.full_messages).to include(
-          /missing data\. For each row, one of these must be provided: label, folio_instance_hrid/
+          /missing data\. For each row, one of these must be provided: title, folio_instance_hrid/
         )
       end
     end

--- a/spec/jobs/register_druids_job_spec.rb
+++ b/spec/jobs/register_druids_job_spec.rb
@@ -19,17 +19,20 @@ RSpec.describe RegisterDruidsJob do
   let(:identification) do
     Cocina::Models::Identification.new(barcode: '36105010101010', catalogLinks: [catalog_link], sourceId: 'foo:bar1')
   end
+  let(:description) do
+    Cocina::Models::Description.new(title: [{ value: 'My object' }], purl: 'https://purl.stanford.edu/123')
+  end
 
   let(:cocina_object) do
     instance_double(Cocina::Models::DROWithMetadata,
                     externalIdentifier: 'druid:123',
-                    label: 'My object',
-                    identification:)
+                    identification:,
+                    description:)
   end
 
   let(:csv_string) do
     <<~CSV
-      administrative_policy_object,collection,initial_workflow,content_type,source_id,label,rights_view,rights_download,tags,tags
+      administrative_policy_object,collection,initial_workflow,content_type,source_id,title,rights_view,rights_download,tags,tags
       druid:bc123df4567,druid:bk024qs1808,accessionWF,book,foo:123,My new object,world,world,csv : test,Project : two
       druid:dj123qx4567,druid:bk024qs1808,accessionWF,book,foo:123,A label,world,world
     CSV
@@ -44,7 +47,7 @@ RSpec.describe RegisterDruidsJob do
   context 'when parsing fails' do
     let(:csv_string) do
       <<~CSV
-        administrative_policy_object,initial_workflow,content_type,source_id,label,rights_view,rights_download
+        administrative_policy_object,initial_workflow,content_type,source_id,title,rights_view,rights_download
         druid:123,accessionWF,book,foo:123,My new object,world,world
       CSV
     end
@@ -63,7 +66,7 @@ RSpec.describe RegisterDruidsJob do
     let(:response) { Failure(RuntimeError.new('connection problem')) }
     let(:csv_string) do
       <<~CSV
-        administrative_policy_object,initial_workflow,content_type,source_id,label,rights_view,rights_download,tags,tags
+        administrative_policy_object,initial_workflow,content_type,source_id,title,rights_view,rights_download,tags,tags
         druid:bc123df4567,accessionWF,book,foo:123,My new object,world,world,csv : test,Project : two
       CSV
     end
@@ -93,7 +96,7 @@ RSpec.describe RegisterDruidsJob do
                                                                    workflow: 'accessionWF')
       expect(log).to have_received(:puts).with(/Registration successful for druid:123/).twice
       expect(bulk_action.druid_count_success).to eq 2
-      expect(File.read(csv_filepath)).to eq("Druid,Barcode,Folio Instance HRID,Source Id,Label\n123,36105010101010,in12345,foo:bar1,My object\n123,36105010101010,in12345,foo:bar1,My object\n")
+      expect(File.read(csv_filepath)).to eq("Druid,Barcode,Folio Instance HRID,Source Id,Title\n123,36105010101010,in12345,foo:bar1,My object\n123,36105010101010,in12345,foo:bar1,My object\n")
     end
   end
 
@@ -101,7 +104,7 @@ RSpec.describe RegisterDruidsJob do
     # Params are provided from registration page (not bulk action page)
     let(:csv_string) do
       <<~CSV
-        source_id,label
+        source_id,title
         foo:123,My new object
         foo:123,A label
       CSV
@@ -136,7 +139,7 @@ RSpec.describe RegisterDruidsJob do
   context 'with valid view:stanford, download:none, and rights_controlledDigitalLending:true' do
     let(:csv_string) do
       <<~CSV
-        administrative_policy_object,collection,initial_workflow,content_type,source_id,label,rights_view,rights_download,rights_controlledDigitalLending,tags,tags
+        administrative_policy_object,collection,initial_workflow,content_type,source_id,title,rights_view,rights_download,rights_controlledDigitalLending,tags,tags
         druid:bc123df4567,druid:bk024qs1808,accessionWF,book,foo:123,My new object,stanford,none,true,csv : test,Project : two
         druid:dj123qx4567,druid:bk024qs1808,accessionWF,book,foo:123,A label,stanford,none,true
       CSV
@@ -161,7 +164,7 @@ RSpec.describe RegisterDruidsJob do
   context 'with invalid view:world, download:none, and rights_controlledDigitalLending:true' do
     let(:csv_string) do
       <<~CSV
-        administrative_policy_object,collection,initial_workflow,content_type,source_id,label,rights_view,rights_download,rights_controlledDigitalLending,tags,tags
+        administrative_policy_object,collection,initial_workflow,content_type,source_id,title,rights_view,rights_download,rights_controlledDigitalLending,tags,tags
         druid:bc123df4567,druid:bk024qs1808,accessionWF,book,foo:123,My new object,world,none,true,csv : test,Project : two
         druid:dj123qx4567,druid:bk024qs1808,accessionWF,book,foo:123,A label,world,none,true
       CSV

--- a/spec/models/permitted_queries_spec.rb
+++ b/spec/models/permitted_queries_spec.rb
@@ -44,8 +44,10 @@ RSpec.describe PermittedQueries do
       before do
         solr_conn.delete_by_query("#{SolrDocument::FIELD_OBJECT_TYPE}:collection")
         solr_conn.add(id: 'druid:bg444xg6666', SolrDocument::FIELD_OBJECT_TYPE => 'collection',
-                      display_title_ss: 'Inactive collection', tag_ssim: PermittedQueries::INACTIVE_TAG)
-        solr_conn.add(id: 'druid:bg555xg7777', SolrDocument::FIELD_OBJECT_TYPE => 'collection', display_title_ss: 'My collection')
+                      display_title_ss: 'Inactive collection', main_title_tenim: 'Inactive collection',
+                      tag_ssim: PermittedQueries::INACTIVE_TAG)
+        solr_conn.add(id: 'druid:bg555xg7777', SolrDocument::FIELD_OBJECT_TYPE => 'collection',
+                      display_title_ss: 'My collection', main_title_tenim: 'My collection')
         solr_conn.commit
       end
 

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -89,10 +89,12 @@ RSpec.describe Report do
       before do
         solr_conn.add(id: 'druid:fg464dn8891',
                       SolrDocument::FIELD_BARE_DRUID => 'fg464dn8891',
-                      obj_label_tesim: 'State Banking Commission Annual Reports')
+                      display_title_ss: 'State Banking Commission Annual Reports',
+                      main_title_tenim: 'State Banking Commission Annual Reports')
         solr_conn.add(id: 'druid:mb062dy1188',
                       SolrDocument::FIELD_BARE_DRUID => 'mb062dy1188',
-                      obj_label_tesim: 'maxims found in the leading English and American reports and elementary works')
+                      display_title_ss: 'maxims found in the leading English and American reports and elementary works',
+                      main_title_tenim: 'maxims found in the leading English and American reports and elementary works')
         solr_conn.commit
       end
 
@@ -132,7 +134,8 @@ RSpec.describe Report do
       before do
         solr_conn.add(id: 'druid:fg464dn8891',
                       SolrDocument::FIELD_BARE_DRUID => 'fg464dn8891',
-                      obj_label_tesim: 'State Banking Commission Annual Reports',
+                      display_title_ss: 'State Banking Commission Annual Reports',
+                      main_title_tenim: 'State Banking Commission Annual Reports',
                       tag_ssim: ['Registered By : llam813', 'Remediated By : 4.6.6.2'])
         solr_conn.commit
       end

--- a/spec/models/track_sheet_spec.rb
+++ b/spec/models/track_sheet_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe TrackSheet do
       it 'builds the table for the solr doc with the correct title' do
         expect(call).to include(
           [
-            'Object Label:',
+            'Object Title:',
             'Correct title' # we get the cocina title out!
           ]
         )
@@ -73,7 +73,7 @@ RSpec.describe TrackSheet do
       it 'builds the table for the solr doc with a truncated title' do
         expect(call).to include(
           [
-            'Object Label:',
+            'Object Title:',
             'Stanford University. School of Engineeering Roger Howe Professorship: Stanford (Calif.), 2010-01-21.  And m...'
           ]
         )
@@ -86,7 +86,7 @@ RSpec.describe TrackSheet do
       it 'builds the table for the solr doc with a blank title' do
         expect(call).to include(
           [
-            'Object Label:',
+            'Object Title:',
             ''
           ]
         )

--- a/spec/presenters/cocina_hash_presenter_spec.rb
+++ b/spec/presenters/cocina_hash_presenter_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe CocinaHashPresenter do
                                lock: cocina_object.lock,
                                type: 'https://cocina.sul.stanford.edu/models/collection',
                                externalIdentifier: cocina_object.externalIdentifier,
-                               label: cocina_object.label,
                                version: 1,
+                               label: '',
                                access: {
                                  view: 'dark'
                                },

--- a/spec/requests/create_collections_spec.rb
+++ b/spec/requests/create_collections_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe 'Create collections' do
         get "/collections/exists?title=#{title}"
         expect(response.body).to eq('true')
         expect(solr_client).to have_received(:get).with('select', params: a_hash_including(
-          q: "_query_:\"{!raw f=#{SolrDocument::FIELD_OBJECT_TYPE}}collection\" AND obj_label_tesim:\"foo\""
+          q: "_query_:\"{!raw f=#{SolrDocument::FIELD_OBJECT_TYPE}}collection\" AND main_title_tenim:\"foo\""
         ))
       end
     end
@@ -97,7 +97,7 @@ RSpec.describe 'Create collections' do
         get '/collections/exists', params: { title: }
         expect(response.body).to eq('true')
         expect(solr_client).to have_received(:get).with('select', params: a_hash_including(
-          q: "_query_:\"{!raw f=#{SolrDocument::FIELD_OBJECT_TYPE}}collection\" AND obj_label_tesim:\"Scrapbook from \\\"Cruise Bravo\\\"\""
+          q: "_query_:\"{!raw f=#{SolrDocument::FIELD_OBJECT_TYPE}}collection\" AND main_title_tenim:\"Scrapbook from \\\"Cruise Bravo\\\"\""
         ))
       end
     end
@@ -130,7 +130,7 @@ RSpec.describe 'Create collections' do
         get "/collections/exists?catalog_record_id=#{catalog_record_id}&title=#{title}"
         expect(response.body).to eq('true')
         expect(solr_client).to have_received(:get).with('select', params: a_hash_including(
-          q: "_query_:\"{!raw f=#{SolrDocument::FIELD_OBJECT_TYPE}}collection\" AND obj_label_tesim:\"foo\" AND identifier_ssim:\"#{CatalogRecordId.indexing_prefix}:123\""
+          q: "_query_:\"{!raw f=#{SolrDocument::FIELD_OBJECT_TYPE}}collection\" AND main_title_tenim:\"foo\" AND identifier_ssim:\"#{CatalogRecordId.indexing_prefix}:123\""
         ))
       end
     end

--- a/spec/requests/create_new_item_spec.rb
+++ b/spec/requests/create_new_item_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Create a new item' do
           items: [
             {
               source_id: '',
-              label: 'test parameters for registration'
+              title: 'test parameters for registration'
             }
           ]
         }
@@ -72,7 +72,7 @@ RSpec.describe 'Create a new item' do
           items: [
             {
               source_id: 'foo:bar',
-              label: 'This things'
+              title: 'This things'
             }
           ],
           tag: ['Registered By : jcoyne85']
@@ -99,7 +99,7 @@ RSpec.describe 'Create a new item' do
             {
               source_id:,
               barcode_id: '36105010362304',
-              label: 'test parameters for registration'
+              title: 'test parameters for registration'
             }
           ]
         }
@@ -128,7 +128,7 @@ RSpec.describe 'Create a new item' do
           items: [
             {
               source_id: 'foo:bar',
-              label: 'test parameters for registration'
+              title: 'test parameters for registration'
             }
           ]
         }
@@ -138,33 +138,24 @@ RSpec.describe 'Create a new item' do
     let(:json) do
       Cocina::Models::DRO.new(externalIdentifier: 'druid:bc234fg5678',
                               type: Cocina::Models::ObjectType.document,
-                              label: 'Test DRO',
+                              label: '',
                               version: 1,
                               description: {
-                                title: [{ value: 'Test DRO' }],
+                                title: [{ value: 'test parameters for registration' }],
                                 purl: 'https://purl.stanford.edu/bc234fg5678'
                               },
                               access: {},
-                              identification: { sourceId: 'sul:1234' },
-                              structural: {},
+                              identification: { sourceId: 'foo:bar' },
+                              structural: {
+                                isMemberOf: ['druid:hv992ry7777']
+                              },
                               administrative: {
                                 hasAdminPolicy: 'druid:hv992ry2431'
                               }).to_json
     end
 
-    let(:request_json) do
-      "{\"cocinaVersion\":\"#{Cocina::Models::VERSION}\",\"type\":\"#{Cocina::Models::ObjectType.document}\"," \
-        '"label":"test parameters for registration","version":1,' \
-        '"access":{"view":"world","download":"world","controlledDigitalLending":false},' \
-        '"administrative":' \
-        '{"hasAdminPolicy":"druid:hv992ry2431"},"identification":' \
-        '{"catalogLinks":[],"sourceId":"foo:bar"},"structural":{"contains":[],"hasMemberOrders":[],' \
-        '"isMemberOf":["druid:hv992ry7777"]}}'
-    end
-
     before do
       stub_request(:post, "#{Settings.dor_services.url}/v1/objects?assign_doi=false")
-        .with(body: request_json)
         .to_return(status: 200, body: json, headers:)
     end
 
@@ -190,7 +181,7 @@ RSpec.describe 'Create a new item' do
           items: [
             {
               source_id: 'foo:bar',
-              label: 'test parameters for registration'
+              title: 'test parameters for registration'
             }
           ]
         }
@@ -200,7 +191,7 @@ RSpec.describe 'Create a new item' do
     let(:json) do
       Cocina::Models::DRO.new(externalIdentifier: 'druid:bc234fg5678',
                               type: Cocina::Models::ObjectType.image,
-                              label: 'Test DRO',
+                              label: '',
                               version: 1,
                               description: {
                                 title: [{ value: 'Test DRO' }],
@@ -216,26 +207,16 @@ RSpec.describe 'Create a new item' do
                                 hasAdminPolicy: 'druid:hv992ry2431'
                               }).to_json
     end
-    let(:request_json) do
-      "{\"cocinaVersion\":\"#{Cocina::Models::VERSION}\",\"type\":\"#{Cocina::Models::ObjectType.image}\"," \
-        '"label":"test parameters for registration","version":1,' \
-        '"access":{"view":"stanford","download":"stanford","controlledDigitalLending":false},' \
-        '"administrative":{"hasAdminPolicy":"druid:hv992ry2431"},"identification":' \
-        '{"catalogLinks":[],"sourceId":"foo:bar"},"structural":{"contains":[],"hasMemberOrders":[],' \
-        '"isMemberOf":["druid:hv992ry7777"]}}'
-    end
 
     before do
       stub_request(:post, "#{Settings.dor_services.url}/v1/objects?assign_doi=false")
-        .with(body: request_json)
         .to_return(status: 200, body: json, headers:)
     end
 
     it 'registers the object' do
       post '/registration', params: submitted
       expect(response).to have_http_status(:ok)
-      expect(workflow_client).to have_received(:create)
-        .with(version: '1')
+      expect(workflow_client).to have_received(:create).with(version: '1')
     end
   end
 
@@ -257,7 +238,7 @@ RSpec.describe 'Create a new item' do
           items: [
             {
               source_id: 'foo:bar',
-              label: 'test parameters for registration'
+              title: 'test parameters for registration'
             }
           ]
         }
@@ -267,7 +248,7 @@ RSpec.describe 'Create a new item' do
     let(:json) do
       Cocina::Models::DRO.new(externalIdentifier: 'druid:bc234fg5678',
                               type: Cocina::Models::ObjectType.book,
-                              label: 'Test DRO',
+                              label: '',
                               version: 1,
                               description: {
                                 title: [{ value: 'xTest DRO' }],
@@ -289,20 +270,8 @@ RSpec.describe 'Create a new item' do
                               }).to_json
     end
 
-    let(:request_json) do
-      "{\"cocinaVersion\":\"#{Cocina::Models::VERSION}\",\"type\":\"#{Cocina::Models::ObjectType.book}\"," \
-        '"label":"test parameters for registration","version":1,' \
-        '"access":{"view":"location-based","download":"location-based","location":' \
-        '"music","controlledDigitalLending":false},' \
-        '"administrative":{"hasAdminPolicy":"druid:hv992ry2431"},' \
-        '"identification":{"catalogLinks":[],"sourceId":"foo:bar"},' \
-        '"structural":{"contains":[],"hasMemberOrders":[{"members":[],' \
-        '"viewingDirection":"left-to-right"}],"isMemberOf":["druid:hv992ry7777"]}}'
-    end
-
     before do
       stub_request(:post, "#{Settings.dor_services.url}/v1/objects?assign_doi=false")
-        .with(body: request_json)
         .to_return(status: 200, body: json, headers:)
     end
 
@@ -330,7 +299,7 @@ RSpec.describe 'Create a new item' do
           items: [
             {
               source_id: 'foo:bar',
-              label: 'test parameters for registration'
+              title: 'test parameters for registration'
             }
           ]
         }
@@ -340,7 +309,7 @@ RSpec.describe 'Create a new item' do
     let(:json) do
       Cocina::Models::DRO.new(externalIdentifier: 'druid:bc234fg5678',
                               type: Cocina::Models::ObjectType.image,
-                              label: 'Test DRO',
+                              label: '',
                               version: 1,
                               description: {
                                 title: [{ value: 'Test DRO' }],
@@ -361,18 +330,8 @@ RSpec.describe 'Create a new item' do
                               }).to_json
     end
 
-    let(:request_json) do
-      "{\"cocinaVersion\":\"#{Cocina::Models::VERSION}\",\"type\":\"#{Cocina::Models::ObjectType.image}\"," \
-        '"label":"test parameters for registration","version":1,' \
-        '"access":{"view":"world","download":"none","controlledDigitalLending":false},' \
-        '"administrative":{"hasAdminPolicy":"druid:hv992ry2431"},"identification":' \
-        '{"catalogLinks":[],"sourceId":"foo:bar"},"structural":{"contains":[],"hasMemberOrders":[{"members":[],' \
-        '"viewingDirection":"right-to-left"}],"isMemberOf":["druid:hv992ry7777"]}}'
-    end
-
     before do
       stub_request(:post, "#{Settings.dor_services.url}/v1/objects?assign_doi=false")
-        .with(body: request_json)
         .to_return(status: 200, body: json, headers:)
     end
 
@@ -394,7 +353,7 @@ RSpec.describe 'Create a new item' do
           items: [
             {
               source_id: 'foo:bar',
-              label: 'test parameters for registration'
+              title: 'test parameters for registration'
             }
           ],
           tag: ['Registered By : jcoyne85'],
@@ -408,7 +367,7 @@ RSpec.describe 'Create a new item' do
     let(:json) do
       Cocina::Models::DRO.new(externalIdentifier: 'druid:bc234fg5678',
                               type: Cocina::Models::ObjectType.image,
-                              label: 'Test DRO',
+                              label: '',
                               version: 1,
                               description: {
                                 title: [{ value: 'Test DRO' }],
@@ -425,18 +384,8 @@ RSpec.describe 'Create a new item' do
                               }).to_json
     end
 
-    let(:request_json) do
-      "{\"cocinaVersion\":\"#{Cocina::Models::VERSION}\",\"type\":\"#{Cocina::Models::ObjectType.image}\"," \
-        '"label":"test parameters for registration","version":1,' \
-        '"access":{"view":"dark","download":"none","controlledDigitalLending":false},' \
-        '"administrative":{"hasAdminPolicy":"druid:hv992ry2431"},' \
-        '"identification":{"catalogLinks":[],"sourceId":"foo:bar"},"structural":{"contains":[],' \
-        '"hasMemberOrders":[],"isMemberOf":["druid:hv992ry7777"]}}'
-    end
-
     before do
       stub_request(:post, "#{Settings.dor_services.url}/v1/objects?assign_doi=false")
-        .with(body: request_json)
         .to_return(status: 200, body: json, headers:)
     end
 
@@ -479,7 +428,7 @@ RSpec.describe 'Create a new item' do
           items: [
             {
               source_id: 'foo:bar',
-              label: 'This things'
+              title: 'This things'
             }
           ],
           tag: ['Registered By : jcoyne85']
@@ -506,7 +455,7 @@ RSpec.describe 'Create a new item' do
           items: [
             {
               source_id: 'foo:bar',
-              label: 'test parameters for registration'
+              title: 'test parameters for registration'
             }
           ]
         }
@@ -516,7 +465,7 @@ RSpec.describe 'Create a new item' do
     let(:json) do
       Cocina::Models::DRO.new(externalIdentifier: 'druid:bc234fg5678',
                               type: Cocina::Models::ObjectType.book,
-                              label: 'Test DRO',
+                              label: '',
                               version: 1,
                               description: {
                                 title: [{ value: 'Test DRO' }],
@@ -533,18 +482,9 @@ RSpec.describe 'Create a new item' do
                                 hasAdminPolicy: 'druid:hv992ry2431'
                               }).to_json
     end
-    let(:request_json) do
-      "{\"cocinaVersion\":\"#{Cocina::Models::VERSION}\",\"type\":\"#{Cocina::Models::ObjectType.book}\"," \
-        '"label":"test parameters for registration","version":1,"access":' \
-        '{"view":"stanford","download":"none","controlledDigitalLending":true},' \
-        '"administrative":{"hasAdminPolicy":"druid:hv992ry2431"},"identification":' \
-        '{"catalogLinks":[],"sourceId":"foo:bar"},"structural":{"contains":[],"hasMemberOrders":[],' \
-        '"isMemberOf":["druid:hv992ry7777"]}}'
-    end
 
     before do
       stub_request(:post, "#{Settings.dor_services.url}/v1/objects?assign_doi=false")
-        .with(body: request_json)
         .to_return(status: 200, body: json, headers:)
     end
 

--- a/spec/services/admin_policy_persister_spec.rb
+++ b/spec/services/admin_policy_persister_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe AdminPolicyPersister do
             purl: 'https://purl.stanford.edu/zt570qh4444'
           },
           externalIdentifier: 'druid:zt570qh4444',
-          label: 'My title',
+          label: '',
           type: Cocina::Models::ObjectType.admin_policy,
           version: 1
         )

--- a/spec/services/registration_csv_converter_spec.rb
+++ b/spec/services/registration_csv_converter_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe RegistrationCsvConverter do
       {
         cocinaVersion: Cocina::Models::VERSION,
         type: Cocina::Models::ObjectType.book,
-        label: 'My new object',
         version: 1,
         access: { view: 'world', download: 'world', controlledDigitalLending: false },
         administrative: { hasAdminPolicy: 'druid:bc123df4567' },
+        description: { title: [{ value: 'My new object' }] },
         identification: { sourceId: 'foo:123' },
         structural: { isMemberOf: ['druid:bk024qs1808'] }
       }
@@ -23,9 +23,9 @@ RSpec.describe RegistrationCsvConverter do
   context 'when all values provided in CSV' do
     let(:csv_string) do
       <<~CSV
-        administrative_policy_object,collection,initial_workflow,content_type,source_id,label,rights_view,rights_download,tags,tags,tickets,tickets
+        administrative_policy_object,collection,initial_workflow,content_type,source_id,title,rights_view,rights_download,tags,tags,tickets,tickets
         druid:bc123df4567,druid:bk024qs1808,accessionWF,book,foo:123,My new object,world,world,csv : test,Project : two,DIGREQ-1234,DIGREQ-5678
-        xdruid:dj123qx4567,druid:bk024qs1808,accessionWF,book,foo:123,A label,world,world
+        xdruid:dj123qx4567,druid:bk024qs1808,accessionWF,book,foo:123,A Title,world,world
       CSV
     end
 
@@ -42,9 +42,9 @@ RSpec.describe RegistrationCsvConverter do
   context 'when values provided in params' do
     let(:csv_string) do
       <<~CSV
-        source_id,label
+        source_id,title
         foo:123,My new object
-        foo:123,A label
+        foo:123,A Title
       CSV
     end
 
@@ -73,7 +73,7 @@ RSpec.describe RegistrationCsvConverter do
   context 'when no rights provided in params' do
     let(:csv_string) do
       <<~CSV
-        source_id,label
+        source_id,title
         foo:123,My new object
       CSV
     end
@@ -98,7 +98,7 @@ RSpec.describe RegistrationCsvConverter do
   context 'when params have rights_view citation-only but no rights_download' do
     let(:csv_string) do
       <<~CSV
-        source_id,label
+        source_id,title
         foo:123,My new object
       CSV
     end
@@ -125,7 +125,7 @@ RSpec.describe RegistrationCsvConverter do
   context 'when CSV has rights_view citation-only but no rights_download' do
     let(:csv_string) do
       <<~CSV
-        source_id,label,rights_view
+        source_id,title,rights_view
         foo:123,My new object,citation-only
       CSV
     end

--- a/spec/support/reset_solr.rb
+++ b/spec/support/reset_solr.rb
@@ -11,7 +11,8 @@ module ResetSolr
     solr_conn.add(id: 'druid:hv992ry2431',
                   SolrDocument::FIELD_OBJECT_TYPE => ['adminPolicy'],
                   apo_register_permissions_ssim: ['workgroup:dlss:developers'],
-                  display_title_ss: ['[Internal System Objects]'])
+                  display_title_ss: ['[Internal System Objects]'],
+                  main_title_tenim: ['[Internal System Objects]'])
     solr_conn.commit
   end
 end

--- a/spec/system/create_collection_from_apo_spec.rb
+++ b/spec/system/create_collection_from_apo_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe 'Add collection from APO show page' do
   let(:result) { { 'response' => { 'numFound' => 1 } } }
   let(:apo_druid) { 'druid:vt333hq2222' }
   let(:cocina_model) do
-    instance_double(Cocina::Models::AdminPolicyWithMetadata, label: 'hey', externalIdentifier: apo_druid)
+    instance_double(Cocina::Models::AdminPolicyWithMetadata, externalIdentifier: apo_druid,
+                                                             description: Cocina::Models::Description.new(title: [{ value: 'My Title' }], purl: "https://purl.stanford.edu/#{apo_druid}"))
   end
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
 

--- a/spec/system/date_range_form_spec.rb
+++ b/spec/system/date_range_form_spec.rb
@@ -12,23 +12,28 @@ RSpec.describe 'Date range form', :js do
     solr_conn.delete_by_query("#{SolrDocument::FIELD_OBJECT_TYPE}:item")
     solr_conn.add(:id => 'druid:xb482ww9999',
                   SolrDocument::FIELD_OBJECT_TYPE => 'item',
-                  :obj_label_tesim => 'Report about stuff',
+                  :display_title_ss => 'Report about stuff',
+                  :main_title_tenim => 'Report about stuff',
                   SolrDocument::FIELD_LAST_PUBLISHED_DATE => last_published)
     solr_conn.add(:id => 'druid:xb482bw3980',
                   SolrDocument::FIELD_OBJECT_TYPE => 'item',
-                  :obj_label_tesim => 'Report about stuff',
+                  :display_title_ss => 'Report about stuff',
+                  :main_title_tenim => 'Report about stuff',
                   SolrDocument::FIELD_LAST_PUBLISHED_DATE => last_published)
     solr_conn.add(:id => 'druid:xb482bw3981',
                   SolrDocument::FIELD_OBJECT_TYPE => 'item',
-                  :obj_label_tesim => 'Report about stuff',
+                  :display_title_ss => 'Report about stuff',
+                  :main_title_tenim => 'Report about stuff',
                   SolrDocument::FIELD_LAST_PUBLISHED_DATE => last_published)
     solr_conn.add(:id => 'druid:xb482bw3982',
                   SolrDocument::FIELD_OBJECT_TYPE => 'item',
-                  :obj_label_tesim => 'Report about stuff',
+                  :display_title_ss => 'Report about stuff',
+                  :main_title_tenim => 'Report about stuff',
                   SolrDocument::FIELD_LAST_PUBLISHED_DATE => last_published)
     solr_conn.add(:id => 'druid:xb482bw3983',
                   SolrDocument::FIELD_OBJECT_TYPE => 'item',
-                  :obj_label_tesim => 'Report about stuff',
+                  :display_title_ss => 'Report about stuff',
+                  :main_title_tenim => 'Report about stuff',
                   SolrDocument::FIELD_LAST_PUBLISHED_DATE => last_published)
     solr_conn.commit
     sign_in create(:user), groups: ['sdr:administrator-role']

--- a/spec/system/item_registration_csv_spec.rb
+++ b/spec/system/item_registration_csv_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Item registration page', :js do
         {
           administrative_policy_object: 'druid:hv992ry2431',
           content_type: 'https://cocina.sul.stanford.edu/models/book',
-          csv_file: "source_id,catkey,barcode,label\nfoo:123,,,My new object\n",
+          csv_file: "source_id,catkey,barcode,title\nfoo:123,,,My new object\n",
           groups:
            ["sunetid:#{user.login}",
             'workgroup:sdr:administrator-role',
@@ -83,7 +83,7 @@ RSpec.describe 'Item registration page', :js do
         {
           administrative_policy_object: 'druid:hv992ry2431',
           content_type: 'https://cocina.sul.stanford.edu/models/book',
-          csv_file: "source_id,catkey,barcode,label\nfoo:123,,,My new object\n",
+          csv_file: "source_id,catkey,barcode,title\nfoo:123,,,My new object\n",
           groups:
            ["sunetid:#{user.login}",
             'workgroup:sdr:administrator-role',
@@ -102,7 +102,7 @@ RSpec.describe 'Item registration page', :js do
   context 'when registration fails validation' do
     let(:non_default_apo) do
       FactoryBot.create_for_repository(:persisted_apo,
-                                       label: 'My First APO',
+                                       title: 'My First APO',
                                        roles: [
                                          {
                                            name: 'dor-apo-manager',
@@ -148,7 +148,7 @@ RSpec.describe 'Item registration page', :js do
         {
           administrative_policy_object: non_default_apo.externalIdentifier,
           content_type: 'https://cocina.sul.stanford.edu/models/object',
-          csv_file: "source_id,catkey,barcode,label\nfoo:123,,,My new object\n",
+          csv_file: "source_id,catkey,barcode,title\nfoo:123,,,My new object\n",
           groups:
             ["sunetid:#{user.login}",
              'workgroup:sdr:administrator-role',

--- a/spec/system/item_registration_spec.rb
+++ b/spec/system/item_registration_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Item registration page', :js do
 
       fill_in 'Barcode', with: barcode
       fill_in 'Source ID', with: 'source:id1'
-      fill_in 'Label', with: 'object title'
+      fill_in 'Title', with: 'object title'
 
       registration_params = {}
       expect_any_instance_of(RegistrationForm).to receive(:validate) do |form, attributes|
@@ -103,7 +103,7 @@ RSpec.describe 'Item registration page', :js do
           '0' => {
             'source_id' => 'source:id1',
             'catalog_record_id' => '',
-            'label' => 'object title',
+            'title' => 'object title',
             'barcode' => barcode
           }
         }
@@ -127,7 +127,7 @@ RSpec.describe 'Item registration page', :js do
 
       fill_in 'Barcode', with: barcode
       fill_in 'Source ID', with: source_id
-      fill_in 'Label', with: 'object title'
+      fill_in 'Title', with: 'object title'
 
       click_button 'Register'
 
@@ -185,7 +185,7 @@ RSpec.describe 'Item registration page', :js do
 
       fill_in CatalogRecordId.label, with: 'not_a_catkey'
       fill_in 'Source ID', with: source_id
-      fill_in 'Label', with: 'object title'
+      fill_in 'Title', with: 'object title'
 
       click_button 'Register'
 
@@ -213,7 +213,7 @@ RSpec.describe 'Item registration page', :js do
 
       fill_in 'Barcode', with: 'not_a_barcode'
       fill_in 'Source ID', with: source_id
-      fill_in 'Label', with: 'object title'
+      fill_in 'Title', with: 'object title'
 
       click_button 'Register'
 
@@ -244,7 +244,7 @@ RSpec.describe 'Item registration page', :js do
 
       fill_in CatalogRecordId.label, with: 'a12345'
       fill_in 'Source ID', with: source_id
-      fill_in 'Label', with: 'object title'
+      fill_in 'Title', with: 'object title'
 
       click_button 'Register'
 

--- a/spec/system/item_view_spec.rb
+++ b/spec/system/item_view_spec.rb
@@ -52,7 +52,8 @@ RSpec.describe 'Item view', :js do
         {
           id: 'druid:hj185xx2222',
           SolrDocument::FIELD_OBJECT_TYPE => 'item',
-          display_title_ss: title
+          display_title_ss: title,
+          main_title_tenim: title
         }
       end
       let(:title) { 'Slides, IA 11, Geodesic Domes, Double Skin "Growth" House, N.C. State, 1953' }
@@ -205,7 +206,8 @@ RSpec.describe 'Item view', :js do
             {
               id: 'druid:hj185xx2222',
               SolrDocument::FIELD_OBJECT_TYPE => 'virtual object',
-              display_title_ss: title
+              display_title_ss: title,
+              main_title_tenim: title
             }
           end
 

--- a/spec/system/report_view_spec.rb
+++ b/spec/system/report_view_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe 'Report view' do
       solr_conn.add(id: 'druid:hj185xx2222',
                     SolrDocument::FIELD_BARE_DRUID => 'hj185xx2222',
                     SolrDocument::FIELD_OBJECT_TYPE => 'item',
-                    display_title_ss: 'Slides, IA 11, Geodesic Domes, Double Skin "Growth" House, N.C. State, 1953')
+                    display_title_ss: 'Slides, IA 11, Geodesic Domes, Double Skin "Growth" House, N.C. State, 1953',
+                    main_title_tenim: 'Slides, IA 11, Geodesic Domes, Double Skin "Growth" House, N.C. State, 1953')
       solr_conn.commit
     end
 

--- a/spec/views/collections/new_modal.html.erb_spec.rb
+++ b/spec/views/collections/new_modal.html.erb_spec.rb
@@ -3,9 +3,20 @@
 require 'rails_helper'
 
 RSpec.describe 'collections/new_modal' do
+  let(:fake_apo) do
+    instance_double(
+      Cocina::Models::AdminPolicy,
+      externalIdentifier: 'druid:zt570qh4444',
+      label: '',
+      description: Cocina::Models::Description.new(
+        title: [{ value: 'My Title' }],
+        purl: 'https://purl.stanford.edu/zt570qh4444'
+      )
+    )
+  end
+
   it 'renders the HTML template form' do
-    assign(:cocina_admin_policy,
-           instance_double(Cocina::Models::AdminPolicy, externalIdentifier: 'druid:zt570qh4444', label: 'My label'))
+    assign(:cocina_admin_policy, fake_apo)
     render
     expect(rendered).to have_field 'collection_title'
     expect(rendered).to have_field 'collection_abstract'

--- a/spec/views/items/_collection_ui.html.erb_spec.rb
+++ b/spec/views/items/_collection_ui.html.erb_spec.rb
@@ -5,7 +5,14 @@ require 'rails_helper'
 RSpec.describe 'items/_collection_ui.html.erb' do
   let(:collection_list) do
     [
-      instance_double(Cocina::Models::Collection, label: 'But catz are nice too', externalIdentifier: 'druid:abc123')
+      instance_double(
+        Cocina::Models::Collection,
+        label: 'Unused',
+        externalIdentifier: 'druid:abc123',
+        description: Cocina::Models::Description.new(
+          title: [{ value: 'But catz are nice too' }], purl: 'https://purl.stanford.edu/abc123'
+        )
+      )
     ]
   end
   let(:current_user) do


### PR DESCRIPTION
HOLD on merging and deploying to prod until Tuesday, July 7, for PO communication. 

# Why was this change made?

Fixes #5158

This commit severs Argo's dependency on the top-level cocina-models `label`
property. To that end, current uses of label, e.g. in indexing and searching,
have been replaced with uses of appropriate title fields `display_title_ss` for
display and `main_title_tenim` for searching.

HOLD until registration changes within have been communicated to users.

# How was this change tested?

- [x] CI
- [ ] QA/stage
