### PR TITLE
[WIP] Change logic around invalid versions

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -372,8 +372,10 @@ class CatalogController < ApplicationController
 
     authorize! :read, @cocina
 
-    unless @cocina.is_a?(Dor::Services::Client::InvalidCocina)
-
+    if @cocina.is_a?(Dor::Services::Client::InvalidCocina)
+      @versions_presenter = VersionsPresenter.new(version_view: version_param, version_inventory: [])
+      @user_versions_presenter = UserVersionsPresenter.new(user_version_view: user_version_param, user_version_inventory: [])
+    else
       @workflows = WorkflowService.workflows_for(druid: druid_param)
 
       @user_versions_presenter = UserVersionsPresenter.new(user_version_view: user_version_param, user_version_inventory: object_client.user_version.inventory)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -372,22 +372,17 @@ class CatalogController < ApplicationController
 
     authorize! :read, @cocina
 
-    if @cocina.is_a?(Dor::Services::Client::InvalidCocina)
-      @versions_presenter = VersionsPresenter.new(version_view: version_param, version_inventory: [])
-      @user_versions_presenter = UserVersionsPresenter.new(user_version_view: user_version_param, user_version_inventory: [])
-    else
-      @workflows = WorkflowService.workflows_for(druid: druid_param)
+    @workflows = WorkflowService.workflows_for(druid: druid_param)
 
-      @user_versions_presenter = UserVersionsPresenter.new(user_version_view: user_version_param, user_version_inventory: object_client.user_version.inventory)
-      @versions_presenter = VersionsPresenter.new(version_view: version_param, version_inventory:)
-      @milestones_presenter = MilestonesPresenter.new(druid: druid_param, version_inventory:)
+    @user_versions_presenter = UserVersionsPresenter.new(user_version_view: user_version_param, user_version_inventory: object_client.user_version.inventory)
+    @versions_presenter = VersionsPresenter.new(version_view: version_param, version_inventory:)
+    @milestones_presenter = MilestonesPresenter.new(druid: druid_param, version_inventory:)
 
-      @head_user_version = @user_versions_presenter.head_user_version
-      @release_tags = @cocina.admin_policy? ? [] : object_client.release_tags.list
+    @head_user_version = @user_versions_presenter.head_user_version
+    @release_tags = @cocina.admin_policy? ? [] : object_client.release_tags.list
 
-      # If you have this token, it indicates you have read access to the object
-      @verified_token_with_expiration = generate_token
-    end
+    # If you have this token, it indicates you have read access to the object
+    @verified_token_with_expiration = generate_token
 
     respond_to do |format|
       format.html { @search_context = setup_next_and_previous_documents }


### PR DESCRIPTION
# Why was this change made?
Refs #5177. Still create versions and user_versions presenters even when cocina is invalid so that the right message can be displayed. 

# How was this change tested?
Need to create tests, none here yet

<!-- Run accessibility checks if there are UI changes. See [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) -->


