### PR TITLE
skip pagination when downloading reports

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -300,9 +300,10 @@ class Report # rubocop:disable Metrics/ClassLength
     # Get the underlying Faraday connection to use its streaming API
     connection = search_service.repository.connection.connection
     fl = @fields.collect { |f| f[:solr_fields] || f[:field] }.flatten.uniq.join(',')
+    search_params = @params.except(:page, :per_page, :rows)
     # Setting wt=csv tells solr to return CSV data
     data = { wt: :csv, rows: 10_000_000, fl:, 'csv.mv.separator' => ';' }
-           .reverse_merge(search_service.search_builder.with(@params)).to_h
+           .reverse_merge(search_service.search_builder.with(search_params)).to_h
 
     first_chunk = true
     connection.post blacklight_config.solr_path do |req|

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -40,6 +40,43 @@ RSpec.describe Report do
       expect(csv[report_field_index(SolrDocument::FIELD_BARE_DRUID)]).to eq('"')
     end
 
+    context 'when the search params specify a later results page' do
+      let(:csv) do
+        stream = StringIO.new
+        described_class.new(
+          {
+            f: { SolrDocument::FIELD_OBJECT_TYPE => ['item'] },
+            page: 2,
+            per_page: 1,
+            sort: 'id asc'
+          },
+          current_user: user
+        ).stream_csv(stream:)
+        stream.string
+      end
+
+      before do
+        solr_conn.add(
+          id: 'druid:aa111aa1111',
+          SolrDocument::FIELD_BARE_DRUID => 'aa111aa1111',
+          SolrDocument::FIELD_OBJECT_TYPE => 'item'
+        )
+        solr_conn.add(
+          id: 'druid:bb222bb2222',
+          SolrDocument::FIELD_BARE_DRUID => 'bb222bb2222',
+          SolrDocument::FIELD_OBJECT_TYPE => 'item'
+        )
+        solr_conn.commit
+      end
+
+      it 'downloads all matching records starting with the first result' do
+        rows = CSV.parse(csv)
+        druid_index = report_field_index(SolrDocument::FIELD_BARE_DRUID)
+
+        expect(rows.drop(1).pluck(druid_index)).to eq %w[aa111aa1111 bb222bb2222]
+      end
+    end
+
     context 'when a field has double quotes' do
       before do
         solr_conn.add(


### PR DESCRIPTION
# Why was this change made?

Fixes #5192 - report view should download all results by skipping pagination

Note: Codex written spec.

# How was this change tested?

Tested on stage with https://argo-stage.stanford.edu/catalog?f%5Bwf_wps_ssimdv%5D%5B%5D=accessionWF%3Astage%3Acompleted&page=53 and then switching to report view and downloading.

Before fix, only get 2 results.  After fix, get all results.

Also, new spec