### PR TITLE
Render abstracts and TOCs in cocina descriptive preview

### DIFF
--- a/app/components/cocina_descriptive_component.rb
+++ b/app/components/cocina_descriptive_component.rb
@@ -10,6 +10,8 @@ class CocinaDescriptiveComponent < ApplicationComponent
   def cocina_display_methods
     %i[
       title_display_data
+      abstract_display_data
+      table_of_contents_display_data
       form_display_data
       form_note_display_data
       event_display_data

--- a/spec/requests/apo_count_spec.rb
+++ b/spec/requests/apo_count_spec.rb
@@ -8,10 +8,12 @@ RSpec.describe 'Count the members of an apo' do
   let(:rendered) do
     Capybara::Node::Simple.new(response.body)
   end
+  let(:solr_conn) do
+    blacklight_config = CatalogController.blacklight_config
+    blacklight_config.repository_class.new(blacklight_config).connection
+  end
 
   before do
-    blacklight_config = CatalogController.blacklight_config
-    solr_conn = blacklight_config.repository_class.new(blacklight_config).connection
     # Ensure we start from fresh or the link text may not be what we expect
     solr_conn.delete_by_query("#{SolrDocument::FIELD_OBJECT_TYPE}:item OR #{SolrDocument::FIELD_OBJECT_TYPE}:collection")
     solr_conn.commit
@@ -22,6 +24,7 @@ RSpec.describe 'Count the members of an apo' do
     before do
       FactoryBot.create_for_repository(:persisted_collection)
       FactoryBot.create_for_repository(:persisted_collection)
+      solr_conn.commit
     end
 
     it 'returns the count' do
@@ -42,6 +45,11 @@ RSpec.describe 'Count the members of an apo' do
   describe 'counting the item members' do
     let(:item) { FactoryBot.create_for_repository(:persisted_item) }
     let(:admin_policy_id) { item.administrative.hasAdminPolicy }
+
+    before do
+      item
+      solr_conn.commit
+    end
 
     it 'returns the count' do
       get "/apo/#{admin_policy_id}/count_items"

--- a/spec/requests/collection_count_spec.rb
+++ b/spec/requests/collection_count_spec.rb
@@ -8,11 +8,17 @@ RSpec.describe 'Count the members of a collection' do
   let(:rendered) do
     Capybara::Node::Simple.new(response.body)
   end
+  let(:solr_conn) do
+    blacklight_config = CatalogController.blacklight_config
+    blacklight_config.repository_class.new(blacklight_config).connection
+  end
 
   before do
     sign_in user, groups: ['sdr:administrator-role']
+
     FactoryBot.create_for_repository(:persisted_item, collection_id: collection.externalIdentifier)
     FactoryBot.create_for_repository(:persisted_item, collection_id: collection.externalIdentifier)
+    solr_conn.commit
   end
 
   it 'returns the count' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,8 +2,8 @@
 
 require 'simplecov'
 SimpleCov.start :rails do
-  add_filter '/spec/'
-  add_filter '/vendor/'
+  skip '/spec/'
+  skip '/vendor/'
 
   if ENV['CI']
     require 'simplecov_json_formatter'

--- a/spec/system/apo_spec.rb
+++ b/spec/system/apo_spec.rb
@@ -13,10 +13,17 @@ RSpec.describe 'Create an apo', :js do
                                      admin_policy_id: agreement.administrative.hasAdminPolicy)
   end
 
-  # let(:workflow_client) { WorkflowClientFactory.build }
   let(:accession_processes) { Dor::Services::Client.workflows.template('accessionWF').fetch('processes').pluck('name') }
 
+  let(:solr_conn) do
+    blacklight_config = CatalogController.blacklight_config
+    blacklight_config.repository_class.new(blacklight_config).connection
+  end
+
   before do
+    preexisting_collection
+    solr_conn.commit
+
     sign_in user, groups: ['sdr:administrator-role']
   end
 
@@ -64,6 +71,8 @@ RSpec.describe 'Create an apo', :js do
     click_button 'Open Version'
     expect(page).to have_text 'open for modification!'
 
+    solr_conn.commit
+
     click_link 'Edit APO'
     expect(page).to have_text 'Add group' # wait for form to render
     expect(find_field('Title').value).to eq('APO Title')
@@ -73,6 +82,7 @@ RSpec.describe 'Create an apo', :js do
     expect(page).to have_css('.permissionName', text: 'developers')
     expect(page).to have_css('.permissionName', text: 'someone')
     expect(find_field('Default use license').value).to eq 'https://creativecommons.org/licenses/by-sa/3.0/legalcode'
+
     within_fieldset 'Default Collections' do
       expect(page).to have_link('New Testing Collection')
     end

--- a/spec/system/item_registration_csv_spec.rb
+++ b/spec/system/item_registration_csv_spec.rb
@@ -5,6 +5,10 @@ require 'rails_helper'
 RSpec.describe 'Item registration page', :js do
   let(:bulk_action) { instance_double(BulkAction, save: true, enqueue_job: true) }
   let(:user) { create(:user) }
+  let(:solr_conn) do
+    blacklight_config = CatalogController.blacklight_config
+    blacklight_config.repository_class.new(blacklight_config).connection
+  end
 
   before do
     ResetSolr.reset_solr
@@ -113,6 +117,7 @@ RSpec.describe 'Item registration page', :js do
 
     before do
       non_default_apo # create a second APO to make sure the form does not reset to the default APO
+      solr_conn.commit
     end
 
     it 'reports error, retains user values, and allows user to submit a corrected CSV' do

--- a/spec/system/set_governing_apo_spec.rb
+++ b/spec/system/set_governing_apo_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'Set governing APO' do
 
     new_apo
     item
+    solr_conn.commit
 
     allow(VersionService).to receive(:new).and_return(version_service)
     allow(WorkflowService).to receive(:accessioned?).and_return(true)


### PR DESCRIPTION
# Why was this change made?

This gets to parity with PURL (which renders these two in a separate component; probably why they were missed initially).

Fixes #5196

# How was this change tested?

CI


