### PR TITLE
Further label removal and changing to title

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -86,7 +86,7 @@ class ItemsController < ApplicationController
                           link.catalog == CatalogRecordId.type
                         end&.catalogRecordId
     if catalog_record_id.blank?
-      render status: :bad_request, plain: "object must have #{CatalogRecordId.label} to refresh descMetadata"
+      render status: :bad_request, plain: "object must have #{CatalogRecordId.label} to refresh descriptive metadata"
       return
     end
 

--- a/app/forms/agreement_form.rb
+++ b/app/forms/agreement_form.rb
@@ -26,7 +26,6 @@ class AgreementForm < ApplicationForm
   def model
     Cocina::Models.build_request({
                                    'type' => Cocina::Models::ObjectType.agreement,
-                                   'label' => title,
                                    'version' => 1,
                                    'access' => { 'view' => 'dark' },
                                    'description' => { 'title' => [{ 'value' => title }] },

--- a/app/forms/collection_form.rb
+++ b/app/forms/collection_form.rb
@@ -49,7 +49,6 @@ class CollectionForm
   # @return [Hash] the parameters used to register a collection. Must be called after `validate`
   def cocina_model
     reg_params = {
-      label: params[:collection_title].presence || ':auto',
       version: 1,
       type: Cocina::Models::ObjectType.collection,
       administrative: {

--- a/app/javascript/controllers/registration_items_controller.js
+++ b/app/javascript/controllers/registration_items_controller.js
@@ -33,13 +33,13 @@ export default class extends Controller {
     const rowsOnPage = this.element.querySelectorAll(this.selectorValue)
 
     lines.forEach((line, index) => {
-      const [barcode, catalogRecordId, sourceId, label] = line.split(/\t/)
+      const [barcode, catalogRecordId, sourceId, title] = line.split(/\t/)
 
       const elements = rowsOnPage[index].querySelectorAll('input')
       elements[0].value = barcode
       elements[1].value = catalogRecordId
       elements[2].value = sourceId
-      elements[3].value = label
+      elements[3].value = title
       // Trigger client side validations for existing rows
       // Newly added rows will validate when the connect for RegistrationItemRowController is run at
       // the conclusion of this method.

--- a/app/presenters/cocina_hash_presenter.rb
+++ b/app/presenters/cocina_hash_presenter.rb
@@ -11,9 +11,9 @@
 class CocinaHashPresenter
   def initialize(cocina_object:, without_metadata: false)
     @cocina_object_hash = if without_metadata
-                            cocina_object.to_h.except(*Cocina::Models::ObjectMetadata.attribute_names)
+                            cocina_object.to_h.except(*Cocina::Models::ObjectMetadata.attribute_names, :label)
                           else
-                            cocina_object.to_h
+                            cocina_object.to_h.except(:label)
                           end
   end
 

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -89,7 +89,7 @@
     <div class="tab-content">
       <div class="tab-pane<%= is_form ? ' active' : '' %>" id="form" role="tabpanel" aria-labelledby="form-tab">
         <div class="my-3 col-lg-7" data-controller="registration-items" data-registration-items-selector-value=".plain-container">
-          <label for="pasteHere" class="form-label">Enter a tab-delimited list of Barcode, <%= CatalogRecordId.label %>, Source ID, and Label in the large data entry box below or enter them individually in the text fields below. Suggested maximum of 500 rows.</label>
+          <label for="pasteHere" class="form-label">Enter a tab-delimited list of Barcode, <%= CatalogRecordId.label %>, Source ID, and Title in the large data entry box below or enter them individually in the text fields below. Suggested maximum of 500 rows.</label>
           <textarea data-action="paste->registration-items#populateFromPastedData" id="pasteHere" class="form-control mb-5"></textarea>
           <template data-registration-items-target='template'>
             <div class="plain-container" style="position: relative" data-controller="registration-item-row">

--- a/spec/components/cocina_descriptive_component_spec.rb
+++ b/spec/components/cocina_descriptive_component_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe CocinaDescriptiveComponent, type: :component do
     { 'cocinaVersion' => '0.86.0',
       'type' => 'https://cocina.sul.stanford.edu/models/book',
       'externalIdentifier' => 'druid:bb000cr7262',
-      'label' => 'Ḥirz-i jān jadīd : yaʻnī k̲h̲ulāṣah Mufīd-i ‘ām',
       'version' => 2,
       'access' =>
       { 'view' => 'stanford',

--- a/spec/components/show/collection/overview_component_spec.rb
+++ b/spec/components/show/collection/overview_component_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Show::Collection::OverviewComponent, type: :component do
   let(:cocina) do
     Cocina::Models::Collection.new(externalIdentifier: 'druid:bc234fg5678',
                                    type: Cocina::Models::ObjectType.collection,
-                                   label: 'my collection',
                                    version: 1,
                                    description: {
                                      title: [{ value: 'my collection' }],

--- a/spec/components/show/item/access_rights_component_spec.rb
+++ b/spec/components/show/item/access_rights_component_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Show::Item::AccessRightsComponent, type: :component do
   let(:cocina) do
     Cocina::Models::DRO.new(externalIdentifier: 'druid:bc234fg5678',
                             type: Cocina::Models::ObjectType.document,
-                            label: 'my dro',
                             version: 1,
                             description: {
                               title: [{ value: 'my dro' }],

--- a/spec/components/show/item/overview_component_spec.rb
+++ b/spec/components/show/item/overview_component_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe Show::Item::OverviewComponent, type: :component do
     let(:cocina) do
       Cocina::Models::DRO.new(externalIdentifier: 'druid:bc234fg5678',
                               type: Cocina::Models::ObjectType.document,
-                              label: 'my dro',
                               version: 1,
                               description: {
                                 title: [{ value: 'my dro' }],

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -6,7 +6,6 @@ FactoryBot.define do
       CollectionMethodSender.new(
         Cocina::Models.build_request({
                                        'type' => type,
-                                       'label' => 'test collection',
                                        'version' => 1,
                                        'description' => description,
                                        'administrative' => {

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -9,7 +9,6 @@ FactoryBot.define do
       ItemMethodSender.new(
         Cocina::Models.build_request({
                                        'type' => type,
-                                       'label' => label,
                                        'version' => 1,
                                        'description' => description,
                                        'identification' => identification,
@@ -32,7 +31,6 @@ FactoryBot.define do
                                                  members: [{ identifier: 'sdr:administrator-role',
                                                              type: 'workgroup' }] }]).externalIdentifier
     end
-    label { 'test object' }
     type { Cocina::Models::ObjectType.object }
     source_id { "sul:#{SecureRandom.uuid}" }
     identification do
@@ -46,7 +44,6 @@ FactoryBot.define do
 
     factory :agreement do
       type { Cocina::Models::ObjectType.agreement }
-      label { 'Test Agreement' }
       admin_policy_id { 'druid:hv992ry2431' }
     end
   end

--- a/spec/forms/embargo_form_spec.rb
+++ b/spec/forms/embargo_form_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe EmbargoForm do
     {
       externalIdentifier: 'druid:bc234fg5678',
       type: Cocina::Models::ObjectType.image,
-      label: 'Test DRO',
       version: 1,
       description: {
         title: [{ value: 'Test DRO' }],

--- a/spec/helpers/value_helper_spec.rb
+++ b/spec/helpers/value_helper_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ValueHelper do
   let(:search_state) { Blacklight::SearchState.new({}, blacklight_config) }
   let(:search_action_path) { '/search_action_path' }
   let(:collection) do
-    double('collection', label: 'Boring Object Label', pid: 'druid:abc123')
+    double('collection', pid: 'druid:abc123')
   end
   let(:honeybadger) { double(Honeybadger) }
 

--- a/spec/jobs/descmetadata_download_job_spec.rb
+++ b/spec/jobs/descmetadata_download_job_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe DescmetadataDownloadJob do
       <?xml version="1.0" encoding="UTF-8"?>
       <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink" version="3.7" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
         <titleInfo>
-          <title>Object Label for Biryani Spice Mix Pine Nut</title>
+          <title>Object Title for Biryani Spice Mix Pine Nut</title>
         </titleInfo>
       </mods>
     XML

--- a/spec/jobs/register_druids_job_spec.rb
+++ b/spec/jobs/register_druids_job_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe RegisterDruidsJob do
     <<~CSV
       administrative_policy_object,collection,initial_workflow,content_type,source_id,title,rights_view,rights_download,tags,tags
       druid:bc123df4567,druid:bk024qs1808,accessionWF,book,foo:123,My new object,world,world,csv : test,Project : two
-      druid:dj123qx4567,druid:bk024qs1808,accessionWF,book,foo:123,A label,world,world
+      druid:dj123qx4567,druid:bk024qs1808,accessionWF,book,foo:123,A title,world,world
     CSV
   end
 
@@ -106,7 +106,7 @@ RSpec.describe RegisterDruidsJob do
       <<~CSV
         source_id,title
         foo:123,My new object
-        foo:123,A label
+        foo:123,A title
       CSV
     end
 
@@ -141,7 +141,7 @@ RSpec.describe RegisterDruidsJob do
       <<~CSV
         administrative_policy_object,collection,initial_workflow,content_type,source_id,title,rights_view,rights_download,rights_controlledDigitalLending,tags,tags
         druid:bc123df4567,druid:bk024qs1808,accessionWF,book,foo:123,My new object,stanford,none,true,csv : test,Project : two
-        druid:dj123qx4567,druid:bk024qs1808,accessionWF,book,foo:123,A label,stanford,none,true
+        druid:dj123qx4567,druid:bk024qs1808,accessionWF,book,foo:123,A title,stanford,none,true
       CSV
     end
 
@@ -166,7 +166,7 @@ RSpec.describe RegisterDruidsJob do
       <<~CSV
         administrative_policy_object,collection,initial_workflow,content_type,source_id,title,rights_view,rights_download,rights_controlledDigitalLending,tags,tags
         druid:bc123df4567,druid:bk024qs1808,accessionWF,book,foo:123,My new object,world,none,true,csv : test,Project : two
-        druid:dj123qx4567,druid:bk024qs1808,accessionWF,book,foo:123,A label,world,none,true
+        druid:dj123qx4567,druid:bk024qs1808,accessionWF,book,foo:123,A title,world,none,true
       CSV
     end
 

--- a/spec/presenters/cocina_hash_presenter_spec.rb
+++ b/spec/presenters/cocina_hash_presenter_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe CocinaHashPresenter do
                                type: 'https://cocina.sul.stanford.edu/models/collection',
                                externalIdentifier: cocina_object.externalIdentifier,
                                version: 1,
-                               label: '',
                                access: {
                                  view: 'dark'
                                },

--- a/spec/requests/create_collections_spec.rb
+++ b/spec/requests/create_collections_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe 'Create collections' do
       post '/collections', params: {
         'apo_druid' => apo_id,
         'modal' => 'true',
-        'label' => ':auto',
         'collection_catalog_record_id' => '1234567',
         'collection_rights_catalog_record_id' => 'dark'
       }

--- a/spec/requests/create_new_item_spec.rb
+++ b/spec/requests/create_new_item_spec.rb
@@ -138,7 +138,6 @@ RSpec.describe 'Create a new item' do
     let(:json) do
       Cocina::Models::DRO.new(externalIdentifier: 'druid:bc234fg5678',
                               type: Cocina::Models::ObjectType.document,
-                              label: '',
                               version: 1,
                               description: {
                                 title: [{ value: 'test parameters for registration' }],
@@ -191,7 +190,6 @@ RSpec.describe 'Create a new item' do
     let(:json) do
       Cocina::Models::DRO.new(externalIdentifier: 'druid:bc234fg5678',
                               type: Cocina::Models::ObjectType.image,
-                              label: '',
                               version: 1,
                               description: {
                                 title: [{ value: 'Test DRO' }],
@@ -248,7 +246,6 @@ RSpec.describe 'Create a new item' do
     let(:json) do
       Cocina::Models::DRO.new(externalIdentifier: 'druid:bc234fg5678',
                               type: Cocina::Models::ObjectType.book,
-                              label: '',
                               version: 1,
                               description: {
                                 title: [{ value: 'xTest DRO' }],
@@ -309,7 +306,6 @@ RSpec.describe 'Create a new item' do
     let(:json) do
       Cocina::Models::DRO.new(externalIdentifier: 'druid:bc234fg5678',
                               type: Cocina::Models::ObjectType.image,
-                              label: '',
                               version: 1,
                               description: {
                                 title: [{ value: 'Test DRO' }],
@@ -367,7 +363,6 @@ RSpec.describe 'Create a new item' do
     let(:json) do
       Cocina::Models::DRO.new(externalIdentifier: 'druid:bc234fg5678',
                               type: Cocina::Models::ObjectType.image,
-                              label: '',
                               version: 1,
                               description: {
                                 title: [{ value: 'Test DRO' }],
@@ -465,7 +460,6 @@ RSpec.describe 'Create a new item' do
     let(:json) do
       Cocina::Models::DRO.new(externalIdentifier: 'druid:bc234fg5678',
                               type: Cocina::Models::ObjectType.book,
-                              label: '',
                               version: 1,
                               description: {
                                 title: [{ value: 'Test DRO' }],

--- a/spec/requests/refresh_metadata_spec.rb
+++ b/spec/requests/refresh_metadata_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Refresh metadata' do
         post "/items/#{druid}/refresh_metadata"
 
         expect(response).to have_http_status(:bad_request)
-        expect(response.body).to eq "object must have #{CatalogRecordId.label} to refresh descMetadata"
+        expect(response.body).to eq "object must have #{CatalogRecordId.label} to refresh descriptive metadata"
       end
     end
 

--- a/spec/services/admin_policy_persister_spec.rb
+++ b/spec/services/admin_policy_persister_spec.rb
@@ -85,7 +85,6 @@ RSpec.describe AdminPolicyPersister do
             purl: 'https://purl.stanford.edu/zt570qh4444'
           },
           externalIdentifier: 'druid:zt570qh4444',
-          label: '',
           type: Cocina::Models::ObjectType.admin_policy,
           version: 1
         )

--- a/spec/services/collection_change_set_persister_spec.rb
+++ b/spec/services/collection_change_set_persister_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe CollectionChangeSetPersister do
     let(:model) do
       model = Cocina::Models::Collection.new(
         externalIdentifier: 'druid:bc123df4568',
-        label: 'test',
         type: Cocina::Models::ObjectType.collection,
         version: 1,
         description: {

--- a/spec/services/csv_upload_validator_spec.rb
+++ b/spec/services/csv_upload_validator_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CsvUploadValidator do
     let(:required_headers) { %w[source_id] }
     let(:csv) do
       <<~CSV
-        barcode,folio_instance_hrid,source_id,label
+        barcode,folio_instance_hrid,source_id,title
         ,,not:blank001,not blank
         ,,not:blank002,blank rows below this line
         ,,,,

--- a/spec/services/item_change_set_persister_spec.rb
+++ b/spec/services/item_change_set_persister_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe ItemChangeSetPersister do
     let(:model) do
       model = Cocina::Models::DRO.new(
         externalIdentifier: 'druid:bc123df4568',
-        label: 'test',
         type: Cocina::Models::ObjectType.object,
         version: 1,
         description: {
@@ -125,7 +124,6 @@ RSpec.describe ItemChangeSetPersister do
       let(:model) do
         model = Cocina::Models::DRO.new(
           externalIdentifier: 'druid:bc123df4568',
-          label: 'test',
           type: Cocina::Models::ObjectType.object,
           version: 1,
           description: {

--- a/spec/services/structure_serializer_spec.rb
+++ b/spec/services/structure_serializer_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe StructureSerializer do
         {
           "type": "#{Cocina::Models::ObjectType.image}",
           "externalIdentifier": "#{druid}",
-          "label": "dood",
           "version": 1,
           "access": {
             "view": "world",
@@ -65,7 +64,6 @@ RSpec.describe StructureSerializer do
         {
           "type": "#{Cocina::Models::ObjectType.image}",
           "externalIdentifier": "#{druid}",
-          "label": "dood",
           "version": 1,
           "access": {
             "view": "world",

--- a/spec/support/collection_method_sender.rb
+++ b/spec/support/collection_method_sender.rb
@@ -10,8 +10,4 @@ class CollectionMethodSender
   def title=(title)
     @cocina_model = @cocina_model.new(description: { title: [{ value: title }] })
   end
-
-  def label=(label)
-    @cocina_model = @cocina_model.new(label:)
-  end
 end

--- a/spec/system/apo_spec.rb
+++ b/spec/system/apo_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe 'Create an apo', :js do
   let(:agreement) { FactoryBot.create_for_repository(:agreement) }
   let!(:preexisting_collection) do
     FactoryBot.create_for_repository(:persisted_collection,
-                                     label: 'Another type of collection label',
                                      title: 'Another type of collection title',
                                      admin_policy_id: agreement.administrative.hasAdminPolicy)
   end

--- a/spec/system/item_registration_spec.rb
+++ b/spec/system/item_registration_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe 'Item registration page', :js do
 
       fill_in CatalogRecordId.label, with: hrid
       fill_in 'Source ID', with: source_id
-      fill_in 'Label', with: 'object title'
+      fill_in 'Title', with: 'object title'
 
       click_button 'Register'
 

--- a/spec/system/item_view_spec.rb
+++ b/spec/system/item_view_spec.rb
@@ -90,7 +90,6 @@ RSpec.describe 'Item view', :js do
           {
             type: Cocina::Models::ObjectType.image.to_s,
             externalIdentifier: 'druid:hj185xx2222',
-            label: 'image integration test miry low_explosive',
             version: 3,
             access: {
               view: 'world',

--- a/spec/system/set_governing_apo_spec.rb
+++ b/spec/system/set_governing_apo_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Set governing APO' do
   let(:version_service) { instance_double(VersionService, open_and_not_assembling?: true, open?: true) }
 
   let(:item) do
-    FactoryBot.create_for_repository(:persisted_item, label: 'Foo', title: 'Test')
+    FactoryBot.create_for_repository(:persisted_item, title: 'Test')
   end
   let(:item_id) { item.externalIdentifier }
   let(:blacklight_config) { CatalogController.blacklight_config }

--- a/spec/system/user_version_view_spec.rb
+++ b/spec/system/user_version_view_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe 'User version view', :js do
       {
         type: Cocina::Models::ObjectType.image.to_s,
         externalIdentifier: 'druid:hj185xx2222',
-        label: title,
         version: 3,
         access: {
           view: 'world',

--- a/spec/system/version_view_spec.rb
+++ b/spec/system/version_view_spec.rb
@@ -56,7 +56,6 @@ RSpec.describe 'Version view', :js do
       {
         type: Cocina::Models::ObjectType.image.to_s,
         externalIdentifier: 'druid:hj185xx2222',
-        label: title,
         version: 3,
         access: {
           view: 'world',

--- a/spec/views/collections/new_modal.html.erb_spec.rb
+++ b/spec/views/collections/new_modal.html.erb_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe 'collections/new_modal' do
     instance_double(
       Cocina::Models::AdminPolicy,
       externalIdentifier: 'druid:zt570qh4444',
-      label: '',
       description: Cocina::Models::Description.new(
         title: [{ value: 'My Title' }],
         purl: 'https://purl.stanford.edu/zt570qh4444'

--- a/spec/views/items/_collection_ui.html.erb_spec.rb
+++ b/spec/views/items/_collection_ui.html.erb_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe 'items/_collection_ui.html.erb' do
     [
       instance_double(
         Cocina::Models::Collection,
-        label: 'Unused',
         externalIdentifier: 'druid:abc123',
         description: Cocina::Models::Description.new(
           title: [{ value: 'But catz are nice too' }], purl: 'https://purl.stanford.edu/abc123'


### PR DESCRIPTION
# Why was this change made?
Fixes #5199 and further removes label references as much as possible.


# How was this change tested?
Tested registration on stage and ran argo-related integration tests. 

