### PR TITLE
Drop nested, valueless notes uploaded via descriptive spreadsheet

### DIFF
--- a/app/services/description_import_filter.rb
+++ b/app/services/description_import_filter.rb
@@ -14,14 +14,16 @@ class DescriptionImportFilter
 
   ATTRIBUTES_TO_FILTER = {
     contributor: :remove_contributors_without_value,
-    date: :remove_date_without_value,
-    digitalLocation: :remove_digital_location_without_value,
-    event: :remove_event_without_value,
-    form: :remove_form_without_value,
-    identifier: :remove_identifiers_without_value,
-    language: :remove_language_without_value,
-    note: :remove_note_without_value,
-    subject: :remove_subject_without_value
+    date: :remove_dates_without_value,
+    digitalLocation: :remove_descriptive_values_without_value,
+    event: :remove_events_without_value,
+    form: :remove_descriptive_values_without_value,
+    identifier: :remove_descriptive_values_without_value,
+    language: :remove_languages_without_value,
+    name: :remove_descriptive_values_without_value,
+    note: :remove_notes_without_value,
+    structuredValue: :remove_descriptive_values_without_value,
+    subject: :remove_descriptive_values_without_value
   }.freeze
 
   MODELS_WITH_NESTED_ATTRIBUTES = {
@@ -32,6 +34,7 @@ class DescriptionImportFilter
     event: Cocina::Models::Event,
     form: Cocina::Models::DescriptiveValue,
     geographic: Cocina::Models::DescriptiveGeographicMetadata,
+    name: Cocina::Models::DescriptiveValue,
     relatedResource: Cocina::Models::RelatedResource,
     structuredValue: Cocina::Models::DescriptiveValue,
     subject: Cocina::Models::DescriptiveValue,
@@ -60,56 +63,29 @@ class DescriptionImportFilter
 
   private
 
-  def remove_digital_location_without_value(digital_locations)
-    Array(digital_locations).delete_if { !descriptive_value_sufficient?(it) }
+  def remove_descriptive_values_without_value(descriptive_values)
+    Array(descriptive_values).delete_if { !descriptive_value_sufficient?(it) }
   end
 
-  def remove_note_without_value(notes)
+  def remove_notes_without_value(notes)
     Array(notes).delete_if { !note_sufficient?(it) }
   end
 
   def remove_contributors_without_value(contributors)
-    Array(contributors).delete_if do |contributor|
-      contributor[:name].nil? && contributor[:identifier].blank? && contributor[:valueAt].blank?
-    end
+    Array(contributors).delete_if { !contributor_sufficient?(it) }
   end
 
-  def remove_identifiers_without_value(identifiers)
-    Array(identifiers).delete_if { !descriptive_value_sufficient?(it) }
-  end
-
-  def remove_form_without_value(forms)
-    Array(forms).delete_if { !descriptive_value_sufficient?(it) }
-  end
-
-  def remove_subject_without_value(subjects)
-    Array(subjects).delete_if { !descriptive_value_sufficient?(it) }
-  end
-
-  def remove_event_without_value(events)
+  def remove_events_without_value(events)
     Array(events).delete_if { !event_sufficient?(it) }
   end
 
-  def remove_language_without_value(languages)
+  def remove_languages_without_value(languages)
     Array(languages).delete_if { !language_sufficient?(it) }
   end
 
   # @param [Array<Hash>] dates an array of hashes that each represent a DescriptiveValue.
-  def remove_date_without_value(dates)
+  def remove_dates_without_value(dates)
     Array(dates).delete_if { !descriptive_value_sufficient?(it) }
-  end
-
-  # Ignore Language that is just "type" or "source"
-  def language_sufficient?(descriptive_value)
-    %i[value code uri note script valueAt structuredValue parallelValue groupedValue].any? do |key|
-      descriptive_value[key].present?
-    end
-  end
-
-  def note_sufficient?(descriptive_value)
-    %i[value valueAt structuredValue parallelValue groupedValue].any? do |key|
-      descriptive_value[key].present?
-    end
   end
 
   # Ignore DescriptiveValue that is just "type" or "source"
@@ -119,10 +95,29 @@ class DescriptionImportFilter
     end
   end
 
+  def note_sufficient?(note)
+    %i[value valueAt structuredValue parallelValue groupedValue].any? do |key|
+      note[key].present?
+    end
+  end
+
+  def contributor_sufficient?(contributor)
+    %i[identifier name valueAt].any? do |key|
+      contributor[key].present?
+    end
+  end
+
+  # Ignore Language that is just "type" or "source"
+  def language_sufficient?(language)
+    %i[value code uri note script valueAt structuredValue parallelValue groupedValue].any? do |key|
+      language[key].present?
+    end
+  end
+
   # Ignore Event that is just "type"
-  def event_sufficient?(descriptive_value)
+  def event_sufficient?(event)
     %i[date contributor location identifier note structuredValue].any? do |key|
-      descriptive_value[key].present?
+      event[key].present?
     end
   end
 end

--- a/app/services/description_import_filter.rb
+++ b/app/services/description_import_filter.rb
@@ -8,6 +8,7 @@ class DescriptionImportFilter
   # @raises Cocina::Models::ValidationError
   def self.filter(compacted_params)
     new.filter(compacted_params)
+
     Cocina::Models::Description.new(compacted_params)
   end
 
@@ -28,15 +29,12 @@ class DescriptionImportFilter
     event: Cocina::Models::Event,
     geographic: Cocina::Models::DescriptiveGeographicMetadata,
     adminMetadata: Cocina::Models::DescriptiveAdminMetadata,
-    access: Cocina::Models::DescriptiveAccessMetadata
+    access: Cocina::Models::DescriptiveAccessMetadata,
+    form: Cocina::Models::DescriptiveValue
   }.freeze
 
-  # recursive, breadth first search for incomplete nodes
+  # recursive, depth first search for incomplete nodes
   def filter(compacted_params, model: Cocina::Models::Description)
-    ATTRIBUTES_TO_FILTER.each do |attribute, method|
-      send(method, compacted_params[attribute]) if model.attribute_names.include?(attribute)
-    end
-
     MODELS_WITH_NESTED_ATTRIBUTES.each do |attribute, model|
       case compacted_params[attribute]
       when Hash
@@ -44,6 +42,12 @@ class DescriptionImportFilter
       when Array
         compacted_params[attribute].each { |attributes| filter(attributes, model:) }
       end
+    end
+
+    ATTRIBUTES_TO_FILTER.each do |attribute, method|
+      next unless model.attribute_names.include?(attribute)
+
+      send(method, compacted_params[attribute])
     end
 
     compacted_params
@@ -56,7 +60,7 @@ class DescriptionImportFilter
   end
 
   def remove_note_without_value(notes)
-    Array(notes).delete_if { !descriptive_value_sufficient?(it) }
+    Array(notes).delete_if { !note_sufficient?(it) }
   end
 
   def remove_contributors_without_value(contributors)
@@ -70,7 +74,6 @@ class DescriptionImportFilter
   end
 
   def remove_form_without_value(forms)
-    Array(forms).each { |form| remove_note_without_value(form[:note]) }
     Array(forms).delete_if { !descriptive_value_sufficient?(it) }
   end
 
@@ -86,6 +89,11 @@ class DescriptionImportFilter
     Array(languages).delete_if { !language_sufficient?(it) }
   end
 
+  # @param [Array<Hash>] dates an array of hashes that each represent a DescriptiveValue.
+  def remove_date_without_value(dates)
+    Array(dates).delete_if { !descriptive_value_sufficient?(it) }
+  end
+
   # Ignore Language that is just "type" or "source"
   def language_sufficient?(descriptive_value)
     %i[value code uri note script valueAt structuredValue parallelValue groupedValue].any? do |key|
@@ -93,10 +101,12 @@ class DescriptionImportFilter
     end
   end
 
-  # @param [Array<Hash>] dates an array of hashes that each represent a DescriptiveValue.
-  def remove_date_without_value(dates)
-    Array(dates).delete_if { !descriptive_value_sufficient?(it) }
+  def note_sufficient?(descriptive_value)
+    %i[value valueAt structuredValue parallelValue groupedValue].any? do |key|
+      descriptive_value[key].present?
+    end
   end
+
 
   # Ignore DescriptiveValue that is just "type" or "source"
   def descriptive_value_sufficient?(descriptive_value)

--- a/app/services/description_import_filter.rb
+++ b/app/services/description_import_filter.rb
@@ -13,24 +13,29 @@ class DescriptionImportFilter
   end
 
   ATTRIBUTES_TO_FILTER = {
-    digitalLocation: :remove_digital_location_without_value,
-    note: :remove_note_without_value,
     contributor: :remove_contributors_without_value,
+    date: :remove_date_without_value,
+    digitalLocation: :remove_digital_location_without_value,
+    event: :remove_event_without_value,
     form: :remove_form_without_value,
     identifier: :remove_identifiers_without_value,
     language: :remove_language_without_value,
-    date: :remove_date_without_value,
-    subject: :remove_subject_without_value,
-    event: :remove_event_without_value
+    note: :remove_note_without_value,
+    subject: :remove_subject_without_value
   }.freeze
 
   MODELS_WITH_NESTED_ATTRIBUTES = {
-    relatedResource: Cocina::Models::RelatedResource,
-    event: Cocina::Models::Event,
-    geographic: Cocina::Models::DescriptiveGeographicMetadata,
-    adminMetadata: Cocina::Models::DescriptiveAdminMetadata,
     access: Cocina::Models::DescriptiveAccessMetadata,
-    form: Cocina::Models::DescriptiveValue
+    adminMetadata: Cocina::Models::DescriptiveAdminMetadata,
+    contributor: Cocina::Models::Contributor,
+    date: Cocina::Models::DescriptiveValue,
+    event: Cocina::Models::Event,
+    form: Cocina::Models::DescriptiveValue,
+    geographic: Cocina::Models::DescriptiveGeographicMetadata,
+    relatedResource: Cocina::Models::RelatedResource,
+    structuredValue: Cocina::Models::DescriptiveValue,
+    subject: Cocina::Models::DescriptiveValue,
+    title: Cocina::Models::DescriptiveValue
   }.freeze
 
   # recursive, depth first search for incomplete nodes
@@ -50,7 +55,7 @@ class DescriptionImportFilter
       send(method, compacted_params[attribute])
     end
 
-    compacted_params
+    compacted_params.compact_blank!
   end
 
   private
@@ -106,7 +111,6 @@ class DescriptionImportFilter
       descriptive_value[key].present?
     end
   end
-
 
   # Ignore DescriptiveValue that is just "type" or "source"
   def descriptive_value_sufficient?(descriptive_value)

--- a/spec/services/description_import_spec.rb
+++ b/spec/services/description_import_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe DescriptionImport do
           }],
           "contributor": [{
             "name": [{
-              "structuredValue": [{#{"\t\t\t\t\t\t"}
+              "structuredValue": [{
                 "value": "Harvey, Robert Gibson",
                 "type": "name"
               }, {
@@ -43,13 +43,13 @@ RSpec.describe DescriptionImport do
             "type": "person",
             "status": "primary"
           }],
-          "event": [{#{"\t\t\t\t"}
-            "location": [{#{"\t\t\t\t\t"}
+          "event": [{
+            "location": [{
               "code": "xx",
               "source": {
                 "code": "marccountry"
               }
-            }],#{"\t\t\t\t"}
+            }],
             "note": [{
               "value": "monographic",
               "type": "issuance",
@@ -125,7 +125,7 @@ RSpec.describe DescriptionImport do
                 }]
               }],
               "type": "organization"
-            }]#{"\t\t\t\t"}
+            }]
           }],
           "adminMetadata": {
             "contributor": [{
@@ -761,8 +761,8 @@ RSpec.describe DescriptionImport do
         CSV
       end
 
-      it 'rejects the item' do
-        expect(updated).to be_failure
+      it 'drops the access node' do
+        expect(updated.value!.access).to be_nil
       end
     end
   end
@@ -949,6 +949,90 @@ RSpec.describe DescriptionImport do
         expect(updated.value!.note).to be_empty
       end
     end
+
+    context 'when note nested under access has no value"' do
+      let(:csv_data) do
+        <<~CSV
+          druid,source_id,title1.value,purl,access.digitalLocation1.value,access.note1.code,access.note1.uri,access.note1.displayLabel
+          druid:bc123df4567,desc:no-title-type,A title,https://purl/bc123df4567,Searchworks,foo,https://example.org,Best Note Label
+        CSV
+      end
+
+      it 'drops the nested note and keeps the access' do
+        expect(updated.value!.access.note).to be_empty
+      end
+    end
+
+    context 'when note nested under adminMetadata has no value"' do
+      let(:csv_data) do
+        <<~CSV
+          druid,source_id,title1.value,purl,adminMetadata.note1.type,adminMetadata.note1.code,adminMetadata.note1.uri,adminMetadata.note1.displayLabel,adminMetadata.identifier1.value
+          druid:bc123df4567,desc:no-title-type,A title,https://purl/bc123df4567,Searchworks,foo,https://example.org,Best Note Label,bc123df4567
+        CSV
+      end
+
+      it 'drops the nested note and keeps the adminMetadata' do
+        expect(updated.value!.adminMetadata.note).to be_empty
+      end
+    end
+
+    # NOTE: These are properties that are valid with a single value-ful identifier
+    %w[contributor event].each do |note_parent|
+      context "when note nested under #{note_parent} has no value" do
+        let(:csv_data) do
+          <<~CSV
+            druid,source_id,title1.value,purl,#{note_parent}1.identifier1.value,#{note_parent}1.note1.code,#{note_parent}1.note1.uri,#{note_parent}1.note1.displayLabel
+            druid:bc123df4567,desc:no-title-type,A title,https://purl/bc123df4567,ParentID,foo,https://example.org,Best Note Label
+          CSV
+        end
+
+        it "drops the nested note and keeps the #{note_parent}" do
+          expect(updated.value!.public_send(note_parent).first.note).to be_empty
+        end
+      end
+    end
+
+    # NOTE: These are properties that are valid with a single basic value
+    %w[subject title].each do |note_parent|
+      context "when note nested under #{note_parent} has no value" do
+        let(:csv_data) do
+          <<~CSV
+            druid,source_id,title1.value,purl,#{note_parent}1.value,#{note_parent}1.note1.code,#{note_parent}1.note1.uri,#{note_parent}1.note1.displayLabel
+            druid:bc123df4567,desc:no-title-type,A title,https://purl/bc123df4567,Parent Value,foo,https://example.org,Best Note Label
+          CSV
+        end
+
+        it "drops the nested note and keeps the #{note_parent}" do
+          expect(updated.value!.public_send(note_parent).first.note).to be_empty
+        end
+      end
+    end
+
+    context 'when note nested under event.date has no value"' do
+      let(:csv_data) do
+        <<~CSV
+          druid,source_id,title1.value,purl,event1.date1.value,event1.date1.type,event1.date1.note1.type
+          druid:bc123df4567,desc:no-title-type,A title,https://purl/bc123df4567,2022-01-05,creation,start
+        CSV
+      end
+
+      it 'drops the nested note and keeps the event.date' do
+        expect(updated.value!.event.first.date.first.note).to be_empty
+      end
+    end
+
+    context 'when note nested under subject.structuredValue has no value"' do
+      let(:csv_data) do
+        <<~CSV
+          druid,source_id,title1.value,purl,subject1.structuredValue1.value,subject1.structuredValue1.type,subject1.structuredValue1.note1.uri
+          druid:bc123df4567,desc:no-title-type,A title,https://purl/bc123df4567,7.37939062,Latitude,https://maps.example.org
+        CSV
+      end
+
+      it 'drops the nested note and keeps the event.date' do
+        expect(updated.value!.subject.first.structuredValue.first.note).to be_empty
+      end
+    end
   end
 
   context 'with event property' do
@@ -1027,8 +1111,8 @@ RSpec.describe DescriptionImport do
           CSV
         end
 
-        it 'rejects the item' do
-          expect(updated).to be_failure
+        it 'drops the adminMetadata' do
+          expect(updated.value!.adminMetadata).to be_nil
         end
       end
 

--- a/spec/services/description_import_spec.rb
+++ b/spec/services/description_import_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe DescriptionImport do
     let(:expected) { Cocina::Models::Description.new(expected_hash) }
 
     [nil, 'Someone'].each do |name|
-      context "when role as code (not value), name: '#{name}'" do
+      context "when role has code (not value), name: '#{name}'" do
         let(:csv_data) do
           <<~CSV
             druid,source_id,purl,title1.value,contributor1.name1.value,contributor1.role1.code,contributor1.role1.value
@@ -291,7 +291,7 @@ RSpec.describe DescriptionImport do
         end
       end
 
-      context "when role as value (not code), name: '#{name}'" do
+      context "when role has value (not code), name: '#{name}'" do
         let(:csv_data) do
           <<~CSV
             druid,source_id,purl,title1.value,contributor1.name1.value,contributor1.role1.code,contributor1.role1.value
@@ -312,7 +312,7 @@ RSpec.describe DescriptionImport do
         end
       end
 
-      context "when role as both code and value, name: '#{name}'" do
+      context "when role has both code and value, name: '#{name}'" do
         let(:csv_data) do
           <<~CSV
             druid,source_id,purl,title1.value,contributor1.name1.value,contributor1.role1.code,contributor1.role1.value
@@ -360,6 +360,20 @@ RSpec.describe DescriptionImport do
     end
   end
 
+  context 'with a valueless contributor within adminMetadata' do
+    let(:csv) { CSV.parse(csv_data, headers: true) }
+    let(:csv_data) do
+      <<~CSV
+        druid,source_id,title1.value,purl,adminMetadata.identifier1.value,adminMetadata.contributor1.name1.source.code,adminMetadata.contributor1.type,adminMetadata.contributor1.role1.value
+        druid:bc123df4567,desc:no-title-type,A title,https://purl/bc123df4567,bc123df4567,marcorg,organization,original cataloging agency
+      CSV
+    end
+
+    it 'drops the contributor' do
+      expect(updated.value!.adminMetadata.contributor).to be_empty
+    end
+  end
+
   context 'with a contributor within an event' do
     subject(:contributors) { updated.value!.event.first.contributor }
 
@@ -383,7 +397,7 @@ RSpec.describe DescriptionImport do
     end
 
     context 'when name value is present ("Someone")' do
-      context 'when role as code (not value)' do
+      context 'when role has code (not value)' do
         let(:csv_data) do
           <<~CSV
             druid,source_id,purl,title1.value,event1.contributor1.name1.value,event1.contributor1.role1.code,event1.contributor1.role1.value,event1.note1.value
@@ -399,7 +413,7 @@ RSpec.describe DescriptionImport do
         end
       end
 
-      context 'when role as value (not code)' do
+      context 'when role has value (not code)' do
         let(:csv_data) do
           <<~CSV
             druid,source_id,purl,title1.value,event1.contributor1.name1.value,event1.contributor1.role1.code,event1.contributor1.role1.value,event1.note1.value
@@ -415,7 +429,7 @@ RSpec.describe DescriptionImport do
         end
       end
 
-      context 'when role as both code and value' do
+      context 'when role has both code and value' do
         let(:csv_data) do
           <<~CSV
             druid,source_id,purl,title1.value,event1.contributor1.name1.value,event1.contributor1.role1.code,event1.contributor1.role1.value,event1.note1.value
@@ -1031,6 +1045,19 @@ RSpec.describe DescriptionImport do
 
       it 'drops the nested note and keeps the event.date' do
         expect(updated.value!.subject.first.structuredValue.first.note).to be_empty
+      end
+    end
+
+    context 'when valueless note nested under valueless structuredValue"' do
+      let(:csv_data) do
+        <<~CSV
+          druid,source_id,title1.value,subject1.structuredValue1.note1.type,subject1.structuredValue1.note1.value,purl
+          druid:dt363zr3464,blank:notes,A main title,affiliation,,https://sul-purl-stage.stanford.edu/dt363zr3464
+        CSV
+      end
+
+      it 'drops the entire subject (incl. structuredValue and note)' do
+        expect(updated.value!.subject).to be_empty
       end
     end
   end

--- a/spec/services/description_import_spec.rb
+++ b/spec/services/description_import_spec.rb
@@ -377,7 +377,7 @@ RSpec.describe DescriptionImport do
         CSV
       end
 
-      it 'has the expected value' do
+      it 'drops the contributor' do
         expect(contributors).to be_empty
       end
     end
@@ -800,7 +800,7 @@ RSpec.describe DescriptionImport do
         CSV
       end
 
-      it 'rejects the item' do
+      it 'drops the identifier' do
         expect(updated.value!.identifier).to be_empty
       end
     end
@@ -840,7 +840,7 @@ RSpec.describe DescriptionImport do
         CSV
       end
 
-      it 'rejects the item' do
+      it 'drops the language' do
         expect(updated.value!.language).to be_empty
       end
     end
@@ -904,7 +904,7 @@ RSpec.describe DescriptionImport do
         CSV
       end
 
-      it 'rejects the item' do
+      it 'drops the subject' do
         expect(updated.value!.subject).to be_empty
       end
     end
@@ -945,7 +945,7 @@ RSpec.describe DescriptionImport do
         CSV
       end
 
-      it 'rejects the item' do
+      it 'drops the note' do
         expect(updated.value!.note).to be_empty
       end
     end
@@ -964,7 +964,7 @@ RSpec.describe DescriptionImport do
         CSV
       end
 
-      it 'rejects the item' do
+      it 'drops the event' do
         expect(updated.value!.event).to be_empty
       end
     end
@@ -989,7 +989,7 @@ RSpec.describe DescriptionImport do
         end
       end
 
-      context 'when event date has no value' do
+      context 'when event contains only a valueless date' do
         let(:csv_data) do
           <<~CSV
             druid,source_id,title1.value,purl,event1.date1.value,event1.date1.type
@@ -997,8 +997,8 @@ RSpec.describe DescriptionImport do
           CSV
         end
 
-        it 'rejects the item' do
-          expect(updated).to be_failure
+        it 'drops the event date & the event' do
+          expect(updated.value!.event).to be_empty
         end
       end
 


### PR DESCRIPTION
# Why was this change made?

Fixes #5191 
Fixes #5204 

- **Fix nested date dropping behavior in DescriptionImportFilter**
  - This commit changes description import filtering from a breadth-first approach to a depth-first one, which allows for clearing out a value-less property nested within another value-less property. Before, only the innermost value-less property was dropped, and parents were left alone due to the breadth-first approach. This work should set up the follow-up commit that directly addresses the changes requested in https://github.com/sul-dlss/argo/issues/5191.
- **Drop valueless nested notes and expand filter coverage**
  - Add support for dropping valueless nested notes under access, adminMetadata, contributor, event, subject, title, and structuredValue to ensure only meaningful notes are retained
  - Update MODELS_WITH_NESTED_ATTRIBUTES to include contributor, date, structuredValue, subject, and title for more comprehensive filtering
  - Change filter to use compact_blank! for more aggressive removal of empty attributes, preventing retention of blank hashes or arrays
  - Expand and revise specs to cover new nested note-dropping behavior, verifying that parent nodes are preserved when only the note is valueless
  - Adjust test expectations for access and adminMetadata to reflect new logic of dropping only the empty node rather than rejecting the entire item
- **Drop valueless contributors within `adminMetadata` and drop valueless `structuredValue`s**
  - Consolidate filtering methods for descriptive values to reduce duplication
  - Add filtering for 'name' and update subject, form, identifier, digitalLocation
  - Refactor contributor filtering to use a new helper for sufficiency
  - Add test to ensure valueless adminMetadata contributors are dropped
  - Update spec context descriptions for clarity and consistency
  - Improve maintainability by centralizing sufficiency checks for each type

# How was this change tested?

- [x] CI
- [x] QA/Stage
