### PR TITLE
Refactor DescriptionImportFilter

### DIFF
--- a/app/services/description_import_filter.rb
+++ b/app/services/description_import_filter.rb
@@ -14,7 +14,7 @@ class DescriptionImportFilter
 
   ATTRIBUTES_TO_FILTER = {
     contributor: :remove_empty_contributors,
-    date: :remove_empty_dates,
+    date: :remove_empty_descriptive_values,
     digitalLocation: :remove_empty_descriptive_values,
     event: :remove_empty_events,
     form: :remove_empty_descriptive_values,
@@ -81,11 +81,6 @@ class DescriptionImportFilter
 
   def remove_empty_languages(languages)
     Array(languages).delete_if { !language_sufficient?(it) }
-  end
-
-  # @param [Array<Hash>] dates an array of hashes that each represent a DescriptiveValue.
-  def remove_empty_dates(dates)
-    Array(dates).delete_if { !descriptive_value_sufficient?(it) }
   end
 
   # Ignore DescriptiveValue that is just "type" or "source"

--- a/app/services/description_import_filter.rb
+++ b/app/services/description_import_filter.rb
@@ -13,17 +13,17 @@ class DescriptionImportFilter
   end
 
   ATTRIBUTES_TO_FILTER = {
-    contributor: :remove_contributors_without_value,
-    date: :remove_dates_without_value,
-    digitalLocation: :remove_descriptive_values_without_value,
-    event: :remove_events_without_value,
-    form: :remove_descriptive_values_without_value,
-    identifier: :remove_descriptive_values_without_value,
-    language: :remove_languages_without_value,
-    name: :remove_descriptive_values_without_value,
-    note: :remove_notes_without_value,
-    structuredValue: :remove_descriptive_values_without_value,
-    subject: :remove_descriptive_values_without_value
+    contributor: :remove_empty_contributors,
+    date: :remove_empty_dates,
+    digitalLocation: :remove_empty_descriptive_values,
+    event: :remove_empty_events,
+    form: :remove_empty_descriptive_values,
+    identifier: :remove_empty_descriptive_values,
+    language: :remove_empty_languages,
+    name: :remove_empty_descriptive_values,
+    note: :remove_empty_notes,
+    structuredValue: :remove_empty_descriptive_values,
+    subject: :remove_empty_descriptive_values
   }.freeze
 
   MODELS_WITH_NESTED_ATTRIBUTES = {
@@ -63,28 +63,28 @@ class DescriptionImportFilter
 
   private
 
-  def remove_descriptive_values_without_value(descriptive_values)
+  def remove_empty_descriptive_values(descriptive_values)
     Array(descriptive_values).delete_if { !descriptive_value_sufficient?(it) }
   end
 
-  def remove_notes_without_value(notes)
+  def remove_empty_notes(notes)
     Array(notes).delete_if { !note_sufficient?(it) }
   end
 
-  def remove_contributors_without_value(contributors)
+  def remove_empty_contributors(contributors)
     Array(contributors).delete_if { !contributor_sufficient?(it) }
   end
 
-  def remove_events_without_value(events)
+  def remove_empty_events(events)
     Array(events).delete_if { !event_sufficient?(it) }
   end
 
-  def remove_languages_without_value(languages)
+  def remove_empty_languages(languages)
     Array(languages).delete_if { !language_sufficient?(it) }
   end
 
   # @param [Array<Hash>] dates an array of hashes that each represent a DescriptiveValue.
-  def remove_dates_without_value(dates)
+  def remove_empty_dates(dates)
     Array(dates).delete_if { !descriptive_value_sufficient?(it) }
   end
 

--- a/app/services/description_import_filter.rb
+++ b/app/services/description_import_filter.rb
@@ -13,17 +13,17 @@ class DescriptionImportFilter
   end
 
   ATTRIBUTES_TO_FILTER = {
-    contributor: :remove_empty_contributors,
-    date: :remove_empty_descriptive_values,
-    digitalLocation: :remove_empty_descriptive_values,
-    event: :remove_empty_events,
-    form: :remove_empty_descriptive_values,
-    identifier: :remove_empty_descriptive_values,
-    language: :remove_empty_languages,
-    name: :remove_empty_descriptive_values,
-    note: :remove_empty_notes,
-    structuredValue: :remove_empty_descriptive_values,
-    subject: :remove_empty_descriptive_values
+    contributor: :contributor_sufficient?,
+    date: :descriptive_value_sufficient?,
+    digitalLocation: :descriptive_value_sufficient?,
+    event: :event_sufficient?,
+    form: :descriptive_value_sufficient?,
+    identifier: :descriptive_value_sufficient?,
+    language: :language_sufficient?,
+    name: :descriptive_value_sufficient?,
+    note: :note_sufficient?,
+    structuredValue: :descriptive_value_sufficient?,
+    subject: :descriptive_value_sufficient?
   }.freeze
 
   MODELS_WITH_NESTED_ATTRIBUTES = {
@@ -41,8 +41,8 @@ class DescriptionImportFilter
     title: Cocina::Models::DescriptiveValue
   }.freeze
 
-  # recursive, depth first search for incomplete nodes
-  def filter(compacted_params, model: Cocina::Models::Description)
+  # Recursive, depth-first search for incomplete nodes
+  def filter(compacted_params, model: Cocina::Models::Description) # rubocop:disable Metrics/CyclomaticComplexity
     MODELS_WITH_NESTED_ATTRIBUTES.each do |attribute, model|
       case compacted_params[attribute]
       when Hash
@@ -53,9 +53,13 @@ class DescriptionImportFilter
     end
 
     ATTRIBUTES_TO_FILTER.each do |attribute, method|
-      next unless model.attribute_names.include?(attribute)
+      # Short-circuit if the attribute to filter is not present in the model class specified in MODELS_WITH_NESTED_ATTRIBUTES
+      next if model.attribute_names.exclude?(attribute)
 
-      send(method, compacted_params[attribute])
+      # Short-circuit if the attribute to filter is blank
+      next if (values = compacted_params[attribute]).blank?
+
+      Array(values).delete_if { |value| !send(method, value) }
     end
 
     compacted_params.compact_blank!
@@ -63,27 +67,6 @@ class DescriptionImportFilter
 
   private
 
-  def remove_empty_descriptive_values(descriptive_values)
-    Array(descriptive_values).delete_if { !descriptive_value_sufficient?(it) }
-  end
-
-  def remove_empty_notes(notes)
-    Array(notes).delete_if { !note_sufficient?(it) }
-  end
-
-  def remove_empty_contributors(contributors)
-    Array(contributors).delete_if { !contributor_sufficient?(it) }
-  end
-
-  def remove_empty_events(events)
-    Array(events).delete_if { !event_sufficient?(it) }
-  end
-
-  def remove_empty_languages(languages)
-    Array(languages).delete_if { !language_sufficient?(it) }
-  end
-
-  # Ignore DescriptiveValue that is just "type" or "source"
   def descriptive_value_sufficient?(descriptive_value)
     %i[value code uri identifier note valueAt structuredValue parallelValue groupedValue].any? do |key|
       descriptive_value[key].present?
@@ -102,7 +85,6 @@ class DescriptionImportFilter
     end
   end
 
-  # Ignore Language that is just "type" or "source"
   def language_sufficient?(language)
     %i[value code uri note script valueAt structuredValue parallelValue groupedValue].any? do |key|
       language[key].present?


### PR DESCRIPTION
# Why was this change made?

As I was working on #5205, I made note of various rough edges or head-scratchers as I went along. Now that #5205 has been shipped, I revisited this class to perform a series of refactors. I would recommend reviewing this commit-by-commit to see the progression. Also, if some of these commits make more sense than others, I'm happy to cherry-pick the stuff we like and ditch the stuff we don't.

## Includes

- **Rename empty property removal methods in DescriptionImportFilter**
- **Remove date-specific handling in DIF class. Handle dates as descriptive values.**
- **Remove one layer of abstraction between attrs and their removal**

# How was this change tested?

CI
