### PR TITLE
derive purl when doing metadata descriptive upload

### DIFF
--- a/app/controllers/descriptives_controller.rb
+++ b/app/controllers/descriptives_controller.rb
@@ -20,7 +20,7 @@ class DescriptivesController < ApplicationController
     csv = CSV.parse(CsvUploadNormalizer.read(params[:data].tempfile), headers: true)
     validator = DescriptionValidator.new(csv)
     if validator.valid?
-      DescriptionImport.import(csv_row: csv.first)
+      DescriptionImport.import(csv_row: csv.first, druid: @cocina.externalIdentifier)
                        .bind { |description| CocinaValidator.validate_and_save(@cocina, description:) }
                        .either(
                          ->(_updated) { display_success },

--- a/app/jobs/descriptive_metadata_import_job.rb
+++ b/app/jobs/descriptive_metadata_import_job.rb
@@ -5,7 +5,7 @@ class DescriptiveMetadataImportJob < BulkActionCsvJob
     def perform
       return unless check_update_ability?
 
-      import_result = DescriptionImport.import(csv_row: row)
+      import_result = DescriptionImport.import(csv_row: row, druid: cocina_object.externalIdentifier)
       return failure!(message: import_result.failure.to_sentence) if import_result.failure?
 
       description = import_result.value!

--- a/app/jobs/validate_cocina_descriptive_job.rb
+++ b/app/jobs/validate_cocina_descriptive_job.rb
@@ -3,7 +3,7 @@
 class ValidateCocinaDescriptiveJob < BulkActionCsvJob
   class ValidateCocinaDescriptiveJobItem < BulkActionCsvJobItem
     def perform
-      import_result = DescriptionImport.import(csv_row: row)
+      import_result = DescriptionImport.import(csv_row: row, druid: cocina_object.externalIdentifier)
       return failure!(message: import_result.failure) if import_result.failure?
 
       description = import_result.value!

--- a/app/services/description_import.rb
+++ b/app/services/description_import.rb
@@ -6,12 +6,13 @@ class DescriptionImport
   class_attribute :permitted_types, default: Cocina::Models::Validators::DescriptionTypesVisitorValidator.new
                                                                                                          .send(:types_yaml).values.flatten.pluck('value')
 
-  def self.import(csv_row:)
-    new(csv_row:).import
+  def self.import(csv_row:, druid:)
+    new(csv_row:, druid:).import
   end
 
-  def initialize(csv_row:)
+  def initialize(csv_row:, druid:)
     @csv_row = csv_row
+    @druid = druid
   end
 
   def import
@@ -25,6 +26,8 @@ class DescriptionImport
     headers.each do |address|
       visit(params, split_address(address), @csv_row[address]) if @csv_row[address]
     end
+
+    params[:purl] = Cocina::Models::Mapping::Purl.for(druid: @druid)
 
     Success(DescriptionImportFilter.filter(compact_params(params)))
   rescue Cocina::Models::ValidationError => e

--- a/spec/jobs/descriptive_metadata_import_job_spec.rb
+++ b/spec/jobs/descriptive_metadata_import_job_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe DescriptiveMetadataImportJob do
   subject(:job) { described_class.new(bulk_action.id, csv_file:) }
 
   let(:druid) { 'druid:bc123df4567' }
+  let(:purl) { "#{Settings.purl_url}/#{druid.delete_prefix('druid:')}" }
   let(:cocina_object) do
     object = build(:dro_with_metadata, id: druid)
     object.new(description: object.description.new(purl:))
   end
-
   let(:expected_cocina_object) do
     cocina_object.new(description: cocina_object.description.new(title: [{ value: 'new title 1' }], purl:))
   end
@@ -27,7 +27,6 @@ RSpec.describe DescriptiveMetadataImportJob do
     end
   end
 
-  let(:purl) { Cocina::Models::Mapping::Purl.for(druid:) }
   let(:csv_file) do
     [
       'druid,source_id,title1:value',

--- a/spec/jobs/descriptive_metadata_import_job_spec.rb
+++ b/spec/jobs/descriptive_metadata_import_job_spec.rb
@@ -6,10 +6,13 @@ RSpec.describe DescriptiveMetadataImportJob do
   subject(:job) { described_class.new(bulk_action.id, csv_file:) }
 
   let(:druid) { 'druid:bc123df4567' }
-  let(:cocina_object) { build(:dro_with_metadata, id: druid) }
+  let(:cocina_object) do
+    object = build(:dro_with_metadata, id: druid)
+    object.new(description: object.description.new(purl:))
+  end
 
   let(:expected_cocina_object) do
-    cocina_object.new(description: cocina_object.description.new(title: [{ value: 'new title 1' }], purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"))
+    cocina_object.new(description: cocina_object.description.new(title: [{ value: 'new title 1' }], purl:))
   end
 
   let(:bulk_action) { create(:bulk_action) }
@@ -24,11 +27,11 @@ RSpec.describe DescriptiveMetadataImportJob do
     end
   end
 
-  let(:purl) { "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}" }
+  let(:purl) { Cocina::Models::Mapping::Purl.for(druid:) }
   let(:csv_file) do
     [
-      'druid,source_id,title1:value,purl',
-      [druid, cocina_object.identification.sourceId, 'new title 1', purl].join(',')
+      'druid,source_id,title1:value',
+      [druid, cocina_object.identification.sourceId, 'new title 1'].join(',')
     ].join("\n")
   end
 
@@ -75,8 +78,8 @@ RSpec.describe DescriptiveMetadataImportJob do
   context 'when validation fails' do
     let(:csv_file) do
       [
-        'druid,source_id,title1.structuredValue1.value,purl',
-        [druid, cocina_object.identification.sourceId, 'new title 1', purl].join(',')
+        'druid,source_id,title1.structuredValue1.value',
+        [druid, cocina_object.identification.sourceId, 'new title 1'].join(',')
       ].join("\n")
     end
 
@@ -118,8 +121,8 @@ RSpec.describe DescriptiveMetadataImportJob do
   context 'when unchanged' do
     let(:csv_file) do
       [
-        'druid,source_id,title1:value,purl',
-        [druid, cocina_object.identification.sourceId, 'factory DRO title', purl].join(',')
+        'druid,source_id,title1:value',
+        [druid, cocina_object.identification.sourceId, 'factory DRO title'].join(',')
       ].join("\n")
     end
 

--- a/spec/jobs/validate_cocina_descriptive_job_spec.rb
+++ b/spec/jobs/validate_cocina_descriptive_job_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe ValidateCocinaDescriptiveJob do
 
   let(:csv_file) do
     [
-      'druid,source_id,title1:value,purl',
-      [cocina_object.externalIdentifier, cocina_object.identification.sourceId, 'new title 1', 'https://purl/bb111cc2222'].join(',')
+      'druid,source_id,title1:value',
+      [cocina_object.externalIdentifier, cocina_object.identification.sourceId, 'new title 1'].join(',')
     ].join("\n")
   end
 
@@ -42,8 +42,8 @@ RSpec.describe ValidateCocinaDescriptiveJob do
   context 'when invalid cocina metadata' do
     let(:csv_file) do
       [
-        'druid,source_id,title1.structuredValue1.value,title1.structuredValue1.type,purl',
-        [cocina_object.externalIdentifier, cocina_object.identification.sourceId, 'new title 1', 'new title 1', 'https://purl/bb111cc2222'].join(',')
+        'druid,source_id,title1.structuredValue1.value,title1.structuredValue1.type',
+        [cocina_object.externalIdentifier, cocina_object.identification.sourceId, 'new title 1', 'new title 1'].join(',')
       ].join("\n")
     end
 

--- a/spec/requests/upload_descriptive_csv_spec.rb
+++ b/spec/requests/upload_descriptive_csv_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe 'Upload the descriptive CSV' do
     context 'when import was successful' do
       it 'updates the descriptive' do
         put "/items/#{druid}/descriptive", params: { data: file }
+        expect(DescriptionImport).to have_received(:import).with(csv_row: instance_of(CSV::Row), druid:)
         expect(object_client).to have_received(:update)
         expect(response).to have_http_status(:see_other)
       end

--- a/spec/services/description_import_spec.rb
+++ b/spec/services/description_import_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe DescriptionImport do
 
   let(:csv_row) { csv.first }
   let(:druid) { csv_row['druid'].presence || 'druid:bc123df4567' }
-  let(:purl) { Cocina::Models::Mapping::Purl.for(druid:) }
+  let(:purl) { "#{Settings.purl_url}/#{druid.delete_prefix('druid:')}" }
 
   context 'with a druid' do
     let(:druid) { 'druid:bc123df4567' }
@@ -16,7 +16,7 @@ RSpec.describe DescriptionImport do
     it 'derives the purl from the druid' do
       result = described_class.import(csv_row: csv.first, druid:)
 
-      expect(result.value!.purl).to eq Cocina::Models::Mapping::Purl.for(druid:)
+      expect(result.value!.purl).to eq purl
     end
 
     context 'when the spreadsheet contains a purl' do

--- a/spec/services/description_import_spec.rb
+++ b/spec/services/description_import_spec.rb
@@ -3,7 +3,32 @@
 require 'rails_helper'
 
 RSpec.describe DescriptionImport do
-  subject(:updated) { described_class.import(csv_row: csv.first) }
+  subject(:updated) { described_class.import(csv_row:, druid:) }
+
+  let(:csv_row) { csv.first }
+  let(:druid) { csv_row['druid'].presence || 'druid:bc123df4567' }
+  let(:purl) { Cocina::Models::Mapping::Purl.for(druid:) }
+
+  context 'with a druid' do
+    let(:druid) { 'druid:bc123df4567' }
+    let(:csv) { CSV.parse("title1.value\nA title\n", headers: true) }
+
+    it 'derives the purl from the druid' do
+      result = described_class.import(csv_row: csv.first, druid:)
+
+      expect(result.value!.purl).to eq Cocina::Models::Mapping::Purl.for(druid:)
+    end
+
+    context 'when the spreadsheet contains a purl' do
+      let(:csv) { CSV.parse("title1.value,purl\nA title,https://example.com/wrong\n", headers: true) }
+
+      it 'uses the purl derived from the druid' do
+        result = described_class.import(csv_row: csv.first, druid:)
+
+        expect(result.value!.purl).to eq Cocina::Models::Mapping::Purl.for(druid:)
+      end
+    end
+  end
 
   context 'with a valid csv' do
     let(:csv) do
@@ -209,7 +234,7 @@ RSpec.describe DescriptionImport do
     end
 
     let(:expected) do
-      Cocina::Models::Description.new(title: [{ value: 'my title' }], purl: 'https://purl')
+      Cocina::Models::Description.new(title: [{ value: 'my title' }], purl:)
     end
 
     it 'ignores the empty field' do
@@ -232,7 +257,7 @@ RSpec.describe DescriptionImport do
     let(:expected) do
       Cocina::Models::Description.new(
         title: [{ value: 'Title 2' }],
-        purl: 'https://purl/jr825qh8124',
+        purl:,
         contributor: [
           { name: [
             { parallelValue: [
@@ -262,7 +287,7 @@ RSpec.describe DescriptionImport do
     let(:expected_hash) do
       {
         title: [{ value: 'my great contributor' }],
-        purl: 'https://purl/jr825qh8124'
+        purl:
       }.tap do |h|
         h[:contributor] = [expected_contributor] if expected_contributor
       end
@@ -508,7 +533,7 @@ RSpec.describe DescriptionImport do
       let(:expected_hash) do
         {
           title: [{ value: title }],
-          purl: 'https://purl/jr825qh8124'
+          purl:
         }.tap do |h|
           h[:form] = [expected_form] if expected_form
         end
@@ -681,7 +706,7 @@ RSpec.describe DescriptionImport do
         let(:expected_hash) do
           {
             title: [{ value: title }],
-            purl: 'https://purl/jr825qh8124'
+            purl:
           }
         end
 
@@ -695,7 +720,7 @@ RSpec.describe DescriptionImport do
       let(:expected_hash) do
         {
           title: [{ value: title }],
-          purl: 'https://purl/jr825qh8124'
+          purl:
         }.tap do |h|
           form_value =
             if expected_form

--- a/spec/system/upload_descriptive_metadata_spec.rb
+++ b/spec/system/upload_descriptive_metadata_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Descriptive metadata spreadsheet upload', :js do
 
   context 'with a csv file' do
     let(:csv) do
-      "title1.value\nmy title\n"
+      "title1.value,purl\nmy title,https://purl.stanford.edu/#{Druid.new(item.externalIdentifier).without_namespace}\n"
     end
     let(:file) do
       Tempfile.new(%w[upload .csv]).tap do |file|
@@ -55,6 +55,8 @@ RSpec.describe 'Descriptive metadata spreadsheet upload', :js do
         # Write our data into the sheet
         worksheet.write('A1', 'title1.value')
         worksheet.write('A2', 'my title from excel')
+        worksheet.write('B1', 'purl')
+        worksheet.write('B2', "https://purl.stanford.edu/#{Druid.new(item.externalIdentifier).without_namespace}")
 
         # Close - require to avoid file curruption
         workbook.close

--- a/spec/system/upload_descriptive_metadata_spec.rb
+++ b/spec/system/upload_descriptive_metadata_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Descriptive metadata spreadsheet upload', :js do
 
   context 'with a csv file' do
     let(:csv) do
-      "title1.value,purl\nmy title,https://purl.stanford.edu/#{Druid.new(item.externalIdentifier).without_namespace}\n"
+      "title1.value\nmy title\n"
     end
     let(:file) do
       Tempfile.new(%w[upload .csv]).tap do |file|
@@ -55,8 +55,6 @@ RSpec.describe 'Descriptive metadata spreadsheet upload', :js do
         # Write our data into the sheet
         worksheet.write('A1', 'title1.value')
         worksheet.write('A2', 'my title from excel')
-        worksheet.write('B1', 'purl')
-        worksheet.write('B2', "https://purl.stanford.edu/#{Druid.new(item.externalIdentifier).without_namespace}")
 
         # Close - require to avoid file curruption
         workbook.close


### PR DESCRIPTION
# Why was this change made?

The user shouldn't need to have a `purl` column when uploading a descriptive metadata spreadsheet, this column can be derived from the druid, which is part of the cocina_object, which we have when updating metadata.

see https://stanfordlib.slack.com/archives/C5RGK4PKM/p1784932056509249

This change passes in the druid to the descriptive import class, and the druid is dervied from the cocina_object, which is available in the job that uses the import class.

HOLD for testing on stage with actual data

See also https://github.com/sul-dlss/argo-b3/pull/234

Note: codex assisted code and spec updates


# How was this change tested?

Specs

