### PR TITLE
make cocina-models a top level dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gem 'barby' # Barby creates barcodes. Used in generating tracksheets
 gem 'bootsnap', require: false # Reduces boot times through caching; required in config/boot.rb
 gem 'cancancan' # authorization
+gem 'cocina-models'
 gem 'coderay' # Pretty format for XML
 gem 'config'
 gem 'cssbundling-rails'
@@ -80,7 +81,6 @@ end
 group :test do
   gem 'capybara'
   gem 'capybara-screenshot'
-  gem 'cocina-models', '~> 0.69' # only need RSpec matchers here; don't need to pin to patch level
   gem 'rspec_junit_formatter' # used by CircleCI to format test results
   gem 'selenium-webdriver' # for js testing
   gem 'simplecov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
       rails (>= 7.1, < 9)
     bootsnap (1.25.0)
       msgpack (~> 1.5)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)
@@ -692,7 +692,7 @@ DEPENDENCIES
   capistrano-rails
   capybara
   capybara-screenshot
-  cocina-models (~> 0.69)
+  cocina-models
   cocina_display
   coderay
   config


### PR DESCRIPTION
# Why was this change made?

Don't rely on it on coming from other dependencies

See also https://github.com/sul-dlss/argo-b3/pull/328
