### PR TITLE
Index object type APO instead of adminPolicy

### DIFF
--- a/app/components/document_component.rb
+++ b/app/components/document_component.rb
@@ -15,7 +15,7 @@ class DocumentComponent < Blacklight::DocumentComponent
       Show::CollectionComponent
     when 'agreement'
       Show::AgreementComponent
-    when 'adminPolicy'
+    when 'APO'
       Show::AdminPolicyComponent
     else
       Show::ItemComponent

--- a/app/components/show/agreement/overview_component.html.erb
+++ b/app/components/show/agreement/overview_component.html.erb
@@ -9,7 +9,7 @@
       </tr>
 
       <tr>
-        <th class="col-3" scope="row">Admin policy</th>
+        <th class="col-3" scope="row">APO</th>
         <td>
           <%= render Show::GovernedByComponent.new(document: @solr_document, presenter: @presenter) %>
         </td>

--- a/app/components/show/collection/overview_component.html.erb
+++ b/app/components/show/collection/overview_component.html.erb
@@ -9,7 +9,7 @@
       </tr>
 
       <tr>
-        <th class="col-3" scope="row">Admin policy</th>
+        <th class="col-3" scope="row">APO</th>
         <td>
           <%= render Show::GovernedByComponent.new(document: @solr_document, presenter: @presenter) %>
         </td>

--- a/app/components/show/item/overview_component.html.erb
+++ b/app/components/show/item/overview_component.html.erb
@@ -9,7 +9,7 @@
       </tr>
 
       <tr>
-        <th class="col-3" scope="row">Admin policy</th>
+        <th class="col-3" scope="row">APO</th>
         <td>
           <%= render Show::GovernedByComponent.new(document: @solr_document, presenter: @presenter) %>
         </td>

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -64,7 +64,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'id', label: 'DRUID'
     config.add_index_field SolrDocument::FIELD_OBJECT_TYPE, label: 'Object Type'
     config.add_index_field SolrDocument::FIELD_CONTENT_TYPE, label: 'Content Type'
-    config.add_index_field SolrDocument::FIELD_APO_ID, label: 'Admin Policy', helper_method: :link_to_admin_policy
+    config.add_index_field SolrDocument::FIELD_APO_ID, label: 'APO', helper_method: :link_to_admin_policy
     config.add_index_field SolrDocument::FIELD_COLLECTION_ID, label: 'Collection', helper_method: :links_to_collections
     config.add_index_field SolrDocument::FIELD_PROJECT_TAG, label: 'Project', link_to_facet: true
     config.add_index_field SolrDocument::FIELD_SOURCE_ID, label: 'Source'
@@ -107,7 +107,7 @@ class CatalogController < ApplicationController
     config.add_facet_field SolrDocument::FIELD_LICENSE, label: 'License', component: true, limit: 10
     config.add_facet_field SolrDocument::FIELD_COLLECTION_TITLE, label: 'Collection', component: true, limit: 10,
                                                                  more_limit: 9999, sort: 'index'
-    config.add_facet_field SolrDocument::FIELD_APO_TITLE, label: 'Admin Policy', component: true, limit: 10,
+    config.add_facet_field SolrDocument::FIELD_APO_TITLE, label: 'APO', component: true, limit: 10,
                                                           more_limit: 9999, sort: 'index'
     config.add_facet_field SolrDocument::FIELD_CURRENT_VERSION, label: 'Version', component: true, limit: 10
     config.add_facet_field SolrDocument::FIELD_PROCESSING_STATUS, label: 'Processing Status', component: true, limit: 10

--- a/app/models/permitted_queries.rb
+++ b/app/models/permitted_queries.rb
@@ -37,7 +37,7 @@ class PermittedQueries
     repository
       .search(
         q:, defType: 'lucene', rows: PERMITTED_QUERIES_LIMIT, fl: "id,#{SolrDocument::FIELD_TITLE}",
-        fq: ["#{SolrDocument::FIELD_OBJECT_TYPE}:adminPolicy", '!project_tag_ssim:Hydrus']
+        fq: ["#{SolrDocument::FIELD_OBJECT_TYPE}:APO", '!project_tag_ssim:Hydrus']
       )
       .dig('response', 'docs')
       .sort_by { |doc| doc.fetch(SolrDocument::FIELD_TITLE).downcase.delete('[]') }

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -82,7 +82,7 @@ class Report # rubocop:disable Metrics/ClassLength
       category: FREQUENTLY_USED_CATEGORY
     },
     {
-      field: SolrDocument::FIELD_APO_TITLE, label: 'Admin policy',
+      field: SolrDocument::FIELD_APO_TITLE, label: 'APO',
       sort: false, default: true, width: 100,
       category: FREQUENTLY_USED_CATEGORY
     },

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -127,13 +127,13 @@ class SolrDocument
     embargo_status == 'embargoed'
   end
 
-  # @return [boolean] true if NOT an adminPolicy or an agreement
+  # @return [boolean] true if NOT an APO or an agreement
   def publishable?
     item? || collection? || virtual_object?
   end
 
   def admin_policy?
-    object_type == 'adminPolicy'
+    object_type == 'APO'
   end
 
   def agreement?

--- a/app/services/admin_policy_options.rb
+++ b/app/services/admin_policy_options.rb
@@ -13,7 +13,7 @@ class AdminPolicyOptions
     SearchService
       .query(
         q, defType: 'lucene', rows: 99_999, fl: "id,tag_ssim,#{SolrDocument::FIELD_TITLE}",
-           fq: ["#{SolrDocument::FIELD_OBJECT_TYPE}:adminPolicy", '!tag_ssim:"Project : Hydrus"', '!tag_ssim:"APO status : inactive"']
+           fq: ["#{SolrDocument::FIELD_OBJECT_TYPE}:APO", '!tag_ssim:"Project : Hydrus"', '!tag_ssim:"APO status : inactive"']
       )
       .dig('response', 'docs')
       .sort_by { |doc| doc.fetch(SolrDocument::FIELD_TITLE).downcase.delete('[]') }

--- a/app/views/collections/new.html.erb
+++ b/app/views/collections/new.html.erb
@@ -5,7 +5,7 @@
 <%= form_tag collections_path do %>
   <div class="mb-4">
     <label for="apo_druid">
-      Admin Policy
+      APO
     </label>
     <%= select_tag :apo_druid, options_for_select(@apo_list), class: 'form-select' %>
   </div>

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -12,7 +12,7 @@
   <div class="row mt-3" data-controller="content-type">
     <div class="col-md-5">
       <div class="row mb-3">
-        <%= f.label :admin_policy, 'Admin Policy', class: 'col-sm-3 col-form-label' %>
+        <%= f.label :admin_policy, 'APO', class: 'col-sm-3 col-form-label' %>
         <div class="col-sm-9">
           <%= f.select :admin_policy, @apo_list, {}, class: 'form-select', onChange: "document.querySelector('#registration-options').src = `/apo/${this.selectedOptions[0].value}/registration_options`" %>
         </div>

--- a/lib/tasks/argo.rake
+++ b/lib/tasks/argo.rake
@@ -7,12 +7,12 @@ end
 # @return [#keys]
 def workgroups_facet(apo_field = nil)
   apo_field = apo_field_default if apo_field.nil?
-  resp = SearchService.query("#{SolrDocument::FIELD_OBJECT_TYPE}:adminPolicy", rows: 0,
-                                                                               'facet.field': apo_field,
-                                                                               'facet.prefix': 'workgroup:',
-                                                                               'facet.mincount': 1,
-                                                                               'facet.limit': -1,
-                                                                               'json.nl': 'map')
+  resp = SearchService.query("#{SolrDocument::FIELD_OBJECT_TYPE}:APO", rows: 0,
+                                                                       'facet.field': apo_field,
+                                                                       'facet.prefix': 'workgroup:',
+                                                                       'facet.mincount': 1,
+                                                                       'facet.limit': -1,
+                                                                       'json.nl': 'map')
   resp['facet_counts']['facet_fields'][apo_field] || {}
 end
 

--- a/spec/components/document_title_component_spec.rb
+++ b/spec/components/document_title_component_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe DocumentTitleComponent, type: :component do
   context 'with an APO' do
     let(:admin_policy) { true }
     let(:virtual_object) { false }
-    let(:object_type) { 'adminPolicy' }
+    let(:object_type) { 'APO' }
 
     it 'renders the expected object type label' do
       expect(rendered.css('div.object-type').first.text.strip).to eq('apo')

--- a/spec/components/show/apo/default_object_rights_component_spec.rb
+++ b/spec/components/show/apo/default_object_rights_component_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Show::Apo::DefaultObjectRightsComponent, type: :component do
   end
   let(:doc) do
     SolrDocument.new('id' => 'druid:bb663yf7144',
-                     SolrDocument::FIELD_OBJECT_TYPE => 'adminPolicy',
+                     SolrDocument::FIELD_OBJECT_TYPE => 'APO',
                      SolrDocument::FIELD_DEFAULT_ACCESS_RIGHTS => 'location - spec')
   end
   let(:rendered) { render_inline(component) }

--- a/spec/components/show/apo/details_component_spec.rb
+++ b/spec/components/show/apo/details_component_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Show::Apo::DetailsComponent, type: :component do
                      SolrDocument::FIELD_REGISTERED_DATE => ['2012-04-05T01:00:04.148Z'],
                      SolrDocument::FIELD_OBJECT_TYPE => object_type)
   end
-  let(:object_type) { 'adminPolicy' }
+  let(:object_type) { 'APO' }
 
   context 'when open is true' do
     it 'renders the appropriate buttons' do

--- a/spec/components/show/apo/overview_component_spec.rb
+++ b/spec/components/show/apo/overview_component_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Show::Apo::OverviewComponent, type: :component do
 
   let(:doc) do
     SolrDocument.new('id' => 'druid:kv840xx0000',
-                     SolrDocument::FIELD_OBJECT_TYPE => 'adminPolicy')
+                     SolrDocument::FIELD_OBJECT_TYPE => 'APO')
   end
 
   context 'when showing an APO including registration workflows' do

--- a/spec/components/show/controls_component_spec.rb
+++ b/spec/components/show/controls_component_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe Show::ControlsComponent, type: :component do
     let(:doc) do
       SolrDocument.new('id' => view_apo_id,
                        SolrDocument::FIELD_PROCESSING_STATUS => 'not registered',
-                       SolrDocument::FIELD_OBJECT_TYPE => 'adminPolicy',
+                       SolrDocument::FIELD_OBJECT_TYPE => 'APO',
                        SolrDocument::FIELD_APO_ID => [governing_apo_id])
     end
 

--- a/spec/components/show/external_links_component_spec.rb
+++ b/spec/components/show/external_links_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Show::ExternalLinksComponent, type: :component do
   let(:user_version) { nil }
   let(:version) { nil }
 
-  context 'for a non-publishable item (adminPolicy)' do
+  context 'for a non-publishable item (APO)' do
     let(:document) do
       instance_double(SolrDocument, id: 'druid:ab123cd3445',
                                     to_param: 'druid:ab123cd3445',

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe SolrDocument do
       it { is_expected.to be false }
     end
 
-    context 'when adminPolicy' do
-      let(:type) { 'adminPolicy' }
+    context 'when APO' do
+      let(:type) { 'APO' }
 
       it { is_expected.to be false }
     end
@@ -65,9 +65,9 @@ RSpec.describe SolrDocument do
   end
 
   describe '#admin_policy?' do
-    context 'when object type is an adminPolicy' do
+    context 'when object type is an APO' do
       let(:document_attributes) do
-        { SolrDocument::FIELD_OBJECT_TYPE => ['adminPolicy'] }
+        { SolrDocument::FIELD_OBJECT_TYPE => ['APO'] }
       end
 
       it 'checks and returns true' do
@@ -75,7 +75,7 @@ RSpec.describe SolrDocument do
       end
     end
 
-    context 'when object type is not an adminPolicy' do
+    context 'when object type is not an APO' do
       let(:document_attributes) do
         { SolrDocument::FIELD_OBJECT_TYPE => ['item'] }
       end

--- a/spec/requests/create_new_admin_policy_spec.rb
+++ b/spec/requests/create_new_admin_policy_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Create a new Admin Policy' do
+RSpec.describe 'Create a new APO' do
   let(:user) { create(:user) }
 
   before do

--- a/spec/requests/update_an_existing_admin_policy_spec.rb
+++ b/spec/requests/update_an_existing_admin_policy_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Update an existing Admin Policy' do
+RSpec.describe 'Update an existing APO' do
   let(:druid) { 'druid:bc123df4567' }
   let(:user) { create(:user) }
   let(:object_client) do

--- a/spec/services/admin_policy_options_spec.rb
+++ b/spec/services/admin_policy_options_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe AdminPolicyOptions do
           defType: 'lucene',
           rows: 99_999,
           fl: 'id,tag_ssim,display_title_ss',
-          fq: ["#{SolrDocument::FIELD_OBJECT_TYPE}:adminPolicy", '!tag_ssim:"Project : Hydrus"', '!tag_ssim:"APO status : inactive"']
+          fq: ["#{SolrDocument::FIELD_OBJECT_TYPE}:APO", '!tag_ssim:"Project : Hydrus"', '!tag_ssim:"APO status : inactive"']
         )
       end
 

--- a/spec/support/create_strategy_repository_pattern.rb
+++ b/spec/support/create_strategy_repository_pattern.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# db/seeds.rb requires this file directly rather than through rails_helper's spec/support glob,
+#   so pull in our own dependency instead of relying on the glob having loaded it.
+require_relative 'solr_commit'
+
 class CreateStategyForRepositoryPattern
   def association(runner)
     runner.run

--- a/spec/support/create_strategy_repository_pattern.rb
+++ b/spec/support/create_strategy_repository_pattern.rb
@@ -11,6 +11,9 @@ class CreateStategyForRepositoryPattern
       evaluation.notify(:after_build, instance)
       evaluation.notify(:before_create, instance)
       result = evaluation.create(instance)
+      # dor-services-app indexes the object it just registered with a deferred commit, so make
+      #   it searchable now rather than up to five seconds from now. See SolrCommit.
+      SolrCommit.commit
       evaluation.notify(:after_create, instance)
     end
 

--- a/spec/support/reset_solr.rb
+++ b/spec/support/reset_solr.rb
@@ -9,7 +9,7 @@ module ResetSolr
     # Solves an odd bootstrapping problem, where the dor-indexing-app can only index cocina-models,
     # but cocina-model can't be built unless the AdminPolicy is found in Solr
     solr_conn.add(id: 'druid:hv992ry2431',
-                  SolrDocument::FIELD_OBJECT_TYPE => ['adminPolicy'],
+                  SolrDocument::FIELD_OBJECT_TYPE => ['APO'],
                   apo_register_permissions_ssim: ['workgroup:dlss:developers'],
                   display_title_ss: ['[Internal System Objects]'],
                   main_title_tenim: ['[Internal System Objects]'])

--- a/spec/support/solr_commit.rb
+++ b/spec/support/solr_commit.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# dor-services-app writes Solr documents with `commitWithin: 5000` (see its Indexer), so an
+#   object it has just registered or reindexed is not searchable for up to five seconds.
+#   Capybara's retries do not help: `have_text` re-examines the already rendered results page
+#   rather than re-running the search. Specs that register objects and then exercise search
+#   therefore need to force the commit instead of waiting it out.
+module SolrCommit
+  def self.commit
+    blacklight_config = CatalogController.blacklight_config
+    blacklight_config.repository_class.new(blacklight_config).connection.soft_commit
+  end
+end

--- a/spec/system/bulk_jobs_spec.rb
+++ b/spec/system/bulk_jobs_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 # Feature tests for the spreadsheet bulk uploads view.
 RSpec.describe 'Bulk jobs view', :js do
   before do
-    solr_conn.add(id: apo_id, SolrDocument::FIELD_OBJECT_TYPE => 'adminPolicy',
+    solr_conn.add(id: apo_id, SolrDocument::FIELD_OBJECT_TYPE => 'APO',
                   'apo_role_dor-apo-manager_ssim': ['workgroup:sdr:map-staff'])
     solr_conn.commit
     sign_in create(:user), groups: ['sdr:map-staff']

--- a/spec/system/indexing_tag_facets_spec.rb
+++ b/spec/system/indexing_tag_facets_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe 'Indexing and facet results for tags', :js, skip: ENV['CI'].prese
     end
     click_link 'Reindex'
     expect(page).to have_text('Successfully updated index') # rubocop:disable RSpec/ExpectInHook
+    SolrCommit.commit # the reindexed document is not searchable until Solr commits
     visit '/'
     fill_in 'q', with: solr_id
     click_button 'search'

--- a/spec/system/indexing_tags_spec.rb
+++ b/spec/system/indexing_tags_spec.rb
@@ -38,7 +38,11 @@ RSpec.describe 'Indexing and search results for tags', :js, skip: ENV['CI'].pres
     end
     click_link 'Reindex'
     expect(page).to have_text('Successfully updated index') # rubocop:disable RSpec/ExpectInHook
-    visit '/'
+    SolrCommit.commit # the reindexed document is not searchable until Solr commits
+    # The factory also registers an APO and an agreement, whose titles are indexed and would
+    #   otherwise turn up in the searches below (the APO title contains "of"). Constrain the
+    #   searches to items so the counts asserted below reflect only the item under test.
+    visit search_catalog_path(f: { SolrDocument::FIELD_OBJECT_TYPE => ['item'] })
   end
 
   after do

--- a/spec/system/indexing_titles_spec.rb
+++ b/spec/system/indexing_titles_spec.rb
@@ -15,7 +15,11 @@ RSpec.describe 'Indexing and search results for titles', skip: ENV['CI'].present
   before do
     sign_in create(:user), groups: ['sdr:administrator-role']
     solr_conn.commit # ensure no deletes are pending
-    visit '/'
+    # Every item the factory registers brings along its own APO and agreement, which the specs
+    #   do not clean up. Their titles ("...APO title to test truncation..." and "A Title") match
+    #   the searches below and crowd the items under test out of the first page of results, so
+    #   constrain these searches, which are only ever about items, to items.
+    visit search_catalog_path(f: { SolrDocument::FIELD_OBJECT_TYPE => ['item'] })
   end
 
   after do

--- a/spec/system/item_registration_csv_spec.rb
+++ b/spec/system/item_registration_csv_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Item registration page', :js do
   context 'when successful registration' do
     it 'starts bulk action' do
       visit registration_path
-      select '[Internal System Objects]', from: 'Admin Policy' # "uber APO"
+      select '[Internal System Objects]', from: 'APO' # "uber APO"
       select 'registrationWF', from: 'Initial Workflow'
       select 'book', from: 'Content Type'
       select 'left-to-right', from: 'Viewing Direction'
@@ -64,7 +64,7 @@ RSpec.describe 'Item registration page', :js do
   context 'when successful registration with dark' do
     it 'starts bulk action and changes download to none' do
       visit registration_path
-      select '[Internal System Objects]', from: 'Admin Policy' # "uber APO"
+      select '[Internal System Objects]', from: 'APO' # "uber APO"
       select 'registrationWF', from: 'Initial Workflow'
       select 'book', from: 'Content Type'
       select 'left-to-right', from: 'Viewing Direction'
@@ -123,7 +123,7 @@ RSpec.describe 'Item registration page', :js do
     it 'reports error, retains user values, and allows user to submit a corrected CSV' do
       visit registration_path
 
-      select 'My First APO', from: 'Admin Policy'
+      select 'My First APO', from: 'APO'
       select 'registrationWF', from: 'Initial Workflow'
       select 'file', from: 'Content Type'
       select 'Dark', from: 'View access'
@@ -171,7 +171,7 @@ RSpec.describe 'Item registration page', :js do
   context 'when invalid CSV' do
     it 'reports error' do
       visit registration_path
-      select '[Internal System Objects]', from: 'Admin Policy' # "uber APO"
+      select '[Internal System Objects]', from: 'APO' # "uber APO"
       select 'registrationWF', from: 'Initial Workflow'
       select 'book', from: 'Content Type'
       select 'left-to-right', from: 'Viewing Direction'

--- a/spec/system/item_registration_spec.rb
+++ b/spec/system/item_registration_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Item registration page', :js do
 
     it 'invokes item registration method with the expected values and relays errors properly' do
       visit registration_path
-      select '[Internal System Objects]', from: 'Admin Policy' # "uber APO"
+      select '[Internal System Objects]', from: 'APO' # "uber APO"
       select 'goobiWF', from: 'Initial Workflow'
       select 'book', from: 'Content Type'
       select 'left-to-right', from: 'Viewing Direction'
@@ -114,7 +114,7 @@ RSpec.describe 'Item registration page', :js do
   context 'when registration succeeds' do
     it 'register an item correctly' do
       visit registration_path
-      select '[Internal System Objects]', from: 'Admin Policy' # "uber APO"
+      select '[Internal System Objects]', from: 'APO' # "uber APO"
       select 'registrationWF', from: 'Initial Workflow'
       select 'book', from: 'Content Type'
       select 'left-to-right', from: 'Viewing Direction'
@@ -173,7 +173,7 @@ RSpec.describe 'Item registration page', :js do
   context 'when invalid catalog_record_id' do
     it 'does not register' do
       visit registration_path
-      select '[Internal System Objects]', from: 'Admin Policy' # "uber APO"
+      select '[Internal System Objects]', from: 'APO' # "uber APO"
       select 'registrationWF', from: 'Initial Workflow'
       select 'book', from: 'Content Type'
       select 'left-to-right', from: 'Viewing Direction'
@@ -201,7 +201,7 @@ RSpec.describe 'Item registration page', :js do
   context 'when invalid barcode' do
     it 'does not register' do
       visit registration_path
-      select '[Internal System Objects]', from: 'Admin Policy' # "uber APO"
+      select '[Internal System Objects]', from: 'APO' # "uber APO"
       select 'registrationWF', from: 'Initial Workflow'
       select 'book', from: 'Content Type'
       select 'left-to-right', from: 'Viewing Direction'
@@ -234,7 +234,7 @@ RSpec.describe 'Item registration page', :js do
 
     it 'displays an error message with the HRID' do
       visit registration_path
-      select '[Internal System Objects]', from: 'Admin Policy' # "uber APO"
+      select '[Internal System Objects]', from: 'APO' # "uber APO"
       select 'registrationWF', from: 'Initial Workflow'
       select 'book', from: 'Content Type'
       select 'left-to-right', from: 'Viewing Direction'
@@ -281,7 +281,7 @@ RSpec.describe 'Item registration page', :js do
 
     it 'displays the MARC warning banner with the affected druid' do
       visit registration_path
-      select '[Internal System Objects]', from: 'Admin Policy'
+      select '[Internal System Objects]', from: 'APO'
       select 'registrationWF', from: 'Initial Workflow'
       select 'book', from: 'Content Type'
       select 'left-to-right', from: 'Viewing Direction'

--- a/spec/system/item_view_spec.rb
+++ b/spec/system/item_view_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe 'Item view', :js do
             within_table('Overview') do
               expect(page).to have_css 'th', text: 'DRUID'
               expect(page).to have_css 'td', text: item_id
-              expect(page).to have_css 'th', text: 'Admin policy'
+              expect(page).to have_css 'th', text: 'APO'
               expect(page).to have_css 'td a', text: 'Stanford University Libraries - Special Collections'
               expect(page).to have_css 'th', text: 'Status'
               expect(page).to have_css 'th', text: 'Access rights'

--- a/spec/system/item_view_spec.rb
+++ b/spec/system/item_view_spec.rb
@@ -333,7 +333,7 @@ RSpec.describe 'Item view', :js do
     end
   end
 
-  context 'for an adminPolicy' do
+  context 'for an APO' do
     let(:cocina_model) { instance_double(Cocina::Models::AdminPolicyWithMetadata, administrative:, as_json: {}) }
     let(:administrative) { instance_double(Cocina::Models::AdminPolicyAdministrative) }
     let(:id) { 'druid:qv778ht9999' }

--- a/spec/system/search_results_spec.rb
+++ b/spec/system/search_results_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'Search results' do
           expect(page).to have_css 'dd', text: 'image'
           expect(page).to have_css 'dt', text: 'Status:'
           expect(page).to have_css 'dd', text: 'v1 Unknown Status'
-          expect(page).to have_css 'dt', text: 'Admin Policy:'
+          expect(page).to have_css 'dt', text: 'APO:'
           expect(page).to have_css 'dd a', text: 'Stanford University Libraries - Special Collections'
           expect(page).to have_css 'dt', text: 'Project:'
           expect(page).to have_css 'dd a', text: 'Fuller Slides'


### PR DESCRIPTION
# Why was this change made?
HOLD until accompanying DSA PR (https://github.com/sul-dlss/dor-services-app/pull/6320) is merged and deployed, and APOs are reindexed. 

Required for https://github.com/sul-dlss/argo-b3/issues/351

This also includes some changes to specs that rely on certain objects being indexed in Solr. These surfaced when I locally built the DSA container, getting the relatively recent soft commit changes. 

# How was this change tested?
Locally and CI. I built the docker image for DSA on its branch with the changes to indexing, in order to see tests pass locally. Three tests will fail in CI until the DSA branch is merged. 

Claude-assisted. 
