### PR TITLE
Handle CSV registration bulk action errors with no title or catalog record id

### DIFF
--- a/app/controllers/bulk_actions/register_druid_jobs_controller.rb
+++ b/app/controllers/bulk_actions/register_druid_jobs_controller.rb
@@ -25,14 +25,24 @@ module BulkActions
 
     def validate_job_params(job_params)
       validate_csv_headers(job_params.fetch(:csv_file), REQUIRED_HEADERS) do |csv|
-        if ADDITIONAL_HEADERS.none? { |header| csv.headers.include?(header) }
-          ["missing header. One of these must be provided: #{ADDITIONAL_HEADERS.join(', ')}"]
-        elsif csv.any? { |row| ADDITIONAL_HEADERS.none? { |header| row[header].present? } }
-          ["missing data. For each row, one of these must be provided: #{ADDITIONAL_HEADERS.join(', ')}"]
-        else
-          []
-        end
+        label_header_errors(csv) + missing_title_errors(csv)
       end
+    end
+
+    private
+
+    def label_header_errors(csv)
+      # "label" has been removed from Cocina but users may still have template files referencing it.
+      return [] if csv.headers.none? { |header| header&.casecmp?('label') }
+
+      ['has a "label" column, which is not valid. Titles must be in a column named "title".']
+    end
+
+    # A missing column reads as blank data for every row, so this covers an absent header too.
+    def missing_title_errors(csv)
+      return [] if csv.all? { |row| ADDITIONAL_HEADERS.any? { |header| row[header].present? } }
+
+      ["missing title. For each row, one of these must be provided: #{ADDITIONAL_HEADERS.join(', ')}"]
     end
   end
 end

--- a/app/controllers/bulk_actions/register_druid_jobs_controller.rb
+++ b/app/controllers/bulk_actions/register_druid_jobs_controller.rb
@@ -15,12 +15,24 @@ module BulkActions
       rights_download
     ].freeze
 
+    # At least one of these is required: a title, or a catalog record id to derive one from.
+    # NOTE: Equivalent validation for the registration page is in CsvRegistrationForm.
+    ADDITIONAL_HEADERS = ['title', CatalogRecordId.csv_header].freeze
+
     def job_params
       { groups: current_user.groups, csv_file: CsvUploadNormalizer.read(params[:csv_file].path) }
     end
 
     def validate_job_params(job_params)
-      validate_csv_headers(job_params.fetch(:csv_file), REQUIRED_HEADERS)
+      validate_csv_headers(job_params.fetch(:csv_file), REQUIRED_HEADERS) do |csv|
+        if ADDITIONAL_HEADERS.none? { |header| csv.headers.include?(header) }
+          ["missing header. One of these must be provided: #{ADDITIONAL_HEADERS.join(', ')}"]
+        elsif csv.any? { |row| ADDITIONAL_HEADERS.none? { |header| row[header].present? } }
+          ["missing data. For each row, one of these must be provided: #{ADDITIONAL_HEADERS.join(', ')}"]
+        else
+          []
+        end
+      end
     end
   end
 end

--- a/app/controllers/bulk_actions/register_druid_jobs_controller.rb
+++ b/app/controllers/bulk_actions/register_druid_jobs_controller.rb
@@ -35,14 +35,14 @@ module BulkActions
       # "label" has been removed from Cocina but users may still have template files referencing it.
       return [] if csv.headers.none? { |header| header&.casecmp?('label') }
 
-      ['has a "label" column, which is not valid. Titles must be in a column named "title".']
+      ['has a "label" column, which is not valid (titles must be in a column named "title")']
     end
 
     # A missing column reads as blank data for every row, so this covers an absent header too.
     def missing_title_errors(csv)
       return [] if csv.all? { |row| ADDITIONAL_HEADERS.any? { |header| row[header].present? } }
 
-      ["missing title. For each row, one of these must be provided: #{ADDITIONAL_HEADERS.join(', ')}"]
+      ["is missing a title (each row needs a value in #{ADDITIONAL_HEADERS.join(' or ')})"]
     end
   end
 end

--- a/app/controllers/concerns/creates_bulk_actions.rb
+++ b/app/controllers/concerns/creates_bulk_actions.rb
@@ -67,9 +67,11 @@ module CreatesBulkActions
     Success()
   end
 
-  def validate_csv_headers(csv, required_headers)
+  # An optional block is passed through to CsvUploadValidator#valid? for additional
+  # checks; it is yielded the parsed CSV and returns an array of error messages.
+  def validate_csv_headers(csv, required_headers, &)
     validator = CsvUploadValidator.new(csv:, required_headers:)
-    return Success() if validator.valid?
+    return Success() if validator.valid?(&)
 
     Failure(validator.errors)
   end

--- a/app/forms/csv_registration_form.rb
+++ b/app/forms/csv_registration_form.rb
@@ -94,7 +94,7 @@ It's legal to have more than one colon in a hierarchy, but at least one colon is
 
   def csv_file_validation
     validator = CsvUploadValidator.new(csv: job_csv, required_headers: 'source_id')
-    errors.add(:csv_file, validator.errors.join(' ')) unless validator.valid? do |csv|
+    errors.add(:csv_file, validator.errors.to_sentence) unless validator.valid? do |csv|
       label_header_errors(csv) + missing_title_errors(csv)
     end
   rescue CSV::MalformedCSVError => e
@@ -105,7 +105,7 @@ It's legal to have more than one colon in a hierarchy, but at least one colon is
     # "label" has been removed from Cocina but users may still have template files referencing it.
     return [] if csv.headers.none? { |header| header&.casecmp?('label') }
 
-    ['has a "label" column, which is not valid. Titles must be in a column named "title".']
+    ['has a "label" column, which is not valid (titles must be in a column named "title")']
   end
 
   # Validates that data is present for one of the required columns. A missing column
@@ -113,7 +113,7 @@ It's legal to have more than one colon in a hierarchy, but at least one colon is
   def missing_title_errors(csv)
     return [] if csv.all? { |row| one_of_data_headers.any? { |header| row[header].present? } }
 
-    ["missing title. For each row, one of these must be provided: #{one_of_data_headers.join(', ')}"]
+    ["is missing a title (each row needs a value in #{one_of_data_headers.join(' or ')})"]
   end
 
   def one_of_data_headers

--- a/app/forms/csv_registration_form.rb
+++ b/app/forms/csv_registration_form.rb
@@ -92,20 +92,28 @@ It's legal to have more than one colon in a hierarchy, but at least one colon is
     @job_csv ||= CsvUploadNormalizer.read(csv_file.path)
   end
 
-  def csv_file_validation # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def csv_file_validation
     validator = CsvUploadValidator.new(csv: job_csv, required_headers: 'source_id')
     errors.add(:csv_file, validator.errors.join(' ')) unless validator.valid? do |csv|
-      # Validates that data is present for one of the required columns.
-      if one_of_data_headers.none? { |header| csv.headers.include?(header) }
-        ["missing header. One of these must be provided: #{one_of_data_headers.join(', ')}"]
-      elsif csv.any? { |row| one_of_data_headers.none? { |header| row[header].present? } }
-        ["missing data. For each row, one of these must be provided: #{one_of_data_headers.join(', ')}"]
-      else
-        []
-      end
+      label_header_errors(csv) + missing_title_errors(csv)
     end
   rescue CSV::MalformedCSVError => e
     errors.add :csv_file, "is invalid: #{e.message}"
+  end
+
+  def label_header_errors(csv)
+    # "label" has been removed from Cocina but users may still have template files referencing it.
+    return [] if csv.headers.none? { |header| header&.casecmp?('label') }
+
+    ['has a "label" column, which is not valid. Titles must be in a column named "title".']
+  end
+
+  # Validates that data is present for one of the required columns. A missing column
+  # reads as blank data for every row, so this covers an absent header too.
+  def missing_title_errors(csv)
+    return [] if csv.all? { |row| one_of_data_headers.any? { |header| row[header].present? } }
+
+    ["missing title. For each row, one of these must be provided: #{one_of_data_headers.join(', ')}"]
   end
 
   def one_of_data_headers

--- a/app/jobs/register_druids_job.rb
+++ b/app/jobs/register_druids_job.rb
@@ -6,11 +6,21 @@ class RegisterDruidsJob < BulkActionJob
   HEADERS = ['Druid', 'Barcode', CatalogRecordId.label, 'Source Id', 'Title'].freeze
 
   def perform_bulk_action
-    convert_results.each.with_index do |convert_result, index|
+    # Index from 2, since the first row of the CSV is the header.
+    convert_results.each.with_index(2) do |convert_result, index|
       perform_item_class.new(druid: 'Unregistered', index:, job: self, convert_result:).perform
     rescue StandardError => e
       failure!(druid: 'Unregistered', message: "Failed #{e.class} #{e.message}", index:)
     end
+  end
+
+  # Rows are not registered yet, so log the CSV line number to identify them.
+  def success!(druid:, message:, index:)
+    super(druid:, message: " - line #{index} - #{message}")
+  end
+
+  def failure!(druid:, message:, index:)
+    super(druid:, message: " - line #{index} - #{message}")
   end
 
   def druid_count
@@ -36,6 +46,14 @@ class RegisterDruidsJob < BulkActionJob
     end
 
     attr_reader :convert_result
+
+    def success!(message:)
+      job.success!(druid: druid, message: "Success: #{message}", index:)
+    end
+
+    def failure!(message:)
+      job.failure!(druid: druid, message: "Error: #{message}", index:)
+    end
 
     def perform
       return failure!(message: convert_result.failure.message) if convert_result.failure?

--- a/app/services/csv_upload_validator.rb
+++ b/app/services/csv_upload_validator.rb
@@ -14,7 +14,8 @@ class CsvUploadValidator
   end
 
   def valid?
-    self.errors += ["missing headers: #{missing_headers.join(', ')}."] if missing_headers.present?
+    # No trailing period: errors are joined into a single sentence for display.
+    self.errors += ["missing headers: #{missing_headers.join(', ')}"] if missing_headers.present?
     self.errors += Array(yield csv) if block_given?
 
     errors.empty?

--- a/app/services/registration_csv_converter.rb
+++ b/app/services/registration_csv_converter.rb
@@ -4,6 +4,13 @@
 class RegistrationCsvConverter
   include Dry::Monads[:result]
 
+  # Raised when the CSV is missing a column that is required for a row.
+  class MissingColumnError < StandardError
+    def initialize(column)
+      super("Missing required column: #{column}")
+    end
+  end
+
   CONTENT_TYPES = [Cocina::Models::ObjectType.book,
                    Cocina::Models::ObjectType.document,
                    Cocina::Models::ObjectType.file,
@@ -56,21 +63,28 @@ class RegistrationCsvConverter
   def convert_row(row)
     model = Cocina::Models::RequestDRO.new(model_params(row))
     Success(model:,
-            workflow: params[:initial_workflow] || row.fetch('initial_workflow'),
+            workflow: params[:initial_workflow] || fetch_column(row, 'initial_workflow'),
             tags: tags(row) + ticket_tags(row))
-  rescue Cocina::Models::ValidationError => e
+  rescue Cocina::Models::ValidationError, MissingColumnError => e
     Failure(e)
+  end
+
+  # Like CSV::Row#fetch, but raises an error naming the missing column.
+  def fetch_column(row, column)
+    raise MissingColumnError, column unless row.headers.include?(column)
+
+    row[column]
   end
 
   def model_params(row)
     model_params = {
-      type: dro_type(params[:content_type] || row.fetch('content_type')),
+      type: dro_type(params[:content_type] || fetch_column(row, 'content_type')),
       version: 1,
       administrative: {
-        hasAdminPolicy: params[:administrative_policy_object] || row.fetch('administrative_policy_object')
+        hasAdminPolicy: params[:administrative_policy_object] || fetch_column(row, 'administrative_policy_object')
       },
       identification: {
-        sourceId: row.fetch('source_id'),
+        sourceId: fetch_column(row, 'source_id'),
         barcode: row['barcode'],
         catalogLinks: catalog_links(row)
       }.compact
@@ -154,7 +168,7 @@ class RegistrationCsvConverter
 
   def description(row)
     {}.tap do |description|
-      title = row[catalog_record_id_column] ? row['title'] : row.fetch('title')
+      title = row[catalog_record_id_column] ? row['title'] : fetch_column(row, 'title')
       description[:title] = [{ value: title }]
     end
   end
@@ -164,8 +178,7 @@ class RegistrationCsvConverter
       access[:view] = params[:rights_view] || row['rights_view']
       access[:download] =
         params[:rights_download] || row['rights_download'] || ('none' if %w[citation-only dark].include? access[:view])
-      access[:location] = (params[:rights_location] || row.fetch('rights_location')) if [access[:view],
-                                                                                         access[:download]].include?('location-based')
+      access[:location] = (params[:rights_location] || fetch_column(row, 'rights_location')) if [access[:view], access[:download]].include?('location-based')
       cdl = params[:rights_controlledDigitalLending] || row['rights_controlledDigitalLending']
       access[:controlledDigitalLending] = ActiveModel::Type::Boolean.new.cast(cdl) if cdl.present?
     end.compact

--- a/spec/fixtures/files/item_registration_label.csv
+++ b/spec/fixtures/files/item_registration_label.csv
@@ -1,0 +1,2 @@
+source_id,label
+foo:123,My new object

--- a/spec/fixtures/files/register_druids.csv
+++ b/spec/fixtures/files/register_druids.csv
@@ -1,0 +1,2 @@
+administrative_policy_object,collection,rights_view,rights_download,initial_workflow,content_type,source_id,title
+druid:fp165nz4391,druid:ww536kz2190,world,world,registrationWF,book,sul-chs:MS-228A_01,Charlotte Brown court transcript

--- a/spec/fixtures/files/register_druids_label_and_title.csv
+++ b/spec/fixtures/files/register_druids_label_and_title.csv
@@ -1,0 +1,2 @@
+administrative_policy_object,collection,rights_view,rights_download,initial_workflow,content_type,source_id,title,label
+druid:fp165nz4391,druid:ww536kz2190,world,world,registrationWF,book,sul-chs:MS-228A_01,Charlotte Brown court transcript,MS-228A

--- a/spec/fixtures/files/register_druids_missing_title.csv
+++ b/spec/fixtures/files/register_druids_missing_title.csv
@@ -1,0 +1,2 @@
+administrative_policy_object,collection,rights_view,rights_download,initial_workflow,content_type,source_id,label
+druid:fp165nz4391,druid:ww536kz2190,world,world,registrationWF,book,sul-chs:MS-228A_01,Charlotte Brown court transcript

--- a/spec/forms/csv_registration_form_spec.rb
+++ b/spec/forms/csv_registration_form_spec.rb
@@ -21,7 +21,21 @@ RSpec.describe CsvRegistrationForm do
 
       it 'returns errors' do
         expect(form.errors.full_messages).to include(
-          /missing header\. One of these must be provided: title, folio_instance_hrid/
+          /missing title\. For each row, one of these must be provided: title, folio_instance_hrid/
+        )
+      end
+    end
+
+    context 'when the CSV has a label column instead of a title column' do
+      let(:csv_fixture) { file_fixture('item_registration_label.csv') }
+
+      it 'is not valid' do
+        expect(form).not_to be_valid
+      end
+
+      it 'returns errors calling out the label column' do
+        expect(form.errors.full_messages).to include(
+          /has a "label" column, which is not valid\. Titles must be in a column named "title"\./
         )
       end
     end
@@ -35,7 +49,7 @@ RSpec.describe CsvRegistrationForm do
 
       it 'returns errors' do
         expect(form.errors.full_messages).to include(
-          /missing data\. For each row, one of these must be provided: title, folio_instance_hrid/
+          /missing title\. For each row, one of these must be provided: title, folio_instance_hrid/
         )
       end
     end

--- a/spec/forms/csv_registration_form_spec.rb
+++ b/spec/forms/csv_registration_form_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CsvRegistrationForm do
 
       it 'returns errors' do
         expect(form.errors.full_messages).to include(
-          /missing title\. For each row, one of these must be provided: title, folio_instance_hrid/
+          /is missing a title \(each row needs a value in title or folio_instance_hrid\)/
         )
       end
     end
@@ -35,7 +35,7 @@ RSpec.describe CsvRegistrationForm do
 
       it 'returns errors calling out the label column' do
         expect(form.errors.full_messages).to include(
-          /has a "label" column, which is not valid\. Titles must be in a column named "title"\./
+          /has a "label" column, which is not valid \(titles must be in a column named "title"\)/
         )
       end
     end
@@ -49,7 +49,7 @@ RSpec.describe CsvRegistrationForm do
 
       it 'returns errors' do
         expect(form.errors.full_messages).to include(
-          /missing title\. For each row, one of these must be provided: title, folio_instance_hrid/
+          /is missing a title \(each row needs a value in title or folio_instance_hrid\)/
         )
       end
     end

--- a/spec/jobs/register_druids_job_spec.rb
+++ b/spec/jobs/register_druids_job_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe RegisterDruidsJob do
       job.perform_now
 
       expect(RegistrationService).not_to have_received(:register)
-      expect(log).to have_received(:puts).with(include('does not match'))
+      expect(log).to have_received(:puts).with(include(' - line 2 - ', 'does not match'))
       expect(bulk_action.druid_count_success).to eq 0
       expect(bulk_action.druid_count_fail).to eq 1
     end
@@ -77,6 +77,29 @@ RSpec.describe RegisterDruidsJob do
       expect(log).to have_received(:puts).with(/connection problem/)
       expect(bulk_action.druid_count_success).to eq 0
       expect(bulk_action.druid_count_fail).to eq 1
+    end
+  end
+
+  context 'when registration raises' do
+    let(:csv_string) do
+      <<~CSV
+        administrative_policy_object,initial_workflow,content_type,source_id,title,rights_view,rights_download
+        druid:bc123df4567,accessionWF,book,foo:123,My new object,world,world
+        druid:bc123df4567,accessionWF,book,foo:456,Another new object,world,world
+      CSV
+    end
+
+    before do
+      allow(RegistrationService).to receive(:register).and_raise('connection problem')
+    end
+
+    it 'logs a failure for each row with its CSV line number' do
+      job.perform_now
+
+      expect(log).to have_received(:puts).with(/ - line 2 - Failed RuntimeError connection problem/)
+      expect(log).to have_received(:puts).with(/ - line 3 - Failed RuntimeError connection problem/)
+      expect(bulk_action.druid_count_fail).to eq 2
+      expect(bulk_action.status).to eq 'Completed'
     end
   end
 

--- a/spec/requests/bulk_actions/register_druid_jobs_spec.rb
+++ b/spec/requests/bulk_actions/register_druid_jobs_spec.rb
@@ -21,13 +21,25 @@ RSpec.describe 'BulkActions::RegisterDruidJobs' do
       expect(response).to have_http_status(:see_other)
     end
 
-    context 'when the CSV has no title or catalog record id column' do
-      it 'does not create the job' do
+    context 'when the CSV has a label column instead of a title column' do
+      it 'does not create the job and calls out the label column' do
         params = { 'csv_file' => fixture_file_upload('register_druids_missing_title.csv', 'text/csv') }
 
         expect { post '/bulk_actions/register_druid_job', params: }.not_to have_enqueued_job(RegisterDruidsJob)
         expect(response).to have_http_status(:unprocessable_content)
-        expect(response.body).to match('One of these must be provided: title')
+        expect(response.body).to match('column, which is not valid')
+        expect(response.body).to match('missing title. For each row, one of these must be provided: title')
+      end
+    end
+
+    context 'when the CSV has a label column alongside a title column' do
+      it 'does not create the job' do
+        params = { 'csv_file' => fixture_file_upload('register_druids_label_and_title.csv', 'text/csv') }
+
+        expect { post '/bulk_actions/register_druid_job', params: }.not_to have_enqueued_job(RegisterDruidsJob)
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to match('column, which is not valid')
+        expect(response.body).not_to match('missing title')
       end
     end
   end

--- a/spec/requests/bulk_actions/register_druid_jobs_spec.rb
+++ b/spec/requests/bulk_actions/register_druid_jobs_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'BulkActions::RegisterDruidJobs' do
+  describe 'create' do
+    let(:user) { build(:user) }
+
+    before do
+      sign_in user, groups: ['sdr:administrator-role']
+    end
+
+    it 'creates a job' do
+      params = { 'csv_file' => fixture_file_upload('register_druids.csv', 'text/csv') }
+
+      expect { post '/bulk_actions/register_druid_job', params: }.to have_enqueued_job(RegisterDruidsJob)
+        .with(Integer, {
+                groups: ["sunetid:#{user.login}", 'workgroup:sdr:administrator-role'],
+                csv_file: String
+              })
+      expect(response).to have_http_status(:see_other)
+    end
+
+    context 'when the CSV has no title or catalog record id column' do
+      it 'does not create the job' do
+        params = { 'csv_file' => fixture_file_upload('register_druids_missing_title.csv', 'text/csv') }
+
+        expect { post '/bulk_actions/register_druid_job', params: }.not_to have_enqueued_job(RegisterDruidsJob)
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to match('One of these must be provided: title')
+      end
+    end
+  end
+end

--- a/spec/requests/bulk_actions/register_druid_jobs_spec.rb
+++ b/spec/requests/bulk_actions/register_druid_jobs_spec.rb
@@ -27,8 +27,9 @@ RSpec.describe 'BulkActions::RegisterDruidJobs' do
 
         expect { post '/bulk_actions/register_druid_job', params: }.not_to have_enqueued_job(RegisterDruidsJob)
         expect(response).to have_http_status(:unprocessable_content)
-        expect(response.body).to match('column, which is not valid')
-        expect(response.body).to match('missing title. For each row, one of these must be provided: title')
+        expect(response.body).to include('column, which is not valid (titles must be in a column named')
+        # Both errors are rendered as one sentence, so they have to read as clauses.
+        expect(response.body).to include(') and is missing a title (each row needs a value in title or folio_instance_hrid)')
       end
     end
 
@@ -38,8 +39,8 @@ RSpec.describe 'BulkActions::RegisterDruidJobs' do
 
         expect { post '/bulk_actions/register_druid_job', params: }.not_to have_enqueued_job(RegisterDruidsJob)
         expect(response).to have_http_status(:unprocessable_content)
-        expect(response.body).to match('column, which is not valid')
-        expect(response.body).not_to match('missing title')
+        expect(response.body).to include('column, which is not valid')
+        expect(response.body).not_to include('is missing a title')
       end
     end
   end

--- a/spec/services/csv_upload_validator_spec.rb
+++ b/spec/services/csv_upload_validator_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe CsvUploadValidator do
     end
 
     it 'returns errors' do
-      expect(validator.errors).to eq(['missing headers: xDruid.'])
+      expect(validator.errors).to eq(['missing headers: xDruid'])
     end
   end
 

--- a/spec/services/registration_csv_converter_spec.rb
+++ b/spec/services/registration_csv_converter_spec.rb
@@ -147,4 +147,20 @@ RSpec.describe RegistrationCsvConverter do
                                                                                'download' => 'none' }))
     end
   end
+
+  context 'when CSV is missing a required column' do
+    # This CSV has a "label" column where "title" is expected.
+    let(:csv_string) do
+      <<~CSV
+        administrative_policy_object,initial_workflow,content_type,source_id,label,rights_view,rights_download
+        druid:bc123df4567,accessionWF,book,foo:123,My new object,world,world
+      CSV
+    end
+
+    it 'returns a failure for each row instead of raising' do
+      expect(results.size).to be 1
+      expect(results.first.failure?).to be true
+      expect(results.first.failure.message).to eq 'Missing required column: title'
+    end
+  end
 end

--- a/spec/system/item_registration_csv_spec.rb
+++ b/spec/system/item_registration_csv_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe 'Item registration page', :js do
       click_button 'Register'
 
       expect(page).to have_text 'Register DOR Items'
-      expect(page).to have_text 'Csv file missing headers: source_id.'
+      expect(page).to have_text 'Csv file missing headers: source_id'
 
       attach_file 'Upload a CSV file', file_fixture('item_registration.csv')
 


### PR DESCRIPTION
## Why was this change made?
If a CSV was used for registration bulk action and it had a label field, and no title or catalog record id, the job would get stuck at "Processing" and a difficult-to-diagnose error would be raised. See: https://app.honeybadger.io/projects/49894/faults/134080271

Now, if there is a label column and no title (or an empty label column), the following appears in Argo (tested in QA):

<img width="1328" height="90" alt="Screenshot 2026-09-04 at 10 08 59 AM" src="https://github.com/user-attachments/assets/fd9a3559-82a6-4187-84ca-86d98f9142c7" />


Used Claude to analyze and find a solution to provide better feedback:
Here's the full summary covering all 16 files in the branch:


A CSV registration bulk action was submitted with a `label` column where `title` was
expected. The job appeared to hang forever: the Bulk Actions page showed "Processing" with
counts of 0 / 0 / 0, the downloadable log contained only the "Starting RegisterDruidsJob"
line, and Honeybadger reported a misleading
`NoMethodError: undefined method 'output_directory' for nil`.

Three separate problems combined to produce that:

1. **A missing column killed the whole job.** `RegistrationCsvConverter` used
   `row.fetch('title')` (and `fetch` for five other columns), which raises `KeyError`.
   `convert_row` only rescued `Cocina::Models::ValidationError`, so the `KeyError` escaped
   `convert`. It surfaced from `druid_count` inside `BulkActionJob#update_druid_count!` —
   before `perform_bulk_action` runs — so the per-row rescue never got a chance and the bulk
   action was left on `status: 'Processing'` with nothing useful logged. Sidekiq then retried
   it, failing identically every time.

2. **Nothing rejected the CSV at upload.** `RegisterDruidJobsController::REQUIRED_HEADERS` did
   not require a title, so a title-less CSV was accepted. The registration page
   (`CsvRegistrationForm`) did check for `title` or a catalog record id; the bulk action route
   did not. Neither path said anything about `label` specifically, which is the actual mistake
   people make — `label` has been removed from Cocina, but template files referencing it are
   still in circulation.

3. **A keyword mismatch broke row-level error reporting.** `RegisterDruidsJob#perform_bulk_action`
   called `failure!(druid:, message:, index:)`, but `RegisterDruidsJob` inherits from
   `BulkActionJob`, whose `failure!` takes only `druid:` and `message:` — the `index:` keyword
   only exists on `BulkActionCsvJob`. Any exception raised while registering a row therefore
   raised `ArgumentError: unknown keyword: :index` from inside the rescue, stranding the bulk
   action on "Processing" with `druid_count_fail: 0` — the same symptom as (1), from a
   different trigger.

The `NoMethodError` in Honeybadger was a masking error, not the underlying cause. When
`perform` fails before `@bulk_action` is assigned, its `ensure` block calls `export_file&.close`
→ `report_filename` → `bulk_action.output_directory` on `nil`. An exception raised in `ensure`
replaces the in-flight exception, so the real error survives only as `#cause`. (Not addressed
here — see follow-ups.)

## Changes

**`RegistrationCsvConverter`** — added a `MissingColumnError` and a `fetch_column` helper that
raises it, replacing all six `row.fetch` calls (`title`, `source_id`, `content_type`,
`administrative_policy_object`, `initial_workflow`, `rights_location`). `convert_row` rescues it
alongside `ValidationError`, so a missing column is now a per-row `Failure` reading
`Missing required column: title` rather than an exception that kills the job. A column that is
present but empty still returns `nil` as before; only an absent header fails.

**Upload validation, in both paths** — `RegisterDruidJobsController` and `CsvRegistrationForm`
now share two checks, worded identically so the same mistake reports the same way regardless of
which upload path is used:

- `label_header_errors` — flags a `label` column, case-insensitively:
  `has a "label" column, which is not valid (titles must be in a column named "title")`
- `missing_title_errors` — requires `title` or `CatalogRecordId.csv_header` to hold data in
  every row: `is missing a title (each row needs a value in title or folio_instance_hrid)`.
  Because a missing column reads as blank for every row, one check covers both the
  absent-header and blank-row cases; this replaces the form's previous if/elsif pair and lets
  its `Metrics/CyclomaticComplexity` / `PerceivedComplexity` disable comment come off.

To support the controller side, `CreatesBulkActions#validate_csv_headers` now forwards an
optional block to `CsvUploadValidator#valid?`, which already accepted one for additional checks.
The block is optional, so the other nine callers are unchanged.

**Error message rendering** — both messages are phrased as clauses rather than sentences,
because `bulk_actions/_errors.html.erb` renders `@errors.to_sentence`; full sentences produced
`". and "` mid-message. For the same reason, `CsvUploadValidator`'s missing-headers error no
longer ends in a period, and `CsvRegistrationForm` now joins with `to_sentence` instead of
`join(' ')` so the registration page and the bulk action page read the same way. A CSV with a
`label` column and no title now reports:

> has a "label" column, which is not valid (titles must be in a column named "title") and is
> missing a title (each row needs a value in title or folio_instance_hrid)

**`RegisterDruidsJob`** — `success!`/`failure!` now accept `index:` and prefix log messages with
`" - line #{index} - "`, following `BulkActionCsvJob`/`BulkActionCsvJobItem`.
`RegisterDruidsJobItem` passes `index:` through, so item-level failures get line numbers too
(they previously had none). Iteration uses `each.with_index(2)` so the index is the real CSV line
number. Since every row logs as `Unregistered`, the line number is the only thing distinguishing
one failure from another.

# How was this change tested?

New and updated specs, QA
